### PR TITLE
Fix mypy errors and dunderkey bug 743

### DIFF
--- a/jina/clients/python/io.py
+++ b/jina/clients/python/io.py
@@ -4,13 +4,13 @@ __license__ = "Apache-2.0"
 import glob
 import itertools as it
 import random
-from typing import List, Union, Iterator
+from typing import List, Union, Iterator, Any
 
 import numpy as np
 
 
 def input_lines(lines: Iterator[str] = None, filepath: str = None, size: int = None, sampling_rate: float = None,
-                read_mode='r') -> None:
+                read_mode='r') -> Iterator[Union[str, bytes]]:
     """ Input function that iterates over list of strings, it can be used in the Flow API
 
     :param filepath: a text file that each line contains a document
@@ -20,27 +20,23 @@ def input_lines(lines: Iterator[str] = None, filepath: str = None, size: int = N
     :param read_mode: specifies the mode in which the file
             is opened. 'r' for reading in text mode, 'rb' for reading in binary
     """
+
+    def sample(iterable):
+        for i in iterable:
+            if sampling_rate is None or random.random() < sampling_rate:
+                yield i
+
     if filepath:
-        fp = open(filepath, read_mode)
+        with open(filepath, read_mode) as f:
+            return it.islice(sample(f), size)
     elif lines:
-        fp = lines
+        return it.islice(sample(lines), size)
     else:
         raise ValueError('"filepath" and "lines" can not be both empty')
 
-    d = 0
-    for l in fp:
-        if sampling_rate is None or random.random() < sampling_rate:
-            yield l
-            d += 1
-        if size is not None and d > size:
-            break
-
-    if filepath:
-        fp.close()
-
-
 def input_files(patterns: Union[str, List[str]], recursive: bool = True,
-                size: int = None, sampling_rate: float = None, read_mode: str = None) -> None:
+                size: int = None, sampling_rate: float = None,
+                read_mode: str = None) -> Iterator[Union[str, bytes]]:
     """ Input function that iterates over files, it can be used in the Flow API
 
     :param patterns: The pattern may contain simple shell-style wildcards, e.g. '\*.py', '[\*.zip, \*.gz]'
@@ -73,7 +69,8 @@ def input_files(patterns: Union[str, List[str]], recursive: bool = True,
             break
 
 
-def input_numpy(array: 'np.ndarray', axis: int = 0, size: int = None, shuffle: bool = False) -> None:
+def input_numpy(array: 'np.ndarray', axis: int = 0, size: int = None,
+                shuffle: bool = False) -> Iterator[Any]:
     """ Input function that iterates over a numpy array, it can be used in the Flow API
 
     :param array: the numpy ndarray data source

--- a/jina/drivers/querylang/queryset/dunderkey.py
+++ b/jina/drivers/querylang/queryset/dunderkey.py
@@ -106,7 +106,7 @@ def dunder_get(_dict: Any, key: str) -> Any:
     a dict. eg::
 
          >>> data = {'a': {'b': 1}}
-         >>> nesget(data, 'a__b')
+         >>> dunder_get(data, 'a__b')
          1
 
     key 'b' can be referrenced as 'a__b'
@@ -149,19 +149,21 @@ def undunder_keys(_dict: Dict) -> Dict:
 
     """
 
-    def f(key, value):
-        parts = key.split('__')
-        return {
-            parts[0]: value if len(parts) == 1 else f(parts[1], value)
-        }
+    def f(keys, value):
+        return {keys[0]: f(keys[1:], value)} if keys else value
+
+    def merge(dict1, dict2):
+        key, val = list(dict2.items())[0]
+
+        if key in dict1:
+            merge(dict1[key], val)
+        else:
+            dict1[key] = val
 
     result = {}
-    for r in [f(k, v) for k, v in _dict.items()]:
-        rk = list(r.keys())[0]
-        if rk not in result:
-            result.update(r)
-        else:
-            result[rk].update(r[rk])
+    for k,v in _dict.items():
+        merge(result, f(k.split('__'), v))
+
     return result
 
 

--- a/jina/drivers/querylang/queryset/dunderkey.py
+++ b/jina/drivers/querylang/queryset/dunderkey.py
@@ -32,7 +32,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ## This module deals with code regarding handling the double
 ## underscore separated keys
-from typing import Tuple, Dict, Any
+from typing import Tuple, Dict, Any, Optional
 from google.protobuf.struct_pb2 import Struct
 from google.protobuf import json_format
 
@@ -52,7 +52,7 @@ def dunderkey(*args: str) -> str:
     return '__'.join(args)
 
 
-def dunder_partition(key: str) -> Union[Tuple[str, str], Tuple[str, None]]:
+def dunder_partition(key: str) -> Tuple[str, Optional[str]]:
     """Splits a dunderkey into 2 parts
 
     The first part is everything before the final double underscore
@@ -65,8 +65,13 @@ def dunder_partition(key: str) -> Union[Tuple[str, str], Tuple[str, None]]:
     :rtype        : 2 Tuple
 
     """
-    parts = key.rsplit('__', 1)
-    return tuple(parts) if len(parts) > 1 else (parts[0], None)
+    part1: str
+    part2: Optional[str]
+    try:
+        part1, part2 = key.rsplit('__', 1)
+    except ValueError:
+        part1, part2 = key, None
+    return part1, part2
 
 
 def dunder_init(key: str) -> str:
@@ -81,23 +86,23 @@ def dunder_init(key: str) -> str:
     return dunder_partition(key)[0]
 
 
-def dunder_last(key: str) -> str:
+def dunder_last(key: str) -> Optional[str]:
     """Returns the last part of the dunder key
 
         >>> dunder_last('a__b__c')
         >>> 'c'
 
     :param neskey : String
-    :rtype        : String
+    :rtype        : Optional String
     """
     return dunder_partition(key)[1]
 
 
-def dunder_get(_dict: Dict, key: str) -> Any:
+def dunder_get(_dict: Any, key: str) -> Any:
     """Returns value for a specified dunderkey
 
     A "dunderkey" is just a fieldname that may or may not contain
-    double underscores (dunderscores!) for referrencing nested keys in
+    double underscores (dunderscores!) for referencing nested keys in
     a dict. eg::
 
          >>> data = {'a': {'b': 1}}
@@ -106,29 +111,29 @@ def dunder_get(_dict: Dict, key: str) -> Any:
 
     key 'b' can be referrenced as 'a__b'
 
-    :param _dict : (dict)
+    :param _dict : (dict, list, struct or object) which we want to index into
     :param key   : (str) that represents a first level or nested key in the dict
     :rtype       : (mixed) value corresponding to the key
 
     """
 
     if isinstance(_dict, Struct):
-        return dunder_get(json_format.MessageToDict(_dict), key)
-
-    parts = key.split('__', 1)
+        _dict = json_format.MessageToDict(_dict)
 
     try:
-        parts[0] = int(parts[0])  # parse int parameter
+        part1, part2 = key.split('__', 1)
     except ValueError:
-        pass
+        part1, part2 = key, ''
 
-    if isinstance(parts[0], int):
-        result = guard_iter(_dict)[parts[0]]
-    elif isinstance(_dict, dict):
-        result = _dict[parts[0]]
-    else:
-        result = getattr(_dict, parts[0])
-    return result if len(parts) == 1 else dunder_get(result, parts[1])
+    try:
+        result = _dict[int(part1)]
+    except ValueError:
+        if isinstance(_dict, dict):
+            result = _dict[part1]
+        else:
+            result = getattr(_dict, part1)
+
+    return dunder_get(result, part2) if part2 else result
 
 
 def undunder_keys(_dict: Dict) -> Dict:

--- a/jina/drivers/querylang/queryset/lookup.py
+++ b/jina/drivers/querylang/queryset/lookup.py
@@ -214,7 +214,7 @@ class LookupTreeElem:
     def __init__(self):
         self.negate = False
 
-    def evaluate(self, item: Dict) -> None:
+    def evaluate(self, item: Dict) -> bool:
         raise NotImplementedError
 
     def __or__(self, other):
@@ -297,7 +297,7 @@ Q = LookupLeaf
 
 ## functions that work on the keys in a dict
 
-def include_keys(items: Iterable[Dict], fields: List) -> Iterable[Dict]:
+def include_keys(items: Iterable[Dict[str, Any]], fields: Iterable[str]) -> Iterable[Dict]:
     """Function to keep only specified fields in data
 
     Returns a list of dict with only the keys mentioned in the
@@ -305,12 +305,15 @@ def include_keys(items: Iterable[Dict], fields: List) -> Iterable[Dict]:
 
         >>> include_keys(items, ['request__url', 'response__status'])
 
+    Note: the resulting keys are "dundered", as they appear in `fields`,
+    rather than nested as they are in `items`.
+
     :param items  : iterable of dicts
-    :param fields : (list) fieldnames to keep
+    :param fields : (iterable) fieldnames to keep
     :rtype        : lazy iterable
 
     """
-    return (dict((f, dunder_get(item, f)) for f in fields) for item in items)
+    return ({f: dunder_get(item, f) for f in fields} for item in items)
 
 
 guard_Q = partial(guard_type, Q)

--- a/jina/helper.py
+++ b/jina/helper.py
@@ -13,8 +13,8 @@ from argparse import ArgumentParser, Namespace
 from datetime import datetime
 from io import StringIO
 from itertools import islice
-from types import SimpleNamespace
-from typing import Tuple, Optional, Iterator, Any, Union, List, Dict, Set, TextIO
+from types import SimpleNamespace, ModuleType
+from typing import Tuple, Optional, Iterator, Any, Union, List, Dict, Set, TextIO, Sequence, Iterable
 
 import numpy as np
 from ruamel.yaml import YAML, nodes
@@ -134,7 +134,7 @@ def touch_dir(base_dir: str) -> None:
         os.makedirs(base_dir)
 
 
-def batch_iterator(data: Union[Iterator[Any], List[Any], np.ndarray], batch_size: int, axis: int = 0,
+def batch_iterator(data: Union[np.ndarray, Iterable[Any]], batch_size: int, axis: int = 0,
                    yield_slice: bool = False) -> Iterator[Any]:
     if not batch_size or batch_size <= 0:
         yield data
@@ -156,13 +156,13 @@ def batch_iterator(data: Union[Iterator[Any], List[Any], np.ndarray], batch_size
                 yield tuple(sl)
             else:
                 yield data[tuple(sl)]
-    elif hasattr(data, '__len__'):
+    elif isinstance(data, Sequence):
         if batch_size >= len(data):
             yield data
             return
         for _ in range(0, len(data), batch_size):
             yield data[_:_ + batch_size]
-    elif isinstance(data, Iterator):
+    elif isinstance(data, Iterable):
         # as iterator, there is no way to know the length of it
         while True:
             chunk = tuple(islice(data, batch_size))
@@ -179,7 +179,7 @@ def _get_yaml():
     return y
 
 
-def parse_arg(v: str) -> Union[bool, int, str]:
+def parse_arg(v: str) -> Union[bool, int, str, list, float, None]:
     if v.startswith('[') and v.endswith(']'):
         # function args must be immutable tuples not list
         tmp = v.replace('[', '').replace(']', '').strip().split(',')
@@ -188,22 +188,23 @@ def parse_arg(v: str) -> Union[bool, int, str]:
         else:
             return []
     try:
-        v = int(v)  # parse int parameter
+        return int(v)  # parse int parameter
     except ValueError:
         try:
-            v = float(v)  # parse float parameter
+            return float(v)  # parse float parameter
         except ValueError:
             if len(v) == 0:
                 # ignore it when the parameter is empty
-                v = None
+                return None
             elif v.lower() == 'true':  # parse boolean parameter
-                v = True
+                return True
             elif v.lower() == 'false':
-                v = False
+                return False
+
     return v
 
 
-def countdown(t: int, reason: str = 'I am blocking this thread') -> None:
+def countdown(t: int, reason: str = 'I am blocking this thread'):
     sys.stdout.write('\n')
     sys.stdout.flush()
     while t > 0:
@@ -246,7 +247,7 @@ class PathImporter:
         return module_name
 
     @staticmethod
-    def add_modules(*paths) -> 'types.ModuleType':
+    def add_modules(*paths) -> Optional[ModuleType]:
         for p in paths:
             if not os.path.exists(p):
                 raise FileNotFoundError('cannot import module from %s, file not exist', p)
@@ -254,7 +255,7 @@ class PathImporter:
         return module
 
     @staticmethod
-    def _path_import(absolute_path: str) -> 'types.ModuleType':
+    def _path_import(absolute_path: str) -> Optional[ModuleType]:
         import importlib.util
         try:
             # module_name = (PathImporter._get_module_name(absolute_path) or
@@ -267,7 +268,7 @@ class PathImporter:
             spec.loader.exec_module(module)
             return module
         except ModuleNotFoundError:
-            pass
+            return None
 
 
 _random_names = (('first', 'great', 'local', 'small', 'right', 'large', 'young', 'early', 'major', 'clear', 'black',
@@ -286,22 +287,20 @@ def random_name() -> str:
     return '_'.join(random.choice(_random_names[j]) for j in range(2))
 
 
-def random_port() -> int:
+def random_port() -> Optional[int]:
     import threading
     from contextlib import closing
     import socket
 
     def _get_port(port=0):
-        _p = None
         with threading.Lock():
             with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
                 try:
                     s.bind(('', port))
                     s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-                    _p = s.getsockname()[1]
+                    return s.getsockname()[1]
                 except socket.error:
-                    pass
-        return _p
+                    return None
 
     _port = None
     if 'JINA_RANDOM_PORTS' in os.environ:
@@ -377,7 +376,7 @@ def get_random_identity() -> str:
 yaml = _get_yaml()
 
 
-def expand_env_var(v: str) -> str:
+def expand_env_var(v: str) -> Union[bool, int, str, list, float, None]:
     if isinstance(v, str):
         return parse_arg(os.path.expandvars(v))
     else:
@@ -605,8 +604,9 @@ def is_valid_local_config_source(path: str) -> bool:
         return False
 
 
-def get_parsed_args(kwargs: Dict[str, Union[str, int, bool]], parser: ArgumentParser, parser_name: str = None) -> Union[
-    Tuple[List[str], Namespace, List[Any]], Tuple[List[str], Namespace, List[str]]]:
+def get_parsed_args(kwargs: Dict[str, Union[str, int, bool]],
+                    parser: ArgumentParser, parser_name: str = None
+                   ) -> Tuple[List[str], Namespace, List[Any]]:
     args = kwargs2list(kwargs)
     try:
         p_args, unknown_args = parser.parse_known_args(args)
@@ -623,7 +623,9 @@ def get_parsed_args(kwargs: Dict[str, Union[str, int, bool]], parser: ArgumentPa
     return args, p_args, unknown_args
 
 
-def get_non_defaults_args(args: Namespace, parser: ArgumentParser, taboo: Set[Optional[str]] = (None,)) -> Dict:
+def get_non_defaults_args(args: Namespace, parser: ArgumentParser, taboo: Set[Optional[str]] = None) -> Dict:
+    if taboo is None:
+        taboo = set()
     non_defaults = {}
     _defaults = vars(parser.parse_args([]))
     for k, v in vars(args).items():
@@ -662,7 +664,8 @@ def get_full_version() -> Tuple[Dict, Dict]:
         env_info = {k: os.getenv(k, '(unset)') for k in __jina_env__}
         return info, env_info
     except Exception as e:
-        default_logger.error(e)
+        default_logger.error(str(e))
+        raise
 
 
 def format_full_version_info(info: Dict, env_info: Dict) -> str:

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,4 @@
+[mypy]
+ignore_missing_imports = True
+allow_untyped_globals = True
+allow_redefinition = True

--- a/tests/unit/drivers/querylang/queryset/test_dunderkeys.py
+++ b/tests/unit/drivers/querylang/queryset/test_dunderkeys.py
@@ -1,0 +1,63 @@
+import pytest
+
+from jina.drivers.querylang.queryset.dunderkey import (
+    dunder_get,
+    dunder_partition,
+    undunder_keys,
+    dunder_truncate,
+)
+from jina.proto.jina_pb2 import Document
+
+def test_dunder_get():
+    assert dunder_get({'a': {'b': 5}}, 'a__b') == 5
+    assert dunder_get({'a': {'b': 8, 'c': {'d': 8}}}, 'a__c__d') == 8
+    assert dunder_get([1, 2, 3, [4, 5, [6]]], '3__1') == 5
+
+    class B:
+        c = 5
+    class A:
+        b = B
+
+    assert dunder_get(A, 'b__c') == 5
+
+    d = Document()
+    d.tags['a'] = 'hello'
+    assert dunder_get(d, 'tags__a') == 'hello'
+
+    # Error on invalid key
+    with pytest.raises(Exception):
+        dunder_get({'a': {'b': 5}}, 'a__c')
+    # Error if key is too nested
+    with pytest.raises(Exception):
+        dunder_get({'a': {'b': 5}, 'c': 8}, 'a__b__c')
+    # Error using str keys on list
+    with pytest.raises(Exception):
+        dunder_get([[1, 2], [3, 4]], 'a')
+
+
+def test_dunder_partition():
+    assert dunder_partition('a') == ('a', None)
+    assert dunder_partition('a__b') == ('a', 'b')
+    assert dunder_partition('a__b__c') == ('a__b', 'c')
+
+def test_undunder_keys():
+    assert undunder_keys({'a__b': 5, 'a__c': 6, 'x': 7}) == {'a': {'b': 5, 'c': 6}, 'x': 7}
+    assert undunder_keys({'a__b__c__d': 5}) == {'a': {'b': {'c': {'d': 5}}}}
+
+    # Error when value should be both dict and int
+    with pytest.raises(Exception):
+        undunder_keys({'a__b__c': 5, 'a__b': 4})
+    with pytest.raises(Exception):
+        undunder_keys({'a__b': 5, 'a__b__c': 4})
+
+def test_dunder_truncate():
+    '''
+    test with unique keys
+    test with nonunique keys
+    test with nonunique keys that are nested lvl 3
+    '''
+    assert dunder_truncate({'a__b': 5, 'a__c': 6}) == {'b': 5, 'c': 6}
+    assert dunder_truncate({'a__b': 5, 'c__b': 6}) == {'a__b': 5, 'c__b': 6}
+
+    # Does not partially truncate keys
+    assert dunder_truncate({'a__b__c': 5, 'a__d__c': 6}) == {'a__b__c': 5, 'a__d__c': 6}


### PR DESCRIPTION
This PR is a combination of fixing mypy errors and fixing a bug in dunderkey.py.

Fixing mypy errors involves:

1. Fixing type annotations, when they're not correct
2. Making the code a little less "dynamically typed"

Although python is a dynamically typed language, it can help with correctness and readability to be as explicit as possible when exploiting python's dynamic features. For example, in the function dunder_partition I made it explicit that we split `key` into a 2-tuple, rather than an arbitrary-length list. This doesn't change the functionality of the code, it just makes it more explicit.

I came across a bug in undunder_keys while completing this work, and since it's a small change I figured I'd include it in this PR. I hope that's OK.