### PR TITLE
feat(executors): Add custom torch vision encoder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,25 +5,31 @@ on: [pull_request]
 jobs:
   commit-lint:
     runs-on: ubuntu-latest
-    env:
-      GITHUB_TOKEN: ${{ secrets.JINA_DEV_BOT }}
     steps:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
       - run: "echo \"module.exports = {extends: ['@commitlint/config-conventional']}\" > commitlint.config.js"
       - uses: wagoid/commitlint-github-action@v1
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
   label-pr:
     needs: commit-lint
     runs-on: ubuntu-latest
     steps:
-      - uses: "pascalgn/size-label-action@v0.2.1"
-        env:
-          GITHUB_TOKEN: "${{ secrets.JINA_DEV_BOT }}"
+      - uses: codelytv/pr-size-labeler@v1
+        with:
+          GITHUB_TOKEN: ${{ secrets.JINA_DEV_BOT }}
+          xs_max_size: '10'
+          s_max_size: '100'
+          m_max_size: '500'
+          l_max_size: '1000'
+          fail_if_xl: 'false'
       - uses: actions/labeler@v2
         with:
           repo-token: "${{ secrets.JINA_DEV_BOT }}"
+
 
   unit-test:
     needs: commit-lint

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -15,7 +15,7 @@ jobs:
         # Alpha Release
         uses: hanxiao/github-action@master
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.JINA_DEV_BOT }}
         with:
           path-to-signatures: '.github/signatures/v1/cla.json'
           path-To-cladocument: 'https://github.com/jina-ai/jina/blob/master/CLA.md'

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -15,7 +15,7 @@ jobs:
         # Alpha Release
         uses: hanxiao/github-action@master
         env:
-          GITHUB_TOKEN: ${{ secrets.JINA_DEV_BOT }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           path-to-signatures: '.github/signatures/v1/cla.json'
           path-To-cladocument: 'https://github.com/jina-ai/jina/blob/master/CLA.md'

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -20,7 +20,7 @@ jobs:
           path-to-signatures: '.github/signatures/v1/cla.json'
           path-To-cladocument: 'https://github.com/jina-ai/jina/blob/master/CLA.md'
           # branch should not be protected
-          branch: 'master'
+          branch: 'cla'
           whitelist: hanxiao,nan-wang,jina-bot,BingHo1013
           empty-commit-flag: false
           blockchain-storage-flag: false

--- a/jina/executors/encoders/image/customtorchvision.py
+++ b/jina/executors/encoders/image/customtorchvision.py
@@ -1,0 +1,44 @@
+__copyright__ = "Copyright (c) 2020 Jina AI Limited. All rights reserved."
+__license__ = "Apache-2.0"
+
+from .torchvision import ImageTorchEncoder
+import numpy as np
+
+
+class CustomImageTorchEncoder(ImageTorchEncoder):
+    """
+    :class:`CustomImageTorchEncoder` encodes data from a ndarray, potentially B x (Channel x Height x Width) into a
+        ndarray of `B x D`.
+    Internally, :class:`CustomImageTorchEncoder` wraps any custom torch model not part of models from `torchvision.models`.
+    https://pytorch.org/docs/stable/torchvision/models.html
+    """
+
+    def __init__(self, model_path: str, layer_name: str, *args, **kwargs):
+        """
+        :param model_path: the path where the model is stored.
+        :layer: Name of the layer from where to extract the feature map.
+        """
+        super().__init__(*args, **kwargs)
+        self.model_path = model_path
+        self.layer_name = layer_name
+
+    def post_init(self):
+        import torch
+        if self.pool_strategy is not None:
+            self.pool_fn = getattr(np, self.pool_strategy)
+        self.model = torch.load(self.model_path)
+        self.model.eval()
+        self.to_device(self.model)
+        self.layer = getattr(self.model, self.layer_name)
+
+    def _get_features(self, data):
+        feature_map = None
+
+        def get_activation(model, input, output):
+            nonlocal feature_map
+            feature_map = output.detach()
+
+        handle = self.layer.register_forward_hook(get_activation)
+        self.model(data)
+        handle.remove()
+        return feature_map

--- a/jina/executors/encoders/image/torchvision.py
+++ b/jina/executors/encoders/image/torchvision.py
@@ -45,6 +45,8 @@ class ImageTorchEncoder(BaseCVTorchEncoder):
 
     def post_init(self):
         import torchvision.models as models
+        if self.pool_strategy is not None:
+            self.pool_fn = getattr(np, self.pool_strategy)
         model = getattr(models, self.model_name)(pretrained=True)
         self.model = model.features.eval()
         self.to_device(self.model)
@@ -55,4 +57,4 @@ class ImageTorchEncoder(BaseCVTorchEncoder):
     def _get_pooling(self, feature_map: 'np.ndarray') -> 'np.ndarray':
         if feature_map.ndim == 2 or self.pool_strategy is None:
             return feature_map
-        return getattr(np, self.pool_strategy)(feature_map, axis=(2, 3))
+        return self.pool_fn(feature_map, axis=(2, 3))

--- a/tests/executors/encoders/image/test_customtorchvision.py
+++ b/tests/executors/encoders/image/test_customtorchvision.py
@@ -1,0 +1,43 @@
+import unittest
+
+from jina.executors.encoders.image.customtorchvision import CustomImageTorchEncoder
+from tests.executors.encoders.image import ImageTestCase
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import tempfile
+
+
+class TestNet(nn.Module):
+    def __init__(self):
+        super(TestNet, self).__init__()
+        self.conv1 = nn.Conv2d(3, 10, 5)
+        self.pool = nn.MaxPool2d(2, 2)
+        self.conv2 = nn.Conv2d(10, 16, 5)
+        self.fc1 = nn.Linear(16 * 53 * 53, 120)
+        self.fc2 = nn.Linear(120, 84)
+        self.fc3 = nn.Linear(84, 10)
+
+    def forward(self, x):
+        x = self.pool(F.relu(self.conv1(x)))
+        x = self.pool(F.relu(self.conv2(x)))
+        x = x.view(-1, 16 * 53 * 53)
+        x = F.relu(self.fc1(x))
+        x = F.relu(self.fc2(x))
+        x = self.fc3(x)
+        return x
+
+
+class MyTestCase(ImageTestCase):
+    def _get_encoder(self, metas):
+        path = tempfile.NamedTemporaryFile().name
+        self.add_tmpfile(path)
+        model = TestNet()
+        torch.save(model, path)
+        self.target_output_dim = 10
+        self.input_dim = 224
+        return CustomImageTorchEncoder(model_path=path, layer_name='conv1', metas=metas)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
**Issue Link**: This commit does not refer to any issue or feature request

**Description:** This commits adds the possibility to the user to use any custom saved torch models.
So far, torchvision encoders can use pretrained models from pytorch (mobilenet, alexnet , resnet and all their flavours) but it can be interested to be able to use custom models trained for a specific purpose and being able to extract feature maps from any of the layers.

Future work could imply creating a hub example on how to deploy your model as document indexer in Jina.



