### PR TITLE
fix(encoders): fix mask prune creation

### DIFF
--- a/jina/executors/encoders/helper.py
+++ b/jina/executors/encoders/helper.py
@@ -49,7 +49,7 @@ def prune_mask(mask, cls_pos='head'):
         result = np.tile(mask_row, (mask.shape[0], 1))
     elif cls_pos == 'tail':
         for num_tokens in np.sum(mask, axis=1).tolist():
-            result[num_tokens - 1] = 1
+            result[:, num_tokens - 1] = 1
     else:
         raise NotImplementedError
     return result

--- a/jina/executors/encoders/nlp/transformer.py
+++ b/jina/executors/encoders/nlp/transformer.py
@@ -204,7 +204,10 @@ class TransformerTFEncoder(BaseTransformerEncoder, BaseTextTFEncoder):
         }
         _model = model_dict[self.model_name].from_pretrained(pretrained_model_name_or_path=self.tmp_model_path)
         if self.model_name in ('xlnet-base-cased', 'openai-gpt', 'gpt2', 'xlm-mlm-enfr-1024'):
-            _model.resize_token_embeddings(len(self.tokenizer))
+            try:
+                _model.resize_token_embeddings(len(self.tokenizer))
+            except NotImplementedError:
+                self.logger.warn(f'Model {self.model_name} does not implement resize_token_embeddings')
         return _model
 
     def get_session(self):
@@ -240,7 +243,10 @@ class TransformerTorchEncoder(BaseTransformerEncoder, BaseTextTorchEncoder):
         }
         _model = model_dict[self.model_name].from_pretrained(self.tmp_model_path)
         if self.model_name in ('xlnet-base-cased', 'openai-gpt', 'gpt2', 'xlm-mlm-enfr-1024'):
-            _model.resize_token_embeddings(len(self.tokenizer))
+            try:
+                _model.resize_token_embeddings(len(self.tokenizer))
+            except NotImplementedError:
+                self.logger.warn(f'Model {self.model_name} does not implement resize_token_embeddings')
         self.to_device(_model)
         return _model
 

--- a/tests/executors/encoders/nlp/test_transformer.py
+++ b/tests/executors/encoders/nlp/test_transformer.py
@@ -20,5 +20,21 @@ class TfTestCase(NlpTestCase):
             metas=metas)
 
 
+class XLNetPytorchTestCase(NlpTestCase):
+    def _get_encoder(self, metas):
+        return TransformerTorchEncoder(
+            model_name='xlnet-base-cased',
+            pooling_strategy='cls',
+            metas=metas)
+
+
+class XLNetTFTestCase(NlpTestCase):
+    def _get_encoder(self, metas):
+        return TransformerTFEncoder(
+            model_name='xlnet-base-cased',
+            pooling_strategy='cls',
+            metas=metas)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
**Issue link**
https://github.com/jina-ai/examples/issues/90

**Description**
Small indexing error when trying to create the prune mask if cls_pos is 'tail' as in the case of model xlnet-base-cased.

**Changes introduced**
Fix the indexing issue, add a couple of tests with the required model in the issue.
Identified another issue while running tests that some models do not implement _resize_token_embeddings_
