### PR TITLE
test: refactor indexer tests and check instance type

### DIFF
--- a/jina/executors/crafters/image/normalize.py
+++ b/jina/executors/crafters/image/normalize.py
@@ -14,7 +14,7 @@ class ImageNormalizer(BaseCrafter):
         it receives values of file names on the doc-level and returns image matrix on the chunk-level """
 
     def __init__(self,
-                 target_size: Union[Tuple[int], int],
+                 target_size: Union[Tuple[int, int], int],
                  img_mean: Tuple[float] = (0, 0, 0),
                  img_std: Tuple[float] = (1, 1, 1),
                  resize_dim: int = 256,

--- a/jina/executors/encoders/image/torchvision.py
+++ b/jina/executors/encoders/image/torchvision.py
@@ -42,6 +42,7 @@ class ImageTorchEncoder(BaseTorchEncoder):
         """
         super().__init__(*args, **kwargs)
         self.channel_axis = channel_axis
+        # axis 0 is the batch
         self._default_channel_axis = 1
         self.model_name = 'mobilenet_v2' or model_name
         if pool_strategy not in ('mean', 'max', None):

--- a/tests/unit/executors/indexers/vector/test_faiss.py
+++ b/tests/unit/executors/indexers/vector/test_faiss.py
@@ -25,15 +25,16 @@ class FaissTestCase(JinaTestCase):
         with gzip.open(train_filepath, 'wb', compresslevel=1) as f:
             f.write(train_data.tobytes())
 
-        with FaissIndexer(index_filename='faiss.test.gz', index_key='IVF10,PQ2', train_filepath=train_filepath) as a:
-            a.add(vec_idx, vec)
-            a.save()
-            self.assertTrue(os.path.exists(a.index_abspath))
-            index_abspath = a.index_abspath
-            save_abspath = a.save_abspath
+        with FaissIndexer(index_filename='faiss.test.gz', index_key='IVF10,PQ2', train_filepath=train_filepath) as indexer:
+            indexer.add(vec_idx, vec)
+            indexer.save()
+            self.assertTrue(os.path.exists(indexer.index_abspath))
+            index_abspath = indexer.index_abspath
+            save_abspath = indexer.save_abspath
 
-        with BaseIndexer.load(save_abspath) as b:
-            idx, dist = b.query(query, top_k=4)
+        with BaseIndexer.load(save_abspath) as indexer:
+            self.assertIsInstance(indexer, FaissIndexer)
+            idx, dist = indexer.query(query, top_k=4)
             global retr_idx
             if retr_idx is None:
                 retr_idx = idx

--- a/tests/unit/executors/indexers/vector/test_milvus.py
+++ b/tests/unit/executors/indexers/vector/test_milvus.py
@@ -1,12 +1,11 @@
 import os
-import unittest
 
 from jina.executors.indexers import BaseIndexer
 from jina.executors.indexers.vector.milvus import MilvusIndexer
 from tests import JinaTestCase
 
 
-class MilvusUnitTestCase(JinaTestCase):
+class MilvusTestCase(JinaTestCase):
 
     def test_milvus_indexer_save_and_load(self):
         with MilvusIndexer('localhost', 19530,
@@ -17,6 +16,7 @@ class MilvusUnitTestCase(JinaTestCase):
             save_abspath = indexer.save_abspath
 
         with BaseIndexer.load(save_abspath) as indexer:
+            self.assertIsInstance(indexer, MilvusIndexer)
             self.assertEqual(indexer.host, 'localhost')
             self.assertEqual(indexer.port, 19530)
             self.assertEqual(indexer.collection_name, 'collection')
@@ -24,7 +24,3 @@ class MilvusUnitTestCase(JinaTestCase):
             self.assertEqual(indexer.index_params['key'], 'value')
 
         self.add_tmpfile(save_abspath)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/tests/unit/executors/indexers/vector/test_ngt.py
+++ b/tests/unit/executors/indexers/vector/test_ngt.py
@@ -1,6 +1,6 @@
 import os
-import unittest
 import numpy as np
+import pytest
 from jina.executors.indexers import BaseIndexer
 from jina.executors.indexers.vector.ngt import NGTIndexer
 from tests import JinaTestCase
@@ -24,9 +24,9 @@ vec = np.random.random([10, 10])
 query = np.array(np.random.random([10, 10]), dtype=np.float32)
 
 
-@unittest.skipIf('py38' == py_tag, 'skip if python3.8 version is tested')
-class MyTestCase(JinaTestCase):
+class NgtIndexerTestCase(JinaTestCase):
 
+    @pytest.mark.skipIf('py38' == py_tag, 'skip if python3.8 version is tested')
     def test_simple_ngt(self):
         import ngtpy
         path = '/tmp/ngt-index'
@@ -54,16 +54,18 @@ class MyTestCase(JinaTestCase):
         self.assertEqual(idx.shape, dist.shape)
         self.assertEqual(idx.shape, (queries, top_k))
 
+    @pytest.mark.skipIf('py38' == py_tag, 'skip if python3.8 version is tested')
     def test_ngt_indexer(self):
-        with NGTIndexer(index_filename='ngt.test.gz') as a:
-            a.add(vec_idx, vec)
-            a.save()
-            self.assertTrue(os.path.exists(a.index_abspath))
-            index_abspath = a.index_abspath
-            save_abspath = a.save_abspath
+        with NGTIndexer(index_filename='ngt.test.gz') as indexer:
+            indexer.add(vec_idx, vec)
+            indexer.save()
+            self.assertTrue(os.path.exists(indexer.index_abspath))
+            index_abspath = indexer.index_abspath
+            save_abspath = indexer.save_abspath
 
-        with BaseIndexer.load(save_abspath) as b:
-            idx, dist = b.query(query, top_k=4)
+        with BaseIndexer.load(save_abspath) as indexer:
+            self.assertIsInstance(indexer, NGTIndexer)
+            idx, dist = indexer.query(query, top_k=4)
             global retr_idx
             if retr_idx is None:
                 retr_idx = idx
@@ -73,7 +75,3 @@ class MyTestCase(JinaTestCase):
             self.assertEqual(idx.shape, (10, 4))
 
         self.add_tmpfile(index_abspath, save_abspath)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/tests/unit/executors/indexers/vector/test_numpy.py
+++ b/tests/unit/executors/indexers/vector/test_numpy.py
@@ -1,5 +1,4 @@
 import os
-import unittest
 
 import numpy as np
 
@@ -16,18 +15,19 @@ query = np.array(np.random.random([10, 10]), dtype=np.float32)
 cur_dir = os.path.dirname(os.path.abspath(__file__))
 
 
-class MyTestCase(JinaTestCase):
+class NumpyIndexerTestCase(JinaTestCase):
 
     def test_np_indexer(self):
-        with NumpyIndexer(index_filename='np.test.gz') as a:
-            a.add(vec_idx, vec)
-            a.save()
-            self.assertTrue(os.path.exists(a.index_abspath))
-            index_abspath = a.index_abspath
-            save_abspath = a.save_abspath
+        with NumpyIndexer(index_filename='np.test.gz') as indexer:
+            indexer.add(vec_idx, vec)
+            indexer.save()
+            self.assertTrue(os.path.exists(indexer.index_abspath))
+            index_abspath = indexer.index_abspath
+            save_abspath = indexer.save_abspath
 
-        with BaseIndexer.load(save_abspath) as b:
-            idx, dist = b.query(query, top_k=4)
+        with BaseIndexer.load(save_abspath) as indexer:
+            self.assertIsInstance(indexer, NumpyIndexer)
+            idx, dist = indexer.query(query, top_k=4)
             global retr_idx
             if retr_idx is None:
                 retr_idx = idx
@@ -44,36 +44,38 @@ class MyTestCase(JinaTestCase):
                             [100, 100, 100],
                             [1000, 1000, 1000]])
         keys = np.array([4, 5, 6, 7]).reshape(-1, 1)
-        with NumpyIndexer(index_filename='np.test.gz') as a:
-            a.add(keys, vectors)
-            a.save()
-            self.assertTrue(os.path.exists(a.index_abspath))
-            index_abspath = a.index_abspath
-            save_abspath = a.save_abspath
+        with NumpyIndexer(index_filename='np.test.gz') as indexer:
+            indexer.add(keys, vectors)
+            indexer.save()
+            self.assertTrue(os.path.exists(indexer.index_abspath))
+            index_abspath = indexer.index_abspath
+            save_abspath = indexer.save_abspath
 
         queries = np.array([[1, 1, 1],
                             [10, 10, 10],
                             [100, 100, 100],
                             [1000, 1000, 1000]])
-        with BaseIndexer.load(save_abspath) as b:
-            idx, dist = b.query(queries, top_k=2)
+        with BaseIndexer.load(save_abspath) as indexer:
+            self.assertIsInstance(indexer, NumpyIndexer)
+            idx, dist = indexer.query(queries, top_k=2)
             np.testing.assert_equal(idx, np.array([[4, 5], [5, 4], [6, 5], [7, 6]]))
             self.assertEqual(idx.shape, dist.shape)
             self.assertEqual(idx.shape, (4, 2))
-            np.testing.assert_equal(b.query_by_id([7, 4]), vectors[[3, 0]])
+            np.testing.assert_equal(indexer.query_by_id([7, 4]), vectors[[3, 0]])
 
         self.add_tmpfile(index_abspath, save_abspath)
 
     def test_scipy_indexer(self):
-        with NumpyIndexer(index_filename='np.test.gz', backend='scipy') as a:
-            a.add(vec_idx, vec)
-            a.save()
-            self.assertTrue(os.path.exists(a.index_abspath))
-            index_abspath = a.index_abspath
-            save_abspath = a.save_abspath
+        with NumpyIndexer(index_filename='np.test.gz', backend='scipy') as indexer:
+            indexer.add(vec_idx, vec)
+            indexer.save()
+            self.assertTrue(os.path.exists(indexer.index_abspath))
+            index_abspath = indexer.index_abspath
+            save_abspath = indexer.save_abspath
 
-        with BaseIndexer.load(save_abspath) as b:
-            idx, dist = b.query(query, top_k=4)
+        with BaseIndexer.load(save_abspath) as indexer:
+            self.assertIsInstance(indexer, NumpyIndexer)
+            idx, dist = indexer.query(query, top_k=4)
             global retr_idx
             if retr_idx is None:
                 retr_idx = idx
@@ -83,7 +85,3 @@ class MyTestCase(JinaTestCase):
             self.assertEqual(idx.shape, (10, 4))
 
         self.add_tmpfile(index_abspath, save_abspath)
-
-
-if __name__ == '__main__':
-    unittest.main()


### PR DESCRIPTION
**Changes introduced**
- Change naming of VectorIndexer tests, plus remove unittest and some small refactoring
- Add check of instance when loading from `save_abspath`