### PR TITLE
feat(flow): add visualize method to Flow class

### DIFF
--- a/extra-requirements.txt
+++ b/extra-requirements.txt
@@ -6,7 +6,7 @@
 #
 # AVAILABLE TAGS
 #
-# nlp, cv, audio, numeric, index, http, sse, framework, perf, network
+# nlp, cv, audio, numeric, index, http, sse, framework, perf, network, viz
 #
 # REMARKS ON TAGS
 # 1. Try to reuse the existing tags if possible.
@@ -51,3 +51,4 @@ grpcio:                     core
 ruamel.yaml>=0.15.89:       core
 tornado>=5.1.0:             core
 cookiecutter:               hub, devel
+graphviz:                   viz


### PR DESCRIPTION
## Description

The motivation for this PR is to able to visualize the Flow Object using the Flow API similar to the Graph being created in the Jina Dashboard.

The Graph would be a static representation of the underlying flow graph with Pods as nodes and the edges as the dependencies. I believe this could be helpful for understanding pods dependencies and possibly debugging & this could be further extended to custom Node attributes(shape, color) depending on the Executor it's inheriting from as well as the Pod status.

### Example

Let's consider the Flower Search Example from the Jina [Examples](https://github.com/jina-ai/examples/tree/master/flower-search) Repo:

#### Index Flow YAML Spec

![flow-viz](https://user-images.githubusercontent.com/45285388/90951324-87defb00-e477-11ea-9fc6-13dbb1a10710.png)


#### Index Flow Graphviz 

![flow-index-v1 gv](https://user-images.githubusercontent.com/45285388/90951357-cffe1d80-e477-11ea-8140-90b58c5596d6.png)


This Graphviz object will be rendered inline if called from an IPython notebook, otherwise, it will be rendered in a new window.  If a `filename` is provided, the object will not be rendered and instead saved to the location specified.

Ref: I had discovered this feature while evaluating [Prefect](https://docs.prefect.io/core/advanced_tutorials/visualization.html) Workflow Engine a few months back.
