### PR TITLE
feat: tree traversal default for SliceQL

### DIFF
--- a/jina/drivers/querylang/filter.py
+++ b/jina/drivers/querylang/filter.py
@@ -28,11 +28,12 @@ class FilterQL(QuerySetReader, BaseRecursiveDriver):
         ensures that the EncodeDriver will only get documents which modality field value is `mode2` by filtering
         those documents at the specific levels that do not comply with this condition
     """
+
     def __init__(self, lookups: Dict[str, Any], *args, **kwargs):
         super().__init__(*args, **kwargs)
         """
-        :param lookups: (dict) a dictionary where keys are interpreted by ``:class:`LookupLeaf`` to form a 
-        an evaluation function. For instance, a dictionary ``{ modality__in: [mode1, mode2] }``, would create 
+        :param lookups: (dict) a dictionary where keys are interpreted by ``:class:`LookupLeaf`` to form a
+        an evaluation function. For instance, a dictionary ``{ modality__in: [mode1, mode2] }``, would create
         an evaluation function that will check if the field `modality` is found in `[mode1, mode2]`
         """
         self._lookups = Q(**lookups) if lookups else None

--- a/jina/drivers/querylang/slice.py
+++ b/jina/drivers/querylang/slice.py
@@ -20,8 +20,7 @@ class SliceQL(QuerySetReader, BaseRecursiveDriver):
             with:
                 reverse: true
                 field: 'score.value'
-                granularity_range: [0, 0]
-                adjacency_range: [0, 1]
+                traversal_paths: ['m']
         - !SliceQL
             with:
                 start: 0

--- a/jina/drivers/querylang/sort.py
+++ b/jina/drivers/querylang/sort.py
@@ -1,7 +1,7 @@
 __copyright__ = "Copyright (c) 2020 Jina AI Limited. All rights reserved."
 __license__ = "Apache-2.0"
 
-from typing import Iterable
+from typing import Iterable, List
 
 from .. import QuerySetReader, BaseRecursiveDriver
 from ...helper import rgetattr
@@ -22,8 +22,7 @@ class SortQL(QuerySetReader, BaseRecursiveDriver):
             with:
                 reverse: true
                 field: 'score.value'
-                granularity_range: [0, 0]
-                adjacency_range: [0, 1]
+                traversal_paths: ['m']
         - !SliceQL
             with:
                 start: 0
@@ -34,13 +33,13 @@ class SortQL(QuerySetReader, BaseRecursiveDriver):
         `SortQL` will ensure that only the documents are sorted by the score value before slicing the first top 50 documents
     """
 
-    def __init__(self, field: str, reverse: bool = False, *args, **kwargs):
+    def __init__(self, field: str, reverse: bool = False, traversal_paths: List[str] = ['c'], *args, **kwargs):
         """
         :param field: the value of the field drives the sort of the iterable docs
         :param reverse: sort the value from big to small
         """
 
-        super().__init__(*args, **kwargs)
+        super().__init__(use_tree_traversal=True, traversal_paths=traversal_paths, *args, **kwargs)
         self._reverse = reverse
         self._field = field
         self.is_apply = False

--- a/jina/resources/executors.requests.BaseRanker.yml
+++ b/jina/resources/executors.requests.BaseRanker.yml
@@ -9,8 +9,6 @@ on:
     - !SortQL
       with:
         field: 'score.value'
-        granularity_range: [0, 0]
-        adjacency_range: [0, 1]
         traversal_paths: ['m']
     - !SliceQL
       with:

--- a/tests/unit/drivers/querylang/test_querylang_drivers.py
+++ b/tests/unit/drivers/querylang/test_querylang_drivers.py
@@ -87,14 +87,13 @@ def test_sort_ql():
 
     f = (Flow().add(uses='DummySegmenter')
         .add(
-        uses='- !SortQL | {field: id, reverse: true, granularity_range: [0, 2], adjacency_range: [0, 2]}'))
+        uses='- !SortQL | {field: id, reverse: true, traversal_paths: [r, c, m]}'))
 
     with f:
         f.index(random_docs(10), output_fn=validate, callback_on_body=True)
 
     f = (Flow().add(uses='DummySegmenter')
-         .add(
-        uses='- !SortQL | {field: id, reverse: false, granularity_range: [0, 2], adjacency_range: [0, 2]}')
+         .add(uses='- !SortQL | {field: id, reverse: false, traversal_paths: [r, c, m]}')
          .add(uses='- !ReverseQL | {granularity_range: [0, 2], adjacency_range: [0, 2]}'))
 
     with f:


### PR DESCRIPTION
This PR should demonstrate, how the adaptation of the traversal will happen. `test_querylang_drivers.py` demonstrates nicely, how things become better understandable. `use_tree_traversal=True` should be set for now, since the tree traversal is not the default, yet. The overwrite of the default `traversal_paths` should only happen, if `['c', 'r']` is not a reasonable default.