### PR TITLE
test: no need of np asarray

### DIFF
--- a/tests/unit/executors/encoders/nlp/test_mock_transformer.py
+++ b/tests/unit/executors/encoders/nlp/test_mock_transformer.py
@@ -1,8 +1,6 @@
 from unittest.case import TestCase
 from unittest.mock import patch
 
-import numpy as np
-
 from jina.executors.encoders.nlp.transformer import TransformerTorchEncoder, TransformerTFEncoder
 
 
@@ -49,7 +47,7 @@ class TransformerEncoderWithMockedModelTestCase(TestCase):
                     pretrained_model_name_or_path=model,
                     pooling_strategy='auto',
                     metas={})
-                encoded_batch = encoder.encode(np.asarray(self.texts))
+                encoded_batch = encoder.encode(self.texts)
                 self.assertEqual(encoded_batch.shape, (2, 768))
 
     def test_encodes_lm_like(self):
@@ -70,5 +68,5 @@ class TransformerEncoderWithMockedModelTestCase(TestCase):
         model = "bert-base-uncased"
         with patch.object(TFAutoModelForPreTraining, 'from_pretrained', return_value=MockTFModel(model)):
             encoder = TransformerTFEncoder(pretrained_model_name_or_path=model)
-            encoded_batch = encoder.encode(np.asarray(self.texts))
+            encoded_batch = encoder.encode(self.texts)
             self.assertEqual(encoded_batch.shape, (2, 768))


### PR DESCRIPTION
**Changes introduced**
Remove np.asarray when inputting to encoder method, no functional change, but it is less confusing when seeing this test as reference on how the encode method for nlp is used