### PR TITLE
fix(cicd): fix pip cache problem

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           python-version: 3.7
       - run: |
-          pip install .
+          pip install .  --no-cache-dir
           jina check --summary-exec ./docs/chapters/all_exec.md --summary-driver ./docs/chapters/all_driver.md
           echo ::set-env name=JINA_VERSION::"$(sed '6q;d' ./jina/__init__.py | cut -d \' -f2)-devel"
           pip install css-html-js-minify
@@ -120,7 +120,7 @@ jobs:
             sudo apt-get install libsndfile1
           fi
           python -m pip install --upgrade pip
-          pip install .[match-py-ver]
+          pip install .[match-py-ver] --no-cache-dir
       - name: Lint with flake8
         run: |
           pip install flake8
@@ -165,7 +165,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install .[match-py-ver]
+          pip install .[match-py-ver] --no-cache-dir
       - name: Test with pytest
         run: |
           # make sure docker exist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
             sudo apt-get install libsndfile1
           fi
           python -m pip install --upgrade pip
-          pip install .[match-py-ver]
+          pip install .[match-py-ver] --no-cache-dir
       - name: Lint with flake8
         run: |
           pip install flake8
@@ -96,7 +96,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install .[match-py-ver]
+          pip install .[match-py-ver] --no-cache-dir
       - name: Test with pytest
         run: |
           # make sure docker exist

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -21,6 +21,6 @@ jobs:
           path-To-cladocument: 'https://github.com/jina-ai/jina/blob/master/CLA.md'
           # branch should not be protected
           branch: 'cla'
-          whitelist: hanxiao,nan-wang,jina-bot,BingHo1013,alexcg1,imsergiy,YueLiu-jina,JoanFM,lusloher
+          whitelist: hanxiao,nan-wang,jina-bot,BingHo1013,alexcg1,imsergiy,YueLiu-jina,JoanFM,lusloher,bwanglzu
           empty-commit-flag: false
           blockchain-storage-flag: false

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -22,7 +22,7 @@ jobs:
       - run: |
           echo ::set-env name=JINA_VERSION::${GITHUB_REF/refs\/tags\/v/}
           echo ::set-env name=V_JINA_VERSION::${GITHUB_REF/refs\/tags\//}
-          pip install .
+          pip install .  --no-cache-dir
       - run: |
           cd schema
           jina export-api --yaml-path "${{env.JINA_VERSION}}.yml" latest.yml --json-path "${{env.JINA_VERSION}}.json" latest.json latest
@@ -44,7 +44,7 @@ jobs:
           echo ::set-output name=V_JINA_VERSION::${GITHUB_REF/refs\/tags\//}
       - name: install the release version
         run: |
-          pip install .
+          pip install .  --no-cache-dir
           ./make-doc.sh release "release $JINA_VERSION of ${{github.repository}}"
         env:
           JINA_VERSION: ${{steps.get_version.outputs.JINA_VERSION}}

--- a/tests/unit/drivers/test_concat_driver.py
+++ b/tests/unit/drivers/test_concat_driver.py
@@ -40,8 +40,9 @@ class ConcatDriverTestCase(JinaTestCase):
             self.assertEqual(req.docs[1].embedding.shape, [e3.shape[0] * 2])
             self.assertEqual(req.docs[0].chunks[0].embedding.shape, [e2.shape[0] * 2])
             self.assertEqual(req.docs[1].chunks[0].embedding.shape, [e4.shape[0] * 2])
-            np.testing.assert_almost_equal(pb2array(req.docs[0].embedding), np.concatenate([e1, e1], axis=0))
-            np.testing.assert_almost_equal(pb2array(req.docs[0].chunks[0].embedding), np.concatenate([e2, e2], axis=0))
+            np.testing.assert_almost_equal(pb2array(req.docs[0].embedding), np.concatenate([e1, e1], axis=0), decimal=4)
+            np.testing.assert_almost_equal(pb2array(req.docs[0].chunks[0].embedding), np.concatenate([e2, e2], axis=0),
+                                           decimal=4)
 
         # simulate two encoders
         flow = (Flow().add(name='a')


### PR DESCRIPTION
```
Collecting docutils<0.16,>=0.10
  Downloading docutils-0.15.2-py3-none-any.whl (547 kB)
ERROR: THESE PACKAGES DO NOT MATCH THE HASHES FROM THE REQUIREMENTS FILE. If you have updated the package versions, please update the hashes. Otherwise, examine the package contents carefully; someone may have tampered with them.
    paddlepaddle from https://files.pythonhosted.org/packages/7a/f5/34dad6d2aaf9ffaf78b64728fae8b968841090a2a00300fffd227b903a62/paddlepaddle-1.8.3-cp37-cp37m-manylinux1_x86_64.whl#sha256=290b3ec2c421571a5fd8293971e314aae1323834e8cddc05d7053b94c2f1999b (from jina==0.4.2):
        Expected sha256 290b3ec2c421571a5fd8293971e314aae1323834e8cddc05d7053b94c2f1999b
             Got        8424b42549292ca4205f10d299a7e55a6c2abf4314fd6a15bd402c65ee21d4aa

##[error]Process completed with exit code 1.
```

found recent failing reasons in our CICD are related to this https://stackoverflow.com/questions/40183108/python-packages-hash-not-matching-whilst-installing-using-pip