### PR TITLE
fix(crafters): fix crop dimension

### DIFF
--- a/jina/executors/crafters/image/crop.py
+++ b/jina/executors/crafters/image/crop.py
@@ -39,7 +39,7 @@ class ImageCropper(BaseCrafter):
         :returns: a chunk dict with the cropped image
         """
         raw_img = _load_image(blob, self.channel_axis)
-        _img, top, left = _crop_image(raw_img, target_size=(self.width, self.height), top=self.top, left=self.left)
+        _img, top, left = _crop_image(raw_img, target_size=(self.height, self.width), top=self.top, left=self.left)
         img = _restore_channel_axis(np.asarray(_img), self.channel_axis)
         return dict(offset=0, weight=1., blob=img.astype('float32'), location=(top, left))
 
@@ -51,7 +51,7 @@ class CenterImageCropper(BaseCrafter):
     """
 
     def __init__(self,
-                 target_size: Union[Tuple[int], int],
+                 target_size: Union[Tuple[int, int], int],
                  channel_axis: int = -1,
                  *args,
                  **kwargs):

--- a/tests/unit/executors/crafters/image/__init__.py
+++ b/tests/unit/executors/crafters/image/__init__.py
@@ -3,9 +3,9 @@ from tests import JinaTestCase
 
 class JinaImageTestCase(JinaTestCase):
     @staticmethod
-    def create_test_image(output_fn, size=50):
+    def create_test_image(output_fn, size_width=50, size_height=50):
         from PIL import Image
-        image = Image.new('RGB', size=(size, size), color=(155, 0, 0))
+        image = Image.new('RGB', size=(size_width, size_height), color=(155, 0, 0))
         with open(output_fn, "wb") as f:
             image.save(f, 'jpeg')
 

--- a/tests/unit/executors/crafters/image/test_crop.py
+++ b/tests/unit/executors/crafters/image/test_crop.py
@@ -1,6 +1,11 @@
+import os
 import numpy as np
+from PIL import Image, ImageChops
+
 from jina.executors.crafters.image.crop import ImageCropper, CenterImageCropper
 from tests.unit.executors.crafters.image import JinaImageTestCase
+
+cur_dir = os.path.dirname(os.path.abspath(__file__))
 
 
 class ImageCropTestCase(JinaImageTestCase):
@@ -9,7 +14,7 @@ class ImageCropTestCase(JinaImageTestCase):
         img_array = self.create_random_img_array(img_size, img_size)
         left = 2
         top = 17
-        width = 20
+        width = 30
         height = 20
         crafter = ImageCropper(top=top, left=left, width=width, height=height)
         crafted_doc = crafter.craft(img_array)
@@ -19,15 +24,40 @@ class ImageCropTestCase(JinaImageTestCase):
                 img_array.shape,
                 crafted_doc['blob'].shape,
                 np.asarray(img_array[left:left + width, top:top + height, :]).shape))
+        crop = Image.fromarray(np.uint8(crafted_doc['blob']))
+        crop_width, crop_height = crop.size
+        self.assertEqual(crop_width, width)
+        self.assertEqual(crop_height, height)
         self.assertEqual(crafted_doc['location'], (top, left))
+
+    def test_crop_file_image(self):
+        tmp_fn = os.path.join(cur_dir, 'test.jpeg')
+        self.create_test_image(tmp_fn, size_width=1024, size_height=512)
+        img = Image.open(tmp_fn)
+        img = img.convert('RGB')
+        width, height = img.size
+        self.assertEqual(width, 1024)
+        self.assertEqual(height, 512)
+        half_width, half_height = int(width/2), int(height/2)
+        img_array = np.array(img).astype('float32')
+        crafter = ImageCropper(top=0, left=0, width=half_width, height=half_height)
+        crafted_doc = crafter.craft(img_array)
+        self.assertEqual(crafted_doc['blob'].shape, (half_height, half_width, 3))
+        self.add_tmpfile(tmp_fn)
 
     def test_center_crop(self):
         img_size = 217
         img_array = self.create_random_img_array(img_size, img_size)
-        output_dim = 20
+        width = 30
+        height = 20
+        output_dim = (height, width)
         crafter = CenterImageCropper(output_dim)
         crafted_doc = crafter.craft(img_array)
-        self.assertEqual(crafted_doc['blob'].shape, (20, 20, 3))
+        self.assertEqual(crafted_doc['blob'].shape, (height, width, 3))
         # int((img_size - output_dim) / 2)
-        (top, left) = (98, 98)
+        crop = Image.fromarray(np.uint8(crafted_doc['blob']))
+        crop_width, crop_height = crop.size
+        self.assertEqual(crop_width, width)
+        self.assertEqual(crop_height, height)
+        (top, left) = (98, 93)
         self.assertEqual(crafted_doc['location'], (top, left))

--- a/tests/unit/executors/crafters/image/test_io.py
+++ b/tests/unit/executors/crafters/image/test_io.py
@@ -2,6 +2,7 @@ import io
 import os
 
 from PIL import Image
+import numpy as np
 from jina.executors.crafters.image.io import ImageReader
 from tests.unit.executors.crafters.image import JinaImageTestCase
 
@@ -11,7 +12,7 @@ class ImageIOTestCase(JinaImageTestCase):
         crafter = ImageReader()
         tmp_fn = os.path.join(crafter.current_workspace, 'test.jpeg')
         img_size = 50
-        self.create_test_image(tmp_fn, size=img_size)
+        self.create_test_image(tmp_fn, size_width=img_size, size_height=img_size)
         test_doc = crafter.craft(buffer=None, uri=tmp_fn)
         self.assertEqual(test_doc['blob'].shape, (img_size, img_size, 3))
         self.add_tmpfile(tmp_fn)
@@ -20,11 +21,12 @@ class ImageIOTestCase(JinaImageTestCase):
         crafter = ImageReader()
         tmp_fn = os.path.join(crafter.current_workspace, 'test.jpeg')
         img_size = 50
-        self.create_test_image(tmp_fn, size=img_size)
+        self.create_test_image(tmp_fn, size_width=img_size, size_height=img_size)
         image_buffer = io.BytesIO()
         img = Image.open(tmp_fn)
         img.save(image_buffer, format='PNG')
         image_buffer.seek(0)
         test_doc = crafter.craft(buffer=image_buffer.getvalue(), uri=None)
         self.assertEqual(test_doc['blob'].shape, (img_size, img_size, 3))
+        np.testing.assert_almost_equal(test_doc['blob'], np.array(img).astype('float32'))
         self.add_tmpfile(tmp_fn)

--- a/tests/unit/executors/crafters/image/test_normalize.py
+++ b/tests/unit/executors/crafters/image/test_normalize.py
@@ -8,5 +8,5 @@ class ImageNormalizerTestCase(JinaImageTestCase):
         target_size = 224
         crafter = ImageNormalizer(target_size=target_size)
         img_array = self.create_random_img_array(img_size, img_size)
-        crafted_chunk = crafter.craft(img_array)
-        self.assertEqual(crafted_chunk["blob"].shape, (224, 224, 3))
+        crafted_doc = crafter.craft(img_array)
+        self.assertEqual(crafted_doc["blob"].shape, (224, 224, 3))

--- a/tests/unit/executors/crafters/image/test_resize.py
+++ b/tests/unit/executors/crafters/image/test_resize.py
@@ -9,5 +9,5 @@ class ImageResizerTestCase(JinaImageTestCase):
         output_dim = 71
         crafter = ImageResizer(target_size=output_dim)
         img_array = self.create_random_img_array(img_width, img_height)
-        crafted_chunk = crafter.craft(img_array)
-        self.assertEqual(min(crafted_chunk['blob'].shape[:-1]), output_dim)
+        crafted_doc = crafter.craft(img_array)
+        self.assertEqual(min(crafted_doc['blob'].shape[:-1]), output_dim)


### PR DESCRIPTION
**Changes introduced**
- Spotted an issue when calling cropping, we were not respecting that `_crop_image` expects dimensions in format (height, width). Issue was not spotted because tests were done with `square` shaped images.

- Add some test with different dimensions

**WARNING - QUESTIONS**
- Qualitatively I have checked the crop, but for `precision` issues that seem to happen when saving by `PIL` cannot test the perfect reconstruction of the `crop`. Any idea how to fix this?