### PR TITLE
fix(executor): add force register for easy debug

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -18,6 +18,9 @@ area/core:
 area/helper:
   - jina/*.py
 
+area/entrypoint:
+  - jina/__init__.py
+
 area/helloworld:
   - jina/helloworld/*
 
@@ -44,6 +47,9 @@ component/driver:
 
 component/executor:
   - jina/executors/**/*
+
+component/docker:
+  - jina/docker/**/*
 
 executor/meta:
   - jina/executors/*.py
@@ -78,3 +84,5 @@ component/proto:
 component/resource:
   - jina/resources/**/*
 
+component/hub:
+  - jina/hub/**/*

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -71,8 +71,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: true
       - name: Set up Docker Buildx
         id: buildx
         uses: crazy-max/ghaction-docker-buildx@v1

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,8 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: true
       - name: Set up Docker Buildx
         id: buildx
         uses: crazy-max/ghaction-docker-buildx@v1

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -66,8 +66,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: true
       - name: Set up Docker Buildx
         id: buildx
         uses: crazy-max/ghaction-docker-buildx@v1

--- a/jina/drivers/__init__.py
+++ b/jina/drivers/__init__.py
@@ -114,8 +114,7 @@ class DriverType(type):
     @staticmethod
     def register_class(cls):
         reg_cls_set = getattr(cls, '_registered_class', set())
-        if cls.__name__ not in reg_cls_set:
-            # print('reg class: %s' % cls.__name__)
+        if cls.__name__ not in reg_cls_set or getattr(cls, 'force_register', False):
             cls.__init__ = store_init_kwargs(cls.__init__)
 
             reg_cls_set.add(cls.__name__)

--- a/jina/enums.py
+++ b/jina/enums.py
@@ -47,9 +47,7 @@ class EnumType(EnumMeta):
     @staticmethod
     def register_class(cls):
         reg_cls_set = getattr(cls, '_registered_class', set())
-        if cls.__name__ not in reg_cls_set:
-            # print('reg class: %s' % cls.__name__)
-
+        if cls.__name__ not in reg_cls_set or getattr(cls, 'force_register', False):
             reg_cls_set.add(cls.__name__)
             setattr(cls, '_registered_class', reg_cls_set)
         from .helper import yaml

--- a/jina/executors/__init__.py
+++ b/jina/executors/__init__.py
@@ -70,8 +70,7 @@ class ExecutorType(type):
                     setattr(cls, f_name, wrapper(getattr(cls, f_name)))
 
         reg_cls_set = getattr(cls, '_registered_class', set())
-        if cls.__name__ not in reg_cls_set:
-            # print('reg class: %s' % cls.__name__)
+        if cls.__name__ not in reg_cls_set or getattr(cls, 'force_register', False):
             cls.__init__ = store_init_kwargs(cls.__init__)
             # if 'JINA_PROFILING' in os.environ:
             #     wrap_func(prof_funcs, profiling)

--- a/tests/unit/test_exectype.py
+++ b/tests/unit/test_exectype.py
@@ -1,0 +1,46 @@
+import pytest
+
+from jina.executors import BaseExecutor
+from jina.executors.indexers import BaseIndexer
+# BaseIndexer is already registered
+from jina.helper import yaml
+
+assert 'BaseIndexer' in BaseExecutor._registered_class
+
+# init from YAML should be okay as well
+BaseExecutor.load_config('BaseIndexer')
+
+BaseIndexer().save_config('tmp.yml')
+with open('tmp.yml') as fp:
+    s = yaml.load(fp)
+
+
+def assert_bi():
+    b = BaseIndexer(1)
+    b.save_config('tmp.yml')
+    with open('tmp.yml') as fp:
+        b = yaml.load(fp)
+        assert b.a == 1
+
+
+# we override BaseIndexer now, without force it shall not store all init values
+class BaseIndexer(BaseExecutor):
+
+    def __init__(self, a=0):
+        super().__init__()
+        self.a = a
+
+
+with pytest.raises(AssertionError):
+    assert_bi()
+
+
+class BaseIndexer(BaseExecutor):
+    force_register = True
+
+    def __init__(self, a=0):
+        super().__init__()
+        self.a = a
+
+
+assert_bi()


### PR DESCRIPTION
- do not include hub component when building docker
- add `force_register` to `BaseExecutor` and `BaseDriver` for easing debug