### PR TITLE
test: proposal for the new flow traversal

### DIFF
--- a/tests/unit/drivers/test_recursive_traversal_tree.py
+++ b/tests/unit/drivers/test_recursive_traversal_tree.py
@@ -43,7 +43,7 @@ def iterate_build(d, current_granularity, max_granularity, current_adjacency, ma
             iterate_build(dc, dc.granularity, max_granularity, dc.adjacency, max_adjacency)
 
 
-@pytest.mark.skip('this is a test for the proposed new flow design')
+@pytest.mark.skip(reason='this is a test for the proposed new flow design')
 def test_only_root():
     docs = build_docs()
     driver = SliceQL(
@@ -61,7 +61,7 @@ def test_only_root():
     assert len(docs[0].matches[0].chunks) == DOCUMENTS_PER_LEVEL
 
 
-@pytest.mark.skip('this is a test for the proposed new flow design')
+@pytest.mark.skip(reason='this is a test for the proposed new flow design')
 def test_only_matches():
     docs = build_docs()
     driver = SliceQL(
@@ -79,7 +79,7 @@ def test_only_matches():
     assert len(docs[0].matches[0].matches[0].chunks) == DOCUMENTS_PER_LEVEL
 
 
-@pytest.mark.skip('this is a test for the proposed new flow design')
+@pytest.mark.skip(reason='this is a test for the proposed new flow design')
 def test_only_chunks():
     docs = build_docs()
     driver = SliceQL(
@@ -97,7 +97,7 @@ def test_only_chunks():
     assert len(docs[0].matches[0].matches[0].chunks) == DOCUMENTS_PER_LEVEL
 
 
-@pytest.mark.skip('this is a test for the proposed new flow design')
+@pytest.mark.skip(reason='this is a test for the proposed new flow design')
 def test_match_chunk():
     docs = build_docs()
     driver = SliceQL(
@@ -115,7 +115,7 @@ def test_match_chunk():
     assert len(docs[0].matches[0].matches[0].chunks) == DOCUMENTS_PER_LEVEL
 
 
-@pytest.mark.skip('this is a test for the proposed new flow design')
+@pytest.mark.skip(reason='this is a test for the proposed new flow design')
 def test_chunk_match():
     docs = build_docs()
     driver = SliceQL(
@@ -133,7 +133,7 @@ def test_chunk_match():
     assert len(docs[0].matches[0].matches[0].chunks) == DOCUMENTS_PER_LEVEL
 
 
-@pytest.mark.skip('this is a test for the proposed new flow design')
+@pytest.mark.skip(reason='this is a test for the proposed new flow design')
 def test_multi_paths():
     docs = build_docs()
     driver = SliceQL(
@@ -152,7 +152,7 @@ def test_multi_paths():
     assert len(docs[0].matches[0].matches[0].chunks) == DOCUMENTS_PER_LEVEL
 
 
-@pytest.mark.skip('this is a test for the proposed new flow design')
+@pytest.mark.skip(reason='this is a test for the proposed new flow design')
 def test_both_from_0():
     docs = build_docs()
     driver = SliceQL(
@@ -172,7 +172,7 @@ def test_both_from_0():
     assert len(docs[0].matches[0].matches[0].chunks) == DOCUMENTS_PER_LEVEL
 
 
-@pytest.mark.skip('this is a test for the proposed new flow design')
+@pytest.mark.skip(reason='this is a test for the proposed new flow design')
 def test_adjacency0_granularity1():
     docs = build_docs()
     driver = SliceQL(
@@ -195,7 +195,7 @@ def test_adjacency0_granularity1():
     assert len(docs[0].matches[0].matches[0].chunks) == DOCUMENTS_PER_LEVEL
 
 
-@pytest.mark.skip('this is a test for the proposed new flow design')
+@pytest.mark.skip(reason='this is a test for the proposed new flow design')
 def test_adjacency1_granularity1():
     docs = build_docs()
     driver = SliceQL(
@@ -220,7 +220,7 @@ def test_adjacency1_granularity1():
     assert len(docs[0].matches[0].matches[0].chunks) == DOCUMENTS_PER_LEVEL
 
 
-@pytest.mark.skip('this is a test for the proposed new flow design')
+@pytest.mark.skip(reason='this is a test for the proposed new flow design')
 def test_selection():
     docs = build_docs()
     driver = SliceQL(
@@ -237,7 +237,7 @@ def test_selection():
     assert len(docs[0].matches[0].chunks[0].matches) == 1
 
 
-@pytest.mark.skip('this is a test for the proposed new flow design')
+@pytest.mark.skip(reason='this is a test for the proposed new flow design')
 def test_traverse_apply():
     docs = build_docs()
     doc = docs[0]

--- a/tests/unit/drivers/test_recursive_traversal_tree.py
+++ b/tests/unit/drivers/test_recursive_traversal_tree.py
@@ -1,0 +1,254 @@
+import os
+import pytest
+
+from jina.proto import jina_pb2
+
+cur_dir = os.path.dirname(os.path.abspath(__file__))
+
+
+from jina.drivers.querylang.slice import SliceQL
+
+cur_dir = os.path.dirname(os.path.abspath(__file__))
+
+DOCUMENTS_PER_LEVEL = 2
+
+
+def build_docs():
+    """ Builds up a complete chunk-match structure, with a depth of 2 in both directions recursively. """
+    docs = []
+    for base_id in range(DOCUMENTS_PER_LEVEL):
+        d = jina_pb2.Document()
+        d.granularity = 0
+        d.adjacency = 0
+        d.id = base_id
+        docs.append(d)
+        iterate_build(d, 0, 2, 0, 2)
+    return docs
+
+
+def iterate_build(d, current_granularity, max_granularity, current_adjacency, max_adjacency):
+    if current_granularity < max_granularity:
+        for i in range(DOCUMENTS_PER_LEVEL):
+            dc = d.chunks.add()
+            dc.granularity = current_granularity + 1
+            dc.adjacency = current_adjacency
+            dc.id = i
+            iterate_build(dc, dc.granularity, max_granularity, dc.adjacency, max_adjacency)
+    if current_adjacency < max_adjacency:
+        for i in range(DOCUMENTS_PER_LEVEL):
+            dc = d.matches.add()
+            dc.granularity = current_granularity
+            dc.adjacency = current_adjacency + 1
+            dc.id = i
+            iterate_build(dc, dc.granularity, max_granularity, dc.adjacency, max_adjacency)
+
+
+@pytest.mark.skip('this is a test for the proposed new flow design')
+def test_only_root():
+    docs = build_docs()
+    driver = SliceQL(
+        start=0,
+        end=1,
+        traversal_paths=['r']
+    )
+    driver._traverse_apply(docs)
+    assert len(docs) == DOCUMENTS_PER_LEVEL
+    assert len(docs[0].chunks) == DOCUMENTS_PER_LEVEL
+    assert len(docs[0].chunks[0].chunks) == DOCUMENTS_PER_LEVEL
+    assert len(docs[0].chunks[0].chunks[0].matches) == DOCUMENTS_PER_LEVEL
+    assert len(docs[0].chunks[0].matches) == DOCUMENTS_PER_LEVEL
+    assert len(docs[0].matches) == DOCUMENTS_PER_LEVEL
+    assert len(docs[0].matches[0].chunks) == DOCUMENTS_PER_LEVEL
+
+
+@pytest.mark.skip('this is a test for the proposed new flow design')
+def test_only_matches():
+    docs = build_docs()
+    driver = SliceQL(
+        start=0,
+        end=1,
+        traversal_paths=['m']
+    )
+    driver._traverse_apply(docs)
+    assert len(docs) == DOCUMENTS_PER_LEVEL
+    assert len(docs[0].chunks) == DOCUMENTS_PER_LEVEL
+    assert len(docs[0].chunks[0].matches) == DOCUMENTS_PER_LEVEL
+    assert len(docs[0].matches) == 1
+    assert len(docs[0].matches[0].chunks) == DOCUMENTS_PER_LEVEL
+    assert len(docs[0].matches[0].matches) == DOCUMENTS_PER_LEVEL
+    assert len(docs[0].matches[0].matches[0].chunks) == DOCUMENTS_PER_LEVEL
+
+
+@pytest.mark.skip('this is a test for the proposed new flow design')
+def test_only_chunks():
+    docs = build_docs()
+    driver = SliceQL(
+        start=0,
+        end=1,
+        traversal_paths=['c']
+    )
+    driver._traverse_apply(docs)
+    assert len(docs) == DOCUMENTS_PER_LEVEL
+    assert len(docs[0].chunks) == 1
+    assert len(docs[0].chunks[0].matches) == DOCUMENTS_PER_LEVEL
+    assert len(docs[0].matches) == DOCUMENTS_PER_LEVEL
+    assert len(docs[0].matches[0].chunks) == DOCUMENTS_PER_LEVEL
+    assert len(docs[0].matches[0].matches) == DOCUMENTS_PER_LEVEL
+    assert len(docs[0].matches[0].matches[0].chunks) == DOCUMENTS_PER_LEVEL
+
+
+@pytest.mark.skip('this is a test for the proposed new flow design')
+def test_match_chunk():
+    docs = build_docs()
+    driver = SliceQL(
+        start=0,
+        end=1,
+        traversal_paths=['mc']
+    )
+    driver._traverse_apply(docs)
+    assert len(docs) == DOCUMENTS_PER_LEVEL
+    assert len(docs[0].chunks) == DOCUMENTS_PER_LEVEL
+    assert len(docs[0].chunks[0].matches) == DOCUMENTS_PER_LEVEL
+    assert len(docs[0].matches) == DOCUMENTS_PER_LEVEL
+    assert len(docs[0].matches[0].chunks) == 1
+    assert len(docs[0].matches[0].matches) == DOCUMENTS_PER_LEVEL
+    assert len(docs[0].matches[0].matches[0].chunks) == DOCUMENTS_PER_LEVEL
+
+
+@pytest.mark.skip('this is a test for the proposed new flow design')
+def test_chunk_match():
+    docs = build_docs()
+    driver = SliceQL(
+        start=0,
+        end=1,
+        traversal_paths=['cm']
+    )
+    driver._traverse_apply(docs)
+    assert len(docs) == DOCUMENTS_PER_LEVEL
+    assert len(docs[0].chunks) == DOCUMENTS_PER_LEVEL
+    assert len(docs[0].chunks[0].matches) == 1
+    assert len(docs[0].matches) == DOCUMENTS_PER_LEVEL
+    assert len(docs[0].matches[0].chunks) == DOCUMENTS_PER_LEVEL
+    assert len(docs[0].matches[0].matches) == DOCUMENTS_PER_LEVEL
+    assert len(docs[0].matches[0].matches[0].chunks) == DOCUMENTS_PER_LEVEL
+
+
+@pytest.mark.skip('this is a test for the proposed new flow design')
+def test_multi_paths():
+    docs = build_docs()
+    driver = SliceQL(
+        start=0,
+        end=1,
+        traversal_paths=['cc', 'mm']
+    )
+    driver._traverse_apply(docs)
+    assert len(docs) == DOCUMENTS_PER_LEVEL
+    assert len(docs[0].chunks) == DOCUMENTS_PER_LEVEL
+    assert len(docs[0].chunks[0].matches) == DOCUMENTS_PER_LEVEL
+    assert len(docs[0].chunks[0].chunks) == 1
+    assert len(docs[0].matches) == DOCUMENTS_PER_LEVEL
+    assert len(docs[0].matches[0].chunks) == DOCUMENTS_PER_LEVEL
+    assert len(docs[0].matches[0].matches) == 1
+    assert len(docs[0].matches[0].matches[0].chunks) == DOCUMENTS_PER_LEVEL
+
+
+@pytest.mark.skip('this is a test for the proposed new flow design')
+def test_both_from_0():
+    docs = build_docs()
+    driver = SliceQL(
+        start=0,
+        end=1,
+        traversal_paths=['r', 'c', 'm', 'cc', 'mm']
+    )
+    driver._traverse_apply(docs)
+    assert len(docs) == 1
+    assert len(docs[0].chunks) == 1
+    assert len(docs[0].chunks[0].chunks) == 1
+    assert len(docs[0].chunks[0].chunks[0].matches) == DOCUMENTS_PER_LEVEL
+    assert len(docs[0].chunks[0].matches) == DOCUMENTS_PER_LEVEL
+    assert len(docs[0].matches) == 1
+    assert len(docs[0].matches[0].chunks) == DOCUMENTS_PER_LEVEL
+    assert len(docs[0].matches[0].matches) == 1
+    assert len(docs[0].matches[0].matches[0].chunks) == DOCUMENTS_PER_LEVEL
+
+
+@pytest.mark.skip('this is a test for the proposed new flow design')
+def test_adjacency0_granularity1():
+    docs = build_docs()
+    driver = SliceQL(
+        start=0,
+        end=1,
+        traversal_paths=['c', 'cc', 'cm', 'cmm']
+    )
+    driver._traverse_apply(docs)
+    assert len(docs) == DOCUMENTS_PER_LEVEL
+    assert len(docs[0].chunks) == 1
+    assert len(docs[0].chunks[0].chunks) == 1
+    assert len(docs[0].chunks[0].chunks[0].matches) == DOCUMENTS_PER_LEVEL
+    assert len(docs[0].chunks[0].matches) == 1
+    assert len(docs[0].chunks[0].matches[0].chunks) == DOCUMENTS_PER_LEVEL
+    assert len(docs[0].chunks[0].matches[0].matches) == 1
+    assert len(docs[0].chunks[0].matches[0].matches[0].chunks) == DOCUMENTS_PER_LEVEL
+    assert len(docs[0].matches) == DOCUMENTS_PER_LEVEL
+    assert len(docs[0].matches[0].chunks) == DOCUMENTS_PER_LEVEL
+    assert len(docs[0].matches[0].matches) == DOCUMENTS_PER_LEVEL
+    assert len(docs[0].matches[0].matches[0].chunks) == DOCUMENTS_PER_LEVEL
+
+
+@pytest.mark.skip('this is a test for the proposed new flow design')
+def test_adjacency1_granularity1():
+    docs = build_docs()
+    driver = SliceQL(
+        start=0,
+        end=1,
+        traversal_paths=['cm', 'cmm' 'mcc']
+    )
+    driver._traverse_apply(docs)
+    assert len(docs) == DOCUMENTS_PER_LEVEL
+    assert len(docs[0].chunks) == DOCUMENTS_PER_LEVEL
+    assert len(docs[0].chunks[0].chunks) == DOCUMENTS_PER_LEVEL
+    assert len(docs[0].chunks[0].chunks[0].matches) == DOCUMENTS_PER_LEVEL
+    assert len(docs[0].chunks[0].matches) == 1
+    assert len(docs[0].chunks[0].matches[0].chunks) == DOCUMENTS_PER_LEVEL
+    assert len(docs[0].chunks[0].matches[0].matches) == 1
+    assert len(docs[0].chunks[0].matches[0].matches[0].chunks) == DOCUMENTS_PER_LEVEL
+    assert len(docs[0].matches) == DOCUMENTS_PER_LEVEL
+    assert len(docs[0].matches[0].chunks) == 1
+    assert len(docs[0].matches[0].chunks[0].chunks) == 1
+    assert len(docs[0].matches[0].chunks[0].matches) == DOCUMENTS_PER_LEVEL
+    assert len(docs[0].matches[0].matches) == DOCUMENTS_PER_LEVEL
+    assert len(docs[0].matches[0].matches[0].chunks) == DOCUMENTS_PER_LEVEL
+
+
+@pytest.mark.skip('this is a test for the proposed new flow design')
+def test_selection():
+    docs = build_docs()
+    driver = SliceQL(
+        start=0,
+        end=1,
+        traversal_paths=['cmm', 'mcm']
+    )
+    driver._traverse_apply(docs)
+    assert docs[0].chunks[0].matches[0].matches[0].granularity == 1
+    assert docs[0].chunks[0].matches[0].matches[0].adjacency == 2
+    assert len(docs[0].chunks[0].matches[0].matches) == 1
+    assert docs[0].matches[0].chunks[0].matches[0].granularity == 1
+    assert docs[0].matches[0].chunks[0].matches[0].adjacency == 2
+    assert len(docs[0].matches[0].chunks[0].matches) == 1
+
+
+@pytest.mark.skip('this is a test for the proposed new flow design')
+def test_traverse_apply():
+    docs = build_docs()
+    doc = docs[0]
+    doc.ClearField('chunks')
+    docs = [doc, ]
+    driver = SliceQL(
+        start=0,
+        end=1,
+        traversal_paths=['mcm']
+    )
+    assert docs[0].matches[0].chunks[0].matches[0].granularity == 1
+    assert docs[0].matches[0].chunks[0].matches[0].adjacency == 2
+    driver._traverse_apply(docs)
+    assert len(docs[0].matches[0].chunks[0].matches) == 1


### PR DESCRIPTION
This is a new adaption of the traversal tests to do a test-driven development of the new traversal proposal. Furthermore, this allows us to decide whether this is the functionality, we want to achieve.

I choose `traversal_paths=['cmc', 'mcm']` over `traversal_paths=[['c', 'm', 'c'], ['m', 'c', 'm']`, since it easier to read, and especially in the `.yml` files it is much easier to write a list of strings instead of a list of lists of strings.

Furthermore, I added the root identifier `r` to also be able to apply a function to the roots of the trees.