### PR TITLE
feat(encoder): improve wav2vec encoder with signal resampling

### DIFF
--- a/jina/executors/encoders/audio/fairseq.py
+++ b/jina/executors/encoders/audio/fairseq.py
@@ -12,19 +12,21 @@ class Wav2VecSpeechEncoder(BaseTorchEncoder, BaseAudioEncoder):
     """
     :class:`Wav2VecSpeechEncoder` is a speech encoder based on `wav2vec` - unsupervised pre-training for speech
     recognition presented and implemented by Facebook: https://github.com/pytorch/fairseq/tree/master/examples/wav2vec
-    :class:`Wav2VecSpeechEncoder` uses a pre-trained model to encodes an audio signal from a `Batch x Signal Length`
+    :class:`Wav2VecSpeechEncoder` uses a pre-trained model to encode an audio signal from a `Batch x Signal Length`
     ndarray into a `Batch x Concatenated Features` ndarray.
     """
 
-    def __init__(self, model_path: str, *args, **kwargs):
+    def __init__(self, model_path: str, input_sample_rate: int = 22050, *args, **kwargs):
         """
         Wav2vec model produces a representation for each time step at a rate of 100 Hz.
 
         :param model_path: the path of the pre-trained model. The pre-trained model can be downloaded at
             https://github.com/pytorch/fairseq/blob/master/examples/Wav2Vec/README.md#pre-trained-models
+        :param input_sample_rate: input sampling rate in Hz (22050 by default)
         """
         super().__init__(*args, **kwargs)
         self.model_path = model_path
+        self.input_sample_rate = input_sample_rate
 
     def post_init(self):
         import torch
@@ -41,24 +43,25 @@ class Wav2VecSpeechEncoder(BaseTorchEncoder, BaseAudioEncoder):
     @as_ndarray
     def encode(self, data: np.ndarray, *args, **kwargs) -> np.ndarray:
         """
-        Segments the audio signal of each Chunk into wav2vec frames, encodes the frames and concatenates Chunk frame
-        embeddings into a single Chunk embedding.
+        Resamples the input audio signal to 16kHz, segments the resampled signal of each Chunk into wav2vec frames,
+        encodes the frames and concatenates Chunk frame embeddings into a single Chunk embedding.
 
         :param data: a `Batch x Signal Length` ndarray, where `Signal Length` is a number of samples
         :return: a `Batch x Concatenated Features` ndarray, where `Concatinated Features` is a 512-dimensional feature
         vector times the number of the wav2vec frames
         """
         assert data.shape[1] >= 465, 'the signal must have at least 465 samples'
+        from librosa import resample
         embeds = []
         with self.session():
             for chunk_data in data:
-                signal_tensor = self.array2tensor(chunk_data.reshape(1, -1))
+                resampled_signal = resample(chunk_data, self.input_sample_rate, 16000)
+                signal_tensor = self.array2tensor(resampled_signal.reshape(1, -1))
                 features = self.model.feature_extractor(signal_tensor)
                 embed_tensor = self.model.feature_aggregator(features)[0]
                 chunk_embed = self.tensor2array(embed_tensor).T.flatten()
                 embeds.append(chunk_embed)
-        result = np.array(embeds)
-        return result
+        return embeds
 
     def array2tensor(self, array):
         tensor = self._tensor_func(array)

--- a/tests/executors/encoders/audio/test_fairseq.py
+++ b/tests/executors/encoders/audio/test_fairseq.py
@@ -6,10 +6,11 @@ import numpy as np
 from jina.executors.encoders.audio.fairseq import Wav2VecSpeechEncoder
 from tests.executors import ExecutorTestCase
 
+
 class MyTestCase(ExecutorTestCase):
     def _get_encoder(self):
         self.target_output_dim = 512
-        return Wav2VecSpeechEncoder(model_path='/tmp/wav2vec_large.pt')
+        return Wav2VecSpeechEncoder(model_path='/tmp/wav2vec_large.pt', input_sample_rate=16000)
 
     @unittest.skipUnless('JINA_TEST_PRETRAINED' in os.environ, 'skip the pretrained test if not set')
     def test_encoding_results(self):


### PR DESCRIPTION
Wav2vec is trained and designed for 16 kHz sampling rate. The resampling of the input audio signal to 16 kHz should improve embedding quality.