### PR TITLE
feat(pod): allow uses-before/after on single pea

### DIFF
--- a/jina/drivers/control.py
+++ b/jina/drivers/control.py
@@ -41,13 +41,6 @@ class WaitDriver(BaseDriver):
         time.sleep(5)
 
 
-class ForwardDriver(BaseDriver):
-    """Forward the message to next pod"""
-
-    def __call__(self, *args, **kwargs):
-        pass
-
-
 class RouteDriver(ControlReqDriver):
     """A simple load balancer forward message to the next available pea
 
@@ -76,11 +69,12 @@ class RouteDriver(ControlReqDriver):
                 if not self.idle_dealer_ids:
                     self.pea.zmqlet.pause_pollin()
                     self.is_pollin_paused = True
-            else:
-                raise RuntimeError('if this router connects more than one dealer, '
-                                   'then this error should never be raised. often when it '
-                                   'is raised, some Pods must fail to start, so please go '
-                                   'up and check the first error message in the log')
+
+            # else branch = FALLBACK to simple pass
+            # 'if this router connects more than one dealer, '
+            # 'then this error should never be raised. often when it '
+            # 'is raised, some Pods must fail to start, so please go '
+            # 'up and check the first error message in the log'
         elif self.req.command == jina_pb2.Request.ControlRequest.IDLE:
             self.idle_dealer_ids.add(self.envelope.receiver_id)
             self.logger.debug(f'{self.envelope.receiver_id} is idle')
@@ -90,3 +84,7 @@ class RouteDriver(ControlReqDriver):
             raise NoExplicitMessage
         else:
             super().__call__(*args, **kwargs)
+
+
+class ForwardDriver(RouteDriver):
+    """Alias to :class:`RouteDriver`"""

--- a/jina/peapods/pod.py
+++ b/jina/peapods/pod.py
@@ -77,7 +77,6 @@ class BasePod(ExitStack):
         if getattr(args, 'parallel', 1) > 1:
             # reasons to separate head and tail from peas is that they
             # can be deducted based on the previous and next pods
-            _set_after_to_pass(args)
             self.is_head_router = True
             self.is_tail_router = True
             peas_args['head'] = _copy_to_head_args(args, args.polling.is_push)
@@ -93,11 +92,9 @@ class BasePod(ExitStack):
                 peas_args['tail'] = _copy_to_tail_args(args)
             peas_args['peas'] = _set_peas_args(args, peas_args.get('head', None), peas_args.get('tail', None))
         else:
-            _set_after_to_pass(args)
             self.is_head_router = False
             self.is_tail_router = False
             peas_args['peas'] = [args]
-
 
         # note that peas_args['peas'][0] exist either way and carries the original property
         return peas_args
@@ -415,14 +412,6 @@ def _set_peas_args(args: Namespace, head_args: Namespace = None, tail_args: Name
             _args.host_out = _fill_in_host(bind_args=tail_args, connect_args=_args)
         result.append(_args)
     return result
-
-
-def _set_after_to_pass(args):
-    # TODO: I don't remember what is this for? once figure out, this function should be removed
-    # remark 1: i think it's related to route driver.
-    if hasattr(args, 'polling') and args.polling.is_push:
-        # ONLY reset when it is push
-        args.uses_after = '_pass'
 
 
 def _copy_to_head_args(args: Namespace, is_push: bool, as_router: bool = True) -> Namespace:

--- a/jina/peapods/pod.py
+++ b/jina/peapods/pod.py
@@ -38,11 +38,6 @@ class BasePod(ExitStack):
         self.deducted_head = None
         self.deducted_tail = None
 
-        # TODO: I don't remember what is this for???
-        # if hasattr(args, 'polling') and args.polling.is_push:
-        #     # ONLY reset when it is push
-        #     args.uses_after = '_pass'
-
         self._args = args
         self.peas_args = self._parse_args(args)
 
@@ -420,6 +415,13 @@ def _set_peas_args(args: Namespace, head_args: Namespace = None, tail_args: Name
     return result
 
 
+def _reset_to_pass(args):
+    # TODO: I don't remember what is this for? once figure out, this function should be removed
+    if hasattr(args, 'polling') and args.polling.is_push:
+        # ONLY reset when it is push
+        args.uses_after = '_pass'
+
+
 def _copy_to_head_args(args: Namespace, is_push: bool, as_router: bool = True) -> Namespace:
     """Set the outgoing args of the head router
     """
@@ -458,6 +460,10 @@ def _copy_to_tail_args(args: Namespace, as_router: bool = True) -> Namespace:
     _tail_args.port_ctrl = random_port()
     _tail_args.socket_in = SocketType.PULL_BIND
     _tail_args.uses = None
+
+    # TODO: unclear usage
+    _reset_to_pass(_tail_args)
+
     if as_router:
         _tail_args.uses = args.uses_after or '_merge'
         _tail_args.name = args.name or ''

--- a/jina/peapods/pod.py
+++ b/jina/peapods/pod.py
@@ -37,9 +37,11 @@ class BasePod(ExitStack):
         self.is_tail_router = False
         self.deducted_head = None
         self.deducted_tail = None
-        if hasattr(args, 'polling') and args.polling.is_push:
-            # ONLY reset when it is push
-            args.uses_after = '_pass'
+
+        # TODO: I don't remember what is this for???
+        # if hasattr(args, 'polling') and args.polling.is_push:
+        #     # ONLY reset when it is push
+        #     args.uses_after = '_pass'
 
         self._args = args
         self.peas_args = self._parse_args(args)

--- a/jina/peapods/pod.py
+++ b/jina/peapods/pod.py
@@ -77,6 +77,7 @@ class BasePod(ExitStack):
         if getattr(args, 'parallel', 1) > 1:
             # reasons to separate head and tail from peas is that they
             # can be deducted based on the previous and next pods
+            _set_after_to_pass(args)
             self.is_head_router = True
             self.is_tail_router = True
             peas_args['head'] = _copy_to_head_args(args, args.polling.is_push)
@@ -92,9 +93,11 @@ class BasePod(ExitStack):
                 peas_args['tail'] = _copy_to_tail_args(args)
             peas_args['peas'] = _set_peas_args(args, peas_args.get('head', None), peas_args.get('tail', None))
         else:
+            _set_after_to_pass(args)
             self.is_head_router = False
             self.is_tail_router = False
             peas_args['peas'] = [args]
+
 
         # note that peas_args['peas'][0] exist either way and carries the original property
         return peas_args
@@ -412,6 +415,14 @@ def _set_peas_args(args: Namespace, head_args: Namespace = None, tail_args: Name
             _args.host_out = _fill_in_host(bind_args=tail_args, connect_args=_args)
         result.append(_args)
     return result
+
+
+def _set_after_to_pass(args):
+    # TODO: I don't remember what is this for? once figure out, this function should be removed
+    # remark 1: i think it's related to route driver.
+    if hasattr(args, 'polling') and args.polling.is_push:
+        # ONLY reset when it is push
+        args.uses_after = '_pass'
 
 
 def _copy_to_head_args(args: Namespace, is_push: bool, as_router: bool = True) -> Namespace:

--- a/jina/peapods/pod.py
+++ b/jina/peapods/pod.py
@@ -78,24 +78,25 @@ class BasePod(ExitStack):
         if getattr(args, 'parallel', 1) > 1:
             # reasons to separate head and tail from peas is that they
             # can be deducted based on the previous and next pods
+            self.is_head_router = True
+            self.is_tail_router = True
             peas_args['head'] = _copy_to_head_args(args, args.polling.is_push)
             peas_args['tail'] = _copy_to_tail_args(args)
             peas_args['peas'] = _set_peas_args(args, peas_args['head'], peas_args['tail'])
-            self.is_head_router = True
-            self.is_tail_router = True
         elif getattr(args, 'uses_before', None) or getattr(args, 'uses_after', None):
             args.scheduling = SchedulerType.ROUND_ROBIN
             if getattr(args, 'uses_before', None):
-                peas_args['head'] = _copy_to_head_args(args, args.polling.is_push)
                 self.is_head_router = True
+                peas_args['head'] = _copy_to_head_args(args, args.polling.is_push)
             if getattr(args, 'uses_after', None):
-                peas_args['tail'] = _copy_to_tail_args(args)
                 self.is_tail_router = True
+                peas_args['tail'] = _copy_to_tail_args(args)
             peas_args['peas'] = _set_peas_args(args, peas_args.get('head', None), peas_args.get('tail', None))
         else:
-            peas_args['peas'] = [args]
             self.is_head_router = False
             self.is_tail_router = False
+            peas_args['peas'] = [args]
+
 
         # note that peas_args['peas'][0] exist either way and carries the original property
         return peas_args

--- a/tests/integration/incremental_indexing/test_incremental_indexing.py
+++ b/tests/integration/incremental_indexing/test_incremental_indexing.py
@@ -1,10 +1,10 @@
 import os
 
-from jina.flow import Flow
 from jina.executors import BaseExecutor
-from jina.executors.indexers.vector import NumpyIndexer
 from jina.executors.indexers.keyvalue import BinaryPbIndexer
-from tests.integration.incremental_indexing import random_workspace, get_duplicate_docs
+from jina.executors.indexers.vector import NumpyIndexer
+from jina.flow import Flow
+from tests.integration.incremental_indexing import get_duplicate_docs
 
 cur_dir = os.path.dirname(os.path.abspath(__file__))
 

--- a/tests/integration/incremental_indexing/test_incremental_indexing.py
+++ b/tests/integration/incremental_indexing/test_incremental_indexing.py
@@ -4,7 +4,7 @@ from jina.executors import BaseExecutor
 from jina.executors.indexers.keyvalue import BinaryPbIndexer
 from jina.executors.indexers.vector import NumpyIndexer
 from jina.flow import Flow
-from tests.integration.incremental_indexing import get_duplicate_docs
+from tests.integration.incremental_indexing import random_workspace, get_duplicate_docs
 
 cur_dir = os.path.dirname(os.path.abspath(__file__))
 

--- a/tests/integration/incremental_indexing/test_unique_indexing.py
+++ b/tests/integration/incremental_indexing/test_unique_indexing.py
@@ -4,12 +4,12 @@ from jina.executors import BaseExecutor
 from jina.executors.indexers.keyvalue import BinaryPbIndexer
 from jina.executors.indexers.vector import NumpyIndexer
 from jina.flow import Flow
-from tests.integration.incremental_indexing import get_duplicate_docs
+from tests.integration.incremental_indexing import random_workspace, get_duplicate_docs
 
 cur_dir = os.path.dirname(os.path.abspath(__file__))
 
 
-def test_incremental_indexing_vecindexers(random_workspace):
+def test_unique_indexing_vecindexers(random_workspace):
     total_docs = 10
     duplicate_docs, num_uniq_docs = get_duplicate_docs(num_docs=total_docs)
 
@@ -24,7 +24,7 @@ def test_incremental_indexing_vecindexers(random_workspace):
         assert vector_indexer.size == num_uniq_docs
 
 
-def test_incremental_indexing_docindexers(random_workspace):
+def test_unique_indexing_docindexers(random_workspace):
     total_docs = 10
     duplicate_docs, num_uniq_docs = get_duplicate_docs(num_docs=total_docs)
 
@@ -60,7 +60,7 @@ def test_unique_indexing_docindexers_before(random_workspace):
     duplicate_docs, num_uniq_docs = get_duplicate_docs(num_docs=total_docs)
 
     f = (Flow()
-         .add(uses=os.path.join(cur_dir, 'uniq_docindexer.yml'),
+         .add(uses=os.path.join(cur_dir, 'docindexer.yml'),
               uses_before='_unique'))
 
     with f:

--- a/tests/integration/incremental_indexing/test_unique_indexing.py
+++ b/tests/integration/incremental_indexing/test_unique_indexing.py
@@ -4,8 +4,7 @@ from jina.executors import BaseExecutor
 from jina.executors.indexers.keyvalue import BinaryPbIndexer
 from jina.executors.indexers.vector import NumpyIndexer
 from jina.flow import Flow
-from tests.integration.incremental_indexing import random_workspace, get_duplicate_docs
-
+from tests.integration.incremental_indexing import get_duplicate_docs
 
 cur_dir = os.path.dirname(os.path.abspath(__file__))
 
@@ -31,6 +30,38 @@ def test_incremental_indexing_docindexers(random_workspace):
 
     f = (Flow()
          .add(uses=os.path.join(cur_dir, 'uniq_docindexer.yml'), shards=1))
+
+    with f:
+        f.index(duplicate_docs)
+
+    with BaseExecutor.load((random_workspace / 'doc_idx.bin')) as doc_indexer:
+        assert isinstance(doc_indexer, BinaryPbIndexer)
+        assert doc_indexer.size == num_uniq_docs
+
+
+def test_unique_indexing_vecindexers_before(random_workspace):
+    total_docs = 10
+    duplicate_docs, num_uniq_docs = get_duplicate_docs(num_docs=total_docs)
+
+    f = (Flow()
+         .add(uses=os.path.join(cur_dir, 'vectorindexer.yml'),
+              uses_before='_unique'))
+
+    with f:
+        f.index(duplicate_docs)
+
+    with BaseExecutor.load((random_workspace / 'vec_idx.bin')) as vector_indexer:
+        assert isinstance(vector_indexer, NumpyIndexer)
+        assert vector_indexer.size == num_uniq_docs
+
+
+def test_unique_indexing_docindexers_before(random_workspace):
+    total_docs = 10
+    duplicate_docs, num_uniq_docs = get_duplicate_docs(num_docs=total_docs)
+
+    f = (Flow()
+         .add(uses=os.path.join(cur_dir, 'uniq_docindexer.yml'),
+              uses_before='_unique'))
 
     with f:
         f.index(duplicate_docs)

--- a/tests/unit/flow/test_flow_before_after.py
+++ b/tests/unit/flow/test_flow_before_after.py
@@ -1,0 +1,49 @@
+from jina.flow import Flow
+from tests import random_docs
+
+
+def test_flow():
+    docs = random_docs(10)
+    f = Flow().add(name='p1')
+
+    with f:
+        f.index(docs)
+        assert f.num_pods == 2
+        assert f._pod_nodes['p1'].num_peas == 1
+        assert f.num_peas == 2
+
+
+def test_flow_before():
+    docs = random_docs(10)
+    f = Flow().add(uses_before='_pass', name='p1')
+
+    with f:
+        f.index(docs)
+        assert f.num_pods == 2
+        assert f._pod_nodes['p1'].num_peas == 2
+        assert f.num_peas == 3
+
+
+def test_flow_after():
+    docs = random_docs(10)
+    f = Flow().add(uses_after='_pass', name='p1')
+
+    with f:
+        f.index(docs)
+        assert f.num_pods == 2
+        assert f._pod_nodes['p1'].num_peas == 2
+        assert f.num_peas == 3
+
+
+def test_flow_before_after():
+    docs = random_docs(10)
+    f = Flow().add(uses_before='_pass', uses_after='_pass', name='p1')
+
+    with f:
+        f.index(docs)
+        assert f.num_pods == 2
+        assert f._pod_nodes['p1'].num_peas == 3
+        assert f.num_peas == 4
+
+def test_flow_before_after_plot():
+    f = Flow().add(uses_before='_pass', uses_after='_pass', name='p1')

--- a/tests/unit/flow/test_flow_before_after.py
+++ b/tests/unit/flow/test_flow_before_after.py
@@ -1,3 +1,5 @@
+import os
+
 from jina.flow import Flow
 from tests import random_docs
 
@@ -45,5 +47,7 @@ def test_flow_before_after():
         assert f._pod_nodes['p1'].num_peas == 3
         assert f.num_peas == 4
 
+
 def test_flow_before_after_plot():
-    f = Flow().add(uses_before='_pass', uses_after='_pass', name='p1')
+    Flow().add(uses_before='_pass', uses_after='_pass', name='p1').plot('tmp.svg')
+    assert os.path.exists('tmp.svg')

--- a/tests/unit/yaml/examples/faces/flow-query.yml
+++ b/tests/unit/yaml/examples/faces/flow-query.yml
@@ -1,7 +1,6 @@
 !Flow
 with:
   read_only: true  # better add this in the query time
-  rest_api: true
   port_expose: 5555
 pods:
   loader:
@@ -20,7 +19,6 @@ pods:
   chunk_indexer:
     polling: all
     parallel: 1
-    uses_after: _merge_topk_chunks
   ranker:
     uses: MinRanker
   doc_indexer:


### PR DESCRIPTION
## New features

- Pod context manager now allows `--uses-before` and `--uses-after` when `--parallel = 1`. Previously `uses-before` and `uses-after` are only respected when `parallel > 1`.

With this new feature, you can build a sequential (microservice-like) quote `CompoundExecutor` unquote (`before -> exec -> after`)  simply via:

```python
f = Flow().add(uses_before='before.yml', uses_after='after.yml', uses='exec.yml')

with f:
    f.index(docs)
```

Another usage is to solve the `todo1` mentioned in #1062: 
> avoid the differences of using DuplicateChecker between single-shard and multi-shards usages. ...

This can now be implemented as 
```python
f = Flow().add(uses=os.path.join(cur_dir, 'docindexer.yml'), uses_before='_unique')
```
See `tests/integration/incremental_indexing/test_unique_indexing.py` for detailed examples.

## Changes (Non-breaking)

- `_pass` and  `_forward` use `RouteDriver` as default
- `ForwardDriver` is now a shortcut to `RouteDriver`
