### PR TITLE
fix: inputlines should always yield

### DIFF
--- a/jina/clients/python/io.py
+++ b/jina/clients/python/io.py
@@ -36,7 +36,8 @@ def input_lines(
             for line in it.islice(sample(f), size):
                 yield line
     elif lines:
-        return it.islice(sample(lines), size)
+        for line in it.islice(sample(lines), size):
+            yield line
     else:
         raise ValueError('"filepath" and "lines" can not be both empty')
 

--- a/tests/unit/clients/python/test_io.py
+++ b/tests/unit/clients/python/test_io.py
@@ -15,6 +15,14 @@ def test_read_file(tmpdir):
     assert result[1] == "2\n"
 
 
+def test_lines():
+    lines = ["1", "2", "3"]
+    result = list(input_lines(lines=lines, size=2))
+    assert len(result) == 2
+    assert result[0] == "1"
+    assert result[1] == "2"
+
+
 def test_io_files():
     PyClient.check_input(input_files('*.*'))
     PyClient.check_input(input_files('*.*', recursive=True))


### PR DESCRIPTION
The `input_lines` function must work as an iterator and not return an iterator.