### PR TITLE
fix: Renamed pea replica_id to pea_id

### DIFF
--- a/jina/enums.py
+++ b/jina/enums.py
@@ -205,11 +205,10 @@ class PeaRoleType(BetterEnum):
     """ The enum of a Pea role
 
     """
-    REPLICA = 0
+    SINGLETON = 0
     HEAD = 1
     TAIL = 2
-    SHARD = 3
-    SINGLETON = 4
+    PARALLEL = 3
 
 
 class PodRoleType(BetterEnum):

--- a/jina/parser.py
+++ b/jina/parser.py
@@ -299,8 +299,8 @@ def set_pea_parser(parser=None):
     gp3.add_argument('--separated-workspace', action='store_true', default=False,
                      help='the data and config files are separated for each pea in this pod, '
                           'only effective when BasePod\'s `parallel` > 1')
-    gp3.add_argument('--replica-id', type=int, default=-1,
-                     help='the id of the storage of this replica, only effective when `separated_workspace=True`'
+    gp3.add_argument('--pea-id', type=int, default=-1,
+                     help='the id of the storage of this pea, only effective when `separated_workspace=True`'
                      if _SHOW_ALL_ARGS else argparse.SUPPRESS)
 
     gp5 = add_arg_group(parser, 'pea messaging arguments')

--- a/jina/peapods/pea.py
+++ b/jina/peapods/pea.py
@@ -107,7 +107,7 @@ class BasePea(metaclass=PeaMeta):
         """ Create a new :class:`BasePea` object
 
         :param args: the arguments received from the CLI
-        :param replica_id: the id used to separate the storage of each pea, only used when ``args.separate_storage=True``
+        :param pea_id: the id used to separate the storage of each pea, only used when ``args.separate_storage=True``
         """
         super().__init__()
         self.args = args
@@ -132,8 +132,8 @@ class BasePea(metaclass=PeaMeta):
             self.daemon = args.daemon
             if self.args.name:
                 self.name = self.args.name
-            if self.args.role == PeaRoleType.REPLICA:
-                self.name = '%s-%d' % (self.name, self.args.replica_id)
+            if self.args.role == PeaRoleType.PARALLEL:
+                self.name = '%s-%d' % (self.name, self.args.pea_id)
             self.ctrl_addr, self.ctrl_with_ipc = Zmqlet.get_ctrl_address(self.args)
             if self.args.name:
                 # everything in this Pea (process) will use the same name for display the log
@@ -196,7 +196,7 @@ class BasePea(metaclass=PeaMeta):
             try:
                 self.executor = BaseExecutor.load_config(
                     self.args.uses if is_valid_local_config_source(self.args.uses) else self.args.uses_internal,
-                    self.args.separated_workspace, self.args.replica_id)
+                    self.args.separated_workspace, self.args.pea_id)
                 self.executor.attach(pea=self)
             except FileNotFoundError:
                 raise ExecutorFailToLoad

--- a/jina/peapods/pod.py
+++ b/jina/peapods/pod.py
@@ -200,12 +200,12 @@ class BasePod(ExitStack):
         # start real peas and accumulate the storage id
         if len(self.peas_args['peas']) > 1:
             start_rep_id = 1
-            role = PeaRoleType.REPLICA
+            role = PeaRoleType.PARALLEL
         else:
             start_rep_id = 0
             role = PeaRoleType.SINGLETON
         for idx, _args in enumerate(self.peas_args['peas'], start=start_rep_id):
-            _args.replica_id = idx
+            _args.pea_id = idx
             _args.role = role
             p = Pea(_args, allow_remote=False)
             self.peas.append(p)


### PR DESCRIPTION
Fixes #1013 

## Changes

- Edited `pea.py` to rename argument `replica_id` to `pea_id`.
- Updated `PeaRoleType`, and changed `PeaRoleType.REPLICA` to `PeaRoleType.PARALLEL` wherever it was used.
