### PR TITLE
perf: numpy indexer use partial sort at query time

### DIFF
--- a/jina/executors/indexers/vector.py
+++ b/jina/executors/indexers/vector.py
@@ -245,10 +245,10 @@ class NumpyIndexer(BaseNumpyIndexer):
         """ Find top-k smallest distances in ascending order.
 
         Idea is to use partial sort to retrieve top-k smallest distances unsorted and then sort these
-        in ascending order. Equivalent to full sort but faster for n >> k. If n == k revert to full sort.
+        in ascending order. Equivalent to full sort but faster for n >> k. If k >= n revert to full sort.
 
         """
-        if top_k == dist.shape[1]:
+        if top_k >= dist.shape[1]:
             idx = dist.argsort(axis=1)[:, :top_k]
             dist = np.take_along_axis(dist, idx, axis=1)
         else:

--- a/jina/executors/indexers/vector.py
+++ b/jina/executors/indexers/vector.py
@@ -263,7 +263,7 @@ class NumpyIndexer(BaseNumpyIndexer):
         else:
             raise NotImplementedError(f'{self.metric} is not implemented')
 
-        idx = np.argpartition(dist, kth=top_k, axis=1)[:, :top_k]
+        idx = dist.argpartition(kth=top_k, axis=1)[:, :top_k]
         dist = np.take_along_axis(dist, idx, axis=1)
         return self.int2ext_id[idx], dist
 

--- a/jina/executors/indexers/vector.py
+++ b/jina/executors/indexers/vector.py
@@ -263,7 +263,7 @@ class NumpyIndexer(BaseNumpyIndexer):
         else:
             raise NotImplementedError(f'{self.metric} is not implemented')
 
-        idx = dist.argsort(axis=1)[:, :top_k]
+        idx = np.argpartition(dist, kth=top_k, axis=1)[:, :top_k]
         dist = np.take_along_axis(dist, idx, axis=1)
         return self.int2ext_id[idx], dist
 

--- a/jina/executors/indexers/vector.py
+++ b/jina/executors/indexers/vector.py
@@ -241,7 +241,7 @@ class NumpyIndexer(BaseNumpyIndexer):
         self.backend = backend
 
     @staticmethod
-    def _find_smallest_distances(dist: 'np.array', top_k: int) -> Tuple['np.ndarray', 'np.ndarray']:
+    def _get_sorted_top_k(dist: 'np.array', top_k: int) -> Tuple['np.ndarray', 'np.ndarray']:
         """ Find top-k smallest distances in ascending order.
 
         Idea is to use partial sort to retrieve top-k smallest distances unsorted and then sort these
@@ -283,7 +283,7 @@ class NumpyIndexer(BaseNumpyIndexer):
         else:
             raise NotImplementedError(f'{self.metric} is not implemented')
 
-        idx, dist = self._find_smallest_distances(dist, top_k)
+        idx, dist = self._get_sorted_top_k(dist, top_k)
         return self.int2ext_id[idx], dist
 
     def build_advanced_index(self, vecs: 'np.ndarray'):

--- a/tests/unit/executors/indexers/test_numpyindexer.py
+++ b/tests/unit/executors/indexers/test_numpyindexer.py
@@ -147,7 +147,7 @@ def test_scipy_indexer_known_big(batch_size, compress_level, test_metas):
         np.testing.assert_equal(indexer.query_by_id([10000, 15000]), vectors[[0, 5000]])
 
 
-@pytest.mark.parametrize('batch_size, num_docs, top_k', [(1, 10, 1), (1, 10, 10), (10, 1, 1), (10, 1000, 10)])
+@pytest.mark.parametrize('batch_size, num_docs, top_k', [(1, 10, 1), (1, 10, 10), (10, 1, 1), (10, 1000, 10), (10, 10, 100)])
 def test__find_smallest_distances(batch_size, num_docs, top_k):
     dist = np.random.uniform(size=(batch_size, num_docs))
 

--- a/tests/unit/executors/indexers/test_numpyindexer.py
+++ b/tests/unit/executors/indexers/test_numpyindexer.py
@@ -148,14 +148,14 @@ def test_scipy_indexer_known_big(batch_size, compress_level, test_metas):
 
 
 @pytest.mark.parametrize('batch_size, num_docs, top_k', [(1, 10, 1), (1, 10, 10), (10, 1, 1), (10, 1000, 10), (10, 10, 100)])
-def test__find_smallest_distances(batch_size, num_docs, top_k):
+def test__get_sorted_top_k(batch_size, num_docs, top_k):
     dist = np.random.uniform(size=(batch_size, num_docs))
 
     expected_idx = np.argsort(dist)[:, :top_k]
     expected_dist = np.sort(dist)[:, :top_k]
 
     with NumpyIndexer() as indexer:
-        idx, dist = indexer._find_smallest_distances(dist, top_k=top_k)
+        idx, dist = indexer._get_sorted_top_k(dist, top_k=top_k)
 
         np.testing.assert_equal(idx, expected_idx)
         np.testing.assert_equal(dist, expected_dist)

--- a/tests/unit/executors/indexers/test_numpyindexer.py
+++ b/tests/unit/executors/indexers/test_numpyindexer.py
@@ -145,3 +145,17 @@ def test_scipy_indexer_known_big(batch_size, compress_level, test_metas):
         assert idx.shape == dist.shape
         assert idx.shape == (10, 1)
         np.testing.assert_equal(indexer.query_by_id([10000, 15000]), vectors[[0, 5000]])
+
+
+@pytest.mark.parametrize('batch_size, num_docs, top_k', [(1, 10, 1), (1, 10, 10), (10, 1, 1), (10, 1000, 10)])
+def test__find_smallest_distances(batch_size, num_docs, top_k):
+    dist = np.random.uniform(size=(batch_size, num_docs))
+
+    expected_idx = np.argsort(dist)[:, :top_k]
+    expected_dist = np.sort(dist)[:, :top_k]
+
+    with NumpyIndexer() as indexer:
+        idx, dist = indexer._find_smallest_distances(dist, top_k=top_k)
+
+        np.testing.assert_equal(idx, expected_idx)
+        np.testing.assert_equal(dist, expected_dist)


### PR DESCRIPTION
Hi, I have recently read your great blog article on your numpy indexer (https://hanxiao.io/2020/09/21/Numpy-Tricks-and-A-Strong-Baseline-for-Vector-Index/) and saw that at query time you do a full sort on the distances to retrieve the top k candidates.

This PR suggests using numpy's partial sort implementation `np.argpartition` which runs in O(n) versus O(n * log(n)) for `np.argsort`. 

With this code change the query method does not return the top k candidates ordered like with full sort before, but it seems the system is not relying on the top k candidates being ordered, at least the docstring does not imply it.

This little example illustrates the difference, the speedup for top 10 retrieval from a 100k array is around 12 fold
```python
# ipython 
import numpy as np

top_k = 10
dist = np.random.rand(100_000)

%%timeit 
idx_sort = dist.argsort()[:top_k]
# 9.4 ms ± 169 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)

%%timeit
idx_partition = dist.argpartition(kth=top_k)[:top_k]
# 779 µs ± 2.85 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)

idx_sort
# array([50384,  7687, 23873, 29129, 38318,   710, 51471, 81669, 47933, 61278])

idx_partition
# array([51471,   710, 47933, 38318, 50384, 61278, 81669, 29129, 23873, 7687])
```

I also ran the benchmarking script mentioned in the blog post (https://gist.github.com/hanxiao/43cad33b60cadd34f45236993689e5d9), the speedup is from 2.07s per run to 1.82s. When increasing the number of indexed documents from 10k to 100k and reducing their dimension from 10k to 1k, the speedup is from 4.05s per run to 3.14s.

Would be great to get your feedback on this :)