### PR TITLE
feat: added Matches2DocRankDriver

### DIFF
--- a/jina/drivers/rank.py
+++ b/jina/drivers/rank.py
@@ -187,12 +187,11 @@ class Matches2DocRankDriver(BaseRankDriver):
 
     def _sort_matches_in_place(self, context_doc, match_scores):
         sorted_scores = self._sort(match_scores)
-
+        old_matches = {match.id: match for match in context_doc.matches}
         context_doc.ClearField('matches')
         for match_id, score in sorted_scores:
             new_match = context_doc.matches.add()
-            new_match.id = int(match_id)
-            new_match.score.ref_id = context_doc.id
+            new_match.CopyFrom(old_matches[match_id])
             new_match.score.value = score
             new_match.score.op_name = exec.__class__.__name__
 

--- a/jina/drivers/rank.py
+++ b/jina/drivers/rank.py
@@ -157,10 +157,10 @@ class Matches2DocRankDriver(BaseRankDriver):
     Input-Output ::
         Input:
         document: {granularity: 0, adjacency: k}
-            |- matches: {granularity: 0, adjacency: k-1}
+            |- matches: {granularity: 0, adjacency: k+1}
         Output:
         document: {granularity: 0, adjacency: k}
-            |- matches: {granularity: 0, adjacency: k-1} (Sorted according to scores from Ranker Executor)
+            |- matches: {granularity: 0, adjacency: k+1} (Sorted according to scores from Ranker Executor)
     """
 
     def __init__(self, reverse=False, *args, **kwargs):

--- a/jina/drivers/rank.py
+++ b/jina/drivers/rank.py
@@ -174,17 +174,15 @@ class Matches2DocRankDriver(BaseRankDriver):
         # if at the top-level already, no need to aggregate further
         if context_doc is None:
             return
-
         query_meta = pb_obj2dict(context_doc, self.exec.required_keys)
-        old_match_scores = {match.id: match.score.value for match in docs}
-        match_meta = {pb_obj2dict(match, self.exec.required_keys) for match in docs}
 
+        old_match_scores = {match.id: match.score.value for match in docs}
+        match_meta = {match.id: pb_obj2dict(match, self.exec.required_keys) for match in docs}
         # if there are no matches, no need to sort them
         if not old_match_scores:
             return
 
         new_match_scores = self.exec.score(query_meta, old_match_scores, match_meta)
-
         self._sort_matches_in_place(context_doc, new_match_scores)
 
     def _sort_matches_in_place(self, context_doc, match_scores):
@@ -194,9 +192,9 @@ class Matches2DocRankDriver(BaseRankDriver):
         for match_id, score in sorted_scores:
             new_match = context_doc.matches.add()
             new_match.id = int(match_id)
-            new_match.ref_id = context_doc.id
-            new_match.value = score
-            new_match.op_name = exec.__class__.__name__
+            new_match.score.ref_id = context_doc.id
+            new_match.score.value = score
+            new_match.score.op_name = exec.__class__.__name__
 
     def _sort(self, docs_scores: 'np.ndarray'):
         return docs_scores[docs_scores[:, -1].argsort()[::-1]]

--- a/jina/executors/rankers/__init__.py
+++ b/jina/executors/rankers/__init__.py
@@ -97,12 +97,25 @@ class Chunk2DocRanker(BaseRanker):
 
 
 class Match2DocRanker(BaseRanker):
-    """ TODO: proper doc-string. possible concrete implementations:
-
-        - IdentityRanker
-        - ReverseRanker
-        - BucketShuffleRanker
+    """
+    Re-scores the matches for a document. This Ranker is only responsible for
+    calculating new scores and not for the actual sorting. The sorting is handled
+    in the respective ``Matches2DocRankDriver``.
+    Possible implementations:
+        - ReverseRanker (reverse scores of all matches)
+        - BucketShuffleRanker (first buckets matches and then sort each bucket)
     """
 
     def score(self, query_meta: Dict, old_match_scores: Dict, match_meta: Dict) -> 'np.ndarray':
+        """
+        This function calculated the new scores for matches and returns them.
+        :query_meta: a dictionary containing all the query meta information
+            requested by the `required_keys` class_variable.
+        :old_match_scores: contains old scores in the format {match_id: score}
+        :match_meta: a dictionary containing all the matches meta information
+            requested by the `required_keys` class_variable.
+            Format: {match_id: {attribute: attribute_value}}e.g.{5: {"length": 3}}
+        :return: a `np.ndarray` in the shape of [N x 2] where `N` is the length of
+            the `old_match_scores`. Semantic: [[match_id, new_score]]
+        """
         raise NotImplementedError

--- a/jina/executors/rankers/__init__.py
+++ b/jina/executors/rankers/__init__.py
@@ -1,7 +1,7 @@
 __copyright__ = "Copyright (c) 2020 Jina AI Limited. All rights reserved."
 __license__ = "Apache-2.0"
 
-from typing import Dict
+from typing import Dict, List
 
 import numpy as np
 
@@ -94,3 +94,15 @@ class Chunk2DocRanker(BaseRanker):
 
     def get_doc_id(self, match_with_same_doc_id):
         return match_with_same_doc_id[0, self.col_doc_id]
+
+
+class Match2DocRanker(BaseRanker):
+    """ TODO: proper doc-string. possible concrete implementations:
+
+        - IdentityRanker
+        - ReverseRanker
+        - BucketShuffleRanker
+    """
+
+    def score(self, query_meta: Dict, old_match_scores: Dict, match_meta: Dict) -> 'np.ndarray':
+        raise NotImplementedError

--- a/tests/unit/drivers/test_matches2doc_rank_drivers.py
+++ b/tests/unit/drivers/test_matches2doc_rank_drivers.py
@@ -1,0 +1,67 @@
+import numpy as np
+
+from jina.drivers.rank import Matches2DocRankDriver
+from jina.executors.rankers import Chunk2DocRanker
+
+from jina.proto import jina_pb2
+
+
+class MockAbsoluteLengthRanker(Chunk2DocRanker):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.required_keys = {'length'}
+
+    def score(self, query_meta, old_match_scores, match_meta):
+        new_scores = [
+            (match_id, - abs(match_meta[match_id]['length'] - query_meta['length']))
+            for match_id, old_score in old_match_scores.items()
+        ]
+        return np.array(new_scores, dtype=np.float64)
+
+class SimpleMatches2DocRankDriver(Matches2DocRankDriver):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    @property
+    def exec_fn(self):
+        return self._exec_fn
+
+
+def create_document_to_score():
+    # doc: 1
+    # |- matches: (id: 2, parent_id: 1, score.value: 2),
+    # |- matches: (id: 3, parent_id: 1, score.value: 3),
+    # |- matches: (id: 4, parent_id: 1, score.value: 4),
+    # |- matches: (id: 5, parent_id: 1, score.value: 5),
+
+    doc = jina_pb2.Document()
+    doc.id = 1
+    doc.length = 5
+    for match_id, match_score in [(2, 3), (3, 6), (4, 1), (5, 8)]:
+        match = doc.matches.add()
+        match.id = match_id
+        match.parent_id = 1
+        match.length = match_score
+        match.score.ref_id = doc.id
+        match.score.value = match_score
+    return doc
+
+
+def test_chunk2doc_ranker_driver_mock_exec():
+    doc = create_document_to_score()
+    driver = SimpleMatches2DocRankDriver()
+    executor = MockAbsoluteLengthRanker()
+    driver.attach(executor=executor, pea=None)
+    driver._apply_all(doc.matches, doc)
+    assert len(doc.matches) == 4
+    assert doc.matches[0].id == 3
+    assert doc.matches[0].score.value == -1
+    assert doc.matches[1].id == 2
+    assert doc.matches[1].score.value == -2
+    assert doc.matches[2].id == 5
+    assert doc.matches[2].score.value == -3
+    assert doc.matches[3].id == 4
+    assert doc.matches[3].score.value == -4
+    for match in doc.matches:
+        assert match.score.ref_id == doc.id

--- a/tests/unit/drivers/test_matches2doc_rank_drivers.py
+++ b/tests/unit/drivers/test_matches2doc_rank_drivers.py
@@ -1,12 +1,12 @@
 import numpy as np
 
 from jina.drivers.rank import Matches2DocRankDriver
-from jina.executors.rankers import Chunk2DocRanker
+from jina.executors.rankers import Match2DocRanker
 
 from jina.proto import jina_pb2
 
 
-class MockAbsoluteLengthRanker(Chunk2DocRanker):
+class MockAbsoluteLengthRanker(Match2DocRanker):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.required_keys = {'length'}


### PR DESCRIPTION
This is a suggested implementation for #891. Missing:

- [x]  tests for the `Matches2DocRankDriver`
- [x]  concrete demo-implementations for the `Match2DocRanker`

Open questions: 

- Rename `Match2DocRanker` to `Match2DocScorer`, since effectively only scores are provided?
- Fix allowed adjacency depth to 0, meaning only the direct matches of a document are re-scored?
- Any obvious design error when thinking about the neural search use case?

Thanks a lot for your feedback already!