### PR TITLE
feat(indexer): add query by ids to BaseNumpyIndexer

### DIFF
--- a/jina/executors/indexers/__init__.py
+++ b/jina/executors/indexers/__init__.py
@@ -176,7 +176,7 @@ class BaseVectorIndexer(BaseIndexer):
     def query_by_id(self, ids: 'np.ndarray', *args, **kwargs):
         """ Get the vectors by id, return a subset of indexed vectors
 
-        :param ids: a list of id
+        :param ids: a list of ``id``, i.e. ``doc.id``
         :param args:
         :param kwargs:
         :return:

--- a/jina/executors/indexers/__init__.py
+++ b/jina/executors/indexers/__init__.py
@@ -173,6 +173,16 @@ class BaseVectorIndexer(BaseIndexer):
     It can be used to tell whether an indexer is vector indexer, via ``isinstance(a, BaseVectorIndexer)``
     """
 
+    def query_by_id(self, ids: 'np.ndarray', *args, **kwargs):
+        """ Get the vectors by id, return a subset of indexed vectors
+
+        :param ids: a list of id
+        :param args:
+        :param kwargs:
+        :return:
+        """
+        raise NotImplementedError
+
 
 class BaseKVIndexer(BaseIndexer):
     """An abstract class for key-value indexer.

--- a/jina/executors/indexers/__init__.py
+++ b/jina/executors/indexers/__init__.py
@@ -176,7 +176,7 @@ class BaseVectorIndexer(BaseIndexer):
     def query_by_id(self, ids: 'np.ndarray', *args, **kwargs):
         """ Get the vectors by id, return a subset of indexed vectors
 
-        :param ids: a list of ``id``, i.e. ``doc.id``
+        :param ids: a list of ``id``, i.e. ``doc.id`` in protobuf
         :param args:
         :param kwargs:
         :return:

--- a/jina/executors/indexers/vector/__init__.py
+++ b/jina/executors/indexers/vector/__init__.py
@@ -3,7 +3,7 @@ __license__ = "Apache-2.0"
 
 import gzip
 from os import path
-from typing import Optional
+from typing import Optional, List, Union
 
 import numpy as np
 
@@ -89,6 +89,12 @@ class BaseNumpyIndexer(BaseVectorIndexer):
             return None
 
     def build_advanced_index(self, vecs: 'np.ndarray'):
+        """
+        Build advanced index structure based on in-memory numpy ndarray, e.g. graph, tree, etc.
+
+        :param vecs: the raw numpy ndarray
+        :return:
+        """
         raise NotImplementedError
 
     def _load_gzip(self, abspath):
@@ -107,7 +113,7 @@ class BaseNumpyIndexer(BaseVectorIndexer):
         return result
 
     @cached_property
-    def raw_ndarray(self):
+    def raw_ndarray(self) -> Optional['np.ndarray']:
         vecs = self._load_gzip(self.index_abspath)
         if vecs is None:
             return None
@@ -124,6 +130,11 @@ class BaseNumpyIndexer(BaseVectorIndexer):
             if vecs.shape[0] == 0:
                 self.logger.warning(f'an empty index is loaded')
 
+            self.ext2int_key = {k: idx for idx, k in enumerate(self.int2ext_key)}
             return vecs
         else:
             return None
+
+    def query_by_id(self, ids: Union[List[int], 'np.ndarray'], *args, **kwargs) -> 'np.ndarray':
+        int_ids = np.array([self.ext2int_key[j] for j in ids])
+        return self.raw_ndarray[int_ids]

--- a/tests/unit/executors/indexers/vector/test_numpy.py
+++ b/tests/unit/executors/indexers/vector/test_numpy.py
@@ -2,6 +2,7 @@ import os
 import unittest
 
 import numpy as np
+
 from jina.executors.indexers import BaseIndexer
 from jina.executors.indexers.vector.numpy import NumpyIndexer
 from tests import JinaTestCase
@@ -42,7 +43,7 @@ class MyTestCase(JinaTestCase):
                             [10, 10, 10],
                             [100, 100, 100],
                             [1000, 1000, 1000]])
-        keys = np.array([0, 1, 2, 3]).reshape(-1, 1)
+        keys = np.array([4, 5, 6, 7]).reshape(-1, 1)
         with NumpyIndexer(index_filename='np.test.gz') as a:
             a.add(keys, vectors)
             a.save()
@@ -56,9 +57,10 @@ class MyTestCase(JinaTestCase):
                             [1000, 1000, 1000]])
         with BaseIndexer.load(save_abspath) as b:
             idx, dist = b.query(queries, top_k=2)
-            np.testing.assert_equal(idx, np.array([[0, 1], [1, 0], [2, 1], [3, 2]]))
+            np.testing.assert_equal(idx, np.array([[4, 5], [5, 4], [6, 5], [7, 6]]))
             self.assertEqual(idx.shape, dist.shape)
             self.assertEqual(idx.shape, (4, 2))
+            np.testing.assert_equal(b.query_by_id([7, 4]), vectors[[3, 0]])
 
         self.add_tmpfile(index_abspath, save_abspath)
 


### PR DESCRIPTION
related to #767 

one (naive) way to implement filter-then-query.