### PR TITLE
fix(clients): update docstring in clients

### DIFF
--- a/jina/clients/__init__.py
+++ b/jina/clients/__init__.py
@@ -5,7 +5,7 @@ __license__ = "Apache-2.0"
 def py_client(**kwargs):
     """A simple Python client for connecting to the gateway.
 
-    For acceptable ``kwargs``, please refer to :cmd:`jina client --help`
+    For acceptable ``kwargs``, please refer to :command:`jina client --help`
 
     Example, assuming a Flow is "standby" on 192.168.1.100, with port_grpc at 55555.
 
@@ -15,13 +15,13 @@ def py_client(**kwargs):
         from jina.clients import py_client
 
         # to test connectivity
-        py_client(port_grpc='192.168.1.100', host=55555).dry_run()
+        py_client(host='192.168.1.100', port_grpc=55555).dry_run()
 
         # to search
-        py_client(port_grpc='192.168.1.100', host=55555).search(input_fn, output_fn)
+        py_client(host='192.168.1.100', port_grpc=55555).search(input_fn, output_fn)
 
         # to index
-        py_client(port_grpc='192.168.1.100', host=55555).index(input_fn, output_fn)
+        py_client(host='192.168.1.100', port_grpc=55555).index(input_fn, output_fn)
     """
     from ..main.parser import set_client_cli_parser
     from ..helper import get_parsed_args

--- a/jina/clients/python/__init__.py
+++ b/jina/clients/python/__init__.py
@@ -30,13 +30,13 @@ class PyClient(GrpcClient):
         from jina.clients import py_client
 
         # to test connectivity
-        py_client(port_grpc='192.168.1.100', host=55555).dry_run()
+        py_client(host='192.168.1.100', port_grpc=55555).dry_run()
 
         # to search
-        py_client(port_grpc='192.168.1.100', host=55555).search(input_fn, output_fn)
+        py_client(host='192.168.1.100', port_grpc=55555).search(input_fn, output_fn)
 
         # to index
-        py_client(port_grpc='192.168.1.100', host=55555).index(input_fn, output_fn)
+        py_client(host='192.168.1.100', port_grpc=55555).index(input_fn, output_fn)
 
     """
 
@@ -44,8 +44,7 @@ class PyClient(GrpcClient):
         """
 
         :param args: args provided by the CLI
-        :param delay: if ``True`` then the client starts sending request after initializing, otherwise one needs to set
-            the :attr:`input_fn` before using :func:`start` or :func:`call`
+
         """
         super().__init__(args)
         self._mode = self.args.mode
@@ -68,7 +67,6 @@ class PyClient(GrpcClient):
         """Validate the input_fn and print the first request if success
 
         :param input_fn: the input function
-        :param input_type: if the input data is in protobuf Document format, or in raw bytes, or data uri
         """
         if hasattr(input_fn, '__call__'):
             input_fn = input_fn()
@@ -141,7 +139,7 @@ class PyClient(GrpcClient):
     @property
     def input_fn(self) -> Union[Iterator['jina_pb2.Document'], Iterator[bytes], Callable]:
         """ An iterator of bytes, each element represents a document's raw content,
-        i.e. ``input_fn`` defined int the protobuf
+        i.e. ``input_fn`` defined in the protobuf
         """
         if self._input_fn is not None:
             return self._input_fn
@@ -158,7 +156,7 @@ class PyClient(GrpcClient):
             self._input_fn = bytes_gen
 
     def dry_run(self) -> bool:
-        """Send a DRYRUN request to the server, passing through all pods on the server
+        """Send a DRYRUN request to the server, passing through all pods on the server,
         useful for testing connectivity and debugging
 
         :return: if dry run is successful or not

--- a/jina/clients/python/grpc.py
+++ b/jina/clients/python/grpc.py
@@ -54,7 +54,7 @@ class GrpcClient:
         self.is_closed = False
 
     def call(self, *args, **kwargs):
-        """Calling the grpc server """
+        """Calling the gRPC server """
         raise NotImplementedError
 
     def __enter__(self):
@@ -88,7 +88,7 @@ class GrpcClient:
         return self
 
     def close(self):
-        """Gracefully shutdown the client and release all grpc-related resources """
+        """Gracefully shutdown the client and release all gRPC-related resources """
         if not self.is_closed:
             self._channel.close()
             self.logger.success(__stop_msg__)

--- a/jina/clients/python/io.py
+++ b/jina/clients/python/io.py
@@ -14,12 +14,11 @@ def input_lines(filepath: str = None, lines: Iterator[str] = None, size: int = N
     """ Input function that iterates over list of strings, it can be used in the Flow API
 
     :param filepath: a text file that each line contains a document
-    :param lines: a list of strings, each is considered as d document
+    :param lines: a list of strings, each is considered as a document
     :param size: the maximum number of the documents
     :param sampling_rate: the sampling rate between [0, 1]
     :param read_mode: specifies the mode in which the file
             is opened. 'r' for reading in text mode, 'rb' for reading in binary
-    :return:
     """
     if filepath:
         fp = open(filepath, read_mode)
@@ -44,14 +43,13 @@ def input_files(patterns: Union[str, List[str]], recursive: bool = True,
                 size: int = None, sampling_rate: float = None, read_mode: str = None):
     """ Input function that iterates over files, it can be used in the Flow API
 
-    :param patterns: The pattern may contain simple shell-style wildcards, e.g. '*.py', '[*.zip, *.gz]'
+    :param patterns: The pattern may contain simple shell-style wildcards, e.g. '\*.py', '[\*.zip, \*.gz]'
     :param recursive: If recursive is true, the pattern '**' will match any files and
                 zero or more directories and subdirectories.
     :param size: the maximum number of the files
     :param sampling_rate: the sampling rate between [0, 1]
     :param read_mode: specifies the mode in which the file
             is opened. 'r' for reading in text mode, 'rb' for reading in binary
-    :return:
     """
 
     def iter_file_exts(ps):
@@ -78,8 +76,7 @@ def input_numpy(array: 'np.ndarray', axis: int = 0, size: int = None, shuffle: b
     :param array: the numpy ndarray data source
     :param axis: iterate over that axis
     :param size: the maximum number of the sub arrays
-    :param shuffle: shuffle the the numpy data source beforehand
-    :return:
+    :param shuffle: shuffle the numpy data source beforehand
     """
     if shuffle:
         # shuffle for random query

--- a/jina/clients/python/request.py
+++ b/jina/clients/python/request.py
@@ -85,12 +85,12 @@ def _generate(data: Union[Iterator[bytes], Iterator['jina_pb2.Document'], Iterat
 
 
 def index(*args, **kwargs):
-    """Generate indexing request"""
+    """Generate a indexing request"""
     yield from _generate(*args, **kwargs)
 
 
 def train(*args, **kwargs):
-    """Generate training request """
+    """Generate a training request """
     yield from _generate(*args, **kwargs)
     req = jina_pb2.Request()
     req.request_id = 1
@@ -99,5 +99,5 @@ def train(*args, **kwargs):
 
 
 def search(*args, **kwargs):
-    """Generate search request """
+    """Generate a searching request """
     yield from _generate(*args, **kwargs)


### PR DESCRIPTION
fix typos,
\*xx\* is interpreted as italic(xx), use \\* to output as \*,
delete empty :return:,
delete invalid :param args:,
:cmd: is invalid, change it to :command: in __init__.py,

":command:`jina client --help`" will appear to be bold(jina client --help) without hyperlink in html, is that the effect we want?

resolves #495