### PR TITLE
chore: add maximilianwerk as codeowner for drivers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -9,4 +9,5 @@
 setup.py  @hanxiao
 jina/peapods @JoanFM
 jina/proto @JoanFM
-jina/tests @bwanglzu
+tests @bwanglzu
+jina/drivers @maximilianwerk


### PR DESCRIPTION
I added me as owner for `jina/drivers`. Am I right, that @bwanglzu should be the owner for `tests` instead of `jina/tests`, since the latter does not exist?