### PR TITLE
fix(toc): add flow api section to table of contents

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,7 +24,7 @@ Welcome to Jina Documentations!
 
    chapters/helloworld/index
    chapters/101/.sphinx
-   chapters/flow/README
+   chapters/flow/index
    chapters/io/index
    chapters/hub/index
    chapters/remote/index


### PR DESCRIPTION
[Flow API](https://docs.jina.ai/chapters/flow/index.html) section is not visible in the Table of Contents. I suppose there's a typo in `index.rst`. This PR fixes it, so TOC look like this.
![Screenshot from 2020-07-18 16-34-01](https://user-images.githubusercontent.com/6877858/87853762-98023880-c915-11ea-87a0-61729d85e59e.png)
