### PR TITLE
Support more pre-trained models for Transformer Encoder

### DIFF
--- a/jina/executors/encoders/helper.py
+++ b/jina/executors/encoders/helper.py
@@ -48,8 +48,8 @@ def prune_mask(mask, cls_pos='head'):
         mask_row[0, 0] = 1
         result = np.tile(mask_row, (mask.shape[0], 1))
     elif cls_pos == 'tail':
-        for num_tokens in np.sum(mask, axis=1).tolist():
-            result[:, num_tokens - 1] = 1
+        for row_index, num_tokens in enumerate(np.sum(mask, axis=1).tolist()):
+            result[row_index, num_tokens - 1] = 1
     else:
         raise NotImplementedError
     return result

--- a/tests/unit/executors/encoders/nlp/test_mock_transformer.py
+++ b/tests/unit/executors/encoders/nlp/test_mock_transformer.py
@@ -1,0 +1,75 @@
+import unittest
+from unittest.case import TestCase
+from unittest.mock import patch
+import numpy as np
+
+from jina.executors.encoders.nlp.transformer import TransformerTorchEncoder, TransformerTFEncoder
+
+
+class MockPtModel:
+    def __init__(self, base_model_prefix):
+        self.base_model_prefix = base_model_prefix
+
+    # Mocks output of models. Embeds each sequence token into integer number: [0, 1, ..., sequence_length -1]
+    def __call__(self, input_ids, *args, **kwargs):
+        import torch
+        batch_size = input_ids.shape[0]
+        seq_length = input_ids.shape[1]
+        return torch.arange(seq_length).view(1, seq_length, 1).repeat(batch_size, 1, 1), None
+
+    def to(self, device):
+        pass
+
+    def resize_token_embeddings(self, n_embeddings):
+        pass
+
+
+class MockTFModel(MockPtModel):
+    def __call__(self, input_ids, *args, **kwargs):
+        import tensorflow as tf
+        batch_size = input_ids.shape[0]
+        seq_length = input_ids.shape[1]
+        return tf.repeat(tf.reshape(tf.range(seq_length), (1, seq_length, 1)), batch_size, axis=0), None
+
+
+class TransformerEncoderWithMockedModelTestCase(TestCase):
+    """To skip weights downloading and model initialization part replaces the actual model with dummy version"""
+    texts = ["Never gonna run around", "and desert you"]
+
+    def test_encodes_bert_like(self):
+        """Tests that for BERT-like models the embedding from first token is used for sequence embedding"""
+        from transformers import AutoModelForPreTraining
+        for model in ["bert-base-uncased", "google/electra-base-discriminator", "roberta-base"]:
+            with patch.object(AutoModelForPreTraining, 'from_pretrained', return_value=MockPtModel(model)):
+                encoder = TransformerTorchEncoder(
+                    pretrained_model_name_or_path=model,
+                    pooling_strategy='auto',
+                    metas={})
+                encoded_batch = encoder.encode(np.asarray(self.texts))
+                assert np.array_equal(encoded_batch.squeeze(), np.asarray([0, 0]))
+
+    def test_encodes_lm_like(self):
+        """Tests that for GPT-like language models the embedding from first token is used for sequence embedding"""
+        from transformers import AutoModelForPreTraining
+        for model in ["gpt2", "openai-gpt"]:
+            with patch.object(AutoModelForPreTraining, 'from_pretrained', return_value=MockPtModel(model)):
+                encoder = TransformerTorchEncoder(
+                    pretrained_model_name_or_path=model,
+                    pooling_strategy='auto',
+                    metas={})
+                tokenized_seq_lengths = [len(encoder.tokenizer.tokenize(t)) for t in self.texts]
+                encoded_batch = encoder.encode(self.texts)
+                assert np.array_equal(encoded_batch.squeeze(), np.asarray(tokenized_seq_lengths) - 1)
+
+    def test_loads_tf_encoder(self):
+        """Tests that TF-based model can be loaded"""
+        from transformers import TFAutoModelForPreTraining
+        model = "bert-base-uncased"
+        with patch.object(TFAutoModelForPreTraining, 'from_pretrained', return_value=MockTFModel(model)):
+            encoder = TransformerTFEncoder(pretrained_model_name_or_path=model)
+            encoded_batch = encoder.encode(np.asarray(self.texts))
+            assert np.array_equal(encoded_batch.squeeze(), np.asarray([0, 0]))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/executors/encoders/nlp/test_transformer.py
+++ b/tests/unit/executors/encoders/nlp/test_transformer.py
@@ -7,32 +7,28 @@ from tests.unit.executors.encoders.nlp import NlpTestCase
 class PytorchTestCase(NlpTestCase):
     def _get_encoder(self, metas):
         return TransformerTorchEncoder(
-            model_name='bert-base-uncased',
-            pooling_strategy='cls',
+            pretrained_model_name_or_path='bert-base-uncased',
             metas=metas)
 
 
 class TfTestCase(NlpTestCase):
     def _get_encoder(self, metas):
         return TransformerTFEncoder(
-            model_name='bert-base-uncased',
-            pooling_strategy='cls',
+            pretrained_model_name_or_path='bert-base-uncased',
             metas=metas)
 
 
 class XLNetPytorchTestCase(NlpTestCase):
     def _get_encoder(self, metas):
         return TransformerTorchEncoder(
-            model_name='xlnet-base-cased',
-            pooling_strategy='cls',
+            pretrained_model_name_or_path='xlnet-base-cased',
             metas=metas)
 
 
 class XLNetTFTestCase(NlpTestCase):
     def _get_encoder(self, metas):
         return TransformerTFEncoder(
-            model_name='xlnet-base-cased',
-            pooling_strategy='cls',
+            pretrained_model_name_or_path='xlnet-base-cased',
             metas=metas)
 
 


### PR DESCRIPTION
Resolves #691

Main change:
* all models from https://huggingface.co/models are now available. It can be done via `AutoModelForPreTraining`

Other changes
* Fixed bug in `prune_mask`
* Added a heuristic for automatic creation sequence embedding from its tokens (if BERT-like, use first token, else last)
* Used `batch_encode_plus` to simplify batching
* `max_length` is set to `None` - so batches will be padded to largest sequence. I think user should determine this parameter based on the task
* Re-implemented saving logic. I got lost in fields like `raw_model_path`, `tmp_model_path`, so instead I just added `model_save_path` field. 
* Added unit tests that are using mock transformer model. The reason is that they can be run relatively (tokenizer is still downloaded) quickly as huge amount of time is saved for model initialization

Let's discuss if some of these changes are not desirable and try to come up with a better solution
