### PR TITLE
fix(docs): code can't be picked up fluently

### DIFF
--- a/docs/_static/main.css
+++ b/docs/_static/main.css
@@ -425,8 +425,8 @@ input {
 
 .table-of-contents .card-content {
     max-width: 250px;
-    max-height: 700px;
-    overflow: hidden;
+    max-height: 600px;
+    overflow: scroll;
     font-size: .9rem;
 }
 

--- a/docs/_static/main.css
+++ b/docs/_static/main.css
@@ -425,8 +425,8 @@ input {
 
 .table-of-contents .card-content {
     max-width: 250px;
-    max-height: 600px;
-    overflow: auto;
+    max-height: 700px;
+    overflow: hidden;
     font-size: .9rem;
 }
 
@@ -442,6 +442,7 @@ input {
     padding-right: 1em;
     vertical-align: inherit;
 }
+
 
 .toc-card-footer:hover {
     background: #32C8CD
@@ -551,7 +552,7 @@ input {
 
 .rst-content pre.literal-block, .rst-content div[class^='highlight'] {
     border: 1px solid #009999;
-    overflow-x: auto;
+    overflow-x: hidden;
     margin: 1px 0 24px 0;
     border-radius: 5px;
     background: rgba(50, 200, 205, 0.01);

--- a/docs/_static/main.css
+++ b/docs/_static/main.css
@@ -426,7 +426,7 @@ input {
 .table-of-contents .card-content {
     max-width: 250px;
     max-height: 600px;
-    overflow: scroll;
+    overflow: auto;
     font-size: .9rem;
 }
 

--- a/docs/template/layout.html
+++ b/docs/template/layout.html
@@ -185,12 +185,12 @@
       </nav>
 
       <div class="card table-of-contents">
-          <span class="card-title">Table of Contents</span>
-            <div class="card-content">
+          <span class="card-title" onclick="showhide_littlenavbar()">Table of Contents</span>
+            <div id="little-navbar" class="card-content">
             {{ toc }}
             </div>
         <a href="https://github.com/jina-ai/jina/">
-          <span class="toc-card-footer">
+          <span class="toc-card-footer" >
             <span>Visit us on Github</span>
           </span>
         </a>
@@ -246,6 +246,21 @@
         x.style.display = "none";
         y.style.marginLeft = "0";
         z.style.left = "0px";
+      }
+
+    }
+    function showhide_littlenavbar() {
+      var x = document.getElementById("little-navbar");
+      //var y = document.getElementsByClassName("wy-nav-content-wrap")[0];
+      //var z = document.getElementById("showhide-navbar-btn");
+      if (x.style.display === "none") {
+        x.style.display = "block";
+        //y.style.marginLeft = "23rem";
+        //z.style.left = "23rem";
+      } else {
+        x.style.display = "none";
+        //y.style.marginLeft = "0";
+        //z.style.left = "0px";
       }
     }
   </script>


### PR DESCRIPTION
Added a function to minimize and maximize the Table of Contents, and canceled the scroll bar on the code in Edge Browser.
Issue Link: https://github.com/jina-ai/jina/issues/772

Screenshot: init page
![screenshot1](https://user-images.githubusercontent.com/69177855/89781073-36fd0780-db45-11ea-8022-7980482746d1.PNG)
Screenshot: minimize Table of Contents
![screenshot2](https://user-images.githubusercontent.com/69177855/89781102-48461400-db45-11ea-8e57-7763ea27349b.PNG)
