### PR TITLE
docs: add docs about common jina practices

### DIFF
--- a/docs/chapters/flow/index.md
+++ b/docs/chapters/flow/index.md
@@ -302,3 +302,17 @@ With Jina Dashboard, you can interactively drag-n-drop Pod, set its attribute an
 
 
 More information on the dashboard can be found [here](https://github.com/jina-ai/dashboard).
+
+# Common design patterns
+
+jina is a really flexible AI-powered neural search framework. It is designed to enable any pattern that can be framed as  
+a neural search problem.
+However, there are basic common patterns that show up when developing search solutions with jina and here is a recopilation of some of them.
+
+- CompoundIndexer (Vector + KV Indexers):
+
+- Indexers at different depth levels:
+
+- NLP Document chunks (Segment + encode):
+
+- Reference Indexer

--- a/docs/chapters/flow/index.md
+++ b/docs/chapters/flow/index.md
@@ -311,6 +311,32 @@ However, there are basic common patterns that show up when developing search sol
 
 - CompoundIndexer (Vector + KV Indexers):
 
+To develop neural search applications, it is useful to use a `CompoundIndexer` in the same `Pod` for both `index` and `query` Flows.
+The following `yaml` file shows an example of this pattern.
+
+```yaml
+!CompoundIndexer
+components:
+  - !NumpyIndexer
+    with:
+      index_filename: vectors.gz
+      metric: cosine
+    metas:
+      name: vecIndexer
+  - !BinaryPbIndexer
+    with:
+      index_filename: values.gz
+    metas:
+      name: kvIndexer  # a customized name
+metas:
+  name: complete indexer
+```
+
+This type of construction will act as a single `indexer` and will allow to seamlessly `query` this index with the `embedding` vector coming
+from any upstream `encoder` and obtain in the response message of the pod the corresponding `binary` information stored in
+the key-value index. This lets the `VectorIndexer` be responsible to obtain the most relevant documents by finding similarities
+in the `embedding` space while targeting the `key-value` database to extract the meaningful data and fields from those relevant documents.
+
 - Indexers at different depth levels:
 
 - NLP Document chunks (Segment + encode):


### PR DESCRIPTION
@alexcg1 @hanxiao 

We have a task to add some documentation about `jina best practices` or `patterns`. Here I showcase the schema I want to introduce and the place. Do you think is good way? Is it the right place in the docs to place it? Are we missing some common pattern that might deserve a little explanation for a user to grasp?

It would be good to review the content @hanxiao, @nan-wang, it may not be so accurate?