### PR TITLE
feature- Using black as code formatter- 374

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.3.0
+    hooks:
+    -   id: check-yaml
+    -   id: end-of-file-fixer
+    -   id: trailing-whitespace
+-   repo: https://github.com/psf/black
+    rev: 19.3b0
+    hooks:
+    -   id: black

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ Jina is released on every Friday evening. The PyPi package and Docker Image will
 - [Release Note (`0.1.11`)](#release-note-0111)
 - [Release Note (`0.1.12`)](#release-note-0112)
 - [Release Note (`0.1.13`)](#release-note-0113)
+- [Release Note (`0.1.14`)](#release-note-0114)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 

--- a/extra-requirements.txt
+++ b/extra-requirements.txt
@@ -37,3 +37,5 @@ plyvel:                     index
 jieba:                      nlp, preprocess
 lz4:                        optimization, devel, production, network
 gevent:                     http, devel
+pre-commit:                 framework, py37
+black:                      framework, py37


### PR DESCRIPTION
Using black with pre-commit checks format of code while committing your file to git. Haven't run **pre-commit run --all-files** thou. Please let me know if i need to run this command and push my code. so that all already existing files will be formatted through it.