### PR TITLE
fix: fix eos token error from transformers

### DIFF
--- a/jina/executors/encoders/nlp/transformer.py
+++ b/jina/executors/encoders/nlp/transformer.py
@@ -82,17 +82,17 @@ class BaseTransformerEncoder(BaseEncoder):
         try:
             if self.tokenizer.pad_token is None:
                 self.tokenizer.pad_token = self.tokenizer.eos_token
+                if self.tokenizer.pad_token is None:
+                    self.tokenizer.add_special_tokens({'pad_token': '[PAD]'})
             ids_info = self.tokenizer.batch_encode_plus(data,
                                                         max_length=self.max_length,
                                                         truncation=self.truncation_strategy,
-                                                        pad_to_max_length=True,
-                                                        padding='max_length')
+                                                        pad_to_max_length=True)
         except ValueError:
             self.model.resize_token_embeddings(len(self.tokenizer))
             ids_info = self.tokenizer.batch_encode_plus(data,
                                                         max_length=self.max_length,
-                                                        pad_to_max_length=True,
-                                                        padding='max_length')
+                                                        pad_to_max_length=True)
         token_ids_batch = self.array2tensor(ids_info['input_ids'])
         mask_ids_batch = self.array2tensor(ids_info['attention_mask'])
         with self.session():

--- a/jina/executors/encoders/nlp/transformer.py
+++ b/jina/executors/encoders/nlp/transformer.py
@@ -80,7 +80,8 @@ class BaseTransformerEncoder(BaseEncoder):
         :return: an ndarray in size `B x D`
         """
         try:
-            self.tokenizer.pad_token = self.tokenizer.eos_token
+            if self.tokenizer.pad_token is None:
+                self.tokenizer.pad_token = self.tokenizer.eos_token
             ids_info = self.tokenizer.batch_encode_plus(data,
                                                         max_length=self.max_length,
                                                         truncation=self.truncation_strategy,

--- a/tests/unit/executors/encoders/nlp/test_mock_transformer.py
+++ b/tests/unit/executors/encoders/nlp/test_mock_transformer.py
@@ -1,9 +1,7 @@
-import os
 from unittest.case import TestCase
 from unittest.mock import patch
 
 import numpy as np
-import pytest
 
 from jina.executors.encoders.nlp.transformer import TransformerTorchEncoder, TransformerTFEncoder
 
@@ -33,7 +31,7 @@ class MockTFModel(MockPtModel):
         seq_length = input_ids.shape[1]
         return tf.repeat(tf.reshape(tf.range(seq_length), (1, seq_length, 1)), batch_size, axis=0), None
 
-@pytest.mark.skip('TODO: fix whatever wrong with transformers')
+
 class TransformerEncoderWithMockedModelTestCase(TestCase):
     """To skip weights downloading and model initialization part replaces the actual model with dummy version"""
     texts = ["Never gonna run around", "and desert you"]


### PR DESCRIPTION
**Changes introduced**

- Assign properly `pad` and `eos` tokens. Transformer tests are working now (tested locally by setting env variable `JINA_TEST_PRETRAINED`

- Following https://github.com/huggingface/transformers/blob/6028ed92bd9e5471e6f8a1d23cfd95a3a63018fb/src/transformers/tokenization_utils_base.py#L1985. `pad_to_max_length=True` is enough to guarantee max length padding. It guarantees backward compatibility with older versions. This fixed some tests also for `XLNet` tests

Closes #773 

