### PR TITLE
feat: potentially add argument of ordered indexes from batch

### DIFF
--- a/tests/unit/executors/test_decorators.py
+++ b/tests/unit/executors/test_decorators.py
@@ -153,3 +153,36 @@ def test_batching_slice_on():
     assert result == [1, 1, 1, 1]
     assert len(instance.batch_sizes) == 1
     assert instance.batch_sizes[0] == 4
+
+
+def test_batching_ordinal_idx_arg(tmpdir):
+
+    path = os.path.join(str(tmpdir), 'vec.gz')
+    vec = np.random.random([10, 10])
+    with open(path, 'wb') as f:
+        f.write(vec.tobytes())
+
+    class A:
+        def __init__(self, batch_size):
+            self.batch_size = batch_size
+            self.ord_idx = []
+
+        @batching(ordinal_idx_arg=2)
+        def f(self, data, ord_idx):
+            print(f' o {ord_idx}')
+            self.ord_idx.append(ord_idx)
+            return data
+
+    instance = A(2)
+    instance.f(np.memmap(path, dtype=vec.dtype.name, mode='r', shape=vec.shape), vec.shape[0])
+    assert len(instance.ord_idx) == 5
+    assert instance.ord_idx[0].start == 0
+    assert instance.ord_idx[0].stop == 2
+    assert instance.ord_idx[1].start == 2
+    assert instance.ord_idx[1].stop == 4
+    assert instance.ord_idx[2].start == 4
+    assert instance.ord_idx[2].stop == 6
+    assert instance.ord_idx[3].start == 6
+    assert instance.ord_idx[3].stop == 8
+    assert instance.ord_idx[4].start == 8
+    assert instance.ord_idx[4].stop == 10


### PR DESCRIPTION
**Changes introduced**
From a bug found in `NmsLibIndexer` I found that some indexers may not only need to have `batched` data but also would need information about which `ordinal` indexers correspond to each data in a batch.

This PR tries to enable https://github.com/jina-ai/jina-hub/pull/458

**Extra change**
I have not seen where the `label` is used in the `batching` decorator and therefore I try to remove it since it results in a lot of `if - else` logic. @hanxiao @nan-wang do you know in which context it is used?