### PR TITLE
fix: transformers are extracting prob distrib over vocab

### DIFF
--- a/jina/executors/encoders/nlp/transformer.py
+++ b/jina/executors/encoders/nlp/transformer.py
@@ -96,9 +96,12 @@ class BaseTransformerEncoder(BaseEncoder):
         token_ids_batch = self.array2tensor(ids_info['input_ids'])
         mask_ids_batch = self.array2tensor(ids_info['attention_mask'])
         with self.session():
-            seq_output, *extra_output = self.model(token_ids_batch, attention_mask=mask_ids_batch)
+            _, _, hidden_states = self.model(token_ids_batch,
+                                             attention_mask=mask_ids_batch,
+                                             output_hidden_states=True)
+            output_embeddings = hidden_states[0]
             _mask_ids_batch = self.tensor2array(mask_ids_batch)
-            _seq_output = self.tensor2array(seq_output)
+            _seq_output = self.tensor2array(output_embeddings)
             if self.pooling_strategy == 'auto':
                 output = auto_reduce(_seq_output, _mask_ids_batch, self.model.base_model_prefix)
             elif self.pooling_strategy == 'mean':

--- a/jina/executors/encoders/nlp/transformer.py
+++ b/jina/executors/encoders/nlp/transformer.py
@@ -96,9 +96,11 @@ class BaseTransformerEncoder(BaseEncoder):
         token_ids_batch = self.array2tensor(ids_info['input_ids'])
         mask_ids_batch = self.array2tensor(ids_info['attention_mask'])
         with self.session():
-            _, _, hidden_states = self.model(token_ids_batch,
-                                             attention_mask=mask_ids_batch,
-                                             output_hidden_states=True)
+            outputs = self.model(token_ids_batch,
+                                 attention_mask=mask_ids_batch,
+                                 output_hidden_states=True)
+
+            hidden_states = outputs[-1]
             output_embeddings = hidden_states[0]
             _mask_ids_batch = self.tensor2array(mask_ids_batch)
             _seq_output = self.tensor2array(output_embeddings)

--- a/tests/unit/executors/encoders/nlp/__init__.py
+++ b/tests/unit/executors/encoders/nlp/__init__.py
@@ -44,7 +44,7 @@ class NlpTestCase(ExecutorTestCase):
             return
         test_data = np.array(['it is a good day!', 'the dog sits on the floor.'])
         encoded_data = encoder.encode(test_data)
-        self.assertEqual(encoded_data.shape[0], 2)
+        self.assertEqual(encoded_data.shape, (2, self.target_output_dim))
 
     @pytest.mark.skipif('JINA_TEST_PRETRAINED' not in os.environ, reason='skip the pretrained test if not set')
     def test_save_and_load(self):

--- a/tests/unit/executors/encoders/nlp/test_transformer.py
+++ b/tests/unit/executors/encoders/nlp/test_transformer.py
@@ -97,14 +97,94 @@ class TfTestCasePollingMax(NlpTestCase):
 
 
 class XLNetPytorchTestCase(NlpTestCase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.target_output_dim = 768
+
     def _get_encoder(self, metas):
         return TransformerTorchEncoder(
             pretrained_model_name_or_path='xlnet-base-cased',
             metas=metas)
 
 
+class XLNetPytorchTestCasePollingMean(NlpTestCase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.target_output_dim = 768
+
+    def _get_encoder(self, metas):
+        return TransformerTorchEncoder(
+            polling_strategy='mean',
+            pretrained_model_name_or_path='xlnet-base-cased',
+            metas=metas)
+
+
+class XLNetPytorchTestCasePollingMax(NlpTestCase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.target_output_dim = 768
+
+    def _get_encoder(self, metas):
+        return TransformerTorchEncoder(
+            polling_strategy='max',
+            pretrained_model_name_or_path='xlnet-base-cased',
+            metas=metas)
+
+
+class XLNetPytorchTestCasePollingMin(NlpTestCase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.target_output_dim = 768
+
+    def _get_encoder(self, metas):
+        return TransformerTorchEncoder(
+            polling_strategy='min',
+            pretrained_model_name_or_path='xlnet-base-cased',
+            metas=metas)
+
+
 class XLNetTFTestCase(NlpTestCase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.target_output_dim = 768
+
     def _get_encoder(self, metas):
         return TransformerTFEncoder(
+            pretrained_model_name_or_path='xlnet-base-cased',
+            metas=metas)
+
+
+class XLNetTFTestCaseCasePollingMean(NlpTestCase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.target_output_dim = 768
+
+    def _get_encoder(self, metas):
+        return TransformerTFEncoder(
+            polling_strategy='mean',
+            pretrained_model_name_or_path='xlnet-base-cased',
+            metas=metas)
+
+
+class XLNetTFTestCaseCasePollingMax(NlpTestCase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.target_output_dim = 768
+
+    def _get_encoder(self, metas):
+        return TransformerTFEncoder(
+            polling_strategy='max',
+            pretrained_model_name_or_path='xlnet-base-cased',
+            metas=metas)
+
+
+class XLNetTFTestCaseCasePollingMin(NlpTestCase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.target_output_dim = 768
+
+    def _get_encoder(self, metas):
+        return TransformerTFEncoder(
+            polling_strategy='min',
             pretrained_model_name_or_path='xlnet-base-cased',
             metas=metas)

--- a/tests/unit/executors/encoders/nlp/test_transformer.py
+++ b/tests/unit/executors/encoders/nlp/test_transformer.py
@@ -3,15 +3,95 @@ from tests.unit.executors.encoders.nlp import NlpTestCase
 
 
 class PytorchTestCase(NlpTestCase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.target_output_dim = 768
+
     def _get_encoder(self, metas):
         return TransformerTorchEncoder(
             pretrained_model_name_or_path='bert-base-uncased',
             metas=metas)
 
 
+class PytorchTestCasePollingMean(NlpTestCase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.target_output_dim = 768
+
+    def _get_encoder(self, metas):
+        return TransformerTorchEncoder(
+            polling_strategy='mean',
+            pretrained_model_name_or_path='bert-base-uncased',
+            metas=metas)
+
+
+class PytorchTestCasePollingMin(NlpTestCase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.target_output_dim = 768
+
+    def _get_encoder(self, metas):
+        return TransformerTorchEncoder(
+            polling_strategy='min',
+            pretrained_model_name_or_path='bert-base-uncased',
+            metas=metas)
+
+
+class PytorchTestCasePollingMax(NlpTestCase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.target_output_dim = 768
+
+    def _get_encoder(self, metas):
+        return TransformerTorchEncoder(
+            polling_strategy='max',
+            pretrained_model_name_or_path='bert-base-uncased',
+            metas=metas)
+
+
 class TfTestCase(NlpTestCase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.target_output_dim = 768
+
     def _get_encoder(self, metas):
         return TransformerTFEncoder(
+            pretrained_model_name_or_path='bert-base-uncased',
+            metas=metas)
+
+
+class TfTestCasePollingMean(NlpTestCase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.target_output_dim = 768
+
+    def _get_encoder(self, metas):
+        return TransformerTFEncoder(
+            polling_strategy='mean',
+            pretrained_model_name_or_path='bert-base-uncased',
+            metas=metas)
+
+
+class TfTestCasePollingMin(NlpTestCase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.target_output_dim = 768
+
+    def _get_encoder(self, metas):
+        return TransformerTFEncoder(
+            polling_strategy='min',
+            pretrained_model_name_or_path='bert-base-uncased',
+            metas=metas)
+
+
+class TfTestCasePollingMax(NlpTestCase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.target_output_dim = 768
+
+    def _get_encoder(self, metas):
+        return TransformerTFEncoder(
+            polling_strategy='max',
             pretrained_model_name_or_path='bert-base-uncased',
             metas=metas)
 


### PR DESCRIPTION
**Changes introduced**
Transformers are not extracting embeddings, but a complete prob distribution over the vocabulary. 
Key finding in https://huggingface.co/transformers/model_doc/bert.html#transformers.BertModel.forward (see hidden_states in output of `forward`) 

Now `transformers test` run in local, you are welcome to try yourself