### PR TITLE
fix(flow): fix access to pod edges, consider IGNORE_GATEWAY optimization should not try to optimize gateway connections

### DIFF
--- a/jina/flow/__init__.py
+++ b/jina/flow/__init__.py
@@ -62,7 +62,8 @@ def build_required(required_level: 'FlowBuildLevel'):
     return __build_level
 
 
-def _traverse_graph(op_flow: 'Flow', outgoing_map: Dict[str, List[str]], func: Callable[['Flow', str, str], None]) -> 'Flow':
+def _traverse_graph(op_flow: 'Flow', outgoing_map: Dict[str, List[str]],
+                    func: Callable[['Flow', str, str], None]) -> 'Flow':
     _outgoing_idx = dict.fromkeys(outgoing_map.keys(), 0)
     stack = deque()
     stack.append('gateway')
@@ -108,29 +109,33 @@ def _optimize_flow(op_flow, outgoing_map: Dict[str, List[str]], pod_edges: {str,
     def _optimize_two_connections(flow: 'Flow', start_node_name: str, end_node_name: str):
         start_node = flow._pod_nodes[start_node_name]
         end_node = flow._pod_nodes[end_node_name]
-        edges_with_same_start = [ed for ed in pod_edges if ed.startswith(start_node_name)]
-        edges_with_same_end = [ed for ed in pod_edges if ed.endswith(end_node_name)]
+        edges_with_same_start = [ed for ed in pod_edges if ed[0].startswith(start_node_name)]
+        edges_with_same_end = [ed for ed in pod_edges if ed[1].endswith(end_node_name)]
         if len(edges_with_same_start) > 1 or len(edges_with_same_end) > 1:
             flow.logger.info(f'Connection between {start_node_name} and {end_node_name} cannot be optimized')
         else:
-            if end_node.is_head_router and start_node_name == 'gateway':
-                flow.logger.info(
-                    f'Node {end_node_name} connects to tail of {start_node_name}')
-                end_node.connect_to_tail_of(start_node)
-            elif start_node.is_tail_router and end_node_name == 'gateway' and start_node.tail_args.num_part <= 1:
-                # connect gateway directly to peas only if this is unblock router
-                # as gateway can not block & reduce message
-                flow.logger.info(
-                    f'Node {start_node_name} connects to head of {end_node_name}')
-                start_node.connect_to_head_of(end_node)
-            elif end_node.is_head_router and not start_node.is_tail_router:
-                flow.logger.info(
-                    f'Node {end_node_name} connects to tail of {start_node_name}')
-                end_node.connect_to_tail_of(start_node)
-            elif start_node.is_tail_router and start_node.tail_args.num_part <= 1:
-                flow.logger.info(
-                    f'Node {start_node_name} connects to head of {end_node_name}')
-                start_node.connect_to_head_of(end_node)
+            if start_node_name == 'gateway':
+                if flow.args.optimize_level > FlowOptimizeLevel.IGNORE_GATEWAY and end_node.is_head_router:
+                    flow.logger.info(
+                        f'Node {end_node_name} connects to tail of {start_node_name}')
+                    end_node.connect_to_tail_of(start_node)
+            elif end_node_name == 'gateway':
+                if flow.args.optimize_level > FlowOptimizeLevel.IGNORE_GATEWAY and \
+                    start_node.is_tail_router and start_node.tail_args.num_part <= 1:
+                    # connect gateway directly to peas only if this is unblock router
+                    # as gateway can not block & reduce message
+                    flow.logger.info(
+                        f'Node {start_node_name} connects to head of {end_node_name}')
+                    start_node.connect_to_head_of(end_node)
+            else:
+                if end_node.is_head_router and not start_node.is_tail_router:
+                    flow.logger.info(
+                        f'Node {end_node_name} connects to tail of {start_node_name}')
+                    end_node.connect_to_tail_of(start_node)
+                elif start_node.is_tail_router and start_node.tail_args.num_part <= 1:
+                    flow.logger.info(
+                        f'Node {start_node_name} connects to head of {end_node_name}')
+                    start_node.connect_to_head_of(end_node)
 
     if op_flow.args.optimize_level > FlowOptimizeLevel.NONE:
         return _traverse_graph(op_flow, outgoing_map, _optimize_two_connections)
@@ -437,7 +442,7 @@ class Flow:
                 if start not in op_flow._pod_nodes:
                     raise FlowMissingPodError(f'{start} is not in this flow, misspelled name?')
                 _outgoing_map[start].append(end)
-                _pod_edges.add(Tuple[start, end])
+                _pod_edges.add((start, end))
 
         op_flow = _build_flow(op_flow, _outgoing_map)
         op_flow = _optimize_flow(op_flow, _outgoing_map, _pod_edges)

--- a/tests/unit/test_index.py
+++ b/tests/unit/test_index.py
@@ -118,8 +118,6 @@ class MyTestCase(JinaTestCase):
         f1 = Flow(fa1).add(yaml_path='_forward', replicas=3)
         f2 = Flow(optimize_level=FlowOptimizeLevel.IGNORE_GATEWAY).add(yaml_path='_forward', replicas=3)
 
-        # f3 = Flow(optimize_level=FlowOptimizeLevel.FULL).add(yaml_path='_forward', replicas=3)
-
         def start_client(fl):
             fl.index(input_fn=random_docs(10))
 
@@ -135,6 +133,7 @@ class MyTestCase(JinaTestCase):
             time.sleep(5)
 
         with f2:
+            # no optimization can be made because we ignored the gateway
             self.assertEqual(f2.num_peas, 6)
             t1 = mp.Process(target=start_client, args=(f2,))
             t1.daemon = True
@@ -145,8 +144,6 @@ class MyTestCase(JinaTestCase):
             t2.start()
             time.sleep(5)
 
-        # with f3.build() as fl3:
-        #     self.assertEqual(fl3.num_peas, 4)
 
     @unittest.skipIf('GITHUB_WORKFLOW' in os.environ, 'skip the network test on github workflow')
     def test_two_client_route(self):


### PR DESCRIPTION
**Changes introduced**
Running in local `pytest tests/unit/test_index.py -k 'test_two_client_route_replicas'`, found an issue in the optimization code.
It solves what was not properly covered by #667 