### PR TITLE
fix: move pea closing from run loop to close as context manager

### DIFF
--- a/jina/peapods/container.py
+++ b/jina/peapods/container.py
@@ -92,7 +92,7 @@ class ContainerPea(BasePea):
         except docker.errors.NotFound:
             self.logger.error('the container can not be started, check your arguments, entrypoint')
 
-    def loop_teardown(self):
+    def teardown(self):
         """Stop the container """
         if getattr(self, '_container', None):
             import docker

--- a/jina/peapods/pea.py
+++ b/jina/peapods/pea.py
@@ -364,12 +364,14 @@ class BasePea(metaclass=PeaMeta):
 
     def close(self) -> None:
         """Gracefully close this pea and release all resources """
-        if self.is_ready.is_set() and hasattr(self, 'ctrl_addr'):
-            send_ctrl_message(self.ctrl_addr, jina_pb2.Request.ControlRequest.TERMINATE,
-                              timeout=self.args.timeout_ctrl)
+
         self.teardown()
-        self.unset_ready()
         self.is_shutdown.set()
+        if self.is_ready.is_set():
+            self.unset_ready()
+            if hasattr(self, 'ctrl_addr'):
+                send_ctrl_message(self.ctrl_addr, jina_pb2.Request.ControlRequest.TERMINATE,
+                                  timeout=self.args.timeout_ctrl)
 
     @property
     def status(self):


### PR DESCRIPTION
**Changes introduced**
Related to #873 and #867 

Right now the closing of the `Pea` is handled inside the `run` loop inside `finally`.

But when Flow is done sending messages, it tries to close its Pods as context manager, and each Pod tries to close its Peas as a context manager.

This can happen while Pea is tearing down itself and closing its files.

Therefore, I propose to move the logic of closing the Pea context and its files and binaries inside the close and __exit__ logic in a  more robust way.

**TODO** (QUESTIONS AND DOUBTS)

- [ ] When the Flow calls exit, and before closing the Pea, we need to ensure that it has handled all the messages or just the last one? Response: I think this is not an issue since Flow waits to have response to start closing everything