### PR TITLE
refactor: set ranker traverse_on to matches

### DIFF
--- a/jina/drivers/rank.py
+++ b/jina/drivers/rank.py
@@ -17,7 +17,7 @@ class BaseRankDriver(BaseExecutableDriver):
     """Drivers inherited from this Driver will bind :meth:`rank` by default """
 
     def __init__(self, executor: str = None, method: str = 'score', *args, **kwargs):
-        super().__init__(executor, method, *args, **kwargs)
+        super().__init__(executor, method, *args, traverse_on='matches', **kwargs)
         self._is_apply = False
 
 

--- a/tests/integration/level_depth/yaml/encoder.yml
+++ b/tests/integration/level_depth/yaml/encoder.yml
@@ -6,12 +6,10 @@ requests:
     IndexRequest:
       - !EncodeDriver
         with:
-          traverse_on: chunks
           recurring_range: [0, 1]
       - !LogInfoDriver {}
     SearchRequest:
       - !EncodeDriver
         with:
-          traverse_on: chunks
           recurring_range: [1, 1]
       - !LogInfoDriver {}

--- a/tests/integration/level_depth/yaml/index-chunk.yml
+++ b/tests/integration/level_depth/yaml/index-chunk.yml
@@ -23,20 +23,17 @@ requests:
       - !VectorIndexDriver
         with:
           executor: vecidx
-          traverse_on: chunks
           recurring_range: [1, 1]
       - !LogInfoDriver {}
       - !KVIndexDriver
         with:
           executor: chunkidx
-          traverse_on: chunks
           recurring_range: [1, 1]
     SearchRequest:
       - !VectorSearchDriver
         with:
           executor: vecidx
           top_k: 1
-          traverse_on: chunks
           recurring_range: [1, 1]
       - !LogInfoDriver {}
       - !KVSearchDriver

--- a/tests/unit/drivers/yaml/mockencoder-mode1.yml
+++ b/tests/unit/drivers/yaml/mockencoder-mode1.yml
@@ -5,10 +5,8 @@ requests:
       - !FilterQL
         with:
           lookups: {modality: mode1}
-          traverse_on: [chunks]
           recurring_range: [1, 2]
       - !EncodeDriver
         with:
           method: encode
-          traverse_on: [chunks]
           recurring_range: [1, 2]

--- a/tests/unit/drivers/yaml/mockencoder-mode2.yml
+++ b/tests/unit/drivers/yaml/mockencoder-mode2.yml
@@ -5,10 +5,8 @@ requests:
       - !FilterQL
         with:
           lookups: {modality: mode2}
-          traverse_on: [chunks]
           recurring_range: [1, 2]
       - !EncodeDriver
         with:
           method: encode
-          traverse_on: [chunks]
           recurring_range: [1, 2]

--- a/tests/unit/flow/yaml/mockencoder-mode1.yml
+++ b/tests/unit/flow/yaml/mockencoder-mode1.yml
@@ -5,10 +5,8 @@ requests:
       - !FilterQL
         with:
           lookups: {modality__in: [mode1]}
-          traverse_on: [chunks]
           recurring_range: [1, 2]
       - !EncodeDriver
         with:
           method: encode
-          traverse_on: [chunks]
           recurring_range: [1, 2]

--- a/tests/unit/flow/yaml/mockencoder-mode2.yml
+++ b/tests/unit/flow/yaml/mockencoder-mode2.yml
@@ -5,10 +5,8 @@ requests:
       - !FilterQL
         with:
           lookups: {modality__in: [mode2]}
-          traverse_on: [chunks]
           recurring_range: [1, 2]
       - !EncodeDriver
         with:
           method: encode
-          traverse_on: [chunks]
           recurring_range: [1, 2]

--- a/tests/unit/flow/yaml/numpy-indexer-1.yml
+++ b/tests/unit/flow/yaml/numpy-indexer-1.yml
@@ -20,7 +20,6 @@ requests:
       - !VectorIndexDriver
         with:
           recurring_range: [1, 2]
-          traverse_on: [chunks]
           executor: vecidx1
       - !ExcludeQL
         with:

--- a/tests/unit/flow/yaml/numpy-indexer-2.yml
+++ b/tests/unit/flow/yaml/numpy-indexer-2.yml
@@ -20,7 +20,6 @@ requests:
       - !VectorIndexDriver
         with:
           recurring_range: [1, 2]
-          traverse_on: [chunks]
           executor: vecidx2
       - !ExcludeQL
         with:


### PR DESCRIPTION
This PR is about simplifying `traverse_on`:

- `BaseExecutableDriver`'s `traverse_on=chunks`. `BaseRankDriver`'s `traverse_on=matches`