### PR TITLE
fix: go back to old sorting

### DIFF
--- a/jina/executors/indexers/vector.py
+++ b/jina/executors/indexers/vector.py
@@ -210,7 +210,8 @@ class NumpyIndexer(BaseNumpyIndexer):
         elif self.metric == 'cosine':
             dist = _cosine(keys, self.query_handler)
 
-        idx = np.argpartition(dist, kth=top_k, axis=1)[:, :top_k]
+        # idx = np.argpartition(dist, kth=top_k, axis=1)[:, :top_k] # To be changed when Doc2DocRanker is available
+        idx = dist.argsort(axis=1)[:, :top_k]
         dist = np.take_along_axis(dist, idx, axis=1)
         return self.int2ext_key[idx], dist
 


### PR DESCRIPTION
**Changes introduced**
Until a new way of Ranking is introduced, for some cases as `faiss indexer` where a flat document structure is indexed and queried, we need to fully go back to sorting the elements by distance. 

Currently we cannot assume that a Ranker will do the sorting afterwards.

Linked to https://github.com/jina-ai/examples/pull/166