### PR TITLE
feat(helloworld): Added the option to configure the logserver via .yml

### DIFF
--- a/jina/main/parser.py
+++ b/jina/main/parser.py
@@ -64,6 +64,10 @@ def set_hw_parser(parser=None):
                          'all data, indices, shards and outputs will be saved there')
     gp.add_argument('--logserver', action='store_true', default=False,
                     help='start a log server for the dashboard')
+    gp.add_argument('--logserver-config', type=str,
+                    default=resource_filename('jina',
+                                              '/'.join(('resources', 'logserver.default.yml'))),
+                    help='the yaml config of the log server')
     gp = add_arg_group(parser, 'scalability arguments')
     gp.add_argument('--shards', type=int,
                     default=2,


### PR DESCRIPTION
Running the dashboard with server IP set to 0.0.0.0 does not work for me. 
The only way that I managed to get it up and running was changing from 0.0.0.0 to 127.0.0.1.
Following the instructions from the [dashboard page](https://github.com/jina-ai/dashboard), it would be useful to be able to change the server IP with a logserver config file.

I would also like to update the [dashboard documentation](https://github.com/jina-ai/dashboard#2-connect-the-dashboard-to-your-log-server) and other related documentation to say that a potential problem is the server IP, but when running:

```bash
> bash make-doc.sh server 8080
```

I got this following error:

```bash
+ docker run --rm -v /home/palotti/github/jina-ai/jina/docs/chapters/proto:/out -v /home/palotti/github/jina-ai/jina/jina/proto:/protos pseudomuto/protoc-gen-doc --doc_opt=markdown,docs.md
protos/*.proto: No such file or directory
```

(submitted it as a separate issue)