### PR TITLE
feat(encoder): add OneHotEncoder and add the option to skip unittest

### DIFF
--- a/docs/chapters/envs.rst
+++ b/docs/chapters/envs.rst
@@ -96,3 +96,9 @@ Here is the list of environment variables that ``jina`` respects during runtime.
     If set, then all container-related tests will be conducted in the unit test.
 
     :default: unset
+
+.. confval:: JINA_SKIP_TEST_PRETRAINED
+
+    Set to `True` to skip the unit tests that depend on the pretrained models.
+
+    :default: unset

--- a/jina/executors/encoders/char.py
+++ b/jina/executors/encoders/char.py
@@ -1,0 +1,41 @@
+import numpy as np
+
+from . import BaseTextEncoder
+
+
+class OneHotTextEncoder(BaseTextEncoder):
+    """
+
+    One-hot Encoder encodes the characters into one-hot vectors. ONLY FOR TESTING USAGES.
+    :param on_value: the default value for the locations represented by characters
+    :param off_value: the default value for the locations not represented by characters
+    """
+    def __init__(self,
+                 on_value: float = 1,
+                 off_value: float = 0,
+                 *args,
+                 **kwargs):
+        super().__init__(*args, **kwargs)
+        self.offset = 32
+        self.dim = 127 - self.offset + 2  # only the Unicode code point between 32 and 127 are embedded, and the rest are considered as ``UNK```
+        self.unk = self.dim
+        self.on_value = on_value
+        self.off_value = off_value
+        self.embeddings = None
+
+    def post_init(self):
+        self.embeddings = np.eye(self.dim) * self.on_value + \
+                          (np.ones((self.dim, self.dim)) - np.eye(self.dim)) * self.off_value
+
+    def encode(self, data: 'np.ndarray', *args, **kwargs) -> 'np.ndarray':
+        """
+
+        :param data: each row is one character, an 1d array of string type (data.dtype.kind == 'U') in size B
+        :return: an ndarray of `B x D`
+        """
+        output = []
+        for r in data:
+            r_emb = [ord(c) - self.offset if self.offset <= ord(c) <= 127 else self.unk for c in r]
+            output.append(self.embeddings[r_emb, :].sum(axis=0))
+        return np.array(output)
+

--- a/tests/test_exec_encoder.py
+++ b/tests/test_exec_encoder.py
@@ -1,0 +1,49 @@
+import unittest
+import numpy as np
+import os
+
+from tests import JinaTestCase
+from jina.executors.encoders.char import OneHotTextEncoder
+from jina.executors import BaseExecutor
+
+
+class MyTestCase(JinaTestCase):
+    def test_encoding_results(self):
+        encoder = OneHotTextEncoder(workspace=os.environ['TEST_WORKDIR'])
+        test_data = np.array(['a', 'b', 'c', 'x', '!'])
+        encoded_data = encoder.encode(test_data)
+        self.assertEqual(encoded_data.shape, (5, 97))
+        self.assertIs(type(encoded_data), np.ndarray)
+
+    def test_save_and_load(self):
+        encoder = OneHotTextEncoder(workspace=os.environ['TEST_WORKDIR'])
+        encoder.save_config()
+        self.assertTrue(os.path.exists(encoder.config_abspath))
+        test_data = np.array(['a', 'b', 'c', 'x', '!'])
+        encoded_data_control = encoder.encode(test_data)
+
+        encoder.touch()
+        encoder.save()
+        self.assertTrue(os.path.exists(encoder.save_abspath))
+        encoder_loaded = BaseExecutor.load(encoder.save_abspath)
+        encoded_data_test = encoder_loaded.encode(test_data)
+
+        np.testing.assert_array_equal(encoded_data_control, encoded_data_test)
+        self.assertEqual(encoder_loaded.dim, encoder.dim)
+
+        self.add_tmpfile(
+            encoder.config_abspath, encoder.save_abspath, encoder_loaded.config_abspath, encoder_loaded.save_abspath)
+
+    def test_save_and_load_config(self):
+        encoder = OneHotTextEncoder(workspace=os.environ['TEST_WORKDIR'])
+        encoder.save_config()
+        self.assertTrue(os.path.exists(encoder.config_abspath))
+
+        encoder_loaded = BaseExecutor.load_config(encoder.config_abspath)
+        self.assertEqual(encoder_loaded.dim, encoder.dim)
+
+        self.add_tmpfile(encoder_loaded.config_abspath, encoder_loaded.save_abspath)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_exec_encoder_ernie.py
+++ b/tests/test_exec_encoder_ernie.py
@@ -9,7 +9,7 @@ from jina.executors import BaseExecutor
 
 
 class MyTestCase(JinaTestCase):
-    @unittest.skip("skip tests depending on pretraining models")
+    @unittest.skipIf(os.getenv('JINA_SKIP_TEST_PRETRAINED', True), 'skip the pretrained test if not set')
     def test_encoding_results(self):
         encoder = ErnieTextEncoder(max_length=10, workspace=os.environ['TEST_WORKDIR'])
         test_data = np.array(['it is a good day!', 'the dog sits on the floor.'])
@@ -18,7 +18,7 @@ class MyTestCase(JinaTestCase):
         self.assertIs(type(encoded_data), np.ndarray)
         self.add_tmpfile(encoder.vocab_filename)
 
-    @unittest.skipIf(sys.version_info >= (3, 8, 0), "paddlepaddle doesn't support python >= 3.8.0")
+    @unittest.skipIf(os.getenv('JINA_SKIP_TEST_PRETRAINED', True), 'skip the pretrained test if not set')
     def test_save_and_load(self):
         encoder = ErnieTextEncoder(
             max_length=10, workspace=os.environ['TEST_WORKDIR'])
@@ -38,7 +38,7 @@ class MyTestCase(JinaTestCase):
         self.add_tmpfile(
             encoder.config_abspath, encoder.save_abspath, encoder_loaded.config_abspath, encoder_loaded.save_abspath, encoder.vocab_filename)
 
-    @unittest.skipIf(sys.version_info >= (3, 8, 0), "paddlepaddle doesn't support python >= 3.8.0")
+    @unittest.skipIf(os.getenv('JINA_SKIP_TEST_PRETRAINED', True), 'skip the pretrained test if not set')
     def test_save_and_load_config(self):
         encoder = ErnieTextEncoder(
             max_length=10, workspace=os.environ['TEST_WORKDIR'])

--- a/tests/test_exec_encoder_flair.py
+++ b/tests/test_exec_encoder_flair.py
@@ -24,7 +24,7 @@ class MyTestCase(JinaTestCase):
         'max', 'min', 'mean'
     ]
 
-    @unittest.skip("skip tests depending on pretraining models")
+    @unittest.skipIf(os.getenv('JINA_SKIP_TEST_PRETRAINED', True), 'skip the pretrained test if not set')
     def test_encoding_results(self):
         encoder = FlairTextEncoder()
         test_data = np.array(['it is a good day!', 'the dog sits on the floor.'])
@@ -32,7 +32,7 @@ class MyTestCase(JinaTestCase):
         self.assertEqual(encoded_data.shape[0], 2)
         self.assertIs(type(encoded_data), np.ndarray)
 
-    @unittest.skip("skip tests depending on pretraining models")
+    @unittest.skipIf(os.getenv('JINA_SKIP_TEST_PRETRAINED', True), 'skip the pretrained test if not set')
     def test_all_encoders(self):
         for model_name in MyTestCase.model_list:
             for pooling_strategy in MyTestCase.pooling_list:
@@ -41,6 +41,7 @@ class MyTestCase(JinaTestCase):
                 encoded_data = encoder.encode(test_data)
                 self.assertEqual(encoded_data.shape[0], 2, '{} failed'.format(model_name))
 
+    @unittest.skipIf(os.getenv('JINA_SKIP_TEST_PRETRAINED', True), 'skip the pretrained test if not set')
     def test_save_and_load(self):
         encoder = FlairTextEncoder(
             embeddings=('word:glove',), pooling_strategy='mean', workspace=os.environ['TEST_WORKDIR'])
@@ -62,6 +63,7 @@ class MyTestCase(JinaTestCase):
         self.add_tmpfile(
             encoder.config_abspath, encoder.save_abspath, encoder_loaded.config_abspath, encoder_loaded.save_abspath)
 
+    @unittest.skipIf(os.getenv('JINA_SKIP_TEST_PRETRAINED', True), 'skip the pretrained test if not set')
     def test_save_and_load_config(self):
         encoder = FlairTextEncoder(
             embeddings=('word:glove',), pooling_strategy='mean', workspace=os.environ['TEST_WORKDIR'])

--- a/tests/test_exec_encoder_transformer.py
+++ b/tests/test_exec_encoder_transformer.py
@@ -9,7 +9,7 @@ from tests import JinaTestCase
 
 
 class MyTestCase(JinaTestCase):
-    @unittest.skip("skip tests depending on pretraining models")
+    @unittest.skipIf(os.getenv('JINA_SKIP_TEST_PRETRAINED', True), 'skip the pretrained test if not set')
     def test_encoding_results(self):
         encoder = TransformerTextEncoder()
         test_data = np.array(['a', 'b', 'xy'])
@@ -17,7 +17,7 @@ class MyTestCase(JinaTestCase):
         self.assertEqual(encoded_data.shape[0], 3)
         self.assertIs(type(encoded_data), np.ndarray)
 
-    @unittest.skip("skip tests depending on pretraining models")
+    @unittest.skipIf(os.getenv('JINA_SKIP_TEST_PRETRAINED', True), 'skip the pretrained test if not set')
     def test_all_encoders(self):
         from transformers import BertModel, BertTokenizer, OpenAIGPTModel, \
             OpenAIGPTTokenizer, GPT2Model, GPT2Tokenizer, \
@@ -34,7 +34,6 @@ class MyTestCase(JinaTestCase):
             'distilbert-base-cased': (DistilBertModel, DistilBertTokenizer),
             'roberta-base': (RobertaModel, RobertaTokenizer),
             'xlm-roberta-base': (XLMRobertaModel, XLMRobertaTokenizer)
-            # 'transfo-xl-wt103': (TransfoXLModel, TransfoXLTokenizer),
         }
 
         for model_name in MODELS:
@@ -43,6 +42,7 @@ class MyTestCase(JinaTestCase):
             encoded_data = encoder.encode(test_data)
             self.assertEqual(encoded_data.shape[0], 3, '{} failed'.format(model_name))
 
+    @unittest.skipIf(os.getenv('JINA_SKIP_TEST_PRETRAINED', True), 'skip the pretrained test if not set')
     def test_save_and_load(self):
         encoder = TransformerTextEncoder(
             max_length=10, pooling_strategy='cls', workspace=os.environ['TEST_WORKDIR'])
@@ -63,6 +63,7 @@ class MyTestCase(JinaTestCase):
         self.tmp_files.append(encoder_loaded.save_abspath)
         self.tmp_files.append(encoder.encoder_abspath)
 
+    @unittest.skipIf(os.getenv('JINA_SKIP_TEST_PRETRAINED', True), 'skip the pretrained test if not set')
     def test_save_and_load_config(self):
         encoder = TransformerTextEncoder(max_length=10, pooling_strategy='cls')
         encoder.save_config()


### PR DESCRIPTION
feat(encoder): add `OneHotEncoder` and add the option to skip unittests that depend on the pretrained models.