### PR TITLE
feat: emphasise slack, link direct to general channel

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,11 @@
 
 Thanks for your interest in contributing to Jina. We're grateful for your initiative! ❤️
 
-I'm Alex C-G, Open Source Evangelist for Jina. I'm all about getting our new contributors up-to-speed, and that's what we'll do below. If you have any feedback or questions, get in touch on [Slack](https://jina-ai.slack.com/).
+I'm Alex C-G, Open Source Evangelist for Jina. I'm all about getting our new contributors up-to-speed, and that's what we'll do below. 
+
+# Join Us on Slack!
+
+The best way to know more about contributing and how to get started is to **[join us on Slack](https://jina-ai.slack.com/messages/general/)** and ask questions in our public channels.
 
 In this guide we're going to go through the steps for each kind of contribution, and good and bad examples of what to do. We look forward to your contributions!
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,6 @@ In this guide we're going to go through the steps for each kind of contribution,
 
 
 - [🏁 Before you Start](#-before-you-start)
-- [Contributing 101](#contributing-101)
 - [🐞 Bugs and Issues](#-bugs-and-issues)
 - [🥇 Making Your First Submission](#-making-your-first-submission)
 - [☑️ Naming Conventions](#-naming-conventions)
@@ -37,9 +36,6 @@ We're happy for any contributions, code or not. If you'd like to write a blog po
 
 * [Contribute docs](#contributing-documentation)
 * For other contributions, please [get in touch](#getting-support) to discuss on Slack
-
-<a name="contributing-101"></a>
-## Contributing 101
 
 <a name="-bugs-and-issues"></a>
 ## 🐞 Bugs and Issues

--- a/README.md
+++ b/README.md
@@ -392,10 +392,10 @@ We welcome all kinds of contributions from the open-source community, individual
 
 ## Community
 
-- [Slack workspace](https://join.slack.com/t/jina-ai/shared_invite/zt-dkl7x8p0-rVCv~3Fdc3~Dpwx7T7XG8w) - a communication platform for developers to discuss Jina
+- [Slack workspace](https://jina-ai.slack.com/messages/general/) - join #general on our Slack to meet the team and ask questions
 - [YouTube channel](https://youtube.com/c/jina-ai) - subscribe to the latest video tutorials, release demos, webinars and presentations.
 - [LinkedIn](https://www.linkedin.com/company/jinaai/) - get to know Jina AI as a company and find job opportunities
-- [![Twitter Follow](https://img.shields.io/twitter/follow/JinaAI_?label=Follow%20%40JinaAI_&style=social)](https://twitter.com/JinaAI_) - follow us and interact with using hashtag `#JinaSearch`
+- [![Twitter Follow](https://img.shields.io/twitter/follow/JinaAI_?label=Follow%20%40JinaAI_&style=social)](https://twitter.com/JinaAI_) - follow and interact with us using hashtag `#JinaSearch`
 - [Company](https://jina.ai) - know more about our company and how we are fully committed to open-source.
 
 ## Open Governance


### PR DESCRIPTION
Based on feedback during devrel call, make Slack more prominent and instruct users to post to #general channel specifically