### PR TITLE
fix(pip install): Adds lz4 dependency to setup.py as current pip install jina asks for lz4 to be installed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ base_dep = [
     'protobuf',
     'grpcio',
     'ruamel.yaml>=0.15.89',
+    'lz4'
 ]
 
 


### PR DESCRIPTION
Adds `lz4` dependency to `base_dep` list in setup.py.