### PR TITLE
[Discussion enabler] fix: remove vecs after bulding advanced index

### DIFF
--- a/jina/executors/indexers/vector.py
+++ b/jina/executors/indexers/vector.py
@@ -90,7 +90,9 @@ class BaseNumpyIndexer(BaseVectorIndexer):
         """
         vecs = self.raw_ndarray
         if vecs is not None:
-            return self.build_advanced_index(vecs)
+            index = self.build_advanced_index(vecs)
+            del vecs
+            return index
         else:
             return None
 


### PR DESCRIPTION
Would this help mitigate the memory problem that is needed for more advanced indexers? 

I know Python is not the best programming language to handle this things, but when loading an indexer such as FaissIndexer or AnnoyIndexer, are we having at the same time the `np.array of the complete index in memory` together with the complex index object created by the library in use?