### PR TITLE
refactor: move base_deps from setup to extra

### DIFF
--- a/extra-requirements.txt
+++ b/extra-requirements.txt
@@ -6,7 +6,7 @@
 #
 # AVAILABLE TAGS
 #
-# nlp, cv, audio, numeric, index, http, sse, framework, optimization, network
+# nlp, cv, audio, numeric, index, http, sse, framework, perf, network
 #
 # REMARKS ON TAGS
 # 1. Try to reuse the existing tags if possible.
@@ -35,11 +35,17 @@ annoy>=1.9.5:               index
 sklearn:                    numeric
 plyvel:                     index
 jieba:                      nlp
-lz4:                        devel, optimization, network
+lz4:                        devel, perf, network
 gevent:                     http, devel
 python-magic:               http, devel
 pymilvus:                   index
 deepsegment:                nlp
 ngt:                        index, py37
 librosa>=0.7.2:             audio
-uvloop:                     devel, optimization
+uvloop:                     devel, perf
+numpy:                      core
+pyzmq>=17.1.0:              core
+protobuf:                   core
+grpcio:                     core
+ruamel.yaml>=0.15.89:       core
+tornado>=5.1.0:             core

--- a/setup.py
+++ b/setup.py
@@ -31,15 +31,6 @@ try:
 except FileNotFoundError:
     _long_description = ''
 
-base_dep = [
-    'numpy',
-    'pyzmq>=17.1.0',
-    'protobuf',
-    'grpcio',
-    'ruamel.yaml>=0.15.89',
-    'tornado>=5.1.0'
-]
-
 
 def get_extra_requires(path, add_all=True):
     import re
@@ -119,6 +110,8 @@ class PostInstallCommand(install):
         register_ac()
 
 
+all_deps = get_extra_requires('extra-requirements.txt')
+
 setup(
     name=pkg_name,
     packages=find_packages(),
@@ -136,8 +129,8 @@ setup(
     setup_requires=[
         'setuptools>=18.0',
     ],
-    install_requires=base_dep,
-    extras_require=get_extra_requires('extra-requirements.txt'),
+    install_requires=list(all_deps['core'].union(all_deps['perf'])),
+    extras_require=all_deps,
     entry_points={
         'console_scripts': ['jina=jina.main:main'],
     },


### PR DESCRIPTION
previous `pip install jina` = current `pip install jina[core]`
current `pip install jina` = previous `pip install jina[perf]`

in other words, `perf` is installed by default unless otherwise specified.
previously, without `perf`, `jina hello-world` can still run but with red warnings all over the places, bad experience