### PR TITLE
feat: add capacity to lookup and use querylang with tags in protobuf …

### DIFF
--- a/jina/drivers/querylang/queryset/dunderkey.py
+++ b/jina/drivers/querylang/queryset/dunderkey.py
@@ -32,7 +32,9 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ## This module deals with code regarding handling the double
 ## underscore separated keys
-from typing import Tuple, Union
+from typing import Tuple
+from google.protobuf.struct_pb2 import Struct
+from google.protobuf import json_format
 
 from .helper import *
 
@@ -109,6 +111,10 @@ def dunder_get(_dict, key):
     :rtype       : (mixed) value corresponding to the key
 
     """
+
+    if isinstance(_dict, Struct):
+        return dunder_get(json_format.MessageToDict(_dict), key)
+
     parts = key.split('__', 1)
 
     try:
@@ -118,6 +124,8 @@ def dunder_get(_dict, key):
 
     if isinstance(parts[0], int):
         result = guard_iter(_dict)[parts[0]]
+    elif isinstance(_dict, dict):
+        result = _dict[parts[0]]
     else:
         result = getattr(_dict, parts[0])
     return result if len(parts) == 1 else dunder_get(result, parts[1])

--- a/tests/unit/drivers/querylang/queryset/test_lookup.py
+++ b/tests/unit/drivers/querylang/queryset/test_lookup.py
@@ -1,142 +1,175 @@
 from jina.drivers.querylang.queryset.lookup import LookupLeaf
-from tests import JinaTestCase
+from jina.proto import jina_pb2
 
 
-class LookupTestCase(JinaTestCase):
+class MockId:
+    def __init__(self, identity):
+        self.id = identity
 
-    class MockId:
-        def __init__(self, identity):
-            self.id = identity
 
-    class MockStr:
-        def __init__(self, string):
-            self.str = string
+class MockStr:
+    def __init__(self, string):
+        self.str = string
 
-    class MockIter:
-        def __init__(self, iterable):
-            self.iter = iterable
 
-    def test_lookup_leaf_exact(self):
-        leaf = LookupLeaf(id__exact=1)
-        mock1 = LookupTestCase.MockId(1)
-        self.assertTrue(leaf.evaluate(mock1))
-        mock2 = LookupTestCase.MockId(2)
-        self.assertFalse(leaf.evaluate(mock2))
+class MockIter:
+    def __init__(self, iterable):
+        self.iter = iterable
 
-    def test_lookup_leaf_neq(self):
-        leaf = LookupLeaf(id__neq=1)
-        mock1 = LookupTestCase.MockId(1)
-        self.assertFalse(leaf.evaluate(mock1))
-        mock2 = LookupTestCase.MockId(2)
-        self.assertTrue(leaf.evaluate(mock2))
 
-    def test_lookup_leaf_gt(self):
-        leaf = LookupLeaf(id__gt=1)
-        mock0 = LookupTestCase.MockId(0)
-        self.assertFalse(leaf.evaluate(mock0))
-        mock1 = LookupTestCase.MockId(1)
-        self.assertFalse(leaf.evaluate(mock1))
-        mock2 = LookupTestCase.MockId(2)
-        self.assertTrue(leaf.evaluate(mock2))
+def test_lookup_leaf_exact():
+    leaf = LookupLeaf(id__exact=1)
+    mock1 = MockId(1)
+    assert leaf.evaluate(mock1)
+    mock2 = MockId(2)
+    assert not leaf.evaluate(mock2)
 
-    def test_lookup_leaf_gte(self):
-        leaf = LookupLeaf(id__gte=1)
-        mock0 = LookupTestCase.MockId(0)
-        self.assertFalse(leaf.evaluate(mock0))
-        mock1 = LookupTestCase.MockId(1)
-        self.assertTrue(leaf.evaluate(mock1))
-        mock2 = LookupTestCase.MockId(2)
-        self.assertTrue(leaf.evaluate(mock2))
 
-    def test_lookup_leaf_lt(self):
-        leaf = LookupLeaf(id__lt=1)
-        mock0 = LookupTestCase.MockId(0)
-        self.assertTrue(leaf.evaluate(mock0))
-        mock1 = LookupTestCase.MockId(1)
-        self.assertFalse(leaf.evaluate(mock1))
-        mock2 = LookupTestCase.MockId(2)
-        self.assertFalse(leaf.evaluate(mock2))
+def test_lookup_leaf_exact_document_tags():
+    doc = jina_pb2.Document()
+    doc.tags.update({'label': 'jina'})
+    leaf = LookupLeaf(tags__label='jina')
+    assert leaf.evaluate(doc)
+    leaf = LookupLeaf(tags__label='not_jina')
+    assert not leaf.evaluate(doc)
 
-    def test_lookup_leaf_lte(self):
-        leaf = LookupLeaf(id__lte=1)
-        mock0 = LookupTestCase.MockId(0)
-        self.assertTrue(leaf.evaluate(mock0))
-        mock1 = LookupTestCase.MockId(1)
-        self.assertTrue(leaf.evaluate(mock1))
-        mock2 = LookupTestCase.MockId(2)
-        self.assertFalse(leaf.evaluate(mock2))
 
-    def test_lookup_leaf_contains(self):
-        leaf = LookupLeaf(str__contains='jina')
-        mock0 = LookupTestCase.MockStr('hey jina how are you')
-        self.assertTrue(leaf.evaluate(mock0))
-        mock1 = LookupTestCase.MockStr('not here')
-        self.assertFalse(leaf.evaluate(mock1))
-        mock2 = LookupTestCase.MockStr('hey jInA how are you')
-        self.assertFalse(leaf.evaluate(mock2))
+def test_lookup_leaf_exact_document_tags_complex():
+    doc = jina_pb2.Document()
+    doc.tags.update({'key1': {'key2': 'jina'}})
+    leaf = LookupLeaf(tags__key1__key2='jina')
+    assert leaf.evaluate(doc)
+    leaf = LookupLeaf(tags__key1__key2='not_jina')
+    assert not leaf.evaluate(doc)
 
-    def test_lookup_leaf_icontains(self):
-        leaf = LookupLeaf(str__icontains='jina')
-        mock0 = LookupTestCase.MockStr('hey jInA how are you')
-        self.assertTrue(leaf.evaluate(mock0))
-        mock1 = LookupTestCase.MockStr('not here')
-        self.assertFalse(leaf.evaluate(mock1))
 
-    def test_lookup_leaf_startswith(self):
-        leaf = LookupLeaf(str__startswith='jina')
-        mock0 = LookupTestCase.MockStr('jina is the neural search solution')
-        self.assertTrue(leaf.evaluate(mock0))
-        mock1 = LookupTestCase.MockStr('hey, jina is the neural search solution')
-        self.assertFalse(leaf.evaluate(mock1))
-        mock2 = LookupTestCase.MockStr('JiNa is the neural search solution')
-        self.assertFalse(leaf.evaluate(mock2))
+def test_lookup_leaf_neq():
+    leaf = LookupLeaf(id__neq=1)
+    mock1 = MockId(1)
+    assert not leaf.evaluate(mock1)
+    mock2 = MockId(2)
+    assert leaf.evaluate(mock2)
 
-    def test_lookup_leaf_istartswith(self):
-        leaf = LookupLeaf(str__istartswith='jina')
-        mock0 = LookupTestCase.MockStr('jina is the neural search solution')
-        self.assertTrue(leaf.evaluate(mock0))
-        mock1 = LookupTestCase.MockStr('hey, jina is the neural search solution')
-        self.assertFalse(leaf.evaluate(mock1))
-        mock2 = LookupTestCase.MockStr('JiNa is the neural search solution')
-        self.assertTrue(leaf.evaluate(mock2))
 
-    def test_lookup_leaf_endswith(self):
-        leaf = LookupLeaf(str__endswith='jina')
-        mock0 = LookupTestCase.MockStr('how is jina')
-        self.assertTrue(leaf.evaluate(mock0))
-        mock1 = LookupTestCase.MockStr('hey, jina is the neural search solution')
-        self.assertFalse(leaf.evaluate(mock1))
-        mock2 = LookupTestCase.MockStr('how is JiNa')
-        self.assertFalse(leaf.evaluate(mock2))
+def test_lookup_leaf_gt():
+    leaf = LookupLeaf(id__gt=1)
+    mock0 = MockId(0)
+    assert not leaf.evaluate(mock0)
+    mock1 = MockId(1)
+    assert not leaf.evaluate(mock1)
+    mock2 = MockId(2)
+    assert leaf.evaluate(mock2)
 
-    def test_lookup_leaf_iendswith(self):
-        leaf = LookupLeaf(str__iendswith='jina')
-        mock0 = LookupTestCase.MockStr('how is jina')
-        self.assertTrue(leaf.evaluate(mock0))
-        mock1 = LookupTestCase.MockStr('hey, jina is the neural search solution')
-        self.assertFalse(leaf.evaluate(mock1))
-        mock2 = LookupTestCase.MockStr('how is JiNa')
-        self.assertTrue(leaf.evaluate(mock2))
 
-    def test_lookup_leaf_regex(self):
-        leaf = LookupLeaf(str__regex='j*na')
-        mock0 = LookupTestCase.MockStr('hey, juna is good')
-        self.assertTrue(leaf.evaluate(mock0))
-        mock1 = LookupTestCase.MockStr('hey, Oinja is the neural search solution')
-        self.assertFalse(leaf.evaluate(mock1))
-        mock2 = LookupTestCase.MockStr('how is JiNa')
-        self.assertFalse(leaf.evaluate(mock2))
+def test_lookup_leaf_gte():
+    leaf = LookupLeaf(id__gte=1)
+    mock0 = MockId(0)
+    assert not leaf.evaluate(mock0)
+    mock1 = MockId(1)
+    assert leaf.evaluate(mock1)
+    mock2 = MockId(2)
+    assert leaf.evaluate(mock2)
 
-    def test_lookup_leaf_in(self):
-        leaf = LookupLeaf(id__in=[0, 1, 2, 3])
-        mock0 = LookupTestCase.MockId(3)
-        self.assertTrue(leaf.evaluate(mock0))
-        mock1 = LookupTestCase.MockId(4)
-        self.assertFalse(leaf.evaluate(mock1))
 
-    def test_lookup_leaf_None(self):
-        leaf = LookupLeaf(id=3)
-        mock0 = LookupTestCase.MockId(3)
-        self.assertTrue(leaf.evaluate(mock0))
-        mock1 = LookupTestCase.MockId(4)
-        self.assertFalse(leaf.evaluate(mock1))
+def test_lookup_leaf_lt():
+    leaf = LookupLeaf(id__lt=1)
+    mock0 = MockId(0)
+    assert leaf.evaluate(mock0)
+    mock1 = MockId(1)
+    assert not leaf.evaluate(mock1)
+    mock2 = MockId(2)
+    assert not leaf.evaluate(mock2)
+
+
+def test_lookup_leaf_lte():
+    leaf = LookupLeaf(id__lte=1)
+    mock0 = MockId(0)
+    assert leaf.evaluate(mock0)
+    mock1 = MockId(1)
+    assert leaf.evaluate(mock1)
+    mock2 = MockId(2)
+    assert not leaf.evaluate(mock2)
+
+
+def test_lookup_leaf_contains():
+    leaf = LookupLeaf(str__contains='jina')
+    mock0 = MockStr('hey jina how are you')
+    assert leaf.evaluate(mock0)
+    mock1 = MockStr('not here')
+    assert not leaf.evaluate(mock1)
+    mock2 = MockStr('hey jInA how are you')
+    assert not leaf.evaluate(mock2)
+
+
+def test_lookup_leaf_icontains():
+    leaf = LookupLeaf(str__icontains='jina')
+    mock0 = MockStr('hey jInA how are you')
+    assert leaf.evaluate(mock0)
+    mock1 = MockStr('not here')
+    assert not leaf.evaluate(mock1)
+
+
+def test_lookup_leaf_startswith():
+    leaf = LookupLeaf(str__startswith='jina')
+    mock0 = MockStr('jina is the neural search solution')
+    assert leaf.evaluate(mock0)
+    mock1 = MockStr('hey, jina is the neural search solution')
+    assert not leaf.evaluate(mock1)
+    mock2 = MockStr('JiNa is the neural search solution')
+    assert not leaf.evaluate(mock2)
+
+
+def test_lookup_leaf_istartswith():
+    leaf = LookupLeaf(str__istartswith='jina')
+    mock0 = MockStr('jina is the neural search solution')
+    assert leaf.evaluate(mock0)
+    mock1 = MockStr('hey, jina is the neural search solution')
+    assert not leaf.evaluate(mock1)
+    mock2 = MockStr('JiNa is the neural search solution')
+    assert leaf.evaluate(mock2)
+
+
+def test_lookup_leaf_endswith():
+    leaf = LookupLeaf(str__endswith='jina')
+    mock0 = MockStr('how is jina')
+    assert leaf.evaluate(mock0)
+    mock1 = MockStr('hey, jina is the neural search solution')
+    assert not leaf.evaluate(mock1)
+    mock2 = MockStr('how is JiNa')
+    assert not leaf.evaluate(mock2)
+
+
+def test_lookup_leaf_iendswith():
+    leaf = LookupLeaf(str__iendswith='jina')
+    mock0 = MockStr('how is jina')
+    assert leaf.evaluate(mock0)
+    mock1 = MockStr('hey, jina is the neural search solution')
+    assert not leaf.evaluate(mock1)
+    mock2 = MockStr('how is JiNa')
+    assert leaf.evaluate(mock2)
+
+
+def test_lookup_leaf_regex():
+    leaf = LookupLeaf(str__regex='j*na')
+    mock0 = MockStr('hey, juna is good')
+    assert leaf.evaluate(mock0)
+    mock1 = MockStr('hey, Oinja is the neural search solution')
+    assert not leaf.evaluate(mock1)
+    mock2 = MockStr('how is JiNa')
+    assert not leaf.evaluate(mock2)
+
+
+def test_lookup_leaf_in():
+    leaf = LookupLeaf(id__in=[0, 1, 2, 3])
+    mock0 = MockId(3)
+    assert leaf.evaluate(mock0)
+    mock1 = MockId(4)
+    assert not leaf.evaluate(mock1)
+
+
+def test_lookup_leaf_None():
+    leaf = LookupLeaf(id=3)
+    mock0 = MockId(3)
+    assert leaf.evaluate(mock0)
+    mock1 = MockId(4)
+    assert not leaf.evaluate(mock1)

--- a/tests/unit/drivers/querylang/queryset/test_queryset.py
+++ b/tests/unit/drivers/querylang/queryset/test_queryset.py
@@ -1,34 +1,53 @@
 import os
-
+import numpy as np
 from jina.drivers.querylang.queryset.lookup import QuerySet, Q
-from tests import JinaTestCase, random_docs
+from jina.proto import jina_pb2
+from jina.drivers.helper import array2pb
+
+
+def random_docs(num_docs, chunks_per_doc=5, embed_dim=10):
+    c_id = 0
+    for j in range(num_docs):
+        d = jina_pb2.Document()
+        d.id = j
+        d.text = b'hello world'
+        d.embedding.CopyFrom(array2pb(np.random.random([embed_dim])))
+        for k in range(chunks_per_doc):
+            c = d.chunks.add()
+            c.text = 'i\'m chunk %d from doc %d' % (c_id, j)
+            c.embedding.CopyFrom(array2pb(np.random.random([embed_dim])))
+            c.id = c_id
+            c.parent_id = j
+            c_id += 1
+        yield d
+
 
 cur_dir = os.path.dirname(os.path.abspath(__file__))
 
 
-class QuerySetTestCase(JinaTestCase):
+def test_docs_filter():
+    s = random_docs(10)
+    ss = QuerySet(s).filter(id__lt=5, id__gt=3)
+    ssr = list(ss)
+    assert len(ssr) == 1
+    for d in ssr:
+        assert (3 < d.id < 5)
 
-    def test_docs_filter(self):
-        s = random_docs(10)
-        ss = QuerySet(s).filter(id__lt=5, id__gt=3)
-        ssr = list(ss)
-        assert len(ssr) == 1
-        for d in ssr:
-            self.assertTrue(3 < d.id < 5)
 
-    def test_docs_filter_equal(self):
-        s = random_docs(10)
-        ss = QuerySet(s).filter(id=4)
-        ssr = list(ss)
-        assert len(ssr) == 1
-        for d in ssr:
-            assert d.id == 4
-            assert len(d.chunks) == 5
+def test_docs_filter_equal():
+    s = random_docs(10)
+    ss = QuerySet(s).filter(id=4)
+    ssr = list(ss)
+    assert len(ssr) == 1
+    for d in ssr:
+        assert d.id == 4
+        assert len(d.chunks) == 5
 
-    def test_nested_chunks_filter(self):
-        s = random_docs(10)
-        ss = QuerySet(s).filter(Q(chunks__filter=Q(id__lt=5, id__gt=3)))
-        ssr = list(ss)
-        assert len(ssr) == 1
-        for d in ssr:
-            assert len(d.chunks) == 5
+
+def test_nested_chunks_filter():
+    s = random_docs(10)
+    ss = QuerySet(s).filter(Q(chunks__filter=Q(id__lt=5, id__gt=3)))
+    ssr = list(ss)
+    assert len(ssr) == 1
+    for d in ssr:
+        assert len(d.chunks) == 5


### PR DESCRIPTION
**Changes introduced**
Enable QueryLangDrivers to work for keys and values from `tags` in protobuf `Document`