### PR TITLE
(WIP) ci(perf): add perf tracker script to publish perf stats

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -36,6 +36,7 @@ jobs:
             --build-arg VCS_REF --build-arg BUILD_DATE --build-arg JINA_VERSION --build-arg INSTALL_DEV \
             -t jinaai/jina:devel -t jinaai/jina:${{env.JINA_VERSION}} \
             --file ./Dockerfiles/debianx.Dockerfile .
+          ./perf_tracker.sh
       - name: Upload to Github Docker Registry
         uses: elgohr/Publish-Docker-Github-Action@master
         with:

--- a/perf_tracker.sh
+++ b/perf_tracker.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -ex
+
+function run_perf_tracker {
+  for j in `seq 3`;
+  do
+    docker run --rm -v /tmp:/tmp jinaai/jina:devel hello-world > /tmp/hw.log;
+    perl -lne 'print "$1\t$2" if(/done in ⏱ (.*)s 🐎 (.*)\/s/)' /tmp/hw.log
+  done
+}
+
+function git_push {
+  git config --local user.email "dev-bot@jina.ai"
+  git config --local user.name "Jina Dev Bot"
+  git add tracking_history.txt
+  git commit -m "Update tracking_history"
+  git push --set-upstream origin master
+}
+
+
+function run_and_publish {
+  git clone https://github.com/jina-ai/perf-tracker.git
+  run_perf_tracker >> perf-tracker/tracking_history.txt
+  cd perf-tracker
+  git_push
+}
+
+run_and_publish


### PR DESCRIPTION
**Proposal Proof of Concept for #619** 

@hanxiao @nan-wang would a skeleton like this make sense to have the idea under #619 implemented?

I was thinking about having a repo perf-tracker.git or whatever name that would get pushes to master from JINA BOT and whenever it does, it recomputes a graph with the performance history.