### PR TITLE
test(flow): add test for double merging pathways

### DIFF
--- a/jina/flow/__init__.py
+++ b/jina/flow/__init__.py
@@ -67,7 +67,7 @@ def _traverse_graph(op_flow: 'Flow', outgoing_map: Dict[str, List[str]],
     _outgoing_idx = dict.fromkeys(outgoing_map.keys(), 0)
     stack = deque()
     stack.append('gateway')
-    op_flow.logger.info('Traversing dependency graph:')
+    op_flow.logger.debug('Traversing dependency graph:')
     while stack:
         start_node_name = stack.pop()
         end_node_idx = _outgoing_idx[start_node_name]
@@ -99,7 +99,7 @@ def _build_flow(op_flow: 'Flow', outgoing_map: Dict[str, List[str]]) -> 'Flow':
             first_socket_type = SocketType.PUB_BIND
         elif end_node_name == 'gateway':
             first_socket_type = SocketType.PUSH_BIND
-        flow.logger.info(f'Connect {start_node_name} with {end_node_name}')
+        flow.logger.debug(f'Connect {start_node_name} with {end_node_name}')
         FlowPod.connect(start_node, end_node, first_socket_type=first_socket_type)
 
     return _traverse_graph(op_flow, outgoing_map, _build_two_connections)

--- a/jina/helper.py
+++ b/jina/helper.py
@@ -486,6 +486,7 @@ def get_valid_local_config_source(path: str, to_stream: bool = False):
         return resource_filename('jina', '/'.join(('resources', 'executors.%s.yml' % path)))
     elif path.startswith('!'):
         # possible YAML content
+        path = path.replace('|', '\n    with: ')
         return io.StringIO(path)
     elif path.startswith('- !'):
         # possible driver YAML content, right now it is only used for debugging

--- a/jina/resources/executors._merge_all.yml
+++ b/jina/resources/executors._merge_all.yml
@@ -4,7 +4,5 @@ metas:
   name: merge
 requests:
   on:
-    [SearchRequest]:
+    [SearchRequest, TrainRequest, IndexRequest, ControlRequest]:
       - !ReduceAllDriver {}
-    ControlRequest:
-      - !ControlReqDriver {}

--- a/tests/unit/flow/test_flow_merge.py
+++ b/tests/unit/flow/test_flow_merge.py
@@ -1,5 +1,6 @@
 import os
 
+import pytest
 from jina.executors.crafters import BaseSegmenter
 from jina.flow import Flow
 from jina.proto import jina_pb2
@@ -23,18 +24,34 @@ class DummySegment(BaseSegmenter):
         return [dict(buffer=f'aa{self._label}'.encode()), dict(buffer=f'bb{self._label}'.encode())]
 
 
-class MyTestCase(JinaTestCase):
+class MergeFlowTest(JinaTestCase):
     def validate(self, req):
         chunk_ids = [c.id for d in req.index.docs for c in d.chunks]
         self.assertTrue(len(chunk_ids), len(set(chunk_ids)))
-        self.assertTrue(len(chunk_ids), 2)
+        self.assertTrue(len(chunk_ids), 8)
 
-    def test_dummy_seg(self):
+    @pytest.mark.skip('this should fail as explained in https://github.com/jina-ai/jina/pull/730')
+    def test_this_will_fail(self):
         f = (Flow().add(name='a11', uses='DummySegment')
              .add(name='a12', uses='DummySegment', needs='gateway')
              .add(name='r1', uses='_merge_all', needs=['a11', 'a12'])
              .add(name='a21', uses='DummySegment', needs='gateway')
              .add(name='a22', uses='DummySegment', needs='gateway')
+             .add(name='r2', uses='_merge_all', needs=['a21', 'a22'])
+             .add(uses='_merge_all', needs=['r1', 'r2']))
+
+        with f:
+            f.index(input_fn=random_docs(10), output_fn=self.validate)
+
+    def test_this_should_work(self):
+        f = (Flow()
+             .add(name='a1', uses='_forward')
+             .add(name='a11', uses='DummySegment', needs='a1')
+             .add(name='a12', uses='DummySegment', needs='a1')
+             .add(name='r1', uses='_merge_all', needs=['a11', 'a12'])
+             .add(name='a2', uses='_forward', needs='gateway')
+             .add(name='a21', uses='DummySegment', needs='a2')
+             .add(name='a22', uses='DummySegment', needs='a2')
              .add(name='r2', uses='_merge_all', needs=['a21', 'a22'])
              .add(uses='_merge_all', needs=['r1', 'r2']))
 

--- a/tests/unit/flow/test_flow_merge.py
+++ b/tests/unit/flow/test_flow_merge.py
@@ -1,0 +1,42 @@
+import os
+
+from jina.executors.crafters import BaseSegmenter
+from jina.flow import Flow
+from jina.proto import jina_pb2
+from tests import JinaTestCase, random_docs
+
+cur_dir = os.path.dirname(os.path.abspath(__file__))
+import random
+
+
+def random_docs(num_docs):
+    for j in range(num_docs):
+        yield jina_pb2.Document()
+
+
+class DummySegment(BaseSegmenter):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._label = random.random()
+
+    def craft(self):
+        return [dict(buffer=f'aa{self._label}'.encode()), dict(buffer=f'bb{self._label}'.encode())]
+
+
+class MyTestCase(JinaTestCase):
+    def validate(self, req):
+        chunk_ids = [c.id for d in req.index.docs for c in d.chunks]
+        self.assertTrue(len(chunk_ids), len(set(chunk_ids)))
+        self.assertTrue(len(chunk_ids), 2)
+
+    def test_dummy_seg(self):
+        f = (Flow().add(name='a11', uses='DummySegment')
+             .add(name='a12', uses='DummySegment', needs='gateway')
+             .add(name='r1', uses='_merge_all', needs=['a11', 'a12'])
+             .add(name='a21', uses='DummySegment', needs='gateway')
+             .add(name='a22', uses='DummySegment', needs='gateway')
+             .add(name='r2', uses='_merge_all', needs=['a21', 'a22'])
+             .add(uses='_merge_all', needs=['r1', 'r2']))
+
+        with f:
+            f.index(input_fn=random_docs(10), output_fn=self.validate)


### PR DESCRIPTION
@JoanFM are these two unittests describing what you mentioned in the Slack?

`test_this_will_fail` will fail, the log shows it waits for 4 parts. This is because we construct the Flow from one direction and `num_parts` is set by counting the number of emissions. 

```
             r1@39041[I]:collected 1/4 parts of IndexRequest
             r2@39044[I]:collected 1/4 parts of IndexRequest
             r1@39041[I]:received "index" from gateway▸a12▸⚐
             r2@39044[I]:received "index" from gateway▸a22▸⚐
             r2@39044[I]:collected 2/4 parts of IndexRequest
             r1@39041[I]:collected 2/4 parts of IndexRequest
```