### PR TITLE
feat: new tree traversal structure

### DIFF
--- a/jina/drivers/__init__.py
+++ b/jina/drivers/__init__.py
@@ -269,7 +269,7 @@ class BaseRecursiveDriver(BaseDriver):
         self._traverse_apply(self.req.docs, *args, **kwargs)
 
     def _traverse_apply(self, docs: Iterable['jina_pb2.Document'], *args, **kwargs) -> None:
-        if os.environ.get('JINA_USE_TREE_TRAVERSAL', False):
+        if os.getenv('JINA_USE_TREE_TRAVERSAL', 'False') == 'True':
             self._traverse_apply_explicit(docs, *args, **kwargs)
         else:
             self._traverse_apply_recur_on(docs, *args, **kwargs)

--- a/jina/drivers/craft.py
+++ b/jina/drivers/craft.py
@@ -45,6 +45,8 @@ class SegmentDriver(CraftDriver):
 
     def __init__(self, first_chunk_id: int = 0, random_chunk_id: bool = True,
                  level_names: List[str] = None, *args, **kwargs):
+        # Important to do the overwrite before calling `super()__init__(...)`
+        kwargs.setdefault('traversal_paths', ['r', 'c'])
         super().__init__(*args, **kwargs)
         if isinstance(level_names, list) and (self._granularity_end - self._granularity_start + 1) != len(self.level_names):
             self.level_names = level_names

--- a/jina/drivers/craft.py
+++ b/jina/drivers/craft.py
@@ -43,11 +43,16 @@ class SegmentDriver(CraftDriver):
     """Segment document into chunks using the executor
     """
 
-    def __init__(self, first_chunk_id: int = 0, random_chunk_id: bool = True,
-                 level_names: List[str] = None, *args, **kwargs):
-        # Important to do the overwrite before calling `super()__init__(...)`
-        kwargs.setdefault('traversal_paths', ['r', 'c'])
-        super().__init__(*args, **kwargs)
+    def __init__(
+        self,
+        first_chunk_id: int = 0,
+        random_chunk_id: bool = True,
+        level_names: List[str] = None,
+        traversal_paths: List[str] = ['r', 'c'],
+        *args,
+        **kwargs
+    ):
+        super().__init__(traversal_paths=traversal_paths, *args, **kwargs)
         if isinstance(level_names, list) and (self._granularity_end - self._granularity_start + 1) != len(self.level_names):
             self.level_names = level_names
         elif level_names is None:

--- a/jina/drivers/querylang/select.py
+++ b/jina/drivers/querylang/select.py
@@ -32,8 +32,6 @@ class ExcludeQL(QuerySetReader, BaseRecursiveDriver):
         else:
             self._fields = set(fields)
 
-        # for deleting field in a recursive structure, postorder is safer
-        self.recursion_order = 'post'
         self.is_apply_all = False
 
     def _apply(self, doc: 'jina_pb2.Document', *args, **kwargs):

--- a/jina/drivers/querylang/slice.py
+++ b/jina/drivers/querylang/slice.py
@@ -15,8 +15,7 @@ class SliceQL(QuerySetReader, BaseRecursiveDriver):
         Example::
         - !ReduceAllDriver
             with:
-                granularity_range: [0, 0]
-                adjacency_range: [0, 1]
+                traversal_paths: ['m']
         - !SortQL
             with:
                 reverse: true

--- a/jina/drivers/querylang/sort.py
+++ b/jina/drivers/querylang/sort.py
@@ -17,8 +17,7 @@ class SortQL(QuerySetReader, BaseRecursiveDriver):
         Example::
         - !ReduceAllDriver
             with:
-                granularity_range: [0, 0]
-                adjacency_range: [0, 1]
+                traversal_paths: ['m']
         - !SortQL
             with:
                 reverse: true

--- a/jina/drivers/rank.py
+++ b/jina/drivers/rank.py
@@ -50,7 +50,6 @@ class Chunk2DocRankDriver(BaseRankDriver):
         if 'adjacency_range' not in kwargs:
             kwargs['adjacency_range'] = (0, 1)
         super().__init__(*args, **kwargs)
-        self.recursion_order = 'post'
 
     def _apply_all(self, docs: Iterable['jina_pb2.Document'], context_doc: 'jina_pb2.Document', *args, **kwargs) -> None:
         """
@@ -114,7 +113,6 @@ class CollectMatches2DocRankDriver(BaseRankDriver):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.recursion_order = 'post'
 
     def _apply_all(self, docs: Iterable['jina_pb2.Document'], context_doc: 'jina_pb2.Document', *args, **kwargs) -> None:
         """
@@ -167,7 +165,6 @@ class Matches2DocRankDriver(BaseRankDriver):
 
     def __init__(self, reverse=False, *args, **kwargs):
         super().__init__(recur_on='matches', *args, **kwargs)
-        self.recursion_order = 'post'
         self.reverse = reverse
 
     def _apply_all(self, docs: Iterable['jina_pb2.Document'], context_doc: 'jina_pb2.Document', *args, **kwargs) -> None:

--- a/jina/drivers/reduce.py
+++ b/jina/drivers/reduce.py
@@ -82,9 +82,8 @@ class ReduceAllDriver(ReduceDriver):
         It uses the last request as a reference.
     """
 
-    def __init__(self, *args, **kwargs):
-        kwargs.setdefault('traversal_paths', ['c'])
-        super().__init__(use_tree_traversal=True, *args, **kwargs)
+    def __init__(self, traversal_paths: List[str] = ['c'], *args, **kwargs):
+        super().__init__(use_tree_traversal=True, traversal_paths=traversal_paths, *args, **kwargs)
         self._is_apply = False
 
     def reduce(self, *args, **kwargs):

--- a/jina/drivers/reduce.py
+++ b/jina/drivers/reduce.py
@@ -83,6 +83,7 @@ class ReduceAllDriver(ReduceDriver):
     """
 
     def __init__(self, *args, **kwargs):
+        kwargs.setdefault('traversal_paths', ['c'])
         super().__init__(use_tree_traversal=True, *args, **kwargs)
         self._is_apply = False
 

--- a/jina/drivers/search.py
+++ b/jina/drivers/search.py
@@ -14,6 +14,8 @@ class BaseSearchDriver(BaseExecutableDriver):
     """Drivers inherited from this Driver will bind :meth:`craft` by default """
 
     def __init__(self, executor: str = None, method: str = 'query', *args, **kwargs):
+        # Important to do the overwrite before calling `super()__init__(...)`
+        kwargs.setdefault('traversal_paths', ['r', 'c'])
         super().__init__(executor, method, *args, **kwargs)
         self._is_apply = False
         # search driver recursion apply in pre-order

--- a/jina/drivers/search.py
+++ b/jina/drivers/search.py
@@ -1,7 +1,7 @@
 __copyright__ = "Copyright (c) 2020 Jina AI Limited. All rights reserved."
 __license__ = "Apache-2.0"
 
-from typing import Iterable
+from typing import Iterable, List
 
 from . import BaseExecutableDriver, QuerySetReader
 from .helper import extract_docs, array2pb
@@ -13,10 +13,15 @@ if False:
 class BaseSearchDriver(BaseExecutableDriver):
     """Drivers inherited from this Driver will bind :meth:`craft` by default """
 
-    def __init__(self, executor: str = None, method: str = 'query', *args, **kwargs):
-        # Important to do the overwrite before calling `super()__init__(...)`
-        kwargs.setdefault('traversal_paths', ['r', 'c'])
-        super().__init__(executor, method, *args, **kwargs)
+    def __init__(
+        self,
+        executor: str = None,
+        method: str = 'query',
+        traversal_paths: List[str] = ['r', 'c'],
+        *args,
+        **kwargs
+    ):
+        super().__init__(executor, method, traversal_paths=traversal_paths, *args, **kwargs)
         self._is_apply = False
         # search driver recursion apply in pre-order
         self.recursion_order = 'pre'

--- a/jina/resources/executors._merge_all.yml
+++ b/jina/resources/executors._merge_all.yml
@@ -5,4 +5,6 @@ metas:
 requests:
   on:
     [SearchRequest, TrainRequest, IndexRequest, ControlRequest]:
-      - !ReduceAllDriver {}
+      - !ReduceAllDriver
+        with:
+          traversal_paths: ['m']

--- a/jina/resources/executors._merge_all.yml
+++ b/jina/resources/executors._merge_all.yml
@@ -5,6 +5,4 @@ metas:
 requests:
   on:
     [SearchRequest, TrainRequest, IndexRequest, ControlRequest]:
-      - !ReduceAllDriver
-        with:
-          traversal_paths: ['m']
+      - !ReduceAllDriver {}

--- a/jina/resources/executors.requests.BaseRanker.yml
+++ b/jina/resources/executors.requests.BaseRanker.yml
@@ -11,9 +11,11 @@ on:
         field: 'score.value'
         granularity_range: [0, 0]
         adjacency_range: [0, 1]
+        traversal_paths: ['m']
     - !SliceQL
       with:
         granularity_range: [0, 0]
         adjacency_range: [0, 1]
+        traversal_paths: ['m']
         start: 0
         end: 50

--- a/jina/resources/executors.requests.CompoundIndexer.yml
+++ b/jina/resources/executors.requests.CompoundIndexer.yml
@@ -10,6 +10,7 @@ on:
     - !KVSearchDriver
       with:
         executor: BaseKVIndexer
+        traversal_paths: ['m']
         granularity_range: [0, 0]
         adjacency_range: [1, 1]
   IndexRequest:

--- a/jina/resources/helloworld.reduce.yml
+++ b/jina/resources/helloworld.reduce.yml
@@ -7,19 +7,18 @@ requests:
     [SearchRequest]:
       - !ReduceAllDriver
         with:
-          granularity_range: [0, 0]
-          adjacency_range: [0, 1]
+          traversal_paths: ['m']
       - !SortQL
         with:
           reverse: true
           field: 'score.value'
-          granularity_range: [0, 0]
-          adjacency_range: [0, 1]
+          use_tree_traversal: True
+          traversal_paths: ['m']
       - !SliceQL
         with:
           start: 0
-          end: 50
-          granularity_range: [0, 0]
-          adjacency_range: [0, 0]
+          end: 20
+          use_tree_traversal: True
+          traversal_paths: ['m']
     ControlRequest:
       - !ControlReqDriver {}

--- a/tests/unit/drivers/test_recursive_traversal_tree.py
+++ b/tests/unit/drivers/test_recursive_traversal_tree.py
@@ -1,231 +1,197 @@
 import os
-import pytest
 
 from jina.proto import jina_pb2
 
-cur_dir = os.path.dirname(os.path.abspath(__file__))
-
-
-from jina.drivers.querylang.slice import SliceQL
+from jina.drivers import BaseRecursiveDriver
 
 cur_dir = os.path.dirname(os.path.abspath(__file__))
 
-DOCUMENTS_PER_LEVEL = 2
+DOCUMENTS_PER_LEVEL = 1
 
 
-@pytest.fixture(autouse=True)
-def set_environment():
-    os.environ['JINA_USE_TREE_TRAVERSAL'] = 'True'
-    yield
-    os.environ['JINA_USE_TREE_TRAVERSAL'] = 'False'
+class AppendOneChunkTwoMatchesCrafter(BaseRecursiveDriver):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.is_apply = False
+        self._use_tree_traversal = True
+
+    def _apply_all(self, docs, *args, **kwargs) -> None:
+        for doc in docs:
+            add_chunk(doc)
+            add_match(doc)
+            add_match(doc)
+
+
+def add_chunk(doc):
+    chunk = doc.chunks.add()
+    chunk.granularity = doc.granularity + 1
+    chunk.adjacency = doc.adjacency
+    return chunk
+
+
+def add_match(doc):
+    match = doc.matches.add()
+    match.granularity = doc.granularity
+    match.adjacency = doc.adjacency + 1
+    return match
 
 
 def build_docs():
     """ Builds up a complete chunk-match structure, with a depth of 2 in both directions recursively. """
+    max_granularity = 2
+    max_adjacency = 2
+
+    def iterate_build(document, current_granularity, current_adjacency):
+        if current_granularity < max_granularity:
+            for i in range(DOCUMENTS_PER_LEVEL):
+                chunk = add_chunk(document)
+                iterate_build(chunk, chunk.granularity, chunk.adjacency)
+        if current_adjacency < max_adjacency:
+            for i in range(DOCUMENTS_PER_LEVEL):
+                match = add_match(document)
+                iterate_build(match, match.granularity, match.adjacency)
+
     docs = []
     for base_id in range(DOCUMENTS_PER_LEVEL):
-        d = jina_pb2.Document()
-        d.granularity = 0
-        d.adjacency = 0
-        d.id = base_id
-        docs.append(d)
-        iterate_build(d, 0, 2, 0, 2)
+        document = jina_pb2.Document()
+        document.granularity = 0
+        document.adjacency = 0
+        document.id = base_id
+        docs.append(document)
+        iterate_build(document, 0, 0)
     return docs
 
 
-def iterate_build(d, current_granularity, max_granularity, current_adjacency, max_adjacency):
-    if current_granularity < max_granularity:
-        for i in range(DOCUMENTS_PER_LEVEL):
-            dc = d.chunks.add()
-            dc.granularity = current_granularity + 1
-            dc.adjacency = current_adjacency
-            dc.id = i
-            iterate_build(dc, dc.granularity, max_granularity, dc.adjacency, max_adjacency)
-    if current_adjacency < max_adjacency:
-        for i in range(DOCUMENTS_PER_LEVEL):
-            dc = d.matches.add()
-            dc.granularity = current_granularity
-            dc.adjacency = current_adjacency + 1
-            dc.id = i
-            iterate_build(dc, dc.granularity, max_granularity, dc.adjacency, max_adjacency)
+def apply_traversal_path(traversal_paths):
+    docs = build_docs()
+    driver = AppendOneChunkTwoMatchesCrafter(traversal_paths=traversal_paths)
+    driver._traverse_apply(docs)
+    return docs
 
 
 def test_only_root():
-    docs = build_docs()
-    driver = SliceQL(
-        start=0,
-        end=1,
-        traversal_paths=['r']
-    )
-    driver._traverse_apply(docs)
+    docs = apply_traversal_path(['r'])
     assert len(docs) == 1
-    assert len(docs[0].chunks) == DOCUMENTS_PER_LEVEL
-    assert len(docs[0].chunks[0].chunks) == DOCUMENTS_PER_LEVEL
-    assert len(docs[0].chunks[0].chunks[0].matches) == DOCUMENTS_PER_LEVEL
-    assert len(docs[0].chunks[0].matches) == DOCUMENTS_PER_LEVEL
-    assert len(docs[0].matches) == DOCUMENTS_PER_LEVEL
-    assert len(docs[0].matches[0].chunks) == DOCUMENTS_PER_LEVEL
+    assert len(docs[0].chunks) == 2
+    assert len(docs[0].chunks[0].chunks) == 1
+    assert len(docs[0].chunks[0].chunks[0].matches) == 1
+    assert len(docs[0].chunks[0].matches) == 1
+    assert len(docs[0].matches) == 3
+    assert len(docs[0].matches[0].chunks) == 1
 
 
 def test_only_matches():
-    docs = build_docs()
-    driver = SliceQL(
-        start=0,
-        end=1,
-        traversal_paths=['m']
-    )
-    driver._traverse_apply(docs)
-    assert len(docs) == DOCUMENTS_PER_LEVEL
-    assert len(docs[0].chunks) == DOCUMENTS_PER_LEVEL
-    assert len(docs[0].chunks[0].matches) == DOCUMENTS_PER_LEVEL
+    docs = apply_traversal_path(['m'])
+    assert len(docs) == 1
+    assert len(docs[0].chunks) == 1
+    assert len(docs[0].chunks[0].matches) == 1
     assert len(docs[0].matches) == 1
-    assert len(docs[0].matches[0].chunks) == DOCUMENTS_PER_LEVEL
-    assert len(docs[0].matches[0].matches) == DOCUMENTS_PER_LEVEL
-    assert len(docs[0].matches[0].matches[0].chunks) == DOCUMENTS_PER_LEVEL
+    assert len(docs[0].matches[0].chunks) == 2
+    assert len(docs[0].matches[0].matches) == 3
+    assert len(docs[0].matches[0].matches[0].chunks) == 1
 
 
 def test_only_chunks():
-    docs = build_docs()
-    driver = SliceQL(
-        start=0,
-        end=1,
-        traversal_paths=['c']
-    )
-    driver._traverse_apply(docs)
-    assert len(docs) == DOCUMENTS_PER_LEVEL
+    docs = apply_traversal_path(['c'])
+    assert len(docs) == 1
     assert len(docs[0].chunks) == 1
-    assert len(docs[0].chunks[0].matches) == DOCUMENTS_PER_LEVEL
-    assert len(docs[0].matches) == DOCUMENTS_PER_LEVEL
-    assert len(docs[0].matches[0].chunks) == DOCUMENTS_PER_LEVEL
-    assert len(docs[0].matches[0].matches) == DOCUMENTS_PER_LEVEL
-    assert len(docs[0].matches[0].matches[0].chunks) == DOCUMENTS_PER_LEVEL
+    assert len(docs[0].chunks[0].chunks) == 2
+    assert len(docs[0].chunks[0].matches) == 3
+    assert len(docs[0].matches) == 1
+    assert len(docs[0].matches[0].chunks) == 1
+    assert len(docs[0].matches[0].matches) == 1
+    assert len(docs[0].matches[0].matches[0].chunks) == 1
 
 
 def test_match_chunk():
-    docs = build_docs()
-    driver = SliceQL(
-        start=0,
-        end=1,
-        traversal_paths=['mc']
-    )
-    driver._traverse_apply(docs)
-    assert len(docs) == DOCUMENTS_PER_LEVEL
-    assert len(docs[0].chunks) == DOCUMENTS_PER_LEVEL
-    assert len(docs[0].chunks[0].matches) == DOCUMENTS_PER_LEVEL
-    assert len(docs[0].matches) == DOCUMENTS_PER_LEVEL
+    docs = apply_traversal_path(['mc'])
+    assert len(docs) == 1
+    assert len(docs[0].chunks) == 1
+    assert len(docs[0].chunks[0].matches) == 1
+    assert len(docs[0].matches) == 1
     assert len(docs[0].matches[0].chunks) == 1
-    assert len(docs[0].matches[0].matches) == DOCUMENTS_PER_LEVEL
-    assert len(docs[0].matches[0].matches[0].chunks) == DOCUMENTS_PER_LEVEL
+    assert len(docs[0].matches[0].chunks[0].chunks) == 2
+    assert len(docs[0].matches[0].matches) == 1
+    assert len(docs[0].matches[0].matches[0].chunks) == 1
 
 
 def test_chunk_match():
-    docs = build_docs()
-    driver = SliceQL(
-        start=0,
-        end=1,
-        traversal_paths=['cm']
-    )
-    driver._traverse_apply(docs)
-    assert len(docs) == DOCUMENTS_PER_LEVEL
-    assert len(docs[0].chunks) == DOCUMENTS_PER_LEVEL
+    docs = apply_traversal_path(['cm'])
+    assert len(docs) == 1
+    assert len(docs[0].chunks) == 1
     assert len(docs[0].chunks[0].matches) == 1
-    assert len(docs[0].matches) == DOCUMENTS_PER_LEVEL
-    assert len(docs[0].matches[0].chunks) == DOCUMENTS_PER_LEVEL
-    assert len(docs[0].matches[0].matches) == DOCUMENTS_PER_LEVEL
-    assert len(docs[0].matches[0].matches[0].chunks) == DOCUMENTS_PER_LEVEL
+    assert len(docs[0].chunks[0].matches[0].chunks) == 2
+    assert len(docs[0].matches) == 1
+    assert len(docs[0].matches[0].chunks) == 1
+    assert len(docs[0].matches[0].matches) == 1
+    assert len(docs[0].matches[0].matches[0].chunks) == 1
 
 
 def test_multi_paths():
-    docs = build_docs()
-    driver = SliceQL(
-        start=0,
-        end=1,
-        traversal_paths=['cc', 'mm']
-    )
-    driver._traverse_apply(docs)
-    assert len(docs) == DOCUMENTS_PER_LEVEL
-    assert len(docs[0].chunks) == DOCUMENTS_PER_LEVEL
-    assert len(docs[0].chunks[0].matches) == DOCUMENTS_PER_LEVEL
+    docs = apply_traversal_path(['cc', 'mm'])
+    assert len(docs) == 1
+    assert len(docs[0].chunks) == 1
+    assert len(docs[0].chunks[0].matches) == 1
     assert len(docs[0].chunks[0].chunks) == 1
-    assert len(docs[0].matches) == DOCUMENTS_PER_LEVEL
-    assert len(docs[0].matches[0].chunks) == DOCUMENTS_PER_LEVEL
+    assert len(docs[0].chunks[0].chunks[0].chunks) == 1
+    assert len(docs[0].matches) == 1
+    assert len(docs[0].matches[0].chunks) == 1
     assert len(docs[0].matches[0].matches) == 1
-    assert len(docs[0].matches[0].matches[0].chunks) == DOCUMENTS_PER_LEVEL
+    assert len(docs[0].matches[0].matches[0].chunks) == 2
 
 
 def test_both_from_0():
-    docs = build_docs()
-    driver = SliceQL(
-        start=0,
-        end=1,
-        traversal_paths=['r', 'c', 'm', 'cc', 'mm']
-    )
-    driver._traverse_apply(docs)
+    docs = apply_traversal_path(['r', 'c', 'm', 'cc', 'mm'])
     assert len(docs) == 1
-    assert len(docs[0].chunks) == 1
-    assert len(docs[0].chunks[0].chunks) == 1
-    assert len(docs[0].chunks[0].chunks[0].matches) == DOCUMENTS_PER_LEVEL
-    assert len(docs[0].chunks[0].matches) == DOCUMENTS_PER_LEVEL
-    assert len(docs[0].matches) == 1
-    assert len(docs[0].matches[0].chunks) == DOCUMENTS_PER_LEVEL
-    assert len(docs[0].matches[0].matches) == 1
-    assert len(docs[0].matches[0].matches[0].chunks) == DOCUMENTS_PER_LEVEL
+    assert len(docs[0].chunks) == 2
+    assert len(docs[0].chunks[0].chunks) == 2
+    assert len(docs[0].chunks[0].chunks[0].matches) == 3
+    assert len(docs[0].chunks[0].chunks[0].chunks) == 1  # 0 before traversal
+    assert len(docs[0].chunks[0].matches) == 3
+    assert len(docs[0].matches) == 3
+    assert len(docs[0].matches[0].chunks) == 2
+    assert len(docs[0].matches[0].matches) == 3
+    assert len(docs[0].matches[0].matches[0].chunks) == 2
 
 
 def test_adjacency0_granularity1():
-    docs = build_docs()
-    driver = SliceQL(
-        start=0,
-        end=1,
-        traversal_paths=['c', 'cc', 'cm', 'cmm']
-    )
-    driver._traverse_apply(docs)
-    assert len(docs) == DOCUMENTS_PER_LEVEL
+    docs = apply_traversal_path(['c', 'cc', 'cm', 'cmm'])
+    assert len(docs) == 1
     assert len(docs[0].chunks) == 1
-    assert len(docs[0].chunks[0].chunks) == 1
-    assert len(docs[0].chunks[0].chunks[0].matches) == DOCUMENTS_PER_LEVEL
-    assert len(docs[0].chunks[0].matches) == 1
-    assert len(docs[0].chunks[0].matches[0].chunks) == DOCUMENTS_PER_LEVEL
-    assert len(docs[0].chunks[0].matches[0].matches) == 1
-    assert len(docs[0].chunks[0].matches[0].matches[0].chunks) == DOCUMENTS_PER_LEVEL
-    assert len(docs[0].matches) == DOCUMENTS_PER_LEVEL
-    assert len(docs[0].matches[0].chunks) == DOCUMENTS_PER_LEVEL
-    assert len(docs[0].matches[0].matches) == DOCUMENTS_PER_LEVEL
-    assert len(docs[0].matches[0].matches[0].chunks) == DOCUMENTS_PER_LEVEL
+    assert len(docs[0].chunks[0].chunks) == 2
+    assert len(docs[0].chunks[0].chunks[0].matches) == 3
+    assert len(docs[0].chunks[0].matches) == 3
+    assert len(docs[0].chunks[0].matches[0].chunks) == 2
+    assert len(docs[0].chunks[0].matches[0].matches) == 3
+    assert len(docs[0].chunks[0].matches[0].matches[0].chunks) == 2
+    assert len(docs[0].matches) == 1
+    assert len(docs[0].matches[0].chunks) == 1
+    assert len(docs[0].matches[0].matches) == 1
+    assert len(docs[0].matches[0].matches[0].chunks) == 1
 
 
 def test_adjacency1_granularity1():
-    docs = build_docs()
-    driver = SliceQL(
-        start=0,
-        end=1,
-        traversal_paths=['cm', 'cmm', 'mcc']
-    )
-    driver._traverse_apply(docs)
-    assert len(docs) == DOCUMENTS_PER_LEVEL
-    assert len(docs[0].chunks) == DOCUMENTS_PER_LEVEL
-    assert len(docs[0].chunks[0].chunks) == DOCUMENTS_PER_LEVEL
-    assert len(docs[0].chunks[0].chunks[0].matches) == DOCUMENTS_PER_LEVEL
+    docs = apply_traversal_path(['cm', 'cmm', 'mcc'])
+    assert len(docs) == 1
+    assert len(docs[0].chunks) == 1
+    assert len(docs[0].chunks[0].chunks) == 1
+    assert len(docs[0].chunks[0].chunks[0].matches) == 1
     assert len(docs[0].chunks[0].matches) == 1
-    assert len(docs[0].chunks[0].matches[0].chunks) == DOCUMENTS_PER_LEVEL
-    assert len(docs[0].chunks[0].matches[0].matches) == 1
-    assert len(docs[0].chunks[0].matches[0].matches[0].chunks) == DOCUMENTS_PER_LEVEL
-    assert len(docs[0].matches) == DOCUMENTS_PER_LEVEL
-    assert len(docs[0].matches[0].chunks) == DOCUMENTS_PER_LEVEL
+    assert len(docs[0].chunks[0].matches[0].chunks) == 2
+    assert len(docs[0].chunks[0].matches[0].matches) == 3
+    assert len(docs[0].chunks[0].matches[0].matches[0].chunks) == 2
+    assert len(docs[0].matches) == 1
+    assert len(docs[0].matches[0].chunks) == 1
     assert len(docs[0].matches[0].chunks[0].chunks) == 1
-    assert len(docs[0].matches[0].chunks[0].matches) == DOCUMENTS_PER_LEVEL
-    assert len(docs[0].matches[0].matches) == DOCUMENTS_PER_LEVEL
-    assert len(docs[0].matches[0].matches[0].chunks) == DOCUMENTS_PER_LEVEL
+    assert len(docs[0].matches[0].chunks[0].chunks[0].matches) == 3
+    assert len(docs[0].matches[0].chunks[0].matches) == 1
+    assert len(docs[0].matches[0].matches) == 1
+    assert len(docs[0].matches[0].matches[0].chunks) == 1
 
 
 def test_selection():
-    docs = build_docs()
-    driver = SliceQL(
-        start=0,
-        end=1,
-        traversal_paths=['cmm', 'mcm']
-    )
-    driver._traverse_apply(docs)
+    docs = apply_traversal_path(['cmm', 'mcm'])
     assert docs[0].chunks[0].matches[0].matches[0].granularity == 1
     assert docs[0].chunks[0].matches[0].matches[0].adjacency == 2
     assert len(docs[0].chunks[0].matches[0].matches) == 1
@@ -234,17 +200,31 @@ def test_selection():
     assert len(docs[0].matches[0].chunks[0].matches) == 1
 
 
+def test_root_chunk():
+    docs = apply_traversal_path(['r', 'c'])
+    assert len(docs) == 1
+    assert len(docs[0].chunks) == 2
+    assert len(docs[0].chunks[0].chunks) == 2
+    assert len(docs[0].chunks[1].chunks) == 1
+
+
+def test_chunk_root():
+    docs = apply_traversal_path(['c', 'r'])
+    assert len(docs) == 1
+    assert len(docs[0].chunks) == 2
+    assert len(docs[0].chunks[0].chunks) == 2
+    assert len(docs[0].chunks[1].chunks) == 0
+
+
 def test_traverse_apply():
     docs = build_docs()
     doc = docs[0]
     doc.ClearField('chunks')
     docs = [doc, ]
-    driver = SliceQL(
-        start=0,
-        end=1,
-        traversal_paths=['mcm']
-    )
+    driver = AppendOneChunkTwoMatchesCrafter(traversal_paths=['mcm'])
     assert docs[0].matches[0].chunks[0].matches[0].granularity == 1
     assert docs[0].matches[0].chunks[0].matches[0].adjacency == 2
     driver._traverse_apply(docs)
     assert len(docs[0].matches[0].chunks[0].matches) == 1
+    assert len(docs[0].matches[0].chunks[0].matches[0].chunks) == 2
+    assert len(docs[0].matches[0].chunks[0].matches[0].matches) == 2

--- a/tests/unit/drivers/test_recursive_traversal_tree.py
+++ b/tests/unit/drivers/test_recursive_traversal_tree.py
@@ -13,6 +13,13 @@ cur_dir = os.path.dirname(os.path.abspath(__file__))
 DOCUMENTS_PER_LEVEL = 2
 
 
+@pytest.fixture(autouse=True)
+def set_environment():
+    os.environ['JINA_USE_TREE_TRAVERSAL'] = 'True'
+    yield
+    os.environ['JINA_USE_TREE_TRAVERSAL'] = 'False'
+
+
 def build_docs():
     """ Builds up a complete chunk-match structure, with a depth of 2 in both directions recursively. """
     docs = []
@@ -43,7 +50,6 @@ def iterate_build(d, current_granularity, max_granularity, current_adjacency, ma
             iterate_build(dc, dc.granularity, max_granularity, dc.adjacency, max_adjacency)
 
 
-@pytest.mark.skip(reason='this is a test for the proposed new flow design')
 def test_only_root():
     docs = build_docs()
     driver = SliceQL(
@@ -52,7 +58,7 @@ def test_only_root():
         traversal_paths=['r']
     )
     driver._traverse_apply(docs)
-    assert len(docs) == DOCUMENTS_PER_LEVEL
+    assert len(docs) == 1
     assert len(docs[0].chunks) == DOCUMENTS_PER_LEVEL
     assert len(docs[0].chunks[0].chunks) == DOCUMENTS_PER_LEVEL
     assert len(docs[0].chunks[0].chunks[0].matches) == DOCUMENTS_PER_LEVEL
@@ -61,7 +67,6 @@ def test_only_root():
     assert len(docs[0].matches[0].chunks) == DOCUMENTS_PER_LEVEL
 
 
-@pytest.mark.skip(reason='this is a test for the proposed new flow design')
 def test_only_matches():
     docs = build_docs()
     driver = SliceQL(
@@ -79,7 +84,6 @@ def test_only_matches():
     assert len(docs[0].matches[0].matches[0].chunks) == DOCUMENTS_PER_LEVEL
 
 
-@pytest.mark.skip(reason='this is a test for the proposed new flow design')
 def test_only_chunks():
     docs = build_docs()
     driver = SliceQL(
@@ -97,7 +101,6 @@ def test_only_chunks():
     assert len(docs[0].matches[0].matches[0].chunks) == DOCUMENTS_PER_LEVEL
 
 
-@pytest.mark.skip(reason='this is a test for the proposed new flow design')
 def test_match_chunk():
     docs = build_docs()
     driver = SliceQL(
@@ -115,7 +118,6 @@ def test_match_chunk():
     assert len(docs[0].matches[0].matches[0].chunks) == DOCUMENTS_PER_LEVEL
 
 
-@pytest.mark.skip(reason='this is a test for the proposed new flow design')
 def test_chunk_match():
     docs = build_docs()
     driver = SliceQL(
@@ -133,7 +135,6 @@ def test_chunk_match():
     assert len(docs[0].matches[0].matches[0].chunks) == DOCUMENTS_PER_LEVEL
 
 
-@pytest.mark.skip(reason='this is a test for the proposed new flow design')
 def test_multi_paths():
     docs = build_docs()
     driver = SliceQL(
@@ -152,7 +153,6 @@ def test_multi_paths():
     assert len(docs[0].matches[0].matches[0].chunks) == DOCUMENTS_PER_LEVEL
 
 
-@pytest.mark.skip(reason='this is a test for the proposed new flow design')
 def test_both_from_0():
     docs = build_docs()
     driver = SliceQL(
@@ -172,7 +172,6 @@ def test_both_from_0():
     assert len(docs[0].matches[0].matches[0].chunks) == DOCUMENTS_PER_LEVEL
 
 
-@pytest.mark.skip(reason='this is a test for the proposed new flow design')
 def test_adjacency0_granularity1():
     docs = build_docs()
     driver = SliceQL(
@@ -195,13 +194,12 @@ def test_adjacency0_granularity1():
     assert len(docs[0].matches[0].matches[0].chunks) == DOCUMENTS_PER_LEVEL
 
 
-@pytest.mark.skip(reason='this is a test for the proposed new flow design')
 def test_adjacency1_granularity1():
     docs = build_docs()
     driver = SliceQL(
         start=0,
         end=1,
-        traversal_paths=['cm', 'cmm' 'mcc']
+        traversal_paths=['cm', 'cmm', 'mcc']
     )
     driver._traverse_apply(docs)
     assert len(docs) == DOCUMENTS_PER_LEVEL
@@ -213,14 +211,13 @@ def test_adjacency1_granularity1():
     assert len(docs[0].chunks[0].matches[0].matches) == 1
     assert len(docs[0].chunks[0].matches[0].matches[0].chunks) == DOCUMENTS_PER_LEVEL
     assert len(docs[0].matches) == DOCUMENTS_PER_LEVEL
-    assert len(docs[0].matches[0].chunks) == 1
+    assert len(docs[0].matches[0].chunks) == DOCUMENTS_PER_LEVEL
     assert len(docs[0].matches[0].chunks[0].chunks) == 1
     assert len(docs[0].matches[0].chunks[0].matches) == DOCUMENTS_PER_LEVEL
     assert len(docs[0].matches[0].matches) == DOCUMENTS_PER_LEVEL
     assert len(docs[0].matches[0].matches[0].chunks) == DOCUMENTS_PER_LEVEL
 
 
-@pytest.mark.skip(reason='this is a test for the proposed new flow design')
 def test_selection():
     docs = build_docs()
     driver = SliceQL(
@@ -237,7 +234,6 @@ def test_selection():
     assert len(docs[0].matches[0].chunks[0].matches) == 1
 
 
-@pytest.mark.skip(reason='this is a test for the proposed new flow design')
 def test_traverse_apply():
     docs = build_docs()
     doc = docs[0]

--- a/tests/unit/drivers/test_reduce_all_driver.py
+++ b/tests/unit/drivers/test_reduce_all_driver.py
@@ -56,7 +56,7 @@ def test_merge_chunks_with_different_modality():
     flow = Flow().add(name='crafter', uses='MockSegmenterReduce'). \
         add(name='encoder1', uses=os.path.join(cur_dir, 'yaml/mockencoder-mode1.yml')). \
         add(name='encoder2', uses=os.path.join(cur_dir, 'yaml/mockencoder-mode2.yml'), needs=['crafter']). \
-        add(name='reducer', uses='- !ReduceAllDriver | {granularity_range: [0, 1], adjacency_range: [0, 0]}',
+        add(name='reducer', uses='- !ReduceAllDriver | {traversal_paths: [c]}',
             needs=['encoder1', 'encoder2'])
 
     with flow:


### PR DESCRIPTION
This enables traversal via explicit tree path definition. The following changes happened:

- added tree traversal itself
-- no need for `granulartiy_range`, `adjacency_range`, `recur_on` or `recursion_order` with the new approach
- added feature toggle to switch between old traversal and new traversal
-- toggle is settable globally or on a per-driver level
- hello-world runs with mixed versions: for most parts use the old traversal, for the reduce functions use the new one.
- refactored `ReduceAllDriver` in order to be more explicit about what happens and have no internal state to reduce idling memory foodprint (and be stateless).