### PR TITLE
perf(indexer): change sort method to argpartition, not sort all the array

### DIFF
--- a/jina/executors/indexers/vector/numpy.py
+++ b/jina/executors/indexers/vector/numpy.py
@@ -53,7 +53,7 @@ class NaiveIndexer(BaseNumpyIndexer):
         elif self.metric == 'cosine':
             dist = _cosine(keys, self.query_handler)
 
-        idx = dist.argsort(axis=1)[:, :top_k]
+        idx = np.argpartition(dist, kth=top_k, axis=1)[:, :top_k]
         dist = np.take_along_axis(dist, idx, axis=1)
         return self.int2ext_key[idx], dist
 

--- a/tests/executors/indexers/vector/test_annoy.py
+++ b/tests/executors/indexers/vector/test_annoy.py
@@ -29,7 +29,6 @@ class MyTestCase(JinaTestCase):
 
         with BaseIndexer.load_config(os.path.join(cur_dir, 'annoy-wrap.yml')) as b:
             idx, dist = b.query(query, top_k=4)
-            print(idx, dist)
             global retr_idx
             if retr_idx is None:
                 retr_idx = idx
@@ -40,7 +39,6 @@ class MyTestCase(JinaTestCase):
 
         with BaseIndexer.load_config(os.path.join(cur_dir, 'nmslib-wrap.yml')) as c:
             idx, dist = c.query(query, top_k=4)
-            print(idx, dist)
             if retr_idx is None:
                 retr_idx = idx
             else:
@@ -64,7 +62,6 @@ class MyTestCase(JinaTestCase):
             self.assertTrue(os.path.exists(a.index_abspath))
             index_abspath = a.index_abspath
             save_abspath = a.save_abspath
-            # a.query(np.array(np.random.random([10, 5]), dtype=np.float32), top_k=4)
 
         with BaseIndexer.load(save_abspath) as b:
             idx, dist = b.query(query, top_k=4)

--- a/tests/executors/indexers/vector/test_faiss.py
+++ b/tests/executors/indexers/vector/test_faiss.py
@@ -34,7 +34,6 @@ class MyTestCase(JinaTestCase):
 
         with BaseIndexer.load(save_abspath) as b:
             idx, dist = b.query(query, top_k=4)
-            print(idx, dist)
             global retr_idx
             if retr_idx is None:
                 retr_idx = idx

--- a/tests/executors/indexers/vector/test_nmslib.py
+++ b/tests/executors/indexers/vector/test_nmslib.py
@@ -28,7 +28,6 @@ class MyTestCase(JinaTestCase):
 
         with BaseIndexer.load(a.save_abspath) as b:
             idx, dist = b.query(query, top_k=4)
-            print(idx, dist)
             global retr_idx
             if retr_idx is None:
                 retr_idx = idx

--- a/tests/executors/indexers/vector/test_numpy.py
+++ b/tests/executors/indexers/vector/test_numpy.py
@@ -27,7 +27,6 @@ class MyTestCase(JinaTestCase):
 
         with BaseIndexer.load(save_abspath) as b:
             idx, dist = b.query(query, top_k=4)
-            print(idx, dist)
             global retr_idx
             if retr_idx is None:
                 retr_idx = idx
@@ -35,6 +34,31 @@ class MyTestCase(JinaTestCase):
                 np.testing.assert_almost_equal(retr_idx, idx)
             self.assertEqual(idx.shape, dist.shape)
             self.assertEqual(idx.shape, (10, 4))
+
+        self.add_tmpfile(index_abspath, save_abspath)
+
+    def test_np_indexer_known(self):
+        vectors = np.array([[1, 1, 1],
+                            [10, 10, 10],
+                            [100, 100, 100],
+                            [1000, 1000, 1000]])
+        keys = np.array([0, 1, 2, 3]).reshape(-1, 1)
+        with NumpyIndexer(index_filename='np.test.gz') as a:
+            a.add(keys, vectors)
+            a.save()
+            self.assertTrue(os.path.exists(a.index_abspath))
+            index_abspath = a.index_abspath
+            save_abspath = a.save_abspath
+
+        queries = np.array([[1, 1, 1],
+                            [10, 10, 10],
+                            [100, 100, 100],
+                            [1000, 1000, 1000]])
+        with BaseIndexer.load(save_abspath) as b:
+            idx, dist = b.query(queries, top_k=2)
+            np.testing.assert_equal(idx, np.array([[0, 1], [1, 0], [2, 1], [3, 2]]))
+            self.assertEqual(idx.shape, dist.shape)
+            self.assertEqual(idx.shape, (4, 2))
 
         self.add_tmpfile(index_abspath, save_abspath)
 
@@ -48,7 +72,6 @@ class MyTestCase(JinaTestCase):
 
         with BaseIndexer.load(save_abspath) as b:
             idx, dist = b.query(query, top_k=4)
-            print(idx, dist)
             global retr_idx
             if retr_idx is None:
                 retr_idx = idx


### PR DESCRIPTION
**Changes introduced**

When sorting chunks and obtaining top_k values, argsort sorts entire array. with argpartition, it guarantees that the **kth** element is in the sorted position, and the indexes before it are smaller and viceversa. Besides that no other ordering is guaranteed, but since it is later the job of **Rankers** to sort the documents at the end, it is not necessary.