### PR TITLE
Avoid passing whole doc to executor for BinaryPbIndexer

### DIFF
--- a/jina/clients/python/request.py
+++ b/jina/clients/python/request.py
@@ -23,6 +23,7 @@ def _add_document(request: 'jina_pb2.Request',
                   docs_in_same_batch: int,
                   mime_type: str,
                   buffer_sniff: bool,
+                  override_doc_id: bool = True,
                   ):
     d = getattr(request, str(mode).lower()).docs.add()
     if isinstance(content, jina_pb2.Document):
@@ -63,14 +64,18 @@ def _add_document(request: 'jina_pb2.Request',
     #   why can't delegate this to crafter? (Han)
     d.weight = 1.0
     d.length = docs_in_same_batch
-    d.id = uid.new_doc_id(d)
+
+    if override_doc_id:
+        d.id = uid.new_doc_id(d)
 
 
 def _generate(data: Union[
     Iterator['jina_pb2.Document'], Iterator[bytes], Iterator['np.ndarray'], Iterator[str], 'np.ndarray',],
               batch_size: int = 0, mode: ClientMode = ClientMode.INDEX,
               top_k: Optional[int] = None,
-              mime_type: str = None, queryset: Iterator['jina_pb2.QueryLang'] = None,
+              mime_type: str = None,
+              override_doc_id: bool = True,
+              queryset: Iterator['jina_pb2.QueryLang'] = None,
               *args,
               **kwargs,
               ) -> Iterator['jina_pb2.Message']:
@@ -118,6 +123,7 @@ def _generate(data: Union[
                           docs_in_same_batch=batch_size,
                           mime_type=mime_type,
                           buffer_sniff=buffer_sniff,
+                          override_doc_id=override_doc_id
                           )
         yield req
 

--- a/jina/drivers/index.py
+++ b/jina/drivers/index.py
@@ -39,4 +39,6 @@ class KVIndexDriver(BaseIndexDriver):
     """
 
     def _apply_all(self, docs: Iterable['jina_pb2.Document'], *args, **kwargs) -> None:
-        self.exec_fn(docs)
+        keys = [uid.id2hash(doc.id) for doc in docs]
+        values = [doc.SerializeToString() for doc in docs]
+        self.exec_fn(keys, values)

--- a/tests/unit/drivers/test_kv_search_driver.py
+++ b/tests/unit/drivers/test_kv_search_driver.py
@@ -42,10 +42,10 @@ class MockIndexer(BaseKVIndexer):
         doc4.id = '4'
         doc4.embedding.CopyFrom(array2pb(np.array([int(doc4.id)])))
         self.db = {
-            1: doc1,
-            2: doc2,
-            3: doc3,
-            4: doc4
+            1: doc1.SerializeToString(),
+            2: doc2.SerializeToString(),
+            3: doc3.SerializeToString(),
+            4: doc4.SerializeToString()
         }
 
 

--- a/tests/unit/executors/indexers/test_binary_indexer.py
+++ b/tests/unit/executors/indexers/test_binary_indexer.py
@@ -33,6 +33,7 @@ def test_binarypb_in_flow(test_metas):
         f.index(docs, override_doc_id=False)
 
     def validate(req):
+        assert len(docs) == len(req.docs)
         for d, d0 in zip(req.docs, docs):
             assert d.embedding.buffer == d0.embedding.buffer
 

--- a/tests/unit/flow/test_flow_index.py
+++ b/tests/unit/flow/test_flow_index.py
@@ -4,7 +4,7 @@ import time
 import pytest
 
 from jina.flow import Flow
-from jina.proto import jina_pb2
+from jina.proto import jina_pb2, uid
 from tests import random_docs, rm_files
 
 cur_dir = os.path.dirname(os.path.abspath(__file__))
@@ -13,9 +13,11 @@ cur_dir = os.path.dirname(os.path.abspath(__file__))
 def random_queries(num_docs, chunks_per_doc=5):
     for j in range(num_docs):
         d = jina_pb2.Document()
+        d.id = uid.new_doc_id()
         for k in range(chunks_per_doc):
             dd = d.chunks.add()
-            dd.id = k + 1  # 1-indexed
+            dd.id = uid.new_doc_id(dd)
+            # dd.id = k + 1  # 1-indexed
         yield d
 
 
@@ -40,7 +42,7 @@ def test_shards_insufficient_data():
     f = Flow().add(name='doc_pb', uses=os.path.join(cur_dir, '../yaml/test-docpb.yml'), parallel=parallel,
                    separated_workspace=True)
     with f:
-        f.index(input_fn=random_docs(index_docs), random_doc_id=False)
+        f.index(input_fn=random_docs(index_docs), override_doc_id=False)
 
     time.sleep(2)
     with f:
@@ -49,7 +51,7 @@ def test_shards_insufficient_data():
     f = Flow().add(name='doc_pb', uses=os.path.join(cur_dir, '../yaml/test-docpb.yml'), parallel=parallel,
                    separated_workspace=True, polling='all', uses_after='_merge_all')
     with f:
-        f.search(input_fn=random_queries(1, index_docs), random_doc_id=False, output_fn=validate,
+        f.search(input_fn=random_queries(1, index_docs), override_doc_id=False,
                  callback_on_body=True)
     time.sleep(2)
     rm_files(['test-docshard-tmp'])

--- a/tests/unit/test_workspace.py
+++ b/tests/unit/test_workspace.py
@@ -64,7 +64,7 @@ class MyTestCase(JinaTestCase):
             assert a[0] == a['test_meta']
             self.assertFalse(a[0].is_updated)
             self.assertFalse(a.is_updated)
-            a[0].add([jina_pb2.Document()])
+            a[0].add([j, j * 2, j * 3], [bytes(j), bytes(j * 2), bytes(j * 3)])
             self.assertTrue(a[0].is_updated)
             self.assertTrue(a.is_updated)
             self.assertFalse(a[1].is_updated)


### PR DESCRIPTION
- Changed invocation of `exec_fn` for `KVIndexDriver` & `KVSearchDriver`
- Test changes 