### PR TITLE
fix: fix set metas overriding default from client

### DIFF
--- a/jina/executors/__init__.py
+++ b/jina/executors/__init__.py
@@ -189,6 +189,8 @@ class BaseExecutor(metaclass=ExecutorType):
                         unresolved_attr = True
                 else:
                     setattr(self, k, v)
+            elif type(getattr(self, k)) == type(v):
+                setattr(self, k, v)
         if not getattr(self, 'name', None):
             _id = str(uuid.uuid4()).split('-')[0]
             _name = f'{self.__class__.__name__}-{_id}'

--- a/tests/integration/issues/github_867/test_close_executor.py
+++ b/tests/integration/issues/github_867/test_close_executor.py
@@ -28,7 +28,6 @@ class SlowSaveExecutor(BaseExecutor):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.name = 'slow-save-executor'
-        self.is_updated = True
 
     @property
     def save_abspath(self) -> str:
@@ -42,7 +41,7 @@ class SlowSaveExecutor(BaseExecutor):
 
 
 def test_close_and_load_executor():
-    with Flow().add(uses='!SlowSaveExecutor').build() as f:
+    with Flow().add(uses=os.path.join(cur_dir, 'yaml/slowexecutor.yml')).build() as f:
         pass
 
     exec = BaseExecutor.load(save_abs_path)
@@ -79,7 +78,7 @@ class OldErrorPea(BasePea):
 
 @patch(target='jina.peapods.pea.BasePea', new=OldErrorPea)
 def test_close_and_load_executor_daemon_failed():
-    with Flow().add(uses='!SlowSaveExecutor', daemon=True).build() as f:
+    with Flow().add(uses=os.path.join(cur_dir, 'yaml/slowexecutor.yml'), daemon=True).build() as f:
         pass
 
     with pytest.raises(BadPersistantFile):

--- a/tests/integration/issues/github_867/yaml/slowexecutor.yml
+++ b/tests/integration/issues/github_867/yaml/slowexecutor.yml
@@ -1,0 +1,3 @@
+!SlowSaveExecutor
+metas:
+  is_updated: True

--- a/tests/unit/executors/test_set_metas.py
+++ b/tests/unit/executors/test_set_metas.py
@@ -1,0 +1,26 @@
+from jina.executors.indexers.vector import NumpyIndexer
+from jina.executors import BaseExecutor
+from jina.executors.metas import get_default_metas
+
+
+def test_set_batch_size():
+    batch_size = 325
+    metas = get_default_metas()
+    metas['batch_size'] = batch_size
+    indexer = NumpyIndexer(index_filename=f'test.gz', metas=metas)
+    assert indexer.batch_size == batch_size
+
+
+def test_set_dummy_meta():
+    dummy = 325
+    metas = get_default_metas()
+    metas['dummy'] = dummy
+    executor = BaseExecutor(metas=metas)
+    assert executor.dummy == dummy
+
+
+def test_set_is_trained_meta():
+    metas = get_default_metas()
+    metas['is_trained'] = True
+    executor = BaseExecutor(metas=metas)
+    assert executor.is_trained


### PR DESCRIPTION
**Changes introduced**
Without these changes, can't override `NumpyIndexer` batch_size