### PR TITLE
refactor: remove apply function

### DIFF
--- a/jina/drivers/__init__.py
+++ b/jina/drivers/__init__.py
@@ -2,9 +2,8 @@ __copyright__ = "Copyright (c) 2020 Jina AI Limited. All rights reserved."
 __license__ = "Apache-2.0"
 
 import inspect
-import os
 from functools import wraps
-from typing import Any, Dict, Callable, Tuple, Iterable, Iterator, Union
+from typing import Any, Dict, Callable, Tuple, Iterable, Iterator
 
 import ruamel.yaml.constructor
 
@@ -40,8 +39,10 @@ def store_init_kwargs(func: Callable) -> Callable:
                 tmp[k] = v
 
         if self.store_args_kwargs:
-            if args: tmp['args'] = args
-            if kwargs: tmp['kwargs'] = {k: v for k, v in kwargs.items() if k not in taboo}
+            if args:
+                tmp['args'] = args
+            if kwargs:
+                tmp['kwargs'] = {k: v for k, v in kwargs.items() if k not in taboo}
 
         if hasattr(self, '_init_kwargs_dict'):
             self._init_kwargs_dict.update(tmp)
@@ -227,16 +228,6 @@ class BaseRecursiveDriver(BaseDriver):
         """
         super().__init__(*args, **kwargs)
         self._traversal_paths = traversal_paths
-        self._is_apply = True
-        self._is_apply_all = True
-
-    def _apply(self, doc: 'jina_pb2.Document', context_doc: 'jina_pb2.Document', field: str, *args, **kwargs):
-        """ Apply function works on each doc, one by one, modify the doc in-place
-
-        :param doc: the :class:`jina_pb2.Document` object to work on. It could come from ``matches``/``chunks``.
-        :param context_doc: the owner of ``doc``
-        :param field: where ``doc`` comes from, either ``matches`` or ``chunks``
-        """
 
     def _apply_all(self, docs: Iterable['jina_pb2.Document'], context_doc: 'jina_pb2.Document', field: str, *args,
                    **kwargs) -> None:
@@ -268,12 +259,7 @@ class BaseRecursiveDriver(BaseDriver):
                 if next_edge == 'c':
                     self._traverse_rec(doc.chunks, doc, "chunks", path[1:], *args, **kwargs)
         else:
-            if self._is_apply:
-                for doc in docs:
-                    self._apply(doc, parent_doc, parent_edge_type, *args, **kwargs)
-
-            if self._is_apply_all:
-                self._apply_all(docs, parent_doc, parent_edge_type, *args, **kwargs)
+            self._apply_all(docs, parent_doc, parent_edge_type, *args, **kwargs)
 
 
 class BaseExecutableDriver(BaseRecursiveDriver):

--- a/jina/drivers/__init__.py
+++ b/jina/drivers/__init__.py
@@ -217,23 +217,22 @@ class BaseDriver(metaclass=DriverType):
 
 class BaseRecursiveDriver(BaseDriver):
 
-    def __init__(self,
-                 traversal_paths: Tuple[str] = ('c', 'r'),
-                 *args,
-                 **kwargs):
+    def __init__(self, traversal_paths: Tuple[str] = ('c', 'r'), *args, **kwargs):
         """
-        :param traversal_paths: The describes the paths on which the _apply and _apply_all functions are called
-        :param args:
-        :param kwargs:
+        :param traversal_paths: The describes the leaves of the document tree on which _apply_all are called
         """
         super().__init__(*args, **kwargs)
-        self._traversal_paths = traversal_paths
+        self._traversal_paths = [path.lower() for path in traversal_paths]
 
-    def _apply_all(self, docs: Iterable['jina_pb2.Document'], context_doc: 'jina_pb2.Document', field: str, *args,
-                   **kwargs) -> None:
+    def _apply_all(
+        self,
+        docs: Iterable['jina_pb2.Document'],
+        context_doc: 'jina_pb2.Document',
+        field: str,
+        *args,
+        **kwargs
+    ) -> None:
         """ Apply function works on a list of docs, modify the docs in-place
-
-        Depending on the value of ``order`` of :class:`BaseRecursiveDriver`, :meth:`apply_all` applies before or after :meth:`apply`
 
         :param docs: a list of :class:`jina_pb2.Document` objects to work on; they could come from ``matches``/``chunks``.
         :param context_doc: the owner of ``docs``

--- a/jina/drivers/convert.py
+++ b/jina/drivers/convert.py
@@ -10,6 +10,8 @@ import zlib
 
 import numpy as np
 
+from typing import Iterable
+
 from . import BaseRecursiveDriver
 from .helper import guess_mime, array2pb, pb2array
 
@@ -29,13 +31,13 @@ class BaseConvertDriver(BaseRecursiveDriver):
         super().__init__(*args, **kwargs)
         self.override = override
         self.target = target
-        self._is_apply_all = False
 
-    def _apply(self, doc: 'jina_pb2.Document', *args, **kwargs):
-        if getattr(doc, self.target) and not self.override:
-            pass
-        else:
-            self.convert(doc)
+    def _apply_all(self, docs: Iterable['jina_pb2.Document'], *args, **kwargs):
+        for doc in docs:
+            if getattr(doc, self.target) and not self.override:
+                pass
+            else:
+                self.convert(doc)
 
     def convert(self, d):
         raise NotImplementedError
@@ -149,6 +151,7 @@ class Blob2PngURI(NdArray2PngURI):
     def convert(self, d):
         arr = pb2array(d.blob)
         d.uri = self.png_convertor(arr)
+
 
 class URI2Buffer(BaseConvertDriver):
     """ Convert local file path, remote URL doc to a buffer doc.

--- a/jina/drivers/craft.py
+++ b/jina/drivers/craft.py
@@ -1,7 +1,7 @@
 __copyright__ = "Copyright (c) 2020 Jina AI Limited. All rights reserved."
 __license__ = "Apache-2.0"
 
-from typing import Dict, Set, Tuple
+from typing import Dict, Iterable, Set, Tuple
 
 from . import BaseExecutableDriver
 from .helper import array2pb, pb_obj2dict
@@ -13,12 +13,12 @@ class CraftDriver(BaseExecutableDriver):
 
     def __init__(self, executor: str = None, method: str = 'craft', *args, **kwargs):
         super().__init__(executor, method, *args, **kwargs)
-        self._is_apply_all = False
 
-    def _apply(self, doc: 'jina_pb2.Document', *args, **kwargs):
-        ret = self.exec_fn(**pb_obj2dict(doc, self.exec.required_keys))
-        if ret:
-            self.set_doc_attr(doc, ret)
+    def _apply_all(self, docs: Iterable['jina_pb2.Document'], *args, **kwargs):
+        for doc in docs:
+            ret = self.exec_fn(**pb_obj2dict(doc, self.exec.required_keys))
+            if ret:
+                self.set_doc_attr(doc, ret)
 
     def set_doc_attr(self, doc: 'jina_pb2.Document', doc_info: Dict, protected_keys: Set = None):
         for k, v in doc_info.items():
@@ -54,19 +54,20 @@ class SegmentDriver(CraftDriver):
 
         self._protected_fields = {'length', 'id', 'parent_id', 'granularity'}
 
-    def _apply(self, doc: 'jina_pb2.Document', *args, **kwargs):
-        _args_dict = pb_obj2dict(doc, self.exec.required_keys)
-        ret = self.exec_fn(**_args_dict)
-        if ret:
-            for r in ret:
-                c = doc.chunks.add()
-                self.set_doc_attr(c, r, self._protected_fields)
-                c.length = len(ret)
-                c.parent_id = doc.id
-                c.granularity = doc.granularity + 1
-                if not c.mime_type:
-                    c.mime_type = doc.mime_type
-                c.id = uid.new_doc_id(c)
+    def _apply_all(self, docs: Iterable['jina_pb2.Document'], *args, **kwargs):
+        for doc in docs:
+            _args_dict = pb_obj2dict(doc, self.exec.required_keys)
+            ret = self.exec_fn(**_args_dict)
+            if ret:
+                for r in ret:
+                    c = doc.chunks.add()
+                    self.set_doc_attr(c, r, self._protected_fields)
+                    c.length = len(ret)
+                    c.parent_id = doc.id
+                    c.granularity = doc.granularity + 1
+                    if not c.mime_type:
+                        c.mime_type = doc.mime_type
+                    c.id = uid.new_doc_id(c)
 
-        else:
-            self.logger.warning(f'doc {doc.id} at level {doc.granularity} gives no chunk')
+            else:
+                self.logger.warning(f'doc {doc.id} at level {doc.granularity} gives no chunk')

--- a/jina/drivers/encode.py
+++ b/jina/drivers/encode.py
@@ -21,10 +21,6 @@ class EncodeDriver(BaseEncodeDriver):
     """Extract the chunk-level content from documents and call executor and do encoding
     """
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self._is_apply = False
-
     def _apply_all(self, docs: Iterable['jina_pb2.Document'], *args, **kwargs) -> None:
         contents, docs_pts, bad_doc_ids = extract_docs(docs, embedding=False)
 

--- a/jina/drivers/index.py
+++ b/jina/drivers/index.py
@@ -18,7 +18,6 @@ class BaseIndexDriver(BaseExecutableDriver):
 
     def __init__(self, executor: str = None, method: str = 'add', *args, **kwargs):
         super().__init__(executor, method, *args, **kwargs)
-        self._is_apply = False
 
 
 class VectorIndexDriver(BaseIndexDriver):

--- a/jina/drivers/querylang/filter.py
+++ b/jina/drivers/querylang/filter.py
@@ -1,7 +1,7 @@
 __copyright__ = "Copyright (c) 2020 Jina AI Limited. All rights reserved."
 __license__ = "Apache-2.0"
 
-from typing import Dict, Any, Iterable, Tuple
+from typing import Dict, Any, Iterable
 
 from .queryset.lookup import Q
 from .. import QuerySetReader, BaseRecursiveDriver
@@ -35,7 +35,6 @@ class FilterQL(QuerySetReader, BaseRecursiveDriver):
         an evaluation function that will check if the field `modality` is found in `[mode1, mode2]`
         """
         self._lookups = Q(**lookups) if lookups else None
-        self.is_apply = False
 
     def _apply_all(self, docs: Iterable['jina_pb2.Document'], *args, **kwargs) -> None:
         if self.lookups:

--- a/jina/drivers/querylang/reverse.py
+++ b/jina/drivers/querylang/reverse.py
@@ -23,7 +23,6 @@ class ReverseQL(QuerySetReader, BaseRecursiveDriver):
 
     def __init__(self, traversal_paths: Tuple[str] = ('c',), *args, **kwargs):
         super().__init__(traversal_paths=traversal_paths, *args, **kwargs)
-        self.is_apply = False
 
     def _apply_all(self, docs: Iterable['jina_pb2.Document'], *args, **kwargs) -> None:
         prev_len = len(docs)

--- a/jina/drivers/querylang/select.py
+++ b/jina/drivers/querylang/select.py
@@ -1,7 +1,7 @@
 __copyright__ = "Copyright (c) 2020 Jina AI Limited. All rights reserved."
 __license__ = "Apache-2.0"
 
-from typing import Tuple
+from typing import Iterable, Tuple
 
 from .. import QuerySetReader, BaseRecursiveDriver
 
@@ -32,11 +32,10 @@ class ExcludeQL(QuerySetReader, BaseRecursiveDriver):
         else:
             self._fields = set(fields)
 
-        self.is_apply_all = False
-
-    def _apply(self, doc: 'jina_pb2.Document', *args, **kwargs):
-        for k in self.fields:
-            doc.ClearField(k)
+    def _apply_all(self, docs: Iterable['jina_pb2.Document'], *args, **kwargs):
+        for doc in docs:
+            for k in self.fields:
+                doc.ClearField(k)
 
 
 class SelectQL(ExcludeQL):
@@ -52,10 +51,11 @@ class SelectQL(ExcludeQL):
         SelectQL will ensure that the `outgoing` documents only contain the field `matches`
     """
 
-    def _apply(self, doc: 'jina_pb2.Document', *args, **kwargs):
-        for k in doc.DESCRIPTOR.fields_by_name.keys():
-            if k not in self.fields:
-                doc.ClearField(k)
+    def _apply_all(self, docs: Iterable['jina_pb2.Document'], *args, **kwargs):
+        for doc in docs:
+            for k in doc.DESCRIPTOR.fields_by_name.keys():
+                if k not in self.fields:
+                    doc.ClearField(k)
 
 
 class ExcludeReqQL(ExcludeQL):

--- a/jina/drivers/querylang/slice.py
+++ b/jina/drivers/querylang/slice.py
@@ -45,7 +45,6 @@ class SliceQL(QuerySetReader, BaseRecursiveDriver):
             self._end = sys.maxsize
         else:
             self._end = int(end)
-        self.is_apply = False
 
     def _apply_all(self, docs: Iterable['jina_pb2.Document'], *args, **kwargs) -> None:
         if self.start <= 0 and (self.end is None or self.end >= len(docs)):

--- a/jina/drivers/querylang/sort.py
+++ b/jina/drivers/querylang/sort.py
@@ -41,7 +41,6 @@ class SortQL(QuerySetReader, BaseRecursiveDriver):
         super().__init__(traversal_paths=traversal_paths, *args, **kwargs)
         self._reverse = reverse
         self._field = field
-        self.is_apply = False
 
     def _apply_all(self, docs: Iterable['jina_pb2.Document'], *args, **kwargs) -> None:
         docs.sort(key=lambda x: dunder_get(x, self.field), reverse=self.reverse)

--- a/jina/drivers/rank.py
+++ b/jina/drivers/rank.py
@@ -20,7 +20,6 @@ class BaseRankDriver(BaseExecutableDriver):
 
     def __init__(self, executor: str = None, method: str = 'score', *args, **kwargs):
         super().__init__(executor, method, *args, **kwargs)
-        self._is_apply = False
 
         self.hash2id = uid.hash2id
         self.id2hash = uid.id2hash

--- a/jina/drivers/search.py
+++ b/jina/drivers/search.py
@@ -29,7 +29,6 @@ class BaseSearchDriver(BaseExecutableDriver):
             *args,
             **kwargs
         )
-        self._is_apply = False
 
         self.hash2id = uid.hash2id
         self.id2hash = uid.id2hash

--- a/tests/unit/drivers/test_concat_driver.py
+++ b/tests/unit/drivers/test_concat_driver.py
@@ -57,7 +57,7 @@ def test_concat_embed_driver():
     # simulate two encoders
     flow = (Flow().add(name='a')
             .add(name='b', needs='gateway')
-            .join(needs=['a', 'b'], uses='- !ConcatEmbedDriver | {}'))
+            .join(needs=['a', 'b'], uses='- !ConcatEmbedDriver | {traversal_paths: [c, r]}'))
 
     with flow:
         flow.index(input_fn=input_fn, output_fn=validate, callback_on_body=True)

--- a/tests/unit/drivers/test_concat_driver.py
+++ b/tests/unit/drivers/test_concat_driver.py
@@ -57,7 +57,7 @@ def test_concat_embed_driver():
     # simulate two encoders
     flow = (Flow().add(name='a')
             .add(name='b', needs='gateway')
-            .join(needs=['a', 'b'], uses='- !ConcatEmbedDriver | {traversal_paths: [c, r]}'))
+            .join(needs=['a', 'b'], uses='- !ConcatEmbedDriver | {}'))
 
     with flow:
         flow.index(input_fn=input_fn, output_fn=validate, callback_on_body=True)

--- a/tests/unit/drivers/test_craft_driver.py
+++ b/tests/unit/drivers/test_craft_driver.py
@@ -46,9 +46,9 @@ def test_craft_driver():
     driver = SimpleCraftDriver()
     executor = MockCrafter()
     driver.attach(executor=executor, pea=None)
-    driver._apply(docs[0])
+    driver._apply_all(docs[:1])
     assert docs[0].blob == array2pb(np.array([0.0, 0.0, 0.0]))
     assert docs[0].weight == 10
     with pytest.raises(AttributeError) as error:
-        driver._apply(docs[1])
+        driver._apply_all(docs[1:2])
     assert error.value.__str__() == '\'Document\' object has no attribute \'non_existing_key\''

--- a/tests/unit/drivers/test_recursive_traversal_tree.py
+++ b/tests/unit/drivers/test_recursive_traversal_tree.py
@@ -149,6 +149,20 @@ def test_both_from_0():
     assert len(docs[0].matches[0].matches[0].chunks) == 2
 
 
+def test_both_from_0_upper_case():
+    docs = apply_traversal_path(['R', 'C', 'M', 'CC', 'MM'])
+    assert len(docs) == 1
+    assert len(docs[0].chunks) == 2
+    assert len(docs[0].chunks[0].chunks) == 2
+    assert len(docs[0].chunks[0].chunks[0].matches) == 3
+    assert len(docs[0].chunks[0].chunks[0].chunks) == 1  # 0 before traversal
+    assert len(docs[0].chunks[0].matches) == 3
+    assert len(docs[0].matches) == 3
+    assert len(docs[0].matches[0].chunks) == 2
+    assert len(docs[0].matches[0].matches) == 3
+    assert len(docs[0].matches[0].matches[0].chunks) == 2
+
+
 def test_adjacency0_granularity1():
     docs = apply_traversal_path(['c', 'cc', 'cm', 'cmm'])
     assert len(docs) == 1

--- a/tests/unit/drivers/test_recursive_traversal_tree.py
+++ b/tests/unit/drivers/test_recursive_traversal_tree.py
@@ -11,10 +11,6 @@ DOCUMENTS_PER_LEVEL = 1
 
 class AppendOneChunkTwoMatchesCrafter(BaseRecursiveDriver):
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.is_apply = False
-
     def _apply_all(self, docs, *args, **kwargs) -> None:
         for doc in docs:
             add_chunk(doc)

--- a/tests/unit/drivers/test_segmenter_driver.py
+++ b/tests/unit/drivers/test_segmenter_driver.py
@@ -42,7 +42,7 @@ def test_segment_driver():
     driver = SimpleSegmentDriver()
     executor = MockSegmenter()
     driver.attach(executor=executor, pea=None)
-    driver._apply(valid_doc)
+    driver._apply_all([valid_doc])
 
     assert valid_doc.length == 2
 
@@ -81,4 +81,4 @@ def test_broken_document():
     assert invalid_doc.length == 2
 
     with pytest.raises(AttributeError):
-        driver._apply(invalid_doc)
+        driver._apply_all([invalid_doc])


### PR DESCRIPTION
This removes the `_apply` function from jina, since there is no real use-case anymore for it. All straight-forward, except the refactoring of `ConcatEmbedDriver`.