### PR TITLE
perf(executor): improving Sentencizer by a factor of 2.5

### DIFF
--- a/jina/executors/crafters/nlp/split.py
+++ b/jina/executors/crafters/nlp/split.py
@@ -10,8 +10,8 @@ from .. import BaseSegmenter
 class Sentencizer(BaseSegmenter):
     """
     :class:`Sentencizer` split the text on the doc-level into sentences on the chunk-level with a rule-base strategy.
-        The text are splitted on the the punctuation characters that are listed in ``punct_chars``. The sentences that
-        are shorter than the ``min_sent_len`` or longer than the ``max_sent_len`` after stripping will be discarded.
+        The text is split by the punctuation characters listed in ``punct_chars``.
+        The sentences that are shorter than the ``min_sent_len`` or longer than the ``max_sent_len`` after stripping will be discarded.
     """
 
     def __init__(self,

--- a/tests/executors/crafters/nlp/split.py
+++ b/tests/executors/crafters/nlp/split.py
@@ -11,6 +11,27 @@ class MyTestCase(JinaTestCase):
         crafted_chunk_list = sentencizer.craft(raw_bytes, 0)
         self.assertEqual(len(crafted_chunk_list), 2)
 
+    def test_sentencier_en_new_lines(self):
+        """
+        New lines are also considered as a separator.
+        """
+        sentencizer = Sentencizer()
+        raw_bytes = b'It is a sunny day!!!! When Andy comes back,\n' \
+                    b'we are going to the zoo.'
+        crafted_chunk_list = sentencizer.craft(raw_bytes, 0)
+        self.assertEqual(len(crafted_chunk_list), 3)
+
+    def test_sentencier_en_float_numbers(self):
+        """
+        Separators in float numbers, URLs, emails, abbreviations (like 'Mr.')
+        are not taking into account.
+        """
+        sentencizer = Sentencizer()
+        raw_bytes = b'With a 0.99 probability this sentence will be ' \
+                    b'tokenized in 2 sentences.'
+        crafted_chunk_list = sentencizer.craft(raw_bytes, 0)
+        self.assertEqual(len(crafted_chunk_list), 2)
+
     def test_sentencier_cn(self):
         sentencizer = Sentencizer()
         raw_bytes = '今天是个大晴天！安迪回来以后，我们准备去动物园。'.encode('utf8')

--- a/tests/executors/crafters/nlp/split.py
+++ b/tests/executors/crafters/nlp/split.py
@@ -32,6 +32,17 @@ class MyTestCase(JinaTestCase):
         crafted_chunk_list = sentencizer.craft(raw_bytes, 0)
         self.assertEqual(len(crafted_chunk_list), 2)
 
+    def test_sentencier_en_trim_spaces(self):
+        """
+        Trimming all spaces at the beginning an end of the chunks.
+        Keeping extra spaces inside chunks.
+        Ignoring chunks with only spaces.
+        """
+        sentencizer = Sentencizer()
+        raw_bytes = b'  This ,  text is...  . Amazing !!'
+        chunks = [i["text"] for i in sentencizer.craft(raw_bytes, 0)]
+        self.assertListEqual(chunks, ["This ,  text is", "Amazing"])
+
     def test_sentencier_cn(self):
         sentencizer = Sentencizer()
         raw_bytes = '今天是个大晴天！安迪回来以后，我们准备去动物园。'.encode('utf8')


### PR DESCRIPTION
The Sententicizer is now 2.5 times faster.
Instead of replacing separators by a '\n' character and splitting later by the new line character, this improved version does that with one regex and using the `findall` method.
The complexity of the new algorithm is also linear but with a low constant time because it uses only one pass over the input string.
The regex also ignores spaces at the beginning and end of the sentences so no `strip` needed.

Adding two tests that show examples of questionable results of the Sentencizer.
If that is the expected behaviour, then it is good to keep those tests here to show that it is not considered a bug.
Those test are:
* Splitting by separators that appear in common constructions like floating point numbers.
* Splitting by the '\n' character. In this efficient version I've included '\n' among the separators to replicate the same behaviour as the previous version, but if '\n' it's not included among the separators then this new version is not going to split by new lines. If this behaviour is necessary, it can easily be modified. If it is not necessary, then it could be removed directly from the separators. Let me know and I will update the code.

## Time improvement

I've test the performance using an stress test that I've pull requested to the stress test repository:
https://github.com/jina-ai/stress-test/pull/1

Hardware details:
* Processor: Intel(R) Core(TM) i7-8565U CPU @ 1.80GHz
* Memory: 16GiB SODIMM DDR4 Synchronous 2667 MHz (0,4 ns)
* OS: Linux Mint 19.3

Old code times:

    41.94MB read 3 times.
    Average per iteration: 2.876222

New code:

    41.94MB read 3 times                                                                                                       
    Average per iteration: 1.151864

Performance improvement: 2.4970
The results of both versions are exactly the same in the tested text.