### PR TITLE
fix(docs): fix navigation bar hidden problem in docs

### DIFF
--- a/docs/_static/main.css
+++ b/docs/_static/main.css
@@ -443,6 +443,7 @@ input {
     vertical-align: inherit;
 }
 
+
 .toc-card-footer:hover {
     background: #32C8CD
 }
@@ -551,7 +552,7 @@ input {
 
 .rst-content pre.literal-block, .rst-content div[class^='highlight'] {
     border: 1px solid #009999;
-    overflow-x: auto;
+    overflow-x: hidden;
     margin: 1px 0 24px 0;
     border-radius: 5px;
     background: rgba(50, 200, 205, 0.01);

--- a/docs/template/layout.html
+++ b/docs/template/layout.html
@@ -185,12 +185,12 @@
       </nav>
 
       <div class="card table-of-contents">
-          <span class="card-title">Table of Contents</span>
-            <div class="card-content">
+          <span class="card-title" onclick="showhide_littlenavbar()">Table of Contents</span>
+            <div id="little-navbar" class="card-content">
             {{ toc }}
             </div>
         <a href="https://github.com/jina-ai/jina/">
-          <span class="toc-card-footer">
+          <span class="toc-card-footer" >
             <span>Visit us on Github</span>
           </span>
         </a>
@@ -246,6 +246,15 @@
         x.style.display = "none";
         y.style.marginLeft = "0";
         z.style.left = "0px";
+      }
+
+    }
+    function showhide_littlenavbar() {
+      var x = document.getElementById("little-navbar");
+      if (x.style.display === "none") {
+        x.style.display = "block";
+      } else {
+        x.style.display = "none";
       }
     }
   </script>


### PR DESCRIPTION
Added a function to minimize and maximize the Table of Contents, and canceled the scroll bar on the code in Edge Browser.
Issue Link: https://github.com/jina-ai/jina/issues/772
resolved #772 

**1.  Screenshot: init page**

![screenshot1](https://user-images.githubusercontent.com/69177855/89848824-b4faf600-dbb9-11ea-9e38-ac97f2b9ba8b.PNG)


**2.  Screenshot: minimize Table of Contents**

![screenshot2](https://user-images.githubusercontent.com/69177855/89848841-c6dc9900-dbb9-11ea-9d39-7f6c639dd822.PNG)
