### PR TITLE
refactor(indexer): refactor cache index add shortcuts

### DIFF
--- a/jina/drivers/cache.py
+++ b/jina/drivers/cache.py
@@ -7,6 +7,20 @@ if False:
 
 
 class BaseCacheDriver(BaseIndexDriver):
+    """
+    The driver related to :class:`BaseCache`
+
+    """
+
+    def __init__(self, with_serialization: bool = False, *args, **kwargs):
+        """
+
+        :param with_serialization: feed serialized doc to the CacheIndexer
+        :param args:
+        :param kwargs:
+        """
+        self.with_serialization = with_serialization
+        super().__init__(*args, **kwargs)
 
     def _apply_all(self, docs: Iterable['jina_pb2.Document'], *args, **kwargs) -> None:
         for d in docs:
@@ -21,7 +35,10 @@ class BaseCacheDriver(BaseIndexDriver):
 
         :param doc: the document in the request but missed in the cache
         """
-        self.exec_fn(doc.id, doc.SerializeToString())
+        if self.with_serialization:
+            self.exec_fn(doc.id, doc.SerializeToString())
+        else:
+            self.exec_fn(doc.id)
 
     def on_hit(self, req_doc: 'jina_pb2.Document', hit_result: Any) -> None:
         """ Function to call when doc is hit

--- a/jina/drivers/convert.py
+++ b/jina/drivers/convert.py
@@ -7,10 +7,9 @@ import struct
 import urllib.parse
 import urllib.request
 import zlib
+from typing import Iterable
 
 import numpy as np
-
-from typing import Iterable
 
 from . import BaseRecursiveDriver
 from .helper import guess_mime, array2pb, pb2array
@@ -18,6 +17,7 @@ from .helper import guess_mime, array2pb, pb2array
 if False:
     from ..proto import jina_pb2
     from PIL import Image
+
 
 class BaseConvertDriver(BaseRecursiveDriver):
 
@@ -107,7 +107,8 @@ class NdArray2PngURI(BaseConvertDriver):
     """Simple DocCrafter used in :command:`jina hello-world`,
         it reads ``NdArray`` into base64 png and stored in ``uri``"""
 
-    def __init__(self, target='uri', width: int = 28, height: int = 28, resize_method: str = 'BILINEAR', *args, **kwargs):
+    def __init__(self, target='uri', width: int = 28, height: int = 28, resize_method: str = 'BILINEAR', *args,
+                 **kwargs):
         super().__init__(target, *args, **kwargs)
         self.width = width
         self.height = height
@@ -149,16 +150,16 @@ class NdArray2PngURI(BaseConvertDriver):
         return img_byte_arr
 
     def png_convertor(self, arr: np.array):
-        from PIL import Image
-
         arr = arr.astype(np.uint8)
 
         if len(arr.shape) == 1:
             return self.png_convertor_1d(arr)
         elif len(arr.shape) == 2:
+            from PIL import Image
             im = Image.fromarray(arr).convert('L')
             im = im.resize((self.width, self.height), getattr(Image, self.resize_method))
         elif len(arr.shape) == 3:
+            from PIL import Image
             im = Image.fromarray(arr).convert('RGB')
             im = im.resize((self.width, self.height), getattr(Image, self.resize_method))
         else:
@@ -166,7 +167,7 @@ class NdArray2PngURI(BaseConvertDriver):
 
         png_bytes = NdArray2PngURI.image_to_byte_array(im, format='PNG')
         return 'data:image/png;base64,' + base64.b64encode(png_bytes).decode()
-    
+
     def convert(self, arr: np.array):
         arr.uri = self.png_convertor(arr)
 

--- a/jina/executors/indexers/__init__.py
+++ b/jina/executors/indexers/__init__.py
@@ -219,6 +219,10 @@ class BaseKVIndexer(BaseIndexer):
         return self.query(key)
 
 
+class UniqueVectorIndexer(CompoundExecutor):
+    """A frequently used pattern for combining a :class:`BaseVectorIndexer` and a :class:`DocIDCache` """
+
+
 class CompoundIndexer(CompoundExecutor):
     """A Frequently used pattern for combining A :class:`BaseVectorIndexer` and :class:`BaseKVIndexer`.
     It will be equipped with predefined ``requests.on`` behaviors:

--- a/jina/executors/indexers/__init__.py
+++ b/jina/executors/indexers/__init__.py
@@ -78,6 +78,7 @@ class BaseIndexer(BaseExecutor):
         .. note::
             :attr:`query_handler` and :attr:`write_handler` are by default mutex
         """
+        r = None
         if (not self.handler_mutex or not self.is_handler_loaded) and self.is_exist:
             r = self.get_query_handler()
             if r is None:
@@ -87,7 +88,14 @@ class BaseIndexer(BaseExecutor):
             else:
                 self.logger.info(f'indexer size: {self.size}')
                 self.is_handler_loaded = True
-            return r
+        if r is None:
+            r = self.null_query_handler
+        return r
+
+    @cached_property
+    def null_query_handler(self) -> Optional[Any]:
+        """The empty query handler when :meth:`get_query_handler` fails"""
+        return
 
     @property
     def is_exist(self) -> bool:

--- a/jina/executors/indexers/cache.py
+++ b/jina/executors/indexers/cache.py
@@ -1,3 +1,4 @@
+import tempfile
 from typing import Optional
 
 import numpy as np
@@ -20,6 +21,12 @@ class BaseCache(BaseKVIndexer):
 
 class DocIDCache(BaseCache):
     """Store doc ids in a int64 set and persistent it to a numpy array """
+
+    def __init__(self, index_filename: str = None, *args, **kwargs):
+        if not index_filename:
+            # create a new temp file if not exist
+            index_filename = tempfile.NamedTemporaryFile(delete=False).name
+        super().__init__(index_filename, *args, **kwargs)
 
     def add(self, doc_id: str, *args, **kwargs):
         d_id = uid.id2hash(doc_id)

--- a/jina/executors/indexers/keyvalue.py
+++ b/jina/executors/indexers/keyvalue.py
@@ -7,6 +7,7 @@ from typing import Iterator, Optional
 import numpy as np
 
 from . import BaseKVIndexer
+from ..compound import CompoundExecutor
 
 
 class BinaryPbIndexer(BaseKVIndexer):
@@ -79,3 +80,7 @@ class BinaryPbIndexer(BaseKVIndexer):
 class DataURIPbIndexer(BinaryPbIndexer):
     """Shortcut for :class:`DocPbIndexer` equipped with ``requests.on`` for storing doc-level protobuf and data uri info,
     differ with :class:`ChunkPbIndexer` only in ``requests.on`` """
+
+
+class UniquePbIndexer(CompoundExecutor):
+    """A frequently used pattern for combining a :class:`BaseKVIndexer` and a :class:`DocIDCache` """

--- a/jina/resources/executors.requests.UniquePbIndexer.yml
+++ b/jina/resources/executors.requests.UniquePbIndexer.yml
@@ -1,0 +1,24 @@
+on:
+  IndexRequest:
+    - !TaggingCacheDriver
+      with:
+        executor: DocIDCache
+        tags:
+          is_indexed: true
+    - !FilterQL
+      with:
+        lookups: {tags__is_indexed__neq: true}
+    - !ExcludeQL
+      with:
+        fields:
+          - chunks
+          - buffer
+    - !KVIndexDriver
+      with:
+        executor: BinaryPbIndexer
+  SearchRequest:
+    - !KVSearchDriver
+      with:
+        executor: BinaryPbIndexer
+  ControlRequest:
+    - !ControlReqDriver {}

--- a/jina/resources/executors.requests.UniqueVectorIndexer.yml
+++ b/jina/resources/executors.requests.UniqueVectorIndexer.yml
@@ -1,0 +1,19 @@
+on:
+  IndexRequest:
+    - !TaggingCacheDriver
+      with:
+        executor: DocIDCache
+        tags:
+          is_indexed: true
+    - !FilterQL
+      with:
+        lookups: {tags__is_indexed__neq: true}
+    - !VectorIndexDriver
+      with:
+        executor: BaseVectorIndexer
+  SearchRequest:
+    - !VectorSearchDriver
+      with:
+        executor: BaseVectorIndexer
+  ControlRequest:
+    - !ControlReqDriver {}

--- a/tests/integration/incremental_indexing/test_unique_indexing.py
+++ b/tests/integration/incremental_indexing/test_unique_indexing.py
@@ -1,0 +1,61 @@
+import os
+
+import numpy as np
+
+from jina.drivers.helper import array2pb
+from jina.executors import BaseExecutor
+from jina.executors.indexers.keyvalue import BinaryPbIndexer
+from jina.executors.indexers.vector import NumpyIndexer
+from jina.flow import Flow
+from jina.proto import jina_pb2
+
+cur_dir = os.path.dirname(os.path.abspath(__file__))
+
+
+def get_duplicate_docs(num_docs=10):
+    result = []
+    unique_set = set()
+    for idx in range(num_docs):
+        doc = jina_pb2.Document()
+        content = int(idx / 2)
+        doc.embedding.CopyFrom(array2pb(np.array([content])))
+        doc.text = f'I am doc{content}'
+        result.append(doc)
+        unique_set.add(content)
+    return result, len(unique_set)
+
+
+def test_incremental_indexing_vecindexers(tmpdir):
+    os.environ['JINA_TEST_INCREMENTAL_INDEX_WORKSPACE'] = str(tmpdir)
+    total_docs = 10
+    duplicate_docs, num_uniq_docs = get_duplicate_docs(num_docs=total_docs)
+
+    f = (Flow()
+         .add(uses=os.path.join(cur_dir, 'uniq_vectorindexer.yml'), name='vec_idx'))
+
+    with f:
+        f.index(duplicate_docs)
+
+    with BaseExecutor.load(os.path.join(tmpdir, 'vec_idx.bin')) as vector_indexer:
+        assert isinstance(vector_indexer, NumpyIndexer)
+        assert vector_indexer.size == num_uniq_docs
+
+    del os.environ['JINA_TEST_INCREMENTAL_INDEX_WORKSPACE']
+
+
+def test_incremental_indexing_docindexers(tmpdir):
+    os.environ['JINA_TEST_INCREMENTAL_INDEX_WORKSPACE'] = str(tmpdir)
+    total_docs = 10
+    duplicate_docs, num_uniq_docs = get_duplicate_docs(num_docs=total_docs)
+
+    f = (Flow()
+         .add(uses=os.path.join(cur_dir, 'uniq_docindexer.yml'), shards=1))
+
+    with f:
+        f.index(duplicate_docs)
+
+    with BaseExecutor.load(os.path.join(tmpdir, 'doc_idx.bin')) as doc_indexer:
+        assert isinstance(doc_indexer, BinaryPbIndexer)
+        assert doc_indexer.size == num_uniq_docs
+
+    del os.environ['JINA_TEST_INCREMENTAL_INDEX_WORKSPACE']

--- a/tests/integration/incremental_indexing/uniq_docindexer.yml
+++ b/tests/integration/incremental_indexing/uniq_docindexer.yml
@@ -1,0 +1,12 @@
+!UniquePbIndexer
+components:
+  - !DocIDCache {}
+  - !BinaryPbIndexer
+    with:
+      index_filename: doc.gz
+    metas:
+      workspace: $JINA_TEST_INCREMENTAL_INDEX_WORKSPACE
+      name: doc_idx
+metas:
+  name: inc_docindexer
+  workspace: $JINA_TEST_INCREMENTAL_INDEX_WORKSPACE

--- a/tests/integration/incremental_indexing/uniq_vectorindexer.yml
+++ b/tests/integration/incremental_indexing/uniq_vectorindexer.yml
@@ -1,0 +1,12 @@
+!UniqueVectorIndexer
+components:
+  - !DocIDCache {}
+  - !NumpyIndexer
+    with:
+      index_filename: vec.gz
+    metas:
+      workspace: $JINA_TEST_INCREMENTAL_INDEX_WORKSPACE
+      name: vec_idx
+metas:
+  name: inc_vecindexer
+  workspace: $JINA_TEST_INCREMENTAL_INDEX_WORKSPACE

--- a/tests/unit/drivers/test_cache_driver.py
+++ b/tests/unit/drivers/test_cache_driver.py
@@ -44,6 +44,27 @@ def test_cache_driver_twice():
         rm_files([filename])
 
 
+def test_cache_driver_tmpfile():
+    docs = list(random_docs(10))
+    driver = MockCacheDriver()
+    with DocIDCache() as executor:
+        assert not executor.handler_mutex
+        driver.attach(executor=executor, pea=None)
+
+        driver._traverse_apply(docs)
+
+        with pytest.raises(NotImplementedError):
+            # duplicate docs
+            driver._traverse_apply(docs)
+
+        # new docs
+        docs = list(random_docs(10))
+        driver._traverse_apply(docs)
+
+    # check persistence
+    assert os.path.exists(executor.index_abspath)
+
+
 def test_cache_driver_from_file():
     docs = list(random_docs(10))
     with open(filename, 'wb') as fp:
@@ -65,4 +86,3 @@ def test_cache_driver_from_file():
         # check persistence
         assert os.path.exists(filename)
         rm_files([filename])
-


### PR DESCRIPTION
Two shortcuts are added in respond to #1062 TODO 1

>  Avoid the differences of using DuplicateChecker between single-shard and multi-shards usages. For the single-shard usage, one needs to construct a CompoundIndexer consist of DuplicateChecker and the VectorIndexer/KVIndexer. While for the multi-shards, one needs to put DuplicateChecker into the uses_before. This is because the uses_before does not play any role when shards==1.


- `UniquePbIndexer`, can be directly used via
```yaml
!UniquePbIndexer
components:
  - !DocIDCache {}
  - !BinaryPbIndexer
    with:
      index_filename: doc.gz
    metas:
      workspace: $JINA_TEST_INCREMENTAL_INDEX_WORKSPACE
      name: doc_idx
metas:
  name: inc_docindexer
  workspace: $JINA_TEST_INCREMENTAL_INDEX_WORKSPACE
```

- `UniqueVectorIndexer`:
```yaml
!UniqueVectorIndexer
components:
  - !DocIDCache {}
  - !NumpyIndexer
    with:
      index_filename: vec.gz
    metas:
      workspace: $JINA_TEST_INCREMENTAL_INDEX_WORKSPACE
      name: vec_idx
metas:
  name: inc_vecindexer
  workspace: $JINA_TEST_INCREMENTAL_INDEX_WORKSPACE
```

`requests.on` is auto-bind according to `jina/resources/executors.requests.UniquePbIndexer.yml` and `jina/resources/executors.requests.UniqueVectorIndexer.yml`
