### PR TITLE
feat(docs-search-box): focus on the search input when "/" is pressed

### DIFF
--- a/docs/_static/main.css
+++ b/docs/_static/main.css
@@ -366,8 +366,9 @@ a:hover {
 }
 
 .doc-searchbox input[type=text] {
+    width: 100%;
     outline: none;
-    padding: 10px;
+    padding: 10px 15px;
     border: 1px solid #009999;
     border-radius: 20px;
     -webkit-transition: box-shadow .5s ease;
@@ -382,19 +383,20 @@ a:hover {
 }
 
 .nav-bar-header {
-    display: table-row;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
 }
 
 .wy-breadcrumbs {
-    display: table-cell;
+    flex-basis: 500px;
     font-size: 1.3rem;
     vertical-align: middle;
 }
 
 .nav-bar-search {
-    display: table-cell;
-    width: 10%;
     vertical-align: middle;
+    flex-basis: 250px;
 }
 
 

--- a/docs/template/layout.html
+++ b/docs/template/layout.html
@@ -250,6 +250,19 @@
     }
   </script>
 
+  <!-- Search box becomes active when you press the slash(/) key anywhere on the page-->
+  <script>
+    const body = document.querySelector('body');
+    const searchBox = document.querySelector('form').querySelector('input[type="text"]');
+
+    body.addEventListener('keyup', event => {
+      event.preventDefault()
+      if (event.key === '/') {
+        searchBox.focus();
+      }
+    });
+  </script>
+
   {# Do not conflict with RTD insertion of analytics script #}
   {% if not READTHEDOCS %}
     {% if theme_analytics_id %}

--- a/docs/template/searchbox.html
+++ b/docs/template/searchbox.html
@@ -1,7 +1,7 @@
 {%- if builder != 'singlehtml' %}
 <div role="search" class="nav-bar-search">
   <form id="rtd-search-form" class="wy-form doc-searchbox" action="{{ pathto('search') }}" method="get">
-    <input type="text" name="q" placeholder="{{ _('Search docs') }}" />
+    <input type="text" name="q" placeholder="{{ _('Search docs (Press / to focus)') }}" />
     <input type="hidden" name="check_keywords" value="yes" />
     <input type="hidden" name="area" value="default" />
   </form>


### PR DESCRIPTION
**Describe the feature**
Users will have a better experience using the documentation if they can easily access the search input without using their mouse.

**Your proposal**
I have implemented a feature that adds focus to the search input when a user presses the "/" key.