### PR TITLE
refactor(indexer): changes detected by using mypy static type checker

### DIFF
--- a/jina/executors/indexers/__init__.py
+++ b/jina/executors/indexers/__init__.py
@@ -85,10 +85,10 @@ class BaseIndexer(BaseExecutor):
         self._query_handler = None
         self._write_handler = None
 
-    def query(self, vectors: 'np.ndarray', top_k: int, *args, **kwargs) -> Tuple['np.ndarray', 'np.ndarray']:
+    def query(self, keys: 'np.ndarray', top_k: int, *args, **kwargs) -> Tuple['np.ndarray', 'np.ndarray']:
         """Find k-NN using query vectors, return chunk ids and chunk scores
 
-        :param vectors: query vectors in ndarray, shape B x D
+        :param keys: query vectors in ndarray, shape B x D
         :param top_k: int, the number of nearest neighbour to return
         :return: a tuple of two ndarray.
             The first is ids in shape B x K (`dtype=int`), the second is scores in shape B x K (`dtype=float`)

--- a/jina/executors/indexers/vector/milvus.py
+++ b/jina/executors/indexers/vector/milvus.py
@@ -45,6 +45,6 @@ class MilvusIndexer(BaseVectorIndexer):
         self._validate_key_vector_shapes(keys, vectors)
         self.write_handler.insert(keys, vectors)
 
-    def query(self, vectors: 'np.ndarray', top_k: int, *args, **kwargs) -> Tuple['np.ndarray', 'np.ndarray']:
-        dist, ids = self.query_handler.search(vectors, top_k, *args, **kwargs)
+    def query(self, keys: 'np.ndarray', top_k: int, *args, **kwargs) -> Tuple['np.ndarray', 'np.ndarray']:
+        dist, ids = self.query_handler.search(keys, top_k, *args, **kwargs)
         return np.array(ids), np.array(dist)

--- a/jina/executors/indexers/vector/ngt.py
+++ b/jina/executors/indexers/vector/ngt.py
@@ -18,7 +18,7 @@ class NGTIndexer(BaseNumpyIndexer):
         Quick Install : pip install ngt
     """
 
-    def __init__(self, num_threads: int = 2, metric: str = 'L2', epsilon: int = 0.1, *args, **kwargs):
+    def __init__(self, num_threads: int = 2, metric: str = 'L2', epsilon: float = 0.1, *args, **kwargs):
         """
         Initialize an NGT Indexer
         :param num_threads: Number of threads to build index
@@ -53,9 +53,7 @@ class NGTIndexer(BaseNumpyIndexer):
         idx = []
         for key in keys:
             results = index.search(key, size=top_k, epsilon=self.epsilon)
-            index_k = []
-            distance_k = []
-            [(index_k.append(result[0]), distance_k.append(result[1])) for result in results]
+            index_k, distance_k = zip(*results)
             idx.append(index_k)
             dist.append(distance_k)
 

--- a/jina/executors/indexers/vector/ngt.py
+++ b/jina/executors/indexers/vector/ngt.py
@@ -53,8 +53,9 @@ class NGTIndexer(BaseNumpyIndexer):
         idx = []
         for key in keys:
             results = index.search(key, size=top_k, epsilon=self.epsilon)
-            index_k, distance_k = zip(*results)
-            idx.append(index_k)
-            dist.append(distance_k)
+            if results:
+                index_k, distance_k = zip(*results)
+                idx.append(index_k)
+                dist.append(distance_k)
 
         return self.int2ext_key[np.array(idx)], np.array(dist)


### PR DESCRIPTION
**Changes introduced**
Some changes suggested by the usage of `mypy` as static type checker for jina.

Usage: 

```bash
pip install mypy
mypy --ignore-missing-imports jina
```
This PR solves:

```bash
jina/executors/indexers/vector/ngt.py:21: error: Incompatible default for argument "epsilon" (default has type "float", argument has type "int")
jina/executors/indexers/vector/ngt.py:47: error: Signature of "query" incompatible with supertype "BaseIndexer"
jina/executors/indexers/vector/ngt.py:58: error: "append" of "list" does not return a value
```
