### PR TITLE
test(indexers) split indexer tests  and add faiss indexer test

### DIFF
--- a/jina/executors/indexers/vector/sptag.py
+++ b/jina/executors/indexers/vector/sptag.py
@@ -25,7 +25,7 @@ class SptagIndexer(BaseNumpyIndexer):
                  num_threads: int = 1,
                  *args, **kwargs):
         """
-        Initialize an NmslibIndexer
+        Initialize an SptagIndexer
 
         :param dist_calc_method: the distance type, currently SPTAG only support Cosine and L2 distances.
         :param method: The index method to use, index Algorithm type (e.g. BKT, KDT), required.

--- a/tests/executors/indexers/vector/test_faiss.py
+++ b/tests/executors/indexers/vector/test_faiss.py
@@ -1,0 +1,50 @@
+import os
+import unittest
+import gzip
+
+import numpy as np
+from jina.executors.indexers import BaseIndexer
+from jina.executors.indexers.vector.faiss import FaissIndexer
+from tests import JinaTestCase
+
+# fix the seed here
+np.random.seed(500)
+retr_idx = None
+vec_idx = np.random.randint(0, high=100, size=[10])
+vec = np.array(np.random.random([10, 10]), dtype=np.float32)
+query = np.array(np.random.random([10, 10]), dtype=np.float32)
+cur_dir = os.path.dirname(os.path.abspath(__file__))
+
+
+class MyTestCase(JinaTestCase):
+
+    @unittest.skip
+    def test_faiss_indexer(self):
+        train_filepath = os.path.join(cur_dir, 'train.tgz')
+        train_data = np.array(np.random.random([1024, 10]), dtype=np.float32)
+        with gzip.open(train_filepath, 'wb', compresslevel=1) as f:
+            f.write(train_data.tobytes())
+
+        with FaissIndexer(index_filename='faiss.test.gz', index_key='IVF10,PQ2', train_filepath=train_filepath) as a:
+            a.add(vec_idx, vec)
+            a.save()
+            self.assertTrue(os.path.exists(a.index_abspath))
+            index_abspath = a.index_abspath
+            save_abspath = a.save_abspath
+
+        with BaseIndexer.load(save_abspath) as b:
+            idx, dist = b.query(query, top_k=4)
+            print(idx, dist)
+            global retr_idx
+            if retr_idx is None:
+                retr_idx = idx
+            else:
+                np.testing.assert_almost_equal(retr_idx, idx)
+            self.assertEqual(idx.shape, dist.shape)
+            self.assertEqual(idx.shape, (10, 4))
+
+        self.add_tmpfile(index_abspath, save_abspath, train_filepath)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/executors/indexers/vector/test_nmslib.py
+++ b/tests/executors/indexers/vector/test_nmslib.py
@@ -1,0 +1,44 @@
+import os
+import unittest
+
+import numpy as np
+from jina.executors.indexers import BaseIndexer
+from jina.executors.indexers.vector.nmslib import NmslibIndexer
+from tests import JinaTestCase
+
+# fix the seed here
+np.random.seed(500)
+retr_idx = None
+vec_idx = np.random.randint(0, high=100, size=[10])
+vec = np.random.random([10, 10])
+query = np.array(np.random.random([10, 10]), dtype=np.float32)
+cur_dir = os.path.dirname(os.path.abspath(__file__))
+
+
+class MyTestCase(JinaTestCase):
+
+    def test_nmslib_indexer(self):
+        with NmslibIndexer(index_filename='np.test.gz', space='l2') as a:
+            a.add(vec_idx, vec)
+            a.save()
+            self.assertTrue(os.path.exists(a.index_abspath))
+            index_abspath = a.index_abspath
+            save_abspath = a.save_abspath
+            # a.query(np.array(np.random.random([10, 5]), dtype=np.float32), top_k=4)
+
+        with BaseIndexer.load(a.save_abspath) as b:
+            idx, dist = b.query(query, top_k=4)
+            print(idx, dist)
+            global retr_idx
+            if retr_idx is None:
+                retr_idx = idx
+            else:
+                np.testing.assert_almost_equal(retr_idx, idx)
+            self.assertEqual(idx.shape, dist.shape)
+            self.assertEqual(idx.shape, (10, 4))
+
+        self.add_tmpfile(index_abspath, save_abspath)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/executors/indexers/vector/test_numpy.py
+++ b/tests/executors/indexers/vector/test_numpy.py
@@ -3,8 +3,6 @@ import unittest
 
 import numpy as np
 from jina.executors.indexers import BaseIndexer
-from jina.executors.indexers.vector.annoy import AnnoyIndexer
-from jina.executors.indexers.vector.nmslib import NmslibIndexer
 from jina.executors.indexers.vector.numpy import NumpyIndexer
 from tests import JinaTestCase
 
@@ -19,15 +17,15 @@ cur_dir = os.path.dirname(os.path.abspath(__file__))
 
 class MyTestCase(JinaTestCase):
 
-    def test_annoy_wrap_indexer(self):
-        with NumpyIndexer(index_filename='wrap-npidx.gz') as a:
-            a.name = 'wrap-npidx'
+    def test_np_indexer(self):
+        with NumpyIndexer(index_filename='np.test.gz') as a:
             a.add(vec_idx, vec)
             a.save()
+            self.assertTrue(os.path.exists(a.index_abspath))
             index_abspath = a.index_abspath
             save_abspath = a.save_abspath
 
-        with BaseIndexer.load_config(os.path.join(cur_dir, 'annoy-wrap.yml')) as b:
+        with BaseIndexer.load(save_abspath) as b:
             idx, dist = b.query(query, top_k=4)
             print(idx, dist)
             global retr_idx
@@ -38,33 +36,15 @@ class MyTestCase(JinaTestCase):
             self.assertEqual(idx.shape, dist.shape)
             self.assertEqual(idx.shape, (10, 4))
 
-        with BaseIndexer.load_config(os.path.join(cur_dir, 'nmslib-wrap.yml')) as c:
-            idx, dist = c.query(query, top_k=4)
-            print(idx, dist)
-            if retr_idx is None:
-                retr_idx = idx
-            else:
-                np.testing.assert_almost_equal(retr_idx, idx)
-            self.assertEqual(idx.shape, dist.shape)
-            self.assertEqual(idx.shape, (10, 4))
-            self.add_tmpfile(index_abspath, save_abspath)
+        self.add_tmpfile(index_abspath, save_abspath)
 
-    def test_simple_annoy(self):
-        from annoy import AnnoyIndex
-        _index = AnnoyIndex(5, 'angular')
-        for j in range(3):
-            _index.add_item(j, np.random.random((5,)))
-        _index.build(4)
-        idx1, _ = _index.get_nns_by_vector(np.random.random((5,)), 3, include_distances=True)
-
-    def test_annoy_indexer(self):
-        with AnnoyIndexer(index_filename='annoy.test.gz') as a:
+    def test_scipy_indexer(self):
+        with NumpyIndexer(index_filename='np.test.gz', backend='scipy') as a:
             a.add(vec_idx, vec)
             a.save()
             self.assertTrue(os.path.exists(a.index_abspath))
             index_abspath = a.index_abspath
             save_abspath = a.save_abspath
-            # a.query(np.array(np.random.random([10, 5]), dtype=np.float32), top_k=4)
 
         with BaseIndexer.load(save_abspath) as b:
             idx, dist = b.query(query, top_k=4)


### PR DESCRIPTION
**Changes introduced**
- Add FaissIndexer tests

- Split vector indexer tests

- Use context manager from executor to avoid closing file handles explicitly. This pattern may save some headaches in the future since some may forget to close.