### PR TITLE
fix(api): change uses to yaml_path

### DIFF
--- a/jina/main/api.py
+++ b/jina/main/api.py
@@ -80,7 +80,7 @@ def flow(args):
     """Start a Flow from a YAML file or a docker image"""
     from ..flow import Flow
     if args.yaml_path:
-        f = Flow.load_config(args.uses)
+        f = Flow.load_config(args.yaml_path)
         f._update_args(args)
         with f:
             f.block()


### PR DESCRIPTION
A follow-up on commit a53185d5bb20d84b26dd5fd6b01e61f8b9b33c6d which forgets to change `uses` to `yaml_path` in one place.