### PR TITLE
fix: disable ci skipping

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,10 @@ name: CI
 
 on:
   pull_request:
-    paths-ignore:
-      - 'README.md'
-      - '.all-contributorsrc'
-      - 'docs/*'
+#    paths-ignore:
+#      - 'README.md'
+#      - '.all-contributorsrc'
+#      - 'docs/*'
 
 jobs:
   commit-lint:


### PR DESCRIPTION
Until found a solution, `all-contributors` PR won't be merged if these conditions are kept