### PR TITLE
refactor: remove send_to rename recv_from to needs

### DIFF
--- a/docs/chapters/yaml/yaml.rst
+++ b/docs/chapters/yaml/yaml.rst
@@ -231,13 +231,13 @@ In the YAML config, one can reference environment variables with ``$ENV``, or us
       encode1:
         driver_group: index-meta-doc
         replicas: 2
-        recv_from: chunk_seg
+        needs: chunk_seg
       encode2:
         driver_group: index-meta-doc
         replicas: 2
-        recv_from: chunk_seg
+        needs: chunk_seg
       join_all:
-        recv_from: [encode1, encode2]
+        needs: [encode1, encode2]
 
 A valid Flow specification starts with ``!Flow`` as the first line.
 
@@ -247,7 +247,7 @@ A valid Flow specification starts with ``!Flow`` as the first line.
 
 .. confval:: pods
 
-     A map of :class:`jina.peapods.pod.BasePod` contained in the flow. The key is the name of this pod and the value is a map of arguments accepted by :command:`jina pod`. One can refer in ``send_to`` and ``recv_from`` to a pod by its name.
+     A map of :class:`jina.peapods.pod.BasePod` contained in the flow. The key is the name of this pod and the value is a map of arguments accepted by :command:`jina pod`. One can refer ``needs`` to a pod by its name.
 
 The flows given by the following Python code and the YAML config are identical.
 
@@ -262,7 +262,7 @@ The flows given by the following Python code and the YAML config are identical.
               exec_yaml_path='index/doc.yml')
          .add(name='tf_encode', driver_group='encode',
               exec_yaml_path='encode/encode.yml',
-              replicas=3, recv_from='chunk_seg')
+              replicas=3, needs='chunk_seg')
          .add(name='chunk_idx', driver_group='index-chunk-and-meta',
               exec_yaml_path='index/npvec.yml')
          .join(['doc_idx', 'chunk_idx'])
@@ -285,14 +285,14 @@ The flows given by the following Python code and the YAML config are identical.
       tf_encode:
         driver_group: encode
         exec_yaml_path: encode/encode.yml
-        recv_from: chunk_seg
+        needs: chunk_seg
         replicas: 3
       chunk_idx:
         driver_group: index-chunk-and-meta
         exec_yaml_path: index/npvec.yml
       join_all:
         driver_group: merge
-        recv_from: [doc_idx, chunk_idx]
+        needs: [doc_idx, chunk_idx]
 
 .. highlight:: python
 .. code-block:: python

--- a/jina/peapods/pod.py
+++ b/jina/peapods/pod.py
@@ -266,18 +266,16 @@ class FlowPod(BasePod):
     other Pods, which comes in handy when used in the Flow API
     """
 
-    def __init__(self, kwargs: Dict, send_to: Set[str] = None,
-                 recv_from: Set[str] = None, parser: Callable = set_pod_parser):
+    def __init__(self, kwargs: Dict,
+                 needs: Set[str] = None, parser: Callable = set_pod_parser):
         """
 
         :param kwargs: unparsed argument in dict, if given the
-        :param send_to: a list of names this BasePod send message to
-        :param recv_from: a list of names this BasePod receive message from
+        :param needs: a list of names this BasePod needs to receive message from
         """
         self.cli_args, self._args, self.unk_args = _get_parsed_args(kwargs, parser)
         super().__init__(self._args)
-        self.send_to = send_to if send_to else set()  #: used in the :class:`jina.flow.Flow` to build the graph
-        self.recv_from = recv_from if recv_from else set()  #: used in the :class:`jina.flow.Flow` to build the graph
+        self.needs = needs if needs else set()  #: used in the :class:`jina.flow.Flow` to build the graph
 
     def to_cli_command(self):
         if isinstance(self, GatewayPod):

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -96,7 +96,7 @@ class MyTestCase(JinaTestCase):
              .add(name='d1', image='jinaai/jina:master-debian', yaml_path='logroute', entrypoint='jina pod')
              .add(name='d2', image='jinaai/jina:master-debian', yaml_path='logroute', entrypoint='jina pod')
              .add(name='d3', image='jinaai/jina:master-debian', yaml_path='logroute',
-                  recv_from='d1', entrypoint='jina pod')
+                  needs='d1', entrypoint='jina pod')
              .join(['d3', 'd2']))
 
         with f.build() as fl:
@@ -107,7 +107,7 @@ class MyTestCase(JinaTestCase):
              .add(name='d1', image='jinaai/jina:master-debian', yaml_path='logroute', entrypoint='jina pod')
              .add(name='d2', yaml_path='logroute')
              .add(name='d3', image='jinaai/jina:master-debian', yaml_path='logroute',
-                  recv_from='d1', entrypoint='jina pod')
+                  needs='d1', entrypoint='jina pod')
              .join(['d3', 'd2'])
              )
 
@@ -119,7 +119,7 @@ class MyTestCase(JinaTestCase):
              .add(name='d1', image='jinaai/jina:master-debian', entrypoint='jina pod', yaml_path='route', replicas=3)
              .add(name='d2', yaml_path='route', replicas=3)
              .add(name='d3', image='jinaai/jina:master-debian', entrypoint='jina pod', yaml_path='route',
-                  recv_from='d1')
+                  needs='d1')
              .join(['d3', 'd2'])
              )
 

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -46,13 +46,13 @@ class MyTestCase(JinaTestCase):
     def test_flow_with_jump(self):
         f = (Flow().add(name='r1', yaml_path='route')
              .add(name='r2', yaml_path='route')
-             .add(name='r3', yaml_path='route', recv_from='r1')
-             .add(name='r4', yaml_path='route', recv_from='r2')
-             .add(name='r5', yaml_path='route', recv_from='r3')
-             .add(name='r6', yaml_path='route', recv_from='r4')
-             .add(name='r8', yaml_path='route', recv_from='r6')
-             .add(name='r9', yaml_path='route', recv_from='r5')
-             .add(name='r10', yaml_path='merge', recv_from=['r9', 'r8']))
+             .add(name='r3', yaml_path='route', needs='r1')
+             .add(name='r4', yaml_path='route', needs='r2')
+             .add(name='r5', yaml_path='route', needs='r3')
+             .add(name='r6', yaml_path='route', needs='r4')
+             .add(name='r8', yaml_path='route', needs='r6')
+             .add(name='r9', yaml_path='route', needs='r5')
+             .add(name='r10', yaml_path='merge', needs=['r9', 'r8']))
 
         with f.build() as fl:
             fl.dry_run()
@@ -79,7 +79,7 @@ class MyTestCase(JinaTestCase):
         b = (Flow()
              .add(name='chunk_seg', replicas=3)
              .add(name='encode1', replicas=2)
-             .add(name='encode2', replicas=2, recv_from='chunk_seg')
+             .add(name='encode2', replicas=2, needs='chunk_seg')
              .join(['encode1', 'encode2']))
 
         self.assertEqual(a, b)

--- a/tests/yaml/test-flow.yml
+++ b/tests/yaml/test-flow.yml
@@ -7,10 +7,10 @@ pods:
     replicas: 3
   encode1:
     replicas: 2
-    recv_from: chunk_seg
+    needs: chunk_seg
   encode2:
     replicas: 2
-    recv_from: chunk_seg
+    needs: chunk_seg
   joiner:
     yaml_path: merge
-    recv_from: [encode1, encode2]
+    needs: [encode1, encode2]


### PR DESCRIPTION
- Remove `send_to` key from YAML spec
- Rename `recv_from` to `needs`
- The default `needs` is the last Pod, when not specifying.

```yaml
!Flow
# ...
pods:
  chunk_seg:
    replicas: 3
  encode1:
    replicas: 2
    needs: chunk_seg
  encode2:
    replicas: 2
    needs: chunk_seg
  joiner:
    yaml_path: merge
    needs: [encode1, encode2]
```

For example, a Flow such as `p1 -> p2 -> p3` can be written as:
```yaml
!Flow
pods:
  p1:
    yaml_path: index/pod1.yml
  p2:
    read_only: true
  p3:
    read_only: true
```