### PR TITLE
fix: issue with hyphen in random name and raise_error

### DIFF
--- a/jina/docker/hubio.py
+++ b/jina/docker/hubio.py
@@ -304,7 +304,7 @@ class HubIO:
 
         if not result['is_build_success'] and self.args.raise_error:
             # remove the very verbose build log when throw error
-            result['build_history'].pop('logs')
+            result['build_history'][0].pop('logs')
             raise RuntimeError(result)
 
         return result

--- a/jina/helper.py
+++ b/jina/helper.py
@@ -274,7 +274,7 @@ _random_names = (('first', 'great', 'local', 'small', 'right', 'large', 'young',
 
 
 def random_name() -> str:
-    return '-'.join(random.choice(_random_names[j]) for j in range(2))
+    return '_'.join(random.choice(_random_names[j]) for j in range(2))
 
 
 def random_port() -> int:


### PR DESCRIPTION
This is related to `jina hub build --test-uses`. We add a `random_name` which has `-` instead of `_`, hence we get the below error

`something wrong but it is probably not your fault. ValueError('name: empty-order is invalid, please follow the python variable name conventions')`

Also had an issue in `raises_error` to pop the right argument, when build fails & we raise error.

https://github.com/jina-ai/jina-hub/runs/1133291527?check_suite_focus=true
