### PR TITLE
fix: keep text, blob and buffer after vectorsearch

### DIFF
--- a/jina/resources/executors.requests.CompoundIndexer.yml
+++ b/jina/resources/executors.requests.CompoundIndexer.yml
@@ -7,9 +7,6 @@ on:
       with:
         fields:
           - embedding
-          - buffer
-          - blob
-          - text
     - !KVSearchDriver
       with:
         executor: BaseKVIndexer
@@ -23,9 +20,6 @@ on:
       with:
         fields:
           - embedding
-          - buffer
-          - blob
-          - text
     - !KVIndexDriver
       with:
         executor: BaseKVIndexer


### PR DESCRIPTION
Keeps the text, blob and buffer in the matches after doing the retrieval from the vectorindexter