### PR TITLE
fix(peas): fix pea names with replicas

### DIFF
--- a/jina/peapods/pea.py
+++ b/jina/peapods/pea.py
@@ -127,7 +127,7 @@ class BasePea(metaclass=PeaMeta):
         if isinstance(args, argparse.Namespace):
             if args.name:
                 self.name = args.name
-            elif args.role == PeaRoleType.REPLICA:
+            if args.role == PeaRoleType.REPLICA:
                 self.name = '%s-%d' % (self.name, args.replica_id)
             self.ctrl_addr, self.ctrl_with_ipc = Zmqlet.get_ctrl_address(args)
             if not args.log_with_own_name and args.name:


### PR DESCRIPTION
**Changes introduced**
I observed that when using multiple replicas in a pod using a docker image, docker cannot run more than one due to name collision. 

Problem introduced by https://github.com/jina-ai/jina/commit/e437c69e83cab94490ce61620bf9325bbe3579fe#diff-5c6a3cdc3670c601c655fdd1b5c76bec