### PR TITLE
refactor(crafters): io crafters should craft documents

### DIFF
--- a/jina/drivers/craft.py
+++ b/jina/drivers/craft.py
@@ -75,7 +75,13 @@ class DocCraftDriver(BaseCraftDriver):
             ret = self.exec_fn(**_args_dict)
             if ret:
                 for k, v in ret.items():
-                    setattr(d, k, v)
+                    if k == 'blob':
+                        if isinstance(v, jina_pb2.NdArray):
+                            d.blob.CopyFrom(v)
+                        else:
+                            d.blob.CopyFrom(array2pb(v))
+                    else:
+                        setattr(d, k, v)
 
 
 class SegmentDriver(BaseCraftDriver):

--- a/jina/executors/crafters/audio/io.py
+++ b/jina/executors/crafters/audio/io.py
@@ -35,4 +35,4 @@ class AudioReader(BaseDocCrafter):
         import librosa
         signal, orig_sr = librosa.load(uri, sr=self.sample_rate, mono=False)
 
-        return dict(doc_id=doc_id, offset=0, weight=1., blob=signal)
+        return dict(doc_id=doc_id, weight=1., blob=signal)

--- a/jina/executors/crafters/image/io.py
+++ b/jina/executors/crafters/image/io.py
@@ -2,16 +2,16 @@ __copyright__ = "Copyright (c) 2020 Jina AI Limited. All rights reserved."
 __license__ = "Apache-2.0"
 
 import io
-from typing import Dict, List
+from typing import Dict
 
 import numpy as np
 
-from .. import BaseSegmenter
+from .. import BaseDocCrafter
 
 
-class ImageReader(BaseSegmenter):
+class ImageReader(BaseDocCrafter):
     """
-    :class:`ImageReader` loads the image from the given file path and save the `ndarray` of the image in the Chunk.
+    :class:`ImageReader` loads the image from the given file path and save the `ndarray` of the image in the Document.
     """
 
     def __init__(self, channel_axis: int = -1, *args, **kwargs):
@@ -23,10 +23,10 @@ class ImageReader(BaseSegmenter):
         super().__init__(*args, **kwargs)
         self.channel_axis = channel_axis
 
-    def craft(self, buffer: bytes, uri: str, doc_id: int, *args, **kwargs) -> List[Dict]:
+    def craft(self, buffer: bytes, uri: str, doc_id: int, *args, **kwargs) -> Dict:
         """
         Read the image from the given file path that specified in `buffer` and save the `ndarray` of the image in
-            the `blob` of the chunk.
+            the `blob` of the document.
 
         :param buffer: the image in raw bytes
         :param uri: the image file path
@@ -44,4 +44,4 @@ class ImageReader(BaseSegmenter):
         img = np.array(raw_img).astype('float32')
         if self.channel_axis != -1:
             img = np.moveaxis(img, -1, self.channel_axis)
-        return [dict(offset=0, weight=1., blob=img)]
+        return dict(weight=1., blob=img)

--- a/jina/executors/crafters/numeric/io.py
+++ b/jina/executors/crafters/numeric/io.py
@@ -9,7 +9,7 @@ from jina.executors.crafters import BaseDocCrafter
 
 class ArrayReader(BaseDocCrafter):
     """
-    :class:`ArrayReader` convert the string of numbers into a numpy array and save to the Chunk.
+    :class:`ArrayReader` convert the string of numbers into a numpy array and save to the Document.
         Numbers are split on the provided delimiter, default is comma (,)
     """
 
@@ -28,7 +28,7 @@ class ArrayReader(BaseDocCrafter):
 
         :param text: the raw text
         :param doc_id: the doc id
-        :return: a chunk dict with the numpy array
+        :return: a dod dict with the numpy array
         """
         _string = text.split(self.delimiter)
         _array = np.array(_string)
@@ -43,4 +43,4 @@ class ArrayReader(BaseDocCrafter):
             self.logger.error(
                 f'Data type mismatch. Cannot convert input to {self.as_type}.')
 
-        return dict(doc_id=doc_id, offset=0, weight=1., blob=_array)
+        return dict(doc_id=doc_id, weight=1., blob=_array)

--- a/tests/executors/crafters/image/test_io.py
+++ b/tests/executors/crafters/image/test_io.py
@@ -1,18 +1,33 @@
 import os
 import unittest
+import io
+from PIL import Image
 
 from jina.executors.crafters.image.io import ImageReader
 from tests.executors.crafters.image import JinaImageTestCase
 
 
 class MyTestCase(JinaImageTestCase):
-    def test_io(self):
+    def test_io_uri(self):
         crafter = ImageReader()
         tmp_fn = os.path.join(crafter.current_workspace, 'test.jpeg')
         img_size = 50
         self.create_test_image(tmp_fn, size=img_size)
-        test_chunk, *_ = crafter.craft(buffer=None, uri=tmp_fn, doc_id=0)
-        self.assertEqual(test_chunk['blob'].shape, (img_size, img_size, 3))
+        test_doc = crafter.craft(buffer=None, uri=tmp_fn, doc_id=0)
+        self.assertEqual(test_doc['blob'].shape, (img_size, img_size, 3))
+        self.add_tmpfile(tmp_fn)
+
+    def test_io_buffer(self):
+        crafter = ImageReader()
+        tmp_fn = os.path.join(crafter.current_workspace, 'test.jpeg')
+        img_size = 50
+        self.create_test_image(tmp_fn, size=img_size)
+        image_buffer = io.BytesIO()
+        img = Image.open(tmp_fn)
+        img.save(image_buffer, format='PNG')
+        image_buffer.seek(0)
+        test_doc = crafter.craft(buffer=image_buffer.getvalue(), uri=None, doc_id=0)
+        self.assertEqual(test_doc['blob'].shape, (img_size, img_size, 3))
         self.add_tmpfile(tmp_fn)
 
 

--- a/tests/executors/crafters/numeric/test_io.py
+++ b/tests/executors/crafters/numeric/test_io.py
@@ -12,9 +12,9 @@ class MyTestCase(JinaTestCase):
         text = ','.join([str(x) for x in sample_array])
 
         reader = ArrayReader()
-        crafted_chunk = reader.craft(text, 0)
+        crafted_doc = reader.craft(text, 0)
 
-        np.testing.assert_array_equal(crafted_chunk['blob'], sample_array)
+        np.testing.assert_array_equal(crafted_doc['blob'], sample_array)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
PR implementing proposal from #620. Linked PR in examples: https://github.com/jina-ai/examples/pull/92

**Changes introduced**
- ImageReader inherits from BaseDocCrafter and returns one document and not chunks. 
- ArrayReader and AudioReader return a document dict, so no offset provided.
- Add tests of image reading from buffer, since often pod may not have the images in a local uri.
- Use CopyFrom in DocCraftDriver to pass blob message field. Avoid error: **_assignment not allowed to field in protocol message object_**

