### PR TITLE
fix(peas): fix pea names with replicas

### DIFF
--- a/jina/peapods/pea.py
+++ b/jina/peapods/pea.py
@@ -127,7 +127,7 @@ class BasePea(metaclass=PeaMeta):
         if isinstance(args, argparse.Namespace):
             if args.name:
                 self.name = args.name
-            elif args.role == PeaRoleType.REPLICA:
+            if args.role == PeaRoleType.REPLICA:
                 self.name = '%s-%d' % (self.name, args.replica_id)
             self.ctrl_addr, self.ctrl_with_ipc = Zmqlet.get_ctrl_address(args)
             if not args.log_with_own_name and args.name:

--- a/tests/unit/peapods/test_peapods.py
+++ b/tests/unit/peapods/test_peapods.py
@@ -7,7 +7,7 @@ from jina.peapods.pod import BasePod, GatewayPod, MutablePod, GatewayFlowPod, Fl
 from tests import JinaTestCase
 
 
-class MyTestCase(JinaTestCase):
+class PeaPodsTestCase(JinaTestCase):
 
     def test_pea_context(self):
         def _test_pea_context(runtime):
@@ -120,6 +120,17 @@ class MyTestCase(JinaTestCase):
         for j in ('process', 'thread'):
             with self.subTest(runtime=j):
                 _test_pod_context(j)
+
+    def test_peas_naming_with_replicas(self):
+        args = set_pod_parser().parse_args(['--name', 'pod',
+                                            '--replicas', '2',
+                                            '--max-idle-time', '5',
+                                            '--shutdown-idle'])
+        with BasePod(args) as bp:
+            self.assertEqual(bp.peas[0].name, 'pod-head')
+            self.assertEqual(bp.peas[1].name, 'pod-tail')
+            self.assertEqual(bp.peas[2].name, 'pod-1')
+            self.assertEqual(bp.peas[3].name, 'pod-2')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Changes introduced
I observed that when using multiple replicas in a pod using a docker image, docker cannot run more than one due to name collision.

Also peapods directory under unit tests has been created

Problem introduced by e437c69#diff-5c6a3cdc3670c601c655fdd1b5c76bec