### PR TITLE
feat: check whether a document has been already indexed

### DIFF
--- a/jina/drivers/cache.py
+++ b/jina/drivers/cache.py
@@ -1,4 +1,4 @@
-from typing import Iterable, Any
+from typing import Iterable, Any, Dict
 
 from .index import BaseIndexDriver
 
@@ -31,3 +31,17 @@ class BaseCacheDriver(BaseIndexDriver):
         :return:
         """
         pass
+
+
+class TaggingCacheDriver(BaseCacheDriver):
+    """Label the hit-cache docs with certain tags """
+
+    def __init__(self, tags: Dict, *args, **kwargs):
+        """
+        :param tags: the tags to be updated on hit docs
+        """
+        super().__init__(*args, **kwargs)
+        self._tags = tags
+
+    def on_hit(self, req_doc: 'jina_pb2.Document', hit_result: Any) -> None:
+        req_doc.tags.update(self._tags)

--- a/jina/drivers/index.py
+++ b/jina/drivers/index.py
@@ -42,5 +42,3 @@ class KVIndexDriver(BaseIndexDriver):
         keys = [uid.id2hash(doc.id) for doc in docs]
         values = [doc.SerializeToString() for doc in docs]
         self.exec_fn(keys, values)
-
-

--- a/jina/drivers/querylang/queryset/dunderkey.py
+++ b/jina/drivers/querylang/queryset/dunderkey.py
@@ -130,7 +130,10 @@ def dunder_get(_dict: Any, key: str) -> Any:
     if isinstance(part1, int):
         result = guard_iter(_dict)[part1]
     elif isinstance(_dict, dict) or isinstance(_dict, Struct):
-        result = _dict[part1]
+        if part1 in _dict:
+            result = _dict[part1]
+        else:
+            result = None
     else:
         result = getattr(_dict, part1)
 

--- a/jina/executors/indexers/cache.py
+++ b/jina/executors/indexers/cache.py
@@ -6,7 +6,7 @@ from . import BaseKVIndexer
 from ...proto import uid
 
 
-class InMemoryIDCache(BaseKVIndexer):
+class DocIDCache(BaseKVIndexer):
     """Store doc ids in a int64 set and persistent it to a numpy array """
 
     def __init__(self, *args, **kwargs):

--- a/jina/logging/formatter.py
+++ b/jina/logging/formatter.py
@@ -27,12 +27,15 @@ class ColorFormatter(Formatter):
 
 
 class PlainFormatter(Formatter):
-    """Remove all control chars from the log and format it as plain text """
+    """Remove all control chars from the log and format it as plain text
+
+    Also restrict the max-length of msg to 512
+    """
 
     def format(self, record):
         cr = copy(record)
         if isinstance(cr.msg, str):
-            cr.msg = re.sub(r'\u001b\[.*?[@-~]', '', str(cr.msg))
+            cr.msg = re.sub(r'\u001b\[.*?[@-~]', '', str(cr.msg))[:512]
         return super().format(cr)
 
 

--- a/jina/resources/executors._unique.yml
+++ b/jina/resources/executors._unique.yml
@@ -1,0 +1,15 @@
+!DocIDCache
+with:
+  index_path: cache.tmp
+requests:
+  on:
+    [SearchRequest, TrainRequest, IndexRequest, ControlRequest]:
+      - !RouteDriver {}
+    IndexRequest:
+      - !TaggingCacheDriver
+        with:
+          tags:
+            is_indexed: true
+      - !FilterQL
+        with:
+          lookups: {tags__is_indexed__neq: true}

--- a/jina/resources/executors._unique.yml
+++ b/jina/resources/executors._unique.yml
@@ -3,7 +3,7 @@ with:
   index_path: cache.tmp
 requests:
   on:
-    [SearchRequest, TrainRequest, IndexRequest, ControlRequest]:
+    [SearchRequest, TrainRequest, IndexRequest, ControlRequest, EvaluateRequest]:
       - !RouteDriver {}
     IndexRequest:
       - !TaggingCacheDriver

--- a/tests/integration/incremental_indexing/inc_docindexer.yml
+++ b/tests/integration/incremental_indexing/inc_docindexer.yml
@@ -1,0 +1,41 @@
+!CompoundExecutor
+components:
+  - !DocIDCache
+    metas:
+      workspace: $JINA_TEST_INCREMENTAL_INDEX_WORKSPACE
+      name: duplicate_checker
+      index_filename: cache.bin
+  - !BinaryPbIndexer
+    with:
+      index_filename: doc.gz
+    metas:
+      workspace: $JINA_TEST_INCREMENTAL_INDEX_WORKSPACE
+      name: doc_idx
+metas:
+  name: inc_docindexer
+  workspace: $JINA_TEST_INCREMENTAL_INDEX_WORKSPACE
+requests:
+  on:
+    IndexRequest:
+      - !TaggingCacheDriver
+        with:
+          executor: duplicate_checker
+          tags:
+            is_indexed: true
+      - !FilterQL
+        with:
+          lookups: {tags__is_indexed__neq: true}
+      - !ExcludeQL
+        with:
+          fields:
+            - chunks
+            - buffer
+      - !KVIndexDriver
+        with:
+          executor: doc_idx
+    SearchRequest:
+      - !KVSearchDriver
+        with:
+          executor: doc_idx
+    ControlRequest:
+      - !ControlReqDriver {}

--- a/tests/integration/incremental_indexing/inc_vectorindexer.yml
+++ b/tests/integration/incremental_indexing/inc_vectorindexer.yml
@@ -1,0 +1,36 @@
+!CompoundExecutor
+components:
+  - !DocIDCache
+    metas:
+      workspace: $JINA_TEST_INCREMENTAL_INDEX_WORKSPACE
+      name: duplicate_checker
+      index_filename: cache.bin
+  - !NumpyIndexer
+    with:
+      index_filename: vec.gz
+    metas:
+      workspace: $JINA_TEST_INCREMENTAL_INDEX_WORKSPACE
+      name: vec_idx
+metas:
+  name: inc_vecindexer
+  workspace: $JINA_TEST_INCREMENTAL_INDEX_WORKSPACE
+requests:
+  on:
+    IndexRequest:
+      - !TaggingCacheDriver
+        with:
+          executor: duplicate_checker
+          tags:
+            is_indexed: true
+      - !FilterQL
+        with:
+          lookups: {tags__is_indexed__neq: true}
+      - !VectorIndexDriver
+        with:
+          executor: vec_idx
+    SearchRequest:
+      - !VectorSearchDriver
+        with:
+          executor: vec_idx
+    ControlRequest:
+      - !ControlReqDriver {}

--- a/tests/integration/incremental_indexing/test_incremental_indexing.py
+++ b/tests/integration/incremental_indexing/test_incremental_indexing.py
@@ -1,5 +1,4 @@
 import os
-import pytest
 import numpy as np
 from jina.flow import Flow
 from jina.proto import jina_pb2
@@ -11,165 +10,185 @@ from jina.executors.indexers.keyvalue import BinaryPbIndexer
 cur_dir = os.path.dirname(os.path.abspath(__file__))
 
 
-@pytest.mark.skip(reason='TDD for incremental indexing')
+def get_duplicate_docs(num_docs=10):
+    result = []
+    unique_set = set()
+    for idx in range(num_docs):
+        doc = jina_pb2.Document()
+        content = int(idx / 2)
+        doc.embedding.CopyFrom(array2pb(np.array([content])))
+        doc.text = f'I am doc{content}'
+        result.append(doc)
+        unique_set.add(content)
+    return result, len(unique_set)
+
+
+def test_incremental_indexing_vecindexers(tmpdir):
+    os.environ['JINA_TEST_INCREMENTAL_INDEX_WORKSPACE'] = str(tmpdir)
+    total_docs = 10
+    duplicate_docs, num_uniq_docs = get_duplicate_docs(num_docs=total_docs)
+
+    f = (Flow()
+         .add(uses=os.path.join(cur_dir, 'inc_vectorindexer.yml'), name='vec_idx'))
+
+    with f:
+        f.index(duplicate_docs)
+
+    with BaseExecutor.load(os.path.join(tmpdir, 'vec_idx.bin')) as vector_indexer:
+        assert isinstance(vector_indexer, NumpyIndexer)
+        assert vector_indexer.size == num_uniq_docs
+
+    del os.environ['JINA_TEST_INCREMENTAL_INDEX_WORKSPACE']
+
+
+def test_incremental_indexing_docindexers(tmpdir):
+    os.environ['JINA_TEST_INCREMENTAL_INDEX_WORKSPACE'] = str(tmpdir)
+    total_docs = 10
+    duplicate_docs, num_uniq_docs = get_duplicate_docs(num_docs=total_docs)
+
+    f = (Flow()
+         .add(uses=os.path.join(cur_dir, 'inc_docindexer.yml'), shards=1))
+
+    with f:
+        f.index(duplicate_docs)
+
+    with BaseExecutor.load(os.path.join(tmpdir, 'doc_idx.bin')) as doc_indexer:
+        assert isinstance(doc_indexer, BinaryPbIndexer)
+        assert doc_indexer.size == num_uniq_docs
+
+    del os.environ['JINA_TEST_INCREMENTAL_INDEX_WORKSPACE']
+
+
 def test_incremental_indexing_sequential_indexers(tmpdir):
     os.environ['JINA_TEST_INCREMENTAL_INDEX_WORKSPACE'] = str(tmpdir)
 
-    doc0 = jina_pb2.Document()
-    doc0.embedding.CopyFrom(array2pb(np.array([0])))
-    doc0.text = 'I am doc0'
-    doc1 = jina_pb2.Document()
-    doc1.embedding.CopyFrom(array2pb(np.array([2])))
-    doc1.text = 'I am doc2'
-    doc2 = jina_pb2.Document()
-    doc2.embedding.CopyFrom(array2pb(np.array([2])))
-    doc2.text = 'I am doc2'
+    total_docs = 20
+    duplicate_docs, num_uniq_docs = get_duplicate_docs(num_docs=total_docs)
 
-    f = Flow(). \
-        add(uses=os.path.join(cur_dir, 'vectorindexer.yml'), shards=1, name='vec_idx').add(
-        uses=os.path.join(cur_dir, 'docindexer.yml'), shards=1, name='doc_idx')
+    f = (Flow()
+         .add(uses=os.path.join(cur_dir, 'inc_vectorindexer.yml'), shards=1)
+         .add(uses=os.path.join(cur_dir, 'inc_docindexer.yml'), shards=1))
+
     with f:
-        f.index([doc0, doc1])
+        f.index(duplicate_docs[:10])
+        f.index(duplicate_docs)
 
     with BaseExecutor.load(os.path.join(tmpdir, 'vec_idx.bin')) as vector_indexer:
         assert isinstance(vector_indexer, NumpyIndexer)
-        assert vector_indexer._size == 2
+        assert vector_indexer._size == num_uniq_docs
 
     with BaseExecutor.load(os.path.join(tmpdir, 'doc_idx.bin')) as doc_indexer:
         assert isinstance(doc_indexer, BinaryPbIndexer)
-        assert doc_indexer._size == 2
+        assert doc_indexer._size == num_uniq_docs
 
-    with f:
-        f.index([doc0, doc2])
-
-    with BaseExecutor.load(os.path.join(tmpdir, 'vec_idx.bin')) as vector_indexer:
-        # only one of the documents must have been added
-        assert isinstance(vector_indexer, NumpyIndexer)
-        assert vector_indexer._size == 3
-
-    with BaseExecutor.load(os.path.join(tmpdir, 'doc_idx.bin')) as doc_indexer:
-        assert isinstance(doc_indexer, BinaryPbIndexer)
-        assert doc_indexer._size == 3
     del os.environ['JINA_TEST_INCREMENTAL_INDEX_WORKSPACE']
 
 
-@pytest.mark.skip(reason='TDD for incremental indexing')
 def test_incremental_indexing_sequential_indexers_with_shards(tmpdir):
     os.environ['JINA_TEST_INCREMENTAL_INDEX_WORKSPACE'] = str(tmpdir)
+    total_docs = 1000
+    duplicate_docs, num_uniq_docs = get_duplicate_docs(num_docs=total_docs)
 
-    docs = []
-    for i in range(1000):
-        doc = jina_pb2.Document()
-        doc.embedding.CopyFrom(array2pb(np.array([i])))
-        doc.text = f'I am doc{i}'
-        docs.append(doc)
-
-    f = Flow(). \
-        add(uses=os.path.join(cur_dir, 'vectorindexer.yml'), shards=3, name='vec_idx').add(
-        uses=os.path.join(cur_dir, 'docindexer.yml'), shards=3, name='doc_idx')
+    num_shards = 4
+    f = (Flow()
+         .add(uses=os.path.join(cur_dir, 'vectorindexer.yml'),
+              uses_before='_unique',
+              shards=num_shards,
+              separated_workspace=True)
+         .add(uses=os.path.join(cur_dir, 'docindexer.yml'),
+              uses_before='_unique',
+              shards=num_shards,
+              separated_workspace=True))
     with f:
-        f.index(docs[0: 900])
+        f.index(duplicate_docs[:500])
+        f.index(duplicate_docs)
 
-    with BaseExecutor.load(os.path.join(tmpdir, 'vec_idx.bin')) as vector_indexer:
-        assert isinstance(vector_indexer, NumpyIndexer)
-        assert vector_indexer._size == 900
+    vect_idx_size = 0
+    for shard_idx in range(num_shards):
+        save_abspath = os.path.join(tmpdir, f'vec_idx-{shard_idx + 1}', 'vec_idx.bin')
+        with BaseExecutor.load(save_abspath) as vector_indexer:
+            assert isinstance(vector_indexer, NumpyIndexer)
+            vect_idx_size += vector_indexer._size
+    assert vect_idx_size == num_uniq_docs
 
-    with BaseExecutor.load(os.path.join(tmpdir, 'doc_idx.bin')) as doc_indexer:
-        assert isinstance(doc_indexer, BinaryPbIndexer)
-        assert doc_indexer._size == 900
+    doc_idx_size = 0
+    for shard_idx in range(num_shards):
+        save_abspath = os.path.join(tmpdir, f'doc_idx-{shard_idx + 1}', 'doc_idx.bin')
+        with BaseExecutor.load(save_abspath) as doc_indexer:
+            assert isinstance(doc_indexer, BinaryPbIndexer)
+            doc_idx_size += doc_indexer._size
+    assert doc_idx_size == num_uniq_docs
 
-    with f:
-        f.index(docs[0: 950])
-
-    with BaseExecutor.load(os.path.join(tmpdir, 'vec_idx.bin')) as vector_indexer:
-        # only one of the documents must have been added
-        assert isinstance(vector_indexer, NumpyIndexer)
-        assert vector_indexer._size == 950
-
-    with BaseExecutor.load(os.path.join(tmpdir, 'doc_idx.bin')) as doc_indexer:
-        assert isinstance(doc_indexer, BinaryPbIndexer)
-        assert doc_indexer._size == 950
     del os.environ['JINA_TEST_INCREMENTAL_INDEX_WORKSPACE']
 
 
-@pytest.mark.skip(reason='TDD for incremental indexing')
 def test_incremental_indexing_parallel_indexers(tmpdir):
     os.environ['JINA_TEST_INCREMENTAL_INDEX_WORKSPACE'] = str(tmpdir)
+    total_docs = 1000
+    duplicate_docs, num_uniq_docs = get_duplicate_docs(num_docs=total_docs)
 
-    doc0 = jina_pb2.Document()
-    doc0.embedding.CopyFrom(array2pb(np.array([0])))
-    doc0.text = 'I am doc0'
-    doc1 = jina_pb2.Document()
-    doc1.embedding.CopyFrom(array2pb(np.array([2])))
-    doc1.text = 'I am doc2'
-    doc2 = jina_pb2.Document()
-    doc2.embedding.CopyFrom(array2pb(np.array([2])))
-    doc2.text = 'I am doc2'
-
-    f = Flow(). \
-        add(uses=os.path.join(cur_dir, 'vectorindexer.yml'), shards=1, name='vec_idx').add(
-        uses=os.path.join(cur_dir, 'docindexer.yml'), shards=1, name='doc_idx',
-        needs=['gateway']). \
-        add(uses='_merge', needs=['vec_idx', 'doc_idx'], name='join_all')
+    f = (Flow()
+         .add(uses=os.path.join(cur_dir, 'inc_vectorindexer.yml'),
+              name='inc_vec')
+         .add(uses=os.path.join(cur_dir, 'inc_docindexer.yml'),
+              name='inc_doc',
+              needs=['gateway'])
+         .add(uses='_merge', needs=['inc_vec', 'inc_doc']))
     with f:
-        f.index([doc0, doc1])
+        f.index(duplicate_docs[:500])
+        f.index(duplicate_docs)
 
     with BaseExecutor.load(os.path.join(tmpdir, 'vec_idx.bin')) as vector_indexer:
         assert isinstance(vector_indexer, NumpyIndexer)
-        assert vector_indexer._size == 2
+        assert vector_indexer._size == num_uniq_docs
 
     with BaseExecutor.load(os.path.join(tmpdir, 'doc_idx.bin')) as doc_indexer:
         assert isinstance(doc_indexer, BinaryPbIndexer)
-        assert doc_indexer._size == 2
+        assert doc_indexer._size == num_uniq_docs
 
-    with f:
-        f.index([doc0, doc2])
-
-    with BaseExecutor.load(os.path.join(tmpdir, 'vec_idx.bin')) as vector_indexer:
-        assert isinstance(vector_indexer, NumpyIndexer)
-        assert vector_indexer._size == 3
-
-    with BaseExecutor.load(os.path.join(tmpdir, 'doc_idx.bin')) as doc_indexer:
-        assert isinstance(doc_indexer, BinaryPbIndexer)
-        assert doc_indexer._size == 3
     del os.environ['JINA_TEST_INCREMENTAL_INDEX_WORKSPACE']
 
 
-@pytest.mark.skip(reason='TDD for incremental indexing')
 def test_incremental_indexing_parallel_indexers_with_shards(tmpdir):
     os.environ['JINA_TEST_INCREMENTAL_INDEX_WORKSPACE'] = str(tmpdir)
+    total_docs = 1000
+    duplicate_docs, num_uniq_docs = get_duplicate_docs(num_docs=total_docs)
 
-    docs = []
-    for i in range(1000):
-        doc = jina_pb2.Document()
-        doc.embedding.CopyFrom(array2pb(np.array([i])))
-        doc.text = f'I am doc{i}'
-        docs.append(doc)
+    num_shards = 4
 
-    f = Flow(). \
-        add(uses=os.path.join(cur_dir, 'vectorindexer.yml'), shards=3, name='vec_idx').add(
-        uses=os.path.join(cur_dir, 'docindexer.yml'), shards=3, name='doc_idx',
-        needs=['gateway']). \
-        add(uses='_merge', needs=['vec_idx', 'doc_idx'], name='join_all')
-    with f:
-        f.index(docs[0: 900])
-
-    with BaseExecutor.load(os.path.join(tmpdir, 'vec_idx.bin')) as vector_indexer:
-        assert isinstance(vector_indexer, NumpyIndexer)
-        assert vector_indexer._size == 900
-
-    with BaseExecutor.load(os.path.join(tmpdir, 'doc_idx.bin')) as doc_indexer:
-        assert isinstance(doc_indexer, BinaryPbIndexer)
-        assert doc_indexer._size == 900
+    f = (Flow()
+         .add(uses=os.path.join(cur_dir, 'vectorindexer.yml'),
+              uses_before='_unique',
+              shards=num_shards,
+              name='inc_vec',
+              separated_workspace=True)
+         .add(uses=os.path.join(cur_dir, 'docindexer.yml'),
+              uses_before='_unique',
+              shards=num_shards,
+              name='inc_doc',
+              needs=['gateway'],
+              separated_workspace=True)
+         .add(uses='_merge',
+              needs=['inc_vec', 'inc_doc']))
 
     with f:
-        f.index(docs[0: 950])
+        f.index(duplicate_docs[:500])
+        f.index(duplicate_docs)
 
-    with BaseExecutor.load(os.path.join(tmpdir, 'vec_idx.bin')) as vector_indexer:
-        assert isinstance(vector_indexer, NumpyIndexer)
-        assert vector_indexer._size == 950
+    vect_idx_size = 0
+    for shard_idx in range(num_shards):
+        save_abspath = os.path.join(tmpdir, f'vec_idx-{shard_idx + 1}', 'vec_idx.bin')
+        with BaseExecutor.load(save_abspath) as vector_indexer:
+            assert isinstance(vector_indexer, NumpyIndexer)
+            vect_idx_size += vector_indexer._size
+    assert vect_idx_size == num_uniq_docs
 
-    with BaseExecutor.load(os.path.join(tmpdir, 'doc_idx.bin')) as doc_indexer:
-        assert isinstance(doc_indexer, BinaryPbIndexer)
-        assert doc_indexer._size == 950
+    doc_idx_size = 0
+    for shard_idx in range(num_shards):
+        save_abspath = os.path.join(tmpdir, f'doc_idx-{shard_idx + 1}', 'doc_idx.bin')
+        with BaseExecutor.load(save_abspath) as doc_indexer:
+            assert isinstance(doc_indexer, BinaryPbIndexer)
+            doc_idx_size += doc_indexer._size
+    assert doc_idx_size == num_uniq_docs
+
     del os.environ['JINA_TEST_INCREMENTAL_INDEX_WORKSPACE']

--- a/tests/unit/drivers/querylang/queryset/test_dunderkeys.py
+++ b/tests/unit/drivers/querylang/queryset/test_dunderkeys.py
@@ -25,8 +25,8 @@ def test_dunder_get():
     assert dunder_get(d, 'tags__a') == 'hello'
 
     # Error on invalid key
-    with pytest.raises(Exception):
-        dunder_get({'a': {'b': 5}}, 'a__c')
+
+    assert dunder_get({'a': {'b': 5}}, 'a__c') is None
     # Error if key is too nested
     with pytest.raises(Exception):
         dunder_get({'a': {'b': 5}, 'c': 8}, 'a__b__c')

--- a/tests/unit/drivers/test_cache_driver.py
+++ b/tests/unit/drivers/test_cache_driver.py
@@ -5,7 +5,7 @@ import numpy as np
 import pytest
 
 from jina.drivers.cache import BaseCacheDriver
-from jina.executors.indexers.cache import InMemoryIDCache
+from jina.executors.indexers.cache import DocIDCache
 from jina.proto import jina_pb2, uid
 from tests import random_docs, rm_files
 
@@ -25,7 +25,7 @@ class MockCacheDriver(BaseCacheDriver):
 def test_cache_driver_twice():
     docs = list(random_docs(10))
     driver = MockCacheDriver()
-    with InMemoryIDCache(filename) as executor:
+    with DocIDCache(filename) as executor:
         assert not executor.handler_mutex
         driver.attach(executor=executor, pea=None)
 
@@ -50,7 +50,7 @@ def test_cache_driver_from_file():
         fp.write(np.array([uid.id2hash(d.id) for d in docs], dtype=np.int64).tobytes())
 
     driver = MockCacheDriver()
-    with InMemoryIDCache(filename) as executor:
+    with DocIDCache(filename) as executor:
         assert not executor.handler_mutex
         driver.attach(executor=executor, pea=None)
 

--- a/tests/unit/executors/test_route_exec.py
+++ b/tests/unit/executors/test_route_exec.py
@@ -1,3 +1,5 @@
+from pprint import pprint
+
 from jina.flow import Flow
 
 from tests import random_docs
@@ -10,11 +12,11 @@ cur_dir = os.path.dirname(os.path.abspath(__file__))
 
 def test_load_driver():
     b = BaseExecutor.load_config(os.path.join(cur_dir, 'yaml/route.yml'))
-    print(b._drivers)
+    pprint(b._drivers)
 
     c = BaseExecutor.load_config('_route')
     assert len(b._drivers['ControlRequest']) == len(c._drivers['ControlRequest'])
-    print(c._drivers)
+    pprint(c._drivers)
 
 
 @pytest.mark.skip('https://github.com/jina-ai/jina/pull/1070')
@@ -27,3 +29,5 @@ def test_route():
 
     with f:
         f.index(docs)
+
+test_load_driver()

--- a/tests/unit/executors/test_route_exec.py
+++ b/tests/unit/executors/test_route_exec.py
@@ -1,0 +1,28 @@
+from jina.flow import Flow
+
+from tests import random_docs
+
+from jina.executors import BaseExecutor
+import os
+
+cur_dir = os.path.dirname(os.path.abspath(__file__))
+
+def test_load_driver():
+    b = BaseExecutor.load_config(os.path.join(cur_dir, 'yaml/route.yml'))
+    print(b._drivers)
+
+    c = BaseExecutor.load_config('_route')
+    assert len(b._drivers['ControlRequest']) == len(c._drivers['ControlRequest'])
+    print(c._drivers)
+
+def test_route():
+    docs = random_docs(num_docs=2, chunks_per_doc=2)
+    f = (Flow()
+         .add(uses='_pass',
+              uses_before=os.path.join(cur_dir, 'yaml', 'route.yml'),
+              shards=2))
+
+    with f:
+        f.index(docs)
+
+test_load_driver()

--- a/tests/unit/executors/test_route_exec.py
+++ b/tests/unit/executors/test_route_exec.py
@@ -1,11 +1,12 @@
 from jina.flow import Flow
 
 from tests import random_docs
-
+import pytest
 from jina.executors import BaseExecutor
 import os
 
 cur_dir = os.path.dirname(os.path.abspath(__file__))
+
 
 def test_load_driver():
     b = BaseExecutor.load_config(os.path.join(cur_dir, 'yaml/route.yml'))
@@ -15,6 +16,8 @@ def test_load_driver():
     assert len(b._drivers['ControlRequest']) == len(c._drivers['ControlRequest'])
     print(c._drivers)
 
+
+@pytest.mark.skip('https://github.com/jina-ai/jina/pull/1070')
 def test_route():
     docs = random_docs(num_docs=2, chunks_per_doc=2)
     f = (Flow()
@@ -24,5 +27,3 @@ def test_route():
 
     with f:
         f.index(docs)
-
-test_load_driver()

--- a/tests/unit/executors/yaml/route.yml
+++ b/tests/unit/executors/yaml/route.yml
@@ -4,6 +4,8 @@ metas:
   name: route
 requests:
   on:
+#    [SearchRequest, TrainRequest, IndexRequest, ControlRequest]:
+#      - !RouteDriver {}
     ControlRequest:
       - !ControlReqDriver {}
       - !RouteDriver {}

--- a/tests/unit/executors/yaml/route.yml
+++ b/tests/unit/executors/yaml/route.yml
@@ -1,0 +1,15 @@
+!BaseExecutor
+with: {}
+metas:
+  name: route
+requests:
+  on:
+    ControlRequest:
+      - !ControlReqDriver {}
+      - !RouteDriver {}
+    SearchRequest:
+      - !RouteDriver {}
+    IndexRequest:
+      - !RouteDriver {}
+    TrainRequest:
+      - !RouteDriver {}

--- a/tests/unit/executors/yaml/route.yml
+++ b/tests/unit/executors/yaml/route.yml
@@ -7,8 +7,8 @@ requests:
 #    [SearchRequest, TrainRequest, IndexRequest, ControlRequest]:
 #      - !RouteDriver {}
     ControlRequest:
-      - !ControlReqDriver {}
       - !RouteDriver {}
+      - !ControlReqDriver {}
     SearchRequest:
       - !RouteDriver {}
     IndexRequest:


### PR DESCRIPTION
this PR is an improvement & replacement for #1062 

## Improvement over #1062 

#1070 takes the tests from #1062 and improves this PR on the following aspects:
- #1070 does not change Protobuf, instead, it uses `tags` in our Protobuf schema
- #1070 does not change `KVIndexDriver` and `VectorIndexDriver` to unselect hit-cache-docs, instead, it uses `FilterQL` and add it to the YAML level.
- #1070 adds `DocIdCache(KVIndexer)` and `BaseCacheDriver(BaseIndexDriver)`

## New high-level feature

- shortcut executor `_unique` is introduced, one can use it in `--uses-before` when indexing to prevent repeated indexing

## Caveats
#1068 test code is included in this PR but the problem is not solved. #1068 wrongly diagnosed the problem, real issue is posted in #1071 