### PR TITLE
fix(peapods): got events closed stream

### DIFF
--- a/jina/peapods/zmq.py
+++ b/jina/peapods/zmq.py
@@ -316,6 +316,8 @@ class ZmqStreamlet(Zmqlet):
         if not self.is_closed:
             super().close()
             self.io_loop.stop()
+            # Replace handle events function, to skip
+            # None event ofter closed sockets
             self.in_sock._handle_events = lambda *args, **kwargs: None
             self.out_sock._handle_events = lambda *args, **kwargs: None
             self.ctrl_sock._handle_events = lambda *args, **kwargs: None

--- a/jina/peapods/zmq.py
+++ b/jina/peapods/zmq.py
@@ -317,10 +317,13 @@ class ZmqStreamlet(Zmqlet):
             super().close()
             self.io_loop.stop()
             # Replace handle events function, to skip
-            # None event ofter closed sockets
-            self.in_sock._handle_events = lambda *args, **kwargs: None
-            self.out_sock._handle_events = lambda *args, **kwargs: None
-            self.ctrl_sock._handle_events = lambda *args, **kwargs: None
+            # None event after sockets are closed.
+            if hasattr(self.in_sock, '_handle_events'):
+                self.in_sock._handle_events = lambda *args, **kwargs: None
+            if hasattr(self.out_sock, '_handle_events'):
+                self.out_sock._handle_events = lambda *args, **kwargs: None
+            if hasattr(self.ctrl_sock, '_handle_events'):
+                self.ctrl_sock._handle_events = lambda *args, **kwargs: None
 
 
     def pause_pollin(self):

--- a/jina/peapods/zmq.py
+++ b/jina/peapods/zmq.py
@@ -316,6 +316,10 @@ class ZmqStreamlet(Zmqlet):
         if not self.is_closed:
             super().close()
             self.io_loop.stop()
+            self.in_sock._handle_events = lambda *args, **kwargs: None
+            self.out_sock._handle_events = lambda *args, **kwargs: None
+            self.ctrl_sock._handle_events = lambda *args, **kwargs: None
+
 
     def pause_pollin(self):
         """Remove :attr:`in_sock` from the poller """


### PR DESCRIPTION
https://github.com/jina-ai/jina/issues/622

https://github.com/zeromq/pyzmq/blob/60e0744e1aed9bebee376268c954582e3b2e393e/zmq/eventloop/zmqstream.py#L452
receives a `None` message and as sockets are already closed the warning is logged.