### PR TITLE
refactor(milvus): check connectivity status before connecting

### DIFF
--- a/jina/executors/indexers/vector/milvusdb/milvusdbhandler.py
+++ b/jina/executors/indexers/vector/milvusdb/milvusdbhandler.py
@@ -76,8 +76,9 @@ class MilvusDBHandler:
         self.close()
 
     def connect(self):
-        self.logger.info(f'Setting connection to Milvus Server at {self.host}:{self.port}')
-        self.milvus_client = Milvus(self.host, self.port)
+        if self.milvus_client is None or not self.milvus_client.server_status()[0].OK():
+            self.logger.info(f'Setting connection to Milvus Server at {self.host}:{self.port}')
+            self.milvus_client = Milvus(self.host, self.port)
         return self
 
     def close(self):


### PR DESCRIPTION
**Changes introduced**
Closes #668 
Make **MilvusIndexer** more robust.
- Check **connection** status so to avoid calling connect multiple times.
- Hesitating if we should check **index_status** before building index, expecting further input from https://github.com/milvus-io/pymilvus/issues/236