### PR TITLE
feat: added black as code formatter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.3.0
+    hooks:
+    -   id: check-yaml
+    -   id: end-of-file-fixer
+    -   id: trailing-whitespace
+-   repo: https://github.com/psf/black
+    rev: 19.3b0
+    hooks:
+    -   id: black

--- a/extra-requirements.txt
+++ b/extra-requirements.txt
@@ -37,3 +37,4 @@ plyvel:                     index
 jieba:                      nlp, preprocess
 lz4:                        optimization, devel, production, network
 gevent:                     http, devel
+pre-commit:                 framework


### PR DESCRIPTION
Added black as code formatter using pre-commit hooks, it will be enabled while committing code to git.
Haven't run **_pre-commit run --all-files_** thou as it will format all existing files. Let me know if i need to run the above command. 