### PR TITLE
docs(101): add link to explain basics of neural search

### DIFF
--- a/docs/chapters/101/README.md
+++ b/docs/chapters/101/README.md
@@ -37,6 +37,7 @@
   </tr>
 </table>
 
+Want a general introduction to neural search and how it's different to regular old symbolic search? [Check out our explainer blog post](https://medium.com/@jina_ai/what-is-jina-and-neural-search-7a9e166608ab) to learn more!
 
 <h2 align="center">Document & Chunk</h2>
 


### PR DESCRIPTION
Just added a link to the top of 101 to our [blog post](https://medium.com/@jina_ai/what-is-jina-and-neural-search-7a9e166608ab) explaining neural search and Jina. Currently linking to Medium since blog not up on our own website yet. When we have our own blog I'll change the link