### PR TITLE
fix(readme): remove broken example

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,14 +269,6 @@ With [Cookiecutter](https://github.com/cookiecutter/cookiecutter) you can easily
 
 <tr>
 <td>
-<h4><a href="https://github.com/jina-ai/examples/tree/master/my-first-jina-app">My First Jina App</a></h4>
-Get started in your Jina journey by building a basic text search app and learning as you go
-</td>
-<td><h3>🐣</h3></td>
-</tr>
-
-<tr>
-<td>
 <h4><a href="https://docs.jina.ai/chapters/flow/index.html">Use Flow API to Compose Your Search Workflow</a></h4>
 Orchestrate Pods to work together: sequentially and in parallel; locally and remotely
 </td>


### PR DESCRIPTION
Removing broken example link for my-first-jina-app, since cookiecutter doesn't work with latest Jina version