### PR TITLE
refactor: move cli interface out of jina module

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,6 +9,7 @@
 !README.md
 !MANIFEST.in
 !tests/**
+!jina_cli/**
 
 # Ignore unnecessary files inside allowed directories
 # This should go after the allowed directories

--- a/Dockerfiles/alpinex.Dockerfile
+++ b/Dockerfiles/alpinex.Dockerfile
@@ -19,7 +19,7 @@ LABEL org.opencontainers.image.created=$BUILD_DATE \
 WORKDIR /jina/
 
 ADD setup.py MANIFEST.in requirements.txt extra-requirements.txt README.md ./
-
+ADD jina_cli ./jina_cli/
 ADD jina ./jina/
 
 ENV PYTHONPATH=$PYTHONPATH:/usr/lib/python3.8/dist-packages:/usr/local/lib/python3.8/site-packages:/usr/lib/python3/dist-packages:/usr/local/lib/python3/site-packages

--- a/Dockerfiles/debianx.Dockerfile
+++ b/Dockerfiles/debianx.Dockerfile
@@ -33,7 +33,7 @@ ENV JINA_BUILD_DATE=$BUILD_DATE
 WORKDIR /jina/
 
 ADD setup.py MANIFEST.in requirements.txt extra-requirements.txt README.md ./
-
+ADD jina_cli ./jina_cli/
 ADD jina ./jina/
 
 RUN ln -s locale.h /usr/include/xlocale.h && \

--- a/Dockerfiles/pip.Dockerfile
+++ b/Dockerfiles/pip.Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y
 WORKDIR /jina/
 
 ADD setup.py MANIFEST.in requirements.txt extra-requirements.txt README.md ./
-
+ADD jina_cli ./jina_cli/
 ADD jina ./jina/
 
 ARG PIP_TAG

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 recursive-include jina/resources *
 include extra-requirements.txt
 prune tests/
+prune **/tests/

--- a/jina/__init__.py
+++ b/jina/__init__.py
@@ -268,5 +268,4 @@ def set_nofile(nofile_atleast=4096):
     default_logger.debug(f'ulimit -n soft,hard: {soft} {hard}')
     return soft, hard
 
-
 set_nofile()

--- a/jina/checker.py
+++ b/jina/checker.py
@@ -3,9 +3,9 @@ __license__ = "Apache-2.0"
 
 import os
 
-from .. import __jina_env__, import_classes
-from ..helper import colored, print_dep_tree_rst
-from ..logging import default_logger
+from . import __jina_env__, import_classes
+from .helper import colored, print_dep_tree_rst
+from .logging import default_logger
 
 if False:
     # fix type-hint complain for sphinx and flake
@@ -50,9 +50,9 @@ class NetworkChecker:
     """Check if a BasePod is running or not """
 
     def __init__(self, args: 'argparse.Namespace'):
-        from ..peapods.pea import send_ctrl_message
-        from ..proto import jina_pb2
-        from ..logging.profile import TimeContext
+        from jina.peapods.pea import send_ctrl_message
+        from jina.proto import jina_pb2
+        from jina.logging.profile import TimeContext
         from google.protobuf.json_format import MessageToJson
         import time
         ctrl_addr = 'tcp://%s:%d' % (args.host, args.port)

--- a/jina/clients/__init__.py
+++ b/jina/clients/__init__.py
@@ -25,7 +25,7 @@ def py_client(**kwargs) -> 'PyClient':
         # to index
         py_client(host='192.168.1.100', port_expose=55555).index(input_fn, output_fn)
     """
-    from ..main.parser import set_client_cli_parser
+    from ..parser import set_client_cli_parser
     from ..helper import get_parsed_args
     from .python import PyClient
     _, args, _ = get_parsed_args(kwargs, set_client_cli_parser(), 'Client')

--- a/jina/flow/__init__.py
+++ b/jina/flow/__init__.py
@@ -174,7 +174,7 @@ class Flow(ExitStack):
         self._update_args(args, **kwargs)
 
     def _update_args(self, args, **kwargs):
-        from jina.parser import set_flow_parser
+        from ..parser import set_flow_parser
         _flow_parser = set_flow_parser()
         if args is None:
             from ..helper import get_parsed_args

--- a/jina/flow/__init__.py
+++ b/jina/flow/__init__.py
@@ -17,7 +17,7 @@ from ruamel.yaml import StringIO
 from .. import JINA_GLOBAL
 from ..enums import FlowBuildLevel, FlowOptimizeLevel
 from ..excepts import FlowTopologyError, FlowMissingPodError, FlowBuildLevelError
-from ..helper import yaml, expand_env_var, get_non_defaults_args, deprecated_alias, random_port, complete_path
+from ..helper import yaml, expand_env_var, get_non_defaults_args, deprecated_alias, complete_path
 from ..logging import get_logger
 from ..logging.sse import start_sse_logger
 from ..peapods.pod import SocketType, FlowPod, GatewayFlowPod
@@ -174,7 +174,7 @@ class Flow(ExitStack):
         self._update_args(args, **kwargs)
 
     def _update_args(self, args, **kwargs):
-        from ..main.parser import set_flow_parser
+        from jina.parser import set_flow_parser
         _flow_parser = set_flow_parser()
         if args is None:
             from ..helper import get_parsed_args

--- a/jina/logging/sse.py
+++ b/jina/logging/sse.py
@@ -93,7 +93,7 @@ def start_sse_logger(server_config_path: str, flow_yaml: str = None):
     def get_podargs():
         """Get the default args of a pod"""
 
-        from jina.main.parser import set_pod_parser
+        from ..parser import set_pod_parser
         from argparse import _StoreAction, _StoreTrueAction
         port_attr = ('help', 'choices', 'default')
         d = {}

--- a/jina/parser.py
+++ b/jina/parser.py
@@ -9,8 +9,8 @@ def add_arg_group(parser, title):
 
 
 def set_base_parser():
-    from .. import __version__
-    from ..helper import colored, get_full_version, format_full_version_info
+    from . import __version__
+    from .helper import colored, get_full_version, format_full_version_info
     # create the top-level parser
     urls = {
         'Jina 101': ('🐣', 'https://101.jina.ai'),
@@ -128,7 +128,7 @@ def set_hub_pushpull_parser(parser=None):
 def set_hw_parser(parser=None):
     if not parser:
         parser = set_base_parser()
-    from ..helper import get_random_identity
+    from .helper import get_random_identity
     from pkg_resources import resource_filename
 
     gp = add_arg_group(parser, 'general arguments')
@@ -181,7 +181,7 @@ def set_hw_parser(parser=None):
 def set_flow_parser(parser=None):
     if not parser:
         parser = set_base_parser()
-    from ..enums import FlowOutputType, FlowOptimizeLevel
+    from jina.enums import FlowOutputType, FlowOptimizeLevel
 
     gp = add_arg_group(parser, 'flow arguments')
     gp.add_argument('--uses', type=str, help='a yaml file represents a flow')
@@ -204,9 +204,9 @@ def set_flow_parser(parser=None):
 
 
 def set_pea_parser(parser=None):
-    from ..enums import SocketType, PeaRoleType, OnErrorSkip
-    from ..helper import random_port, get_random_identity
-    from .. import __default_host__
+    from .enums import SocketType, PeaRoleType, OnErrorSkip
+    from .helper import random_port, get_random_identity
+    from . import __default_host__
     import os
     show_all = 'JINA_FULL_CLI' in os.environ
     if not parser:
@@ -332,7 +332,7 @@ def set_pea_parser(parser=None):
 
 
 def set_pod_parser(parser=None):
-    from ..enums import PollingType, SchedulerType
+    from .enums import PollingType, SchedulerType
     if not parser:
         parser = set_base_parser()
     set_pea_parser(parser)
@@ -413,8 +413,8 @@ def set_export_api_parser(parser=None):
 def _set_grpc_parser(parser=None):
     if not parser:
         parser = set_base_parser()
-    from ..helper import random_port
-    from .. import __default_host__
+    from jina.helper import random_port
+    from jina import __default_host__
     gp1 = add_arg_group(parser, 'grpc and remote arguments')
     gp1.add_argument('--host', type=str, default=__default_host__,
                      help=f'host address of the pea/gateway, by default it is {__default_host__}.')
@@ -457,7 +457,7 @@ def _set_grpc_parser(parser=None):
 
 
 def set_gateway_parser(parser=None):
-    from ..enums import SocketType
+    from jina.enums import SocketType
     if not parser:
         parser = set_base_parser()
     set_pea_parser(parser)
@@ -486,7 +486,7 @@ def set_client_cli_parser(parser=None):
     if not parser:
         parser = set_base_parser()
 
-    from ..enums import ClientMode
+    from .enums import ClientMode
 
     _set_grpc_parser(parser)
 
@@ -633,7 +633,7 @@ class _ColoredHelpFormatter(argparse.ArgumentDefaultsHelpFormatter):
 
             # add the heading if the section was non-empty
             if self.heading is not argparse.SUPPRESS and self.heading is not None:
-                from ..helper import colored
+                from .helper import colored
                 current_indent = self.formatter._current_indent
                 captial_heading = ' '.join(v[0].upper() + v[1:] for v in self.heading.split(' '))
                 heading = '⚙️  %*s%s\n' % (
@@ -654,7 +654,7 @@ class _ColoredHelpFormatter(argparse.ArgumentDefaultsHelpFormatter):
         help = action.help
         if '%(default)' not in action.help:
             if action.default is not argparse.SUPPRESS:
-                from ..helper import colored
+                from .helper import colored
                 defaulting_nargs = [argparse.OPTIONAL, argparse.ZERO_OR_MORE]
                 if isinstance(action, argparse._StoreTrueAction):
 

--- a/jina/parser.py
+++ b/jina/parser.py
@@ -181,7 +181,7 @@ def set_hw_parser(parser=None):
 def set_flow_parser(parser=None):
     if not parser:
         parser = set_base_parser()
-    from jina.enums import FlowOutputType, FlowOptimizeLevel
+    from .enums import FlowOutputType, FlowOptimizeLevel
 
     gp = add_arg_group(parser, 'flow arguments')
     gp.add_argument('--uses', type=str, help='a yaml file represents a flow')
@@ -413,8 +413,8 @@ def set_export_api_parser(parser=None):
 def _set_grpc_parser(parser=None):
     if not parser:
         parser = set_base_parser()
-    from jina.helper import random_port
-    from jina import __default_host__
+    from .helper import random_port
+    from . import __default_host__
     gp1 = add_arg_group(parser, 'grpc and remote arguments')
     gp1.add_argument('--host', type=str, default=__default_host__,
                      help=f'host address of the pea/gateway, by default it is {__default_host__}.')
@@ -457,7 +457,7 @@ def _set_grpc_parser(parser=None):
 
 
 def set_gateway_parser(parser=None):
-    from jina.enums import SocketType
+    from .enums import SocketType
     if not parser:
         parser = set_base_parser()
     set_pea_parser(parser)

--- a/jina/peapods/__init__.py
+++ b/jina/peapods/__init__.py
@@ -21,7 +21,7 @@ def Pea(args: 'argparse.Namespace' = None, allow_remote: bool = True, **kwargs):
 
     """
     if args is None:
-        from ..main.parser import set_pea_parser
+        from ..parser import set_pea_parser
         from ..helper import get_parsed_args
         _, args, _ = get_parsed_args(kwargs, set_pea_parser(), 'Pea')
     if not allow_remote:
@@ -55,7 +55,7 @@ def Pod(args: Union['argparse.Namespace', Dict] = None, allow_remote: bool = Tru
     :param kwargs: all supported arguments from CLI
     """
     if args is None:
-        from ..main.parser import set_pod_parser
+        from ..parser import set_pod_parser
         from ..helper import get_parsed_args
         _, args, _ = get_parsed_args(kwargs, set_pod_parser(), 'Pod')
     if isinstance(args, dict):

--- a/jina/peapods/container.py
+++ b/jina/peapods/container.py
@@ -24,7 +24,7 @@ class ContainerPea(BasePea):
         # the image arg should be ignored otherwise it keeps using ContainerPea in the container
         # basically all args in BasePea-docker arg group should be ignored.
         # this prevent setting containerPea twice
-        from ..main.parser import set_pea_parser
+        from ..parser import set_pea_parser
         non_defaults = get_non_defaults_args(self.args, set_pea_parser(),
                                              taboo={'uses', 'entrypoint', 'volumes', 'pull_latest'})
 

--- a/jina/peapods/gateway.py
+++ b/jina/peapods/gateway.py
@@ -18,7 +18,7 @@ from ..excepts import NoDriverForRequest, BadRequestType, GatewayPartialMessage
 from ..helper import use_uvloop
 from ..logging.base import get_logger
 from ..logging.profile import TimeContext
-from ..main.parser import set_pea_parser, set_pod_parser
+from ..parser import set_pea_parser, set_pod_parser
 from ..proto import jina_pb2_grpc, jina_pb2
 
 use_uvloop()

--- a/jina/peapods/pod.py
+++ b/jina/peapods/pod.py
@@ -18,7 +18,7 @@ from .. import __default_host__
 from ..enums import *
 from ..helper import random_port, get_random_identity, get_parsed_args, get_non_defaults_args, \
     is_valid_local_config_source
-from ..main.parser import set_pod_parser, set_gateway_parser
+from ..parser import set_pod_parser, set_gateway_parser
 
 
 class BasePod(ExitStack):

--- a/jina/peapods/remote.py
+++ b/jina/peapods/remote.py
@@ -113,7 +113,7 @@ def peas_args2mutable_pod_req(peas_args: Dict):
 
 
 def mutable_pod_req2peas_args(req):
-    from ..main.parser import set_pea_parser
+    from ..parser import set_pea_parser
     return {
         'head': set_pea_parser().parse_known_args(req.head.args)[0] if req.head.args else None,
         'tail': set_pea_parser().parse_known_args(req.tail.args)[0] if req.tail.args else None,

--- a/jina_cli/__init__.py
+++ b/jina_cli/__init__.py
@@ -5,9 +5,9 @@ import sys
 
 
 def _get_run_args(print_args: bool = True):
-    from ..logging import default_logger
-    from .parser import get_main_parser
-    from ..helper import colored
+    from jina.logging import default_logger
+    from jina.parser import get_main_parser
+    from jina.helper import colored
 
     parser = get_main_parser()
     if len(sys.argv) > 1:

--- a/jina_cli/api.py
+++ b/jina_cli/api.py
@@ -4,14 +4,14 @@ __license__ = "Apache-2.0"
 
 def pod(args):
     """Start a Pod"""
-    from ..peapods import Pod
+    from jina.peapods import Pod
     with Pod(args) as p:
         p.join()
 
 
 def pea(args):
     """Start a Pea"""
-    from ..peapods import Pea
+    from jina.peapods import Pea
     try:
         with Pea(args) as p:
             p.join()
@@ -21,43 +21,43 @@ def pea(args):
 
 def gateway(args):
     """Start a Gateway Pod"""
-    from ..peapods.pod import GatewayPod
+    from jina.peapods.pod import GatewayPod
     with GatewayPod(args) as fs:
         fs.join()
 
 
 def log(args):
     """Receive piped log output and beautify the log"""
-    from ..logging.pipe import PipeLogger
+    from jina.logging.pipe import PipeLogger
     PipeLogger(args).start()
 
 
 def check(args):
     """Check jina config, settings, imports, network etc"""
-    from .checker import ImportChecker
+    from jina.checker import ImportChecker
     ImportChecker(args)
 
 
 def ping(args):
-    from .checker import NetworkChecker
+    from jina.checker import NetworkChecker
     NetworkChecker(args)
 
 
 def client(args):
     """Start a client connects to the gateway"""
-    from ..clients.python import PyClient
+    from jina.clients.python import PyClient
     PyClient(args)
 
 
 def export_api(args):
     from .export import api_to_dict
-    from .. import __version__
-    from ..logging import default_logger
+    from jina import __version__
+    from jina.logging import default_logger
 
     if args.yaml_path:
         for yp in args.yaml_path:
             f_name = (yp % __version__) if '%s' in yp else yp
-            from ..helper import yaml
+            from jina.helper import yaml
             with open(f_name, 'w', encoding='utf8') as fp:
                 yaml.dump(api_to_dict(), fp)
             default_logger.info(f'API is exported to {f_name}')
@@ -72,13 +72,13 @@ def export_api(args):
 
 
 def hello_world(args):
-    from ..helloworld import hello_world
+    from jina.helloworld import hello_world
     hello_world(args)
 
 
 def flow(args):
     """Start a Flow from a YAML file or a docker image"""
-    from ..flow import Flow
+    from jina.flow import Flow
     if args.uses:
         f = Flow.load_config(args.uses)
         with f:

--- a/jina_cli/autocomplete.py
+++ b/jina_cli/autocomplete.py
@@ -3,7 +3,7 @@ __license__ = "Apache-2.0"
 
 
 def _update_autocomplete():
-    from jina.main.parser import get_main_parser
+    from jina.parser import get_main_parser
 
     def _gaa(parser):
         _compl = []

--- a/jina_cli/export.py
+++ b/jina_cli/export.py
@@ -5,9 +5,9 @@ import os
 
 
 def api_to_dict():
-    from ..enums import BetterEnum
-    from .. import __version__
-    from .parser import get_main_parser
+    from jina.enums import BetterEnum
+    from jina import __version__
+    from jina.parser import get_main_parser
 
     from argparse import _StoreAction, _StoreTrueAction
     port_attr = ('help', 'choices', 'default', 'required', 'option_strings', 'dest')

--- a/setup.py
+++ b/setup.py
@@ -132,7 +132,7 @@ setup(
     install_requires=list(all_deps['core'].union(all_deps['perf'])),
     extras_require=all_deps,
     entry_points={
-        'console_scripts': ['jina=jina.main:main'],
+        'console_scripts': ['jina=jina_cli:main'],
     },
     cmdclass={
         'develop': PostDevelopCommand,

--- a/tests/integration/hub_usage/test_hub_usage.py
+++ b/tests/integration/hub_usage/test_hub_usage.py
@@ -7,7 +7,7 @@ from jina.docker.hubio import HubIO
 from jina.excepts import PeaFailToStart
 from jina.executors import BaseExecutor
 from jina.flow import Flow
-from jina.main.parser import set_pod_parser, set_hub_build_parser
+from jina.parser import set_pod_parser, set_hub_build_parser
 from jina.peapods import Pod
 
 cur_dir = os.path.dirname(os.path.abspath(__file__))

--- a/tests/integration/issues/github_936/test_flow_with_sse_no_deadlock.py
+++ b/tests/integration/issues/github_936/test_flow_with_sse_no_deadlock.py
@@ -3,7 +3,7 @@ import os
 
 from jina.flow import Flow
 from jina.peapods import Pod
-from jina.main.parser import set_pod_parser
+from jina.parser import set_pod_parser
 
 """
 Github issue: https://github.com/jina-ai/jina/issues/936

--- a/tests/integration/test_helloworld.py
+++ b/tests/integration/test_helloworld.py
@@ -9,7 +9,7 @@ from jina.clients import py_client
 from jina.clients.python.io import input_numpy
 from jina.flow import Flow
 from jina.helloworld import download_data
-from jina.main.parser import set_hw_parser
+from jina.parser import set_hw_parser
 from tests import JinaTestCase
 
 
@@ -21,7 +21,7 @@ class HelloWorldTestCase(JinaTestCase):
 
     @pytest.mark.timeout(360)
     def test_helloworld_py(self):
-        from jina.main.parser import set_hw_parser
+        from jina.parser import set_hw_parser
         from jina.helloworld import hello_world
         hello_world(set_hw_parser().parse_args([]))
 

--- a/tests/unit/clients/python/test_client.py
+++ b/tests/unit/clients/python/test_client.py
@@ -7,7 +7,7 @@ from jina.clients.python import PyClient
 from jina.clients.python.io import input_files, input_numpy
 from jina.enums import ClientMode
 from jina.flow import Flow
-from jina.main.parser import set_gateway_parser
+from jina.parser import set_gateway_parser
 from jina.peapods.gateway import RESTGatewayPea
 from jina.proto.jina_pb2 import Document
 from tests import JinaTestCase

--- a/tests/unit/docker/test_hub_build.py
+++ b/tests/unit/docker/test_hub_build.py
@@ -4,7 +4,7 @@ import pytest
 
 from jina.docker.hubio import HubIO
 from jina.helper import yaml
-from jina.main.parser import set_hub_build_parser, set_hub_pushpull_parser
+from jina.parser import set_hub_build_parser, set_hub_pushpull_parser
 
 cur_dir = os.path.dirname(os.path.abspath(__file__))
 

--- a/tests/unit/flow/test_flow.py
+++ b/tests/unit/flow/test_flow.py
@@ -6,8 +6,8 @@ import requests
 from jina import JINA_GLOBAL
 from jina.enums import FlowOptimizeLevel, SocketType
 from jina.flow import Flow
-from jina.main.checker import NetworkChecker
-from jina.main.parser import set_pea_parser, set_ping_parser, set_flow_parser, set_pod_parser
+from jina.checker import NetworkChecker
+from jina.parser import set_pea_parser, set_ping_parser, set_flow_parser, set_pod_parser
 from jina.peapods.pea import BasePea
 from jina.peapods.pod import BasePod
 from jina.proto.jina_pb2 import Document

--- a/tests/unit/peapods/test_pea.py
+++ b/tests/unit/peapods/test_pea.py
@@ -1,7 +1,7 @@
 import pytest
 
 from jina.excepts import PeaFailToStart
-from jina.main.parser import set_pea_parser, set_pod_parser, set_gateway_parser
+from jina.parser import set_pea_parser, set_pod_parser, set_gateway_parser
 from jina.peapods.gateway import GatewayPea
 from jina.peapods.pea import BasePea
 from jina.peapods.pod import BasePod

--- a/tests/unit/peapods/test_pods.py
+++ b/tests/unit/peapods/test_pods.py
@@ -1,6 +1,6 @@
 import pytest
 
-from jina.main.parser import set_pod_parser, set_gateway_parser
+from jina.parser import set_pod_parser, set_gateway_parser
 from jina.peapods.pod import BasePod, GatewayPod, MutablePod, GatewayFlowPod, FlowPod
 
 

--- a/tests/unit/test_container.py
+++ b/tests/unit/test_container.py
@@ -4,8 +4,8 @@ from sys import platform
 
 from jina.flow import Flow
 from jina.helper import random_name
-from jina.main.checker import NetworkChecker
-from jina.main.parser import set_pea_parser, set_ping_parser
+from jina.checker import NetworkChecker
+from jina.parser import set_pea_parser, set_ping_parser
 from jina.peapods.container import ContainerPea
 from jina.peapods.pea import BasePea
 from tests import JinaTestCase, random_docs

--- a/tests/unit/test_driver_yaml.py
+++ b/tests/unit/test_driver_yaml.py
@@ -6,7 +6,7 @@ from jina.drivers.control import ControlReqDriver
 from jina.drivers.search import KVSearchDriver
 from jina.executors import BaseExecutor
 from jina.helper import yaml
-from jina.main.parser import set_pod_parser
+from jina.parser import set_pod_parser
 from jina.peapods import Pod
 from pkg_resources import resource_filename
 from tests import JinaTestCase

--- a/tests/unit/test_echostream.py
+++ b/tests/unit/test_echostream.py
@@ -1,5 +1,5 @@
 from jina.flow import Flow
-from jina.main.parser import set_pea_parser
+from jina.parser import set_pea_parser
 from jina.peapods.pea import BasePea
 from jina.peapods.zmq import Zmqlet, add_envelope
 from jina.proto import jina_pb2

--- a/tests/unit/test_index.py
+++ b/tests/unit/test_index.py
@@ -8,7 +8,7 @@ import numpy as np
 from jina.enums import FlowOptimizeLevel
 from jina.executors.indexers.vector import NumpyIndexer
 from jina.flow import Flow
-from jina.main.parser import set_flow_parser
+from jina.parser import set_flow_parser
 from jina.proto import jina_pb2
 from tests import JinaTestCase, random_docs
 

--- a/tests/unit/test_index_remote.py
+++ b/tests/unit/test_index_remote.py
@@ -7,7 +7,7 @@ import numpy as np
 from jina.enums import FlowOptimizeLevel
 from jina.executors.indexers.vector import NumpyIndexer
 from jina.flow import Flow
-from jina.main.parser import set_gateway_parser
+from jina.parser import set_gateway_parser
 from jina.peapods.pod import GatewayPod
 from tests import JinaTestCase, random_docs
 

--- a/tests/unit/test_remote.py
+++ b/tests/unit/test_remote.py
@@ -3,7 +3,7 @@ import time
 import unittest
 
 from jina.logging import get_logger
-from jina.main.parser import set_gateway_parser, set_pea_parser
+from jina.parser import set_gateway_parser, set_pea_parser
 from jina.peapods.pod import GatewayPod
 from jina.peapods.remote import PeaSpawnHelper
 from tests import JinaTestCase

--- a/tests/unit/test_remote2.py
+++ b/tests/unit/test_remote2.py
@@ -5,7 +5,7 @@ import unittest
 from multiprocessing import Process
 
 from jina.logging import get_logger
-from jina.main.parser import set_gateway_parser, set_pea_parser, set_pod_parser
+from jina.parser import set_gateway_parser, set_pea_parser, set_pod_parser
 from jina.peapods.pod import GatewayPod, BasePod
 from jina.peapods.remote import RemotePea, PodSpawnHelper, PeaSpawnHelper, MutablePodSpawnHelper, RemotePod, \
     RemoteMutablePod

--- a/tests/unit/test_yamlparser.py
+++ b/tests/unit/test_yamlparser.py
@@ -5,7 +5,7 @@ from pkg_resources import resource_filename
 from jina.executors import BaseExecutor
 from jina.executors.metas import fill_metas_with_defaults
 from jina.helper import yaml, expand_dict
-from jina.main.parser import set_pea_parser
+from jina.parser import set_pea_parser
 from jina.peapods.pea import BasePea
 
 cur_dir = os.path.dirname(os.path.abspath(__file__))


### PR DESCRIPTION
very minor thing about CLI & autocomplete `\tab` in shell

Previously, ac triggers full `jina` module `__init__.py` given the previous module structure, making the whole ac slow and has some side-effect

By refactoring the module structure, `jina_cli` is now separated from `jina` and `jina_cli:main` is now used as the entrypoint in `setup.py`