### PR TITLE
refactor(tests): use fixture and parammeterized pytest

### DIFF
--- a/tests/unit/drivers/test_chunk2doc_rank_drivers.py
+++ b/tests/unit/drivers/test_chunk2doc_rank_drivers.py
@@ -66,12 +66,11 @@ class Chunk2DocRankerDriverTestCase(JinaTestCase):
             # match score is computed w.r.t to doc.id
             self.assertEqual(match.score.ref_id, doc_with_score.id)
 
-    @pytest.maxk.parameterize("index, ranker, expected", [
+    @pytest.maxk.parameterize("index, expected", [
         (0, 7),
         (1, 6),
         (2, 5),
         (3, 4),
-
     ])
     def test_doc_score_chunk2doc_driver(self, index, expected, driver, doc_with_score):
         driver._apply_all(doc_with_score.chunks, doc_with_score)


### PR DESCRIPTION
This is a Proof of concept PR (not intended to be merged) on how should we refactor duplicated tests with:

1. pytest fixtures.
2. pytest parameterized mark.
3. Replace `assertEqual(a, b)` syntax with `assert a==b` which is more pythonic.

Besides, class `unittest` style of class based test could be replace by function based test.