### PR TITLE
fix(encode): extract should work at chunk level

### DIFF
--- a/jina/drivers/encode.py
+++ b/jina/drivers/encode.py
@@ -22,11 +22,8 @@ class EncodeDriver(BaseEncodeDriver):
     """
 
     def _apply_all(self, docs: Iterable['jina_pb2.Document'], *args, **kwargs):
-        contents, chunk_pts, no_chunk_docs, bad_chunk_ids = extract_docs(docs,
-                                                                         embedding=False)
-
-        if no_chunk_docs:
-            self.logger.warning(f'these docs contain no chunk: {no_chunk_docs}')
+        contents, chunk_pts, bad_chunk_ids = extract_docs(docs,
+                                                          embedding=False)
 
         if bad_chunk_ids:
             self.logger.warning(f'these bad chunks can not be added: {bad_chunk_ids}')

--- a/jina/drivers/helper.py
+++ b/jina/drivers/helper.py
@@ -87,7 +87,6 @@ def extract_docs(docs: Iterable['jina_pb2.Document'],
     """
     _contents = []
     chunk_pts = []
-    no_chunk_docs = []
     bad_chunk_ids = []
 
     if embedding:
@@ -95,17 +94,18 @@ def extract_docs(docs: Iterable['jina_pb2.Document'],
     else:
         _extract_fn = lambda c: c.text or c.buffer or (c.blob and pb2array(c.blob))
 
-    for c in docs:
-        _c = _extract_fn(c)
+    for d in docs:
+        for c in d:
+            _c = _extract_fn(c)
 
-        if _c is not None:
-            _contents.append(_c)
-            chunk_pts.append(c)
-        else:
-            bad_chunk_ids.append((c.id, c.parent_id))
+            if _c is not None:
+                _contents.append(_c)
+                chunk_pts.append(c)
+            else:
+                bad_chunk_ids.append((c.id, c.parent_id))
 
     contents = np.stack(_contents) if _contents else None
-    return contents, chunk_pts, no_chunk_docs, bad_chunk_ids
+    return contents, chunk_pts, bad_chunk_ids
 
 
 def routes2str(msg: 'jina_pb2.Message', flag_current: bool = False) -> str:


### PR DESCRIPTION
**Changes introduced**
Right now, **extract_docs** is not looping on document **chunks**.  I have identified something strange working on #712 . Encoders are receiving the complete document content instead of encoding one chunk at a time.

**Disclaimer**
Maybe I am missing something on how **encoders** should receive now information since the big refactor from #652. 

**TODO**
Add encoder driver test