### PR TITLE
test: force ignore hub directory in config

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,8 @@
 codecov:
   # https://docs.codecov.io/docs/comparing-commits
   allow_coverage_offsets: true
+ignore:
+  - "jina/hub"
 coverage:
   status:
     project:


### PR DESCRIPTION
A follow-up PR for #1054 , in 1054 coverage has back to 80% while the coverage not being updated on master branch. This one force codecov ignore `jina/hub` folder.