### PR TITLE
feat: add type annotations

### DIFF
--- a/jina/executors/compound.py
+++ b/jina/executors/compound.py
@@ -2,7 +2,7 @@ __copyright__ = "Copyright (c) 2020 Jina AI Limited. All rights reserved."
 __license__ = "Apache-2.0"
 
 from collections import defaultdict
-from typing import Dict, List, Callable, Union
+from typing import Dict, List, Callable, Union, Set
 
 from . import BaseExecutor, AnyExecutor
 
@@ -301,16 +301,16 @@ class CompoundExecutor(BaseExecutor):
     def _set_routes(self) -> None:
         import inspect
         # add all existing routes
-        r = defaultdict(list)
-        common = {}  # set(dir(BaseExecutor()))
+        r: defaultdict[str, list] = defaultdict(list)
+        common: Set[str] = {}  # set(dir(BaseExecutor()))
 
         for c in self.components:
             for m, _ in inspect.getmembers(c, predicate=inspect.ismethod):
                 if not m.startswith('_') and m not in common:
                     r[m].append((c.name, getattr(c, m)))
 
-        new_routes = []
-        bad_routes = []
+        new_routes: List[str] = []
+        bad_routes: List[str] = []
         for k, v in r.items():
             if len(v) == 1:
                 setattr(self, k, v[0][1])

--- a/jina/executors/requests.py
+++ b/jina/executors/requests.py
@@ -1,9 +1,9 @@
 __copyright__ = "Copyright (c) 2020 Jina AI Limited. All rights reserved."
 __license__ = "Apache-2.0"
 
-from typing import Dict, List
+from typing import Dict, List, Any
 
-_defaults = {}
+_defaults: Dict[str, Dict[str, Any]] = {}
 
 
 def get_default_reqs(cls_mro: List[type]) -> Dict:

--- a/jina/flow/__init__.py
+++ b/jina/flow/__init__.py
@@ -9,7 +9,7 @@ import time
 from collections import OrderedDict, defaultdict, deque
 from contextlib import ExitStack
 from functools import wraps
-from typing import Union, Tuple, List, Set, Dict, Iterator, Callable, Type, TextIO, Any
+from typing import Union, Tuple, List, Set, Dict, Iterator, Callable, Type, TextIO, Deque, Any
 
 import ruamel.yaml
 from ruamel.yaml import StringIO
@@ -65,7 +65,7 @@ def build_required(required_level: 'FlowBuildLevel'):
 def _traverse_graph(op_flow: 'Flow', outgoing_map: Dict[str, List[str]],
                     func: Callable[['Flow', str, str], None]) -> 'Flow':
     _outgoing_idx = dict.fromkeys(outgoing_map.keys(), 0)
-    stack = deque()
+    stack: Deque[str] = deque()
     stack.append('gateway')
     op_flow.logger.debug('Traversing dependency graph:')
     while stack:

--- a/jina/helper.py
+++ b/jina/helper.py
@@ -292,7 +292,7 @@ def get_registered_ports(stack_id: int = JINA_GLOBAL.stack.id):
 
 def deregister_all_ports(stack_id: int = JINA_GLOBAL.stack.id):
     config_path = os.environ.get('JINA_STACK_CONFIG', '.jina-stack.yml')
-    _all = {'stacks': []}
+    _all: Dict[str, List[Dict[str, Any]]] = {'stacks': []}
     if os.path.exists(config_path):
         with open(config_path) as fp:
             _all = yaml.load(fp)

--- a/jina/logging/pipe.py
+++ b/jina/logging/pipe.py
@@ -19,7 +19,7 @@ class PipeLogger:
         :param args: the parsed arguments from the CLI
         """
         self.args = args
-        self._preserved_logs = defaultdict(str)
+        self._preserved_logs: defaultdict[str, str] = defaultdict(str)
 
     def start(self):
         """ Start to receive logs from pipe"""

--- a/jina/logging/queue.py
+++ b/jina/logging/queue.py
@@ -4,9 +4,9 @@ __license__ = "Apache-2.0"
 import atexit
 import multiprocessing
 
-__sse_queue__ = multiprocessing.Queue()  #: the global sse log queue
-__profile_queue__ = multiprocessing.Queue()  #: the global profile log queue
-__log_queue__ = multiprocessing.Queue()  #: the global log queue
+__sse_queue__: "multiprocessing.queues.Queue" = multiprocessing.Queue()  #: the global sse log queue
+__profile_queue__: "multiprocessing.queues.Queue" = multiprocessing.Queue()  #: the global profile log queue
+__log_queue__: "multiprocessing.queues.Queue" = multiprocessing.Queue()  #: the global log queue
 
 
 def clear_queue():

--- a/jina/peapods/pea.py
+++ b/jina/peapods/pea.py
@@ -8,7 +8,7 @@ import threading
 import time
 import traceback
 from queue import Empty
-from typing import Dict, Optional, Union
+from typing import Dict, Optional, Union, Any
 
 import zmq
 
@@ -29,7 +29,7 @@ __all__ = ['PeaMeta', 'BasePea']
 
 class PeaMeta(type):
     """Meta class of :class:`BasePea` to enable switching between ``thread`` and ``process`` backend. """
-    _dct = {}
+    _dct: Dict[str, Dict[str, Any]] = {}
 
     def __new__(cls, name, bases, dct):
         _cls = super().__new__(cls, name, bases, dct)

--- a/jina/peapods/pod.py
+++ b/jina/peapods/pod.py
@@ -30,7 +30,7 @@ class BasePod:
 
         :param args: arguments parsed from the CLI
         """
-        self.peas = []
+        self.peas: List[BasePea] = []
         self.is_head_router = False
         self.is_tail_router = False
         self.deducted_head = None

--- a/jina/peapods/remote.py
+++ b/jina/peapods/remote.py
@@ -11,6 +11,7 @@ from ..clients.python import GrpcClient
 from ..helper import kwargs2list
 from ..logging import get_logger
 from ..proto import jina_pb2
+from typing import List, Tuple
 
 if False:
     import argparse
@@ -63,7 +64,7 @@ class PodSpawnHelper(PeaSpawnHelper):
 
     def __init__(self, args: 'argparse.Namespace'):
         super().__init__(args)
-        self.all_ctrl_addr = []  #: all peas control address and ports of this pod, need to be set in set_ready()
+        self.all_ctrl_addr: List[Tuple[str, bool]] = []  #: all peas control address and ports of this pod, need to be set in set_ready()
 
     def close(self):
         if not self.is_closed:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -3,6 +3,7 @@ import shutil
 import sys
 import unittest
 from os.path import dirname
+from typing import List
 
 import numpy as np
 
@@ -13,7 +14,7 @@ from jina.proto import jina_pb2
 class JinaTestCase(unittest.TestCase):
 
     def setUp(self) -> None:
-        self.tmp_files = []
+        self.tmp_files: List[str] = []
         os.environ['TEST_WORKDIR'] = os.getcwd()
 
     def tearDown(self) -> None:


### PR DESCRIPTION
**Change Description** :
Add missing type annotations to variables across the source tree
as reported by `mypy` by executing the following command (in the source directory)

`mypy --ignore-missing-imports . | grep "type annotations"`

resolves #743.