### PR TITLE
fix: have url regex pattern compiled just once

### DIFF
--- a/jina/clients/python/request.py
+++ b/jina/clients/python/request.py
@@ -4,7 +4,7 @@ __license__ = "Apache-2.0"
 import mimetypes
 import os
 import urllib.parse
-from typing import Iterator, Union, Tuple, List
+from typing import Iterator, Union
 
 import numpy as np
 

--- a/jina/helper.py
+++ b/jina/helper.py
@@ -260,7 +260,6 @@ def random_name() -> str:
 
 
 def random_port() -> int:
-
     import threading
     from contextlib import closing
     import socket
@@ -433,6 +432,44 @@ _COLORS = {
 
 _RESET = '\033[0m'
 
+
+def build_url_regex_pattern():
+    ul = '\u00a1-\uffff'  # Unicode letters range (must not be a raw string).
+
+    # IP patterns
+    ipv4_re = r'(?:25[0-5]|2[0-4]\d|[0-1]?\d?\d)(?:\.(?:25[0-5]|2[0-4]\d|[0-1]?\d?\d)){3}'
+    ipv6_re = r'\[[0-9a-f:.]+\]'  # (simple regex, validated later)
+
+    # Host patterns
+    hostname_re = r'[a-z' + ul + r'0-9](?:[a-z' + ul + r'0-9-]{0,61}[a-z' + ul + r'0-9])?'
+    # Max length for domain name labels is 63 characters per RFC 1034 sec. 3.1
+    domain_re = r'(?:\.(?!-)[a-z' + ul + r'0-9-]{1,63}(?<!-))*'
+    tld_re = (
+            r'\.'  # dot
+            r'(?!-)'  # can't start with a dash
+            r'(?:[a-z' + ul + '-]{2,63}'  # domain label
+                              r'|xn--[a-z0-9]{1,59})'  # or punycode label
+                              r'(?<!-)'  # can't end with a dash
+                              r'\.?'  # may have a trailing dot
+    )
+    host_re = '(' + hostname_re + domain_re + tld_re + '|localhost)'
+
+    return re.compile(
+        r'^(?:[a-z0-9.+-]*)://'  # scheme is validated separately
+        r'(?:[^\s:@/]+(?::[^\s:@/]*)?@)?'  # user:pass authentication
+        r'(?:' + ipv4_re + '|' + ipv6_re + '|' + host_re + ')'
+                                                           r'(?::\d{2,5})?'  # port
+                                                           r'(?:[/?#][^\s]*)?'  # resource path
+                                                           r'\Z', re.IGNORECASE)
+
+
+url_pat = build_url_regex_pattern()
+
+
+def is_url(text):
+    return url_pat.match(text) is not None
+
+
 if os.name == 'nt':
     os.system('color')
 
@@ -594,38 +631,6 @@ def get_full_version() -> str:
         return version_info + '\n' + env_info
     except Exception as e:
         default_logger.exception(e)
-
-
-def is_url(text):
-    ul = '\u00a1-\uffff'  # Unicode letters range (must not be a raw string).
-
-    # IP patterns
-    ipv4_re = r'(?:25[0-5]|2[0-4]\d|[0-1]?\d?\d)(?:\.(?:25[0-5]|2[0-4]\d|[0-1]?\d?\d)){3}'
-    ipv6_re = r'\[[0-9a-f:.]+\]'  # (simple regex, validated later)
-
-    # Host patterns
-    hostname_re = r'[a-z' + ul + r'0-9](?:[a-z' + ul + r'0-9-]{0,61}[a-z' + ul + r'0-9])?'
-    # Max length for domain name labels is 63 characters per RFC 1034 sec. 3.1
-    domain_re = r'(?:\.(?!-)[a-z' + ul + r'0-9-]{1,63}(?<!-))*'
-    tld_re = (
-            r'\.'  # dot
-            r'(?!-)'  # can't start with a dash
-            r'(?:[a-z' + ul + '-]{2,63}'  # domain label
-                              r'|xn--[a-z0-9]{1,59})'  # or punycode label
-                              r'(?<!-)'  # can't end with a dash
-                              r'\.?'  # may have a trailing dot
-    )
-    host_re = '(' + hostname_re + domain_re + tld_re + '|localhost)'
-
-    url_pat = re.compile(
-        r'^(?:[a-z0-9.+-]*)://'  # scheme is validated separately
-        r'(?:[^\s:@/]+(?::[^\s:@/]*)?@)?'  # user:pass authentication
-        r'(?:' + ipv4_re + '|' + ipv6_re + '|' + host_re + ')'
-        r'(?::\d{2,5})?'  # port
-        r'(?:[/?#][^\s]*)?'  # resource path
-        r'\Z', re.IGNORECASE)
-
-    return url_pat.match(text) is not None
 
 
 def use_uvloop():


### PR DESCRIPTION
**Changes introduced**
To avoid compiling the url regular expression at every `is_url` call, move it outside and do it only once.