### PR TITLE
Bookkeeping for jina hub push flows

### DIFF
--- a/extra-requirements.txt
+++ b/extra-requirements.txt
@@ -58,4 +58,4 @@ pytest-timeout:             test
 pytest-cov:                 test
 flaky:                      test
 mock:                       test
-pymongo[srv]:               hub
+pymongo[srv]:               hub, devel

--- a/extra-requirements.txt
+++ b/extra-requirements.txt
@@ -58,3 +58,4 @@ pytest-timeout:             test
 pytest-cov:                 test
 flaky:                      test
 mock:                       test
+pymongo[srv]:               hub

--- a/jina/docker/checker.py
+++ b/jina/docker/checker.py
@@ -5,6 +5,7 @@ import os
 import re
 import unicodedata
 
+import tempfile
 from pkg_resources import resource_stream
 
 from ..helper import yaml
@@ -74,6 +75,9 @@ def get_exist_path(directory, s):
     r = os.path.join(directory, s)
     if os.path.exists(r):
         return r
+
+def get_summary_path(image_name: str):
+    return os.path.join(tempfile.gettempdir(), image_name.replace('/', '_'), 'summary.json')
 
 
 def is_error_message(s):

--- a/jina/docker/checker.py
+++ b/jina/docker/checker.py
@@ -81,9 +81,8 @@ def is_error_message(s):
 
 def db_env_variables_set():
     """ Checks if any of the db env variables are not set """
-    none_exists = None in [
-        os.environ.get('db_username', None), os.environ.get('db_password', None),
-        os.environ.get('db_hostname', None), os.environ.get('db_name', None),
-        os.environ.get('db_collection', None)
-    ]
-    return not none_exists
+    keys = ['JINA_DB_HOSTNAME', 'JINA_DB_USERNAME', 'JINA_DB_PASSWORD', 'JINA_DB_NAME', 'JINA_DB_COLLECTION']
+    for k in keys:
+        if k not in os.environ:
+            return False
+    return True

--- a/jina/docker/checker.py
+++ b/jina/docker/checker.py
@@ -77,7 +77,7 @@ def get_exist_path(directory, s):
         return r
 
 def get_summary_path(image_name: str):
-    return os.path.join(tempfile.gettempdir(), image_name.replace('/', '_'), 'summary.json')
+    return os.path.join(tempfile.gettempdir(), image_name.replace('/', '_') + '_summary.json')
 
 
 def is_error_message(s):

--- a/jina/docker/checker.py
+++ b/jina/docker/checker.py
@@ -77,3 +77,13 @@ def get_exist_path(directory, s):
 
 def is_error_message(s):
     return re.search(excepts_regex, s, re.IGNORECASE | re.UNICODE) is not None
+
+
+def db_env_variables_set():
+    """ Checks if any of the db env variables are not set """
+    none_exists = None in [
+        os.environ.get('db_username', None), os.environ.get('db_password', None),
+        os.environ.get('db_hostname', None), os.environ.get('db_name', None),
+        os.environ.get('db_collection', None)
+    ]
+    return not none_exists

--- a/jina/docker/checker.py
+++ b/jina/docker/checker.py
@@ -5,8 +5,9 @@ import os
 import re
 import unicodedata
 
-from ..helper import yaml
 from pkg_resources import resource_stream
+
+from ..helper import yaml
 
 image_tag_regex = r'^hub.[a-zA-Z_$][a-zA-Z_\s\-\.$0-9]*$'
 required = {'name', 'description'}
@@ -79,10 +80,7 @@ def is_error_message(s):
     return re.search(excepts_regex, s, re.IGNORECASE | re.UNICODE) is not None
 
 
-def db_env_variables_set():
+def is_db_envs_set():
     """ Checks if any of the db env variables are not set """
     keys = ['JINA_DB_HOSTNAME', 'JINA_DB_USERNAME', 'JINA_DB_PASSWORD', 'JINA_DB_NAME', 'JINA_DB_COLLECTION']
-    for k in keys:
-        if k not in os.environ:
-            return False
-    return True
+    return all(k in os.environ for k in keys)

--- a/jina/docker/database.py
+++ b/jina/docker/database.py
@@ -9,7 +9,7 @@ class MongoDBHandler:
     """
     Mongodb Handler to connect to the database & insert documents in the collection
     """
-    def __init__(self, hostname: str, username: int, password: str,
+    def __init__(self, hostname: str, username: str, password: str,
                  database_name: str, collection_name: str):
         self.logger = get_logger(self.__class__.__name__)
         self.hostname = hostname

--- a/jina/docker/database.py
+++ b/jina/docker/database.py
@@ -1,0 +1,56 @@
+
+import pymongo
+
+from ..excepts import MongoDBException
+from ..logging import get_logger
+
+
+class MongoDBHandler():
+    """
+    Mongodb Handler to connect to the database & insert documents in the collection
+    """
+    def __init__(self, hostname: str, username: int, password: str,
+                 database_name: str, collection_name: str):
+        self.logger = get_logger(self.__class__.__name__)
+        self.hostname = hostname
+        self.username = username
+        self.password = password
+        self.database_name = database_name
+        self.collection_name = collection_name
+        self.connection_string = \
+            f'mongodb+srv://{self.username}:{self.password}@{self.hostname}'
+        
+    def __enter__(self):
+        return self.connect()
+    
+    def connect(self):
+        try:
+            self.client = pymongo.MongoClient(self.connection_string)
+            self.client.admin.command('ismaster')
+            self.logger.info('Successfully connected to the database')
+        except pymongo.errors.ConnectionFailure:
+            raise MongoDBException("Database server is not available")
+        except pymongo.errors.ConfigurationError:
+            raise MongoDBException("Credentials passed are not correct!")
+        except pymongo.errors.PyMongoError as exp:
+            raise MongoDBException(exp)
+        return self
+        
+    @property
+    def database(self):
+        return self.client[self.database_name]
+    
+    @property
+    def collection(self):
+        return self.database[self.collection_name]
+    
+    def insert(self, document: str):
+        result = self.collection.insert_one(document)
+        self.logger.info(f'Pushed current summary to the database')
+        return result.inserted_id
+    
+    def __exit__(self,  exc_type, exc_val, exc_tb):
+        try:
+            self.client.close()
+        except pymongo.errors.PyMongoError as exp:
+            raise MongoDBException(exp)

--- a/jina/docker/database.py
+++ b/jina/docker/database.py
@@ -5,7 +5,7 @@ from ..excepts import MongoDBException
 from ..logging import get_logger
 
 
-class MongoDBHandler():
+class MongoDBHandler:
     """
     Mongodb Handler to connect to the database & insert documents in the collection
     """
@@ -29,9 +29,9 @@ class MongoDBHandler():
             self.client.admin.command('ismaster')
             self.logger.info('Successfully connected to the database')
         except pymongo.errors.ConnectionFailure:
-            raise MongoDBException("Database server is not available")
+            raise MongoDBException('Database server is not available')
         except pymongo.errors.ConfigurationError:
-            raise MongoDBException("Credentials passed are not correct!")
+            raise MongoDBException('Credentials passed are not correct!')
         except pymongo.errors.PyMongoError as exp:
             raise MongoDBException(exp)
         return self

--- a/jina/docker/helper.py
+++ b/jina/docker/helper.py
@@ -34,3 +34,14 @@ def get_default_login():
             login_info[k] = _decode(v)
 
     return login_info
+
+
+def handle_dot_in_keys(document):
+    updated_document = {}
+    for key, value in document.items():
+        if isinstance(value, dict):
+            value = handle_dot_in_keys(value)
+        if isinstance(value, list) and len(value) > 0 and isinstance(value[0], dict):
+            value[0] = handle_dot_in_keys(value[0])
+        updated_document[key.replace('.', '_')] = value
+    return updated_document

--- a/jina/docker/hubio.py
+++ b/jina/docker/hubio.py
@@ -313,11 +313,11 @@ class HubIO:
             return
     
         build_summary = handle_dot_in_keys(document=summary)
-        with MongoDBHandler(hostname=os.environ['db_hostname'], 
-                            username=os.environ['db_username'],
-                            password=os.environ['db_password'],
-                            database_name=os.environ['db_name'],
-                            collection_name=os.environ['db_collection']) as db:
+        with MongoDBHandler(hostname=os.environ['JINA_DB_HOSTNAME'], 
+                            username=os.environ['JINA_DB_USERNAME'],
+                            password=os.environ['JINA_DB_PASSWORD'],
+                            database_name=os.environ['JINA_DB_NAME'],
+                            collection_name=os.environ['JINA_DB_COLLECTION']) as db:
             inserted_id = db.insert(document=build_summary)
             self.logger.debug(f'Inserted the build + push summary in db with id {inserted_id}')
             

--- a/jina/docker/hubio.py
+++ b/jina/docker/hubio.py
@@ -3,7 +3,6 @@ __license__ = "Apache-2.0"
 
 import glob
 import json
-import tempfile
 import urllib.parse
 import webbrowser
 from typing import Dict
@@ -84,7 +83,7 @@ class HubIO:
         except:
             self.logger.error(f'can not push to the registry')
 
-        file_path = self._get_summary_path(name)
+        file_path = get_summary_path(name)
         if os.path.isfile(file_path):
             with open(file_path) as f:
                 result = json.load(f)
@@ -308,7 +307,7 @@ class HubIO:
 
     def _write_summary_to_db(self, summary):
         if not is_db_envs_set():
-            self.logger.critical(f'DB environment variables are not set! bookkeeping skipped.')
+            self.logger.error('DB environment variables are not set! bookkeeping skipped.')
             return
 
         build_summary = handle_dot_in_keys(document=summary)
@@ -320,14 +319,11 @@ class HubIO:
             inserted_id = db.insert(document=build_summary)
             self.logger.debug(f'Inserted the build + push summary in db with id {inserted_id}')
 
-    def _get_summary_path(self, image_name: str):
-        return os.path.join(tempfile.gettempdir(), image_name.replace('/', '_'), 'summary.json')
-
     def _write_summary_to_file(self, summary: Dict):
-        file_path = self._get_summary_path(summary['name'])
+        file_path = get_summary_path(summary['name'])
         with open(file_path, 'w+') as f:
             json.dump(summary, f)
-        self.logger.debug(f'Stored the summary from build in local disk')
+        self.logger.debug(f'stored the summary from build to {file_path}')
 
     def _check_completeness(self) -> Dict:
         self.dockerfile_path = get_exist_path(self.args.path, 'Dockerfile')

--- a/jina/docker/hubio.py
+++ b/jina/docker/hubio.py
@@ -77,7 +77,7 @@ class HubIO:
         """ A wrapper of docker push """
         is_build_success, is_push_success = True, False
         try:
-            # self._push(name, readme_path)
+            self._push(name, readme_path)
             is_push_success = True
         except Exception:
             self.logger.error(f'can not push to the registry')
@@ -295,8 +295,8 @@ class HubIO:
             self._write_summary_to_db(summary=result)
         elif result['is_build_success']:
             self._write_summary_to_file(summary=result)
-        else:
-            return result
+        
+        return result
 
     def dry_run(self) -> Dict:
         try:

--- a/jina/excepts.py
+++ b/jina/excepts.py
@@ -98,3 +98,7 @@ class GatewayPartialMessage(Exception):
 
 class UndefinedModel(Exception):
     """Any time a non-defined model is tried to be used """
+
+
+class MongoDBException(Exception):
+    """ Any errors raised by MongoDb """


### PR DESCRIPTION
- Enabled `jina hub build --push` & `jina hub push` flows to update summaries to Mongodb Atlas.
- Currently reads the database credentials from `os.environ`
- Uses the following env variables 
  - db_username
  - db_password
  - db_hostname
  - db_name
  - db_collection

Doing `jina hub build` - builds the docker & writes the summary json to a local file.

Doing `jina hub push` - pushed the docker to docker hub. Tries reading the json from local disk. If unable, builds its summary (without build data). writes the summary to mongo collection.

Doing `jina hub build --push` - builds the docker, pushes it to docker hub, writes the summary from build to mongo collection.

Pending - 
- Enable hub-builder to push the image too
- Enable CD in jina-hub via updated hub-builder
- Unit tests for DB related modules