### PR TITLE
feat: add `if` expression to BaseDriver

### DIFF
--- a/jina/drivers/__init__.py
+++ b/jina/drivers/__init__.py
@@ -3,7 +3,7 @@ __license__ = "Apache-2.0"
 
 import inspect
 from functools import wraps
-from typing import Callable, List
+from typing import Callable, Iterator
 
 import ruamel.yaml.constructor
 
@@ -77,13 +77,18 @@ class BaseDriver(metaclass=DriverType):
 
     A :class:`BaseDriver` needs to be :attr:`attached` to a :class:`jina.peapods.pea.BasePea` before using. This is done by
     :func:`attach`. Note that a deserialized :class:`BaseDriver` from file is always unattached.
+
+    .. note::
+        ``if`` accepts a single expression. It can be used for filter doc and chunk
     """
 
     store_args_kwargs = False  #: set this to ``True`` to save ``args`` (in a list) and ``kwargs`` (in a map) in YAML config
+    if_expression = ''
 
     def __init__(self, *args, **kwargs):
         self.attached = False  #: represent if this driver is attached to a :class:`jina.peapods.pea.BasePea` (& :class:`jina.executors.BaseExecutor`)
         self.pea = None  # type: 'BasePea'
+        self._compiled_if = None
 
     def attach(self, pea: 'BasePea', *args, **kwargs):
         """Attach this driver to a :class:`jina.peapods.pea.BasePea`
@@ -94,11 +99,46 @@ class BaseDriver(metaclass=DriverType):
         self.attached = True
 
     @property
+    def compiled_if(self):
+        """Get the bytecode of the if expression, faster for :func:`eval` """
+        if self._compiled_if:
+            return self._compiled_if
+        elif self.if_expression:
+            self._compiled_if = compile(self.if_expression, '<string>', 'eval')
+            return self._compiled_if
+
+    def _test_eval_if(self):
+        return eval(self.compiled_if)
+
+    @property
+    def docs(self):
+        """Get all docs in the request, filtered by ``if`` when the expression contains ``doc``
+
+        Always use ``self.docs`` instead of ``self.req.docs`` to access filtered docs
+        """
+        if 'doc' not in self.if_expression:
+            yield from self.req.docs
+        else:
+            for doc in self.req.docs:
+                if eval(self.compiled_if):
+                    yield doc
+
+    def chunks(self, d) -> Iterator['jina_pb2.Chunk']:
+        """Get all chunks in the document ``d``, filtered by ``if`` when the expression contains ``chunk``
+
+        Always use ``self.chunks(d)`` instead of ``d.chunks`` to access filtered chunks
+        """
+        if 'chunk' not in self.if_expression:
+            yield from d.chunks
+        else:
+            for chunk in d.chunks:
+                if eval(self.compiled_if):
+                    yield chunk
+
+    @property
     def req(self) -> 'jina_pb2.Request':
         """Get the current request, shortcut to ``self.pea.request``"""
         return self.pea.request
-
-
 
     @property
     def msg(self) -> 'jina_pb2.Message':
@@ -125,6 +165,8 @@ class BaseDriver(metaclass=DriverType):
         r = {}
         if a:
             r['with'] = a
+        if getattr(data, 'if_expression'):
+            r['if'] = data.if_expression
         return r
 
     @classmethod
@@ -144,6 +186,8 @@ class BaseDriver(metaclass=DriverType):
             constructor, node, deep=True)
 
         obj = cls(**data.get('with', {}))
+        # priority YAML if > class member
+        obj.if_expression = data.get('if', getattr(obj, 'if_expression', ''))
         return obj
 
     def __eq__(self, other):

--- a/jina/drivers/__init__.py
+++ b/jina/drivers/__init__.py
@@ -80,6 +80,27 @@ class BaseDriver(metaclass=DriverType):
 
     .. note::
         ``if`` accepts a single expression. It can be used for filter doc and chunk
+
+        Usage in YAML:
+
+        .. highlight:: yaml
+        .. code-block:: yaml
+
+            !Encode2
+            requests:
+              on:
+                IndexRequest:
+                  - !EncodeDriver
+                    if: doc.mime_type.startswith('image')
+
+        Usage in Python
+
+        .. highlight:: python
+        .. code-block:: python
+
+            class FilterDriver(PruneDriver):
+                if_expression = 'doc.doc_id % 2 ==0'
+
     """
 
     store_args_kwargs = False  #: set this to ``True`` to save ``args`` (in a list) and ``kwargs`` (in a map) in YAML config

--- a/jina/drivers/convert.py
+++ b/jina/drivers/convert.py
@@ -29,7 +29,7 @@ class BaseConvertDriver(BaseDriver):
         self.target = target
 
     def __call__(self, *args, **kwargs):
-        for d in self.req.docs:
+        for d in self.docs:
             if getattr(d, self.target) and not self.override:
                 continue
             self.convert(d)
@@ -141,7 +141,6 @@ class URI2Buffer(BaseConvertDriver):
         super().__init__(target, *args, **kwargs)
 
     def convert(self, d):
-        print(d)
         if urllib.parse.urlparse(d.uri).scheme in {'http', 'https', 'data'}:
             page = urllib.request.Request(d.uri, headers={'User-Agent': 'Mozilla/5.0'})
             tmp = urllib.request.urlopen(page)
@@ -168,7 +167,7 @@ class URI2DataURI(URI2Buffer):
 
     def __call__(self, *args, **kwargs):
         super().__call__()
-        for d in self.req.docs:
+        for d in self.docs:
             if d.uri and not self.override:
                 continue
 

--- a/jina/drivers/craft.py
+++ b/jina/drivers/craft.py
@@ -24,12 +24,12 @@ class ChunkCraftDriver(BaseCraftDriver):
     def __call__(self, *args, **kwargs):
         no_chunk_docs = []
 
-        for d in self.req.docs:
-            if not d.chunks:
+        for d in self.docs:
+            if not list(self.chunks(d)):
                 no_chunk_docs.append(d.doc_id)
                 continue
             _chunks_to_add = []
-            for c in d.chunks:
+            for c in self.chunks(d):
                 _args_dict = pb_obj2dict(c, self.exec.required_keys)
                 if 'blob' in self.exec.required_keys:
                     _args_dict['blob'] = pb2array(c.blob)
@@ -60,9 +60,9 @@ class ChunkCraftDriver(BaseCraftDriver):
                                             f'anyway')
                     else:
                         setattr(c, k, v)
-                c.length = len(_chunks_to_add) + len(d.chunks)
+                c.length = len(list(self.chunks(d)))
                 c.chunk_id = random.randint(0, ctypes.c_uint(-1).value)
-            d.length = len(_chunks_to_add) + len(d.chunks)
+            d.length = len(list(self.chunks(d)))
 
         if no_chunk_docs:
             self.logger.warning(f'these docs contain no chunk: {no_chunk_docs}')
@@ -74,7 +74,7 @@ class DocCraftDriver(BaseCraftDriver):
     """
 
     def __call__(self, *args, **kwargs):
-        for d in self.req.docs:
+        for d in self.docs:
             _args_dict = pb_obj2dict(d, self.exec.required_keys)
             if 'blob' in self.exec.required_keys:
                 _args_dict['blob'] = pb2array(d.blob)
@@ -100,7 +100,7 @@ class SegmentDriver(BaseCraftDriver):
         self.save_buffer = save_buffer
 
     def __call__(self, *args, **kwargs):
-        for d in self.req.docs:
+        for d in self.docs:
             _args_dict = pb_obj2dict(d, self.exec.required_keys)
             if 'blob' in self.exec.required_keys:
                 _args_dict['blob'] = pb2array(d.blob)
@@ -145,7 +145,7 @@ class UnarySegmentDriver(BaseDriver):
         self.random_chunk_id = random_chunk_id
 
     def __call__(self, *args, **kwargs):
-        for d in self.req.docs:
+        for d in self.docs:
             c = d.chunks.add()
             c.length = 1
             d_type = d.WhichOneof('content')

--- a/jina/drivers/craft.py
+++ b/jina/drivers/craft.py
@@ -3,6 +3,7 @@ __license__ = "Apache-2.0"
 
 import ctypes
 import random
+from typing import Dict
 
 from . import BaseExecutableDriver, BaseDriver
 from .helper import array2pb, pb_obj2dict, pb2array
@@ -15,6 +16,22 @@ class BaseCraftDriver(BaseExecutableDriver):
     def __init__(self, executor: str = None, method: str = 'craft', *args, **kwargs):
         super().__init__(executor, method, *args, **kwargs)
 
+    def set_chunk(self, chunk: 'jina_pb2.Chunk', chunk_info: Dict, new_chunk_id: bool = True):
+        for k, v in chunk_info.items():
+            if k == 'blob':
+                if isinstance(v, jina_pb2.NdArray):
+                    chunk.blob.CopyFrom(v)
+                else:
+                    chunk.blob.CopyFrom(array2pb(v))
+            elif k == 'chunk_id':
+                self.logger.warning(f'you are assigning a chunk_id in in {self.exec.__class__}, '
+                                    f'is it intentional? chunk_id will be override by {self.__class__} '
+                                    f'anyway')
+            else:
+                setattr(chunk, k, v)
+        if new_chunk_id:
+            chunk.chunk_id = random.randint(0, ctypes.c_uint(-1).value)
+
 
 class ChunkCraftDriver(BaseCraftDriver):
     """Craft the chunk-level information on given keys using the executor
@@ -25,43 +42,17 @@ class ChunkCraftDriver(BaseCraftDriver):
         no_chunk_docs = []
 
         for d in self.docs:
-            if not list(self.chunks(d)):
-                no_chunk_docs.append(d.doc_id)
-                continue
-            _chunks_to_add = []
             for c in self.chunks(d):
                 _args_dict = pb_obj2dict(c, self.exec.required_keys)
                 if 'blob' in self.exec.required_keys:
                     _args_dict['blob'] = pb2array(c.blob)
                 ret = self.exec_fn(**_args_dict)
-                if isinstance(ret, dict):
-                    for k, v in ret.items():
-                        if k == 'blob':
-                            if isinstance(v, jina_pb2.NdArray):
-                                c.blob.CopyFrom(v)
-                            else:
-                                c.blob.CopyFrom(array2pb(v))
-                        else:
-                            setattr(c, k, v)
-                    continue
-                elif isinstance(ret, list):
-                    _chunks_to_add.extend(ret)
-            for c_dict in _chunks_to_add:
-                c = d.chunks.add()
-                for k, v in c_dict.items():
-                    if k == 'blob':
-                        if isinstance(v, jina_pb2.NdArray):
-                            c.blob.CopyFrom(v)
-                        else:
-                            c.blob.CopyFrom(array2pb(v))
-                    elif k == 'chunk_id':
-                        self.logger.warning(f'you are assigning a chunk_id in in {self.exec.__class__}, '
-                                            f'is it intentional? chunk_id will be override by {self.__class__} '
-                                            f'anyway')
-                    else:
-                        setattr(c, k, v)
-                c.length = len(list(self.chunks(d)))
-                c.chunk_id = random.randint(0, ctypes.c_uint(-1).value)
+                if isinstance(ret, dict):  #: 1-to-1
+                    self.set_chunk(c, ret, new_chunk_id=False)
+                elif isinstance(ret, list):  #: 1-to-many
+                    d.chunks.remove(c)  # remove the current one?
+                    for c_dict in ret:
+                        self.set_chunk(d.chunks.add(), c_dict)
             d.length = len(list(self.chunks(d)))
 
         if no_chunk_docs:
@@ -108,18 +99,7 @@ class SegmentDriver(BaseCraftDriver):
             if ret:
                 for r in ret:
                     c = d.chunks.add()
-                    for k, v in r.items():
-                        if k == 'blob':
-                            if isinstance(v, jina_pb2.NdArray):
-                                c.blob.CopyFrom(v)
-                            else:
-                                c.blob.CopyFrom(array2pb(v))
-                        elif k == 'chunk_id':
-                            self.logger.warning(f'you are assigning a chunk_id in in {self.exec.__class__}, '
-                                                f'is it intentional? chunk_id will be override by {self.__class__} '
-                                                f'anyway')
-                        else:
-                            setattr(c, k, v)
+                    self.set_chunk(c, r)
                     c.length = len(ret)
                     c.chunk_id = self.first_chunk_id if not self.random_chunk_id else random.randint(0, ctypes.c_uint(
                         -1).value)

--- a/jina/drivers/encode.py
+++ b/jina/drivers/encode.py
@@ -17,7 +17,7 @@ class EncodeDriver(BaseEncodeDriver):
     """
 
     def __call__(self, *args, **kwargs):
-        contents, chunk_pts, no_chunk_docs, bad_chunk_ids = extract_chunks(self.req.docs,
+        contents, chunk_pts, no_chunk_docs, bad_chunk_ids = extract_chunks(self.docs, self.chunks,
                                                                            self.req.filter_by,
                                                                            embedding=False)
 

--- a/jina/drivers/filter.py
+++ b/jina/drivers/filter.py
@@ -11,11 +11,11 @@ class TopKFilterDriver(BaseDriver):
     """
 
     def __call__(self, *args, **kwargs):
-        for d in self.req.docs:
+        for d in self.docs:
             _topk = [k for k in d.topk_results[:self.req.top_k]]
             d.ClearField('topk_results')
             d.topk_results.extend(_topk)
-            for c in d.chunks:
+            for c in self.chunks(d):
                 _topk = [k for k in c.topk_results[:self.req.top_k]]
                 c.ClearField('topk_results')
                 c.topk_results.extend(_topk)
@@ -37,11 +37,11 @@ class TopKSortDriver(BaseDriver):
         self.descending = descending
 
     def __call__(self, *args, **kwargs):
-        for d in self.req.docs:
+        for d in self.docs:
             _sort = sorted(d.topk_results, key=lambda x: x.score.value, reverse=self.descending)
             d.ClearField('topk_results')
             d.topk_results.extend(_sort)
-            for c in d.chunks:
+            for c in self.chunks(d):
                 _sort = sorted(c.topk_results, key=lambda x: x.score.value, reverse=self.descending)
                 c.ClearField('topk_results')
                 c.topk_results.extend(_sort)

--- a/jina/drivers/index.py
+++ b/jina/drivers/index.py
@@ -20,7 +20,7 @@ class VectorIndexDriver(BaseIndexDriver):
     """
 
     def __call__(self, *args, **kwargs):
-        embed_vecs, chunk_pts, no_chunk_docs, bad_chunk_ids = extract_chunks(self.req.docs,
+        embed_vecs, chunk_pts, no_chunk_docs, bad_chunk_ids = extract_chunks(self.docs, self.chunks,
                                                                              self.req.filter_by,
                                                                              embedding=True)
 
@@ -60,10 +60,10 @@ class KVIndexDriver(BaseIndexDriver):
 
     def __call__(self, *args, **kwargs):
         if self.level == 'doc':
-            content = self.req.docs
+            content = self.docs
         elif self.level == 'chunk':
-            content = [c for d in self.req.docs for c in d.chunks if
-                       (not self.req.filter_by or c.field_name in self.req.filter_by)]
+            content = (c for d in self.docs for c in self.chunks(d) if
+                       (not self.req.filter_by or c.field_name in self.req.filter_by))
         else:
             raise TypeError(f'level={self.level} is not supported, must choose from "chunk" or "doc" ')
         if content:

--- a/jina/drivers/prune.py
+++ b/jina/drivers/prune.py
@@ -31,20 +31,20 @@ class PruneDriver(BaseDriver):
 
     def __call__(self, *args, **kwargs):
         if self.level == 'chunk':
-            for d in self.req.docs:
-                for c in d.chunks:
+            for d in self.docs:
+                for c in self.chunks(d):
                     for k in self.pruned:
                         c.ClearField(k)
         elif self.level == 'doc':
-            for d in self.req.docs:
+            for d in self.docs:
                 for k in self.pruned:
                     d.ClearField(k)
         elif self.level == 'request':
             for k in self.pruned:
                 self.msg.ClearField(k)
         elif self.level == 'all':
-            for d in self.req.docs:
-                for c in d.chunks:
+            for d in self.docs:
+                for c in self.chunks(d):
                     for k in self.pruned:
                         c.ClearField(k)
                 for k in self.pruned:

--- a/jina/drivers/reduce.py
+++ b/jina/drivers/reduce.py
@@ -96,18 +96,18 @@ class MergeTopKDriver(MergeDriver):
 
     def reduce(self, *args, **kwargs):
         if self.level == 'chunk':
-            for _d_id, _doc in enumerate(self.req.docs):
+            for _d_id, _doc in enumerate(self.docs):
                 for _c_id, _chunk in enumerate(_doc.chunks):
                     _flat_topk = [k for r in self.prev_reqs for k in r.docs[_d_id].chunks[_c_id].topk_results]
                     _chunk.ClearField('topk_results')
                     _chunk.topk_results.extend(sorted(_flat_topk, key=lambda x: x.score.value))
         elif self.level == 'doc':
-            for _d_id, _doc in enumerate(self.req.docs):
+            for _d_id, _doc in enumerate(self.docs):
                 _flat_topk = [k for r in self.prev_reqs for k in r.docs[_d_id].topk_results]
                 _doc.ClearField('topk_results')
                 _doc.topk_results.extend(sorted(_flat_topk, key=lambda x: x.score.value))
         elif self.level == 'all':
-            for _d_id, _doc in enumerate(self.req.docs):
+            for _d_id, _doc in enumerate(self.docs):
                 _flat_topk = [k for r in self.prev_reqs for k in r.docs[_d_id].topk_results]
                 _doc.ClearField('topk_results')
                 _doc.topk_results.extend(sorted(_flat_topk, key=lambda x: x.score.value))

--- a/jina/drivers/score.py
+++ b/jina/drivers/score.py
@@ -23,11 +23,11 @@ class Chunk2DocRankDriver(BaseRankDriver):
     def __call__(self, *args, **kwargs):
         exec = self.exec
 
-        for d in self.req.docs:  # d is a query in this context, i.e. for each query, compute separately
+        for d in self.docs:  # d is a query in this context, i.e. for each query, compute separately
             match_idx = []
             query_chunk_meta = {}
             match_chunk_meta = {}
-            for c in d.chunks:
+            for c in self.chunks(d):
                 for k in c.topk_results:
                     match_idx.append((k.match_chunk.doc_id, k.match_chunk.chunk_id, c.chunk_id, k.score.value))
                     query_chunk_meta[c.chunk_id] = pb_obj2dict(c, exec.required_keys)

--- a/jina/drivers/search.py
+++ b/jina/drivers/search.py
@@ -42,16 +42,16 @@ class KVSearchDriver(BaseSearchDriver):
 
     def __call__(self, *args, **kwargs):
         if self.level == 'doc':
-            for d in self.req.docs:
+            for d in self.docs:
                 self._update_topk_docs(d)
         elif self.level == 'chunk':
-            for d in self.req.docs:
-                for c in d.chunks:
+            for d in self.docs:
+                for c in self.chunks(d):
                     self._update_topk_chunks(c)
         elif self.level == 'all':
-            for d in self.req.docs:
+            for d in self.docs:
                 self._update_topk_docs(d)
-                for c in d.chunks:
+                for c in self.chunks(d):
                     self._update_topk_chunks(c)
         else:
             raise TypeError(f'level={self.level} is not supported, must choose from "chunk" or "doc" ')
@@ -101,7 +101,8 @@ class VectorSearchDriver(BaseSearchDriver):
     """
 
     def __call__(self, *args, **kwargs):
-        embed_vecs, chunk_pts, no_chunk_docs, bad_chunk_ids = extract_chunks(self.req.docs, self.req.filter_by,
+        embed_vecs, chunk_pts, no_chunk_docs, bad_chunk_ids = extract_chunks(self.docs, self.chunks,
+                                                                             self.req.filter_by,
                                                                              embedding=True)
 
         if no_chunk_docs:

--- a/jina/executors/indexers/keyvalue/proto.py
+++ b/jina/executors/indexers/keyvalue/proto.py
@@ -3,7 +3,7 @@ __license__ = "Apache-2.0"
 
 import gzip
 import json
-from typing import Union, List
+from typing import Union, List, Iterator
 
 from google.protobuf.json_format import Parse
 
@@ -79,7 +79,7 @@ class JsonPbIndexer(BasePbIndexer):
                         r[k] = Parse(v, self._parser())
         return r
 
-    def _add(self, keys: List[Union['jina_pb2.Chunk', 'jina_pb2.Document']], *args, **kwargs):
+    def _add(self, keys: Iterator[Union['jina_pb2.Chunk', 'jina_pb2.Document']], *args, **kwargs):
         """Add a JSON-friendly object to the indexer
 
         :param obj: an object can be jsonified
@@ -119,7 +119,7 @@ class BinaryPbIndexer(BasePbIndexer):
                 r[b.doc_id] = b
         return r
 
-    def _add(self, keys: List[Union['jina_pb2.Chunk', 'jina_pb2.Document']], *args, **kwargs):
+    def _add(self, keys: Iterator[Union['jina_pb2.Chunk', 'jina_pb2.Document']], *args, **kwargs):
         """Add a object to the indexer
 
         :param obj: an object

--- a/tests/test_driver_if.py
+++ b/tests/test_driver_if.py
@@ -1,0 +1,73 @@
+from typing import Any
+
+import numpy as np
+
+from jina.drivers.helper import array2pb
+from jina.drivers.prune import PruneDriver
+from jina.executors import BaseExecutor
+from jina.executors.encoders import BaseEncoder
+from jina.flow import Flow
+from jina.proto.jina_pb2 import Document
+from tests import JinaTestCase
+
+
+class FilterDriver(PruneDriver):
+    if_expression = 'doc.doc_id % 2 ==0'
+
+    def __init__(self, pruned=('text',), level='doc', *args, **kwargs):
+        super().__init__(pruned, level, *args, **kwargs)
+
+
+class Encode1(BaseEncoder):
+    def encode(self, data: Any, *args, **kwargs) -> Any:
+        print('i only encode text/plain')
+        return np.random.random([data.shape[0], 3])
+
+
+class Encode2(BaseEncoder):
+    def encode(self, data: Any, *args, **kwargs) -> Any:
+        print('i only encode image/png')
+        return np.zeros([data.shape[0], 3])
+
+
+def input_fn():
+    d = Document()
+    d.mime_type = 'text/plain'
+    c = d.chunks.add()
+    c.blob.CopyFrom(array2pb(np.random.random(7)))
+    yield d
+    d = Document()
+    d.mime_type = 'image/png'
+    c = d.chunks.add()
+    c.blob.CopyFrom(array2pb(np.random.random(5)))
+    yield d
+
+
+class MyTestCase(JinaTestCase):
+
+    def test_driver_save_load(self):
+        id = BaseExecutor.load_config('yaml/test-ifdriver1.yml')
+        id.save_config('tmp.yml')
+        id = BaseExecutor.load_config('tmp.yml')
+        self.assertEqual(id._drivers['IndexRequest'][0].if_expression, '2 > 1')
+        self.add_tmpfile('tmp.yml')
+
+    def test_driver_simple_filter(self):
+        def validate(req):
+            for idx, d in enumerate(req.docs):
+                if idx % 2 == 0:
+                    self.assertEqual(d.text, '')
+                else:
+                    self.assertNotEqual(d.text, '')
+
+        f = (Flow().add(yaml_path='yaml/test-ifdriver2.yml'))
+        with f:
+            f.index_lines(['a', 'b', 'c'], output_fn=validate, callback_on_body=True)
+
+    def test_mime_encode(self):
+        # TODO: what is the merge strateg for join() here?
+        f = (Flow().add(name='encode1', yaml_path='yaml/test-if-encode1.yml')
+             .add(name='encode2', yaml_path='yaml/test-if-encode2.yml', needs='gateway')
+             .join(['encode1', 'encode2']))
+        with f:
+            f.index(input_fn, output_fn=print, callback_on_body=True)

--- a/tests/yaml/test-if-encode1.yml
+++ b/tests/yaml/test-if-encode1.yml
@@ -1,0 +1,6 @@
+!Encode1
+requests:
+  on:
+    IndexRequest:
+      - !EncodeDriver
+        if: doc.mime_type.startswith('text')

--- a/tests/yaml/test-if-encode2.yml
+++ b/tests/yaml/test-if-encode2.yml
@@ -1,0 +1,6 @@
+!Encode2
+requests:
+  on:
+    IndexRequest:
+      - !EncodeDriver
+        if: doc.mime_type.startswith('image')

--- a/tests/yaml/test-if-flow.yml
+++ b/tests/yaml/test-if-flow.yml
@@ -1,0 +1,7 @@
+!Flow
+pods:
+  encode1:
+    yaml_path: test-if-encode1.yml
+  encode2:
+    yaml_path: test-if-encode2.yml
+    needs: gateway

--- a/tests/yaml/test-ifdriver1.yml
+++ b/tests/yaml/test-ifdriver1.yml
@@ -1,0 +1,6 @@
+!BaseExecutor
+requests:
+  on:
+    IndexRequest:
+      - !BaseDriver
+        if: '2 > 1'

--- a/tests/yaml/test-ifdriver2.yml
+++ b/tests/yaml/test-ifdriver2.yml
@@ -1,0 +1,5 @@
+!BaseExecutor
+requests:
+  on:
+    IndexRequest:
+      - !FilterDriver {}


### PR DESCRIPTION
`if` expression is added to `BaseDriver` to allow user filter docs/chunks by a *single expression*.

Examples:

only encode MIME `text/*`
```yaml
!Encode1
requests:
  on:
    IndexRequest:
      - !EncodeDriver
        if: doc.mime_type.startswith('text')
```

One can also use it in Python:

only prune docs with even `doc_id`

```python
class PruneEvenDriver(PruneDriver):
    if_expression = 'doc.doc_id % 2 ==0'

    def __init__(self, pruned=('text',), level='doc', *args, **kwargs):
        super().__init__(pruned, level, *args, **kwargs)
```

## Limitations

- Does not work with "compositional expression":
   - Like the `lambda` function, `if` supports the **single expression** only: https://docs.python.org/3/reference/expressions.html
   - Can not filter `docs` AND `chunks` at the same time, e.g. `doc.doc_id % 2 == 0 && chunk.chunk_id % 2 == 0` does not work
- Relying on the assumption that `doc` and `chunk` are always in the context of `eval`.