### PR TITLE
fix: disabled pip cache in docker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
           jina check
           export JINA_LOG_VERBOSITY="ERROR"
           pip install .[test]
-          pytest --force-flaky --min-passes 1 --cov=jina --cov-report=xml -n 1 --timeout=240 -v tests/unit
+          pytest --force-flaky --min-passes 1 --cov=jina --cov-report=xml -n 1 --timeout=600 -v tests/unit
           mv coverage.xml unit-test-coverage.xml
         timeout-minutes: 30
         env:
@@ -102,7 +102,7 @@ jobs:
           jina check
           export JINA_LOG_VERBOSITY="ERROR"
           pip install .[test]
-          pytest --force-flaky --min-passes 1 --cov=jina --cov-report=xml -n 1 --timeout=240 -v --ignore-glob='tests/integration/hub_usage/dummyhub*' tests/integration
+          pytest --force-flaky --min-passes 1 --cov=jina --cov-report=xml -n 1 --timeout=600 -v --ignore-glob='tests/integration/hub_usage/dummyhub*' tests/integration
           mv coverage.xml integration-test-coverage.xml
         timeout-minutes: 30
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
           pip install .[test]
           pytest --force-flaky --min-passes 1 --cov=jina --cov-report=xml -n 1 --timeout=120 -v tests/unit
           mv coverage.xml unit-test-coverage.xml
-        timeout-minutes: 30
+        timeout-minutes: 40
         env:
           JINAHUB_USERNAME: ${{ secrets.JINAHUB_USERNAME }}
           JINAHUB_PASSWORD: ${{ secrets.JINAHUB_PASSWORD }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
           pip install .[test]
           pytest --force-flaky --min-passes 1 --cov=jina --cov-report=xml -n 1 --timeout=120 -v tests/unit
           mv coverage.xml unit-test-coverage.xml
-        timeout-minutes: 40
+        timeout-minutes: 30
         env:
           JINAHUB_USERNAME: ${{ secrets.JINAHUB_USERNAME }}
           JINAHUB_PASSWORD: ${{ secrets.JINAHUB_PASSWORD }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
           jina check
           export JINA_LOG_VERBOSITY="ERROR"
           pip install .[test]
-          pytest --force-flaky --min-passes 1 --cov=jina --cov-report=xml -n 1 --timeout=600 -v tests/unit
+          pytest --force-flaky --min-passes 1 --cov=jina --cov-report=xml -n 1 --timeout=120 -v tests/unit
           mv coverage.xml unit-test-coverage.xml
         timeout-minutes: 30
         env:
@@ -102,7 +102,7 @@ jobs:
           jina check
           export JINA_LOG_VERBOSITY="ERROR"
           pip install .[test]
-          pytest --force-flaky --min-passes 1 --cov=jina --cov-report=xml -n 1 --timeout=600 -v --ignore-glob='tests/integration/hub_usage/dummyhub*' tests/integration
+          pytest --force-flaky --min-passes 1 --cov=jina --cov-report=xml -n 1 --timeout=120 -v --ignore-glob='tests/integration/hub_usage/dummyhub*' tests/integration
           mv coverage.xml integration-test-coverage.xml
         timeout-minutes: 30
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
           jina check
           export JINA_LOG_VERBOSITY="ERROR"
           pip install .[test]
-          pytest --force-flaky --min-passes 1 --cov=jina --cov-report=xml -n 1 --timeout=120 -v tests/unit
+          pytest --force-flaky --min-passes 1 --cov=jina --cov-report=xml -n 1 --timeout=240 -v tests/unit
           mv coverage.xml unit-test-coverage.xml
         timeout-minutes: 30
         env:
@@ -102,7 +102,7 @@ jobs:
           jina check
           export JINA_LOG_VERBOSITY="ERROR"
           pip install .[test]
-          pytest --force-flaky --min-passes 1 --cov=jina --cov-report=xml -n 1 --timeout=120 -v --ignore-glob='tests/integration/hub_usage/dummyhub*' tests/integration
+          pytest --force-flaky --min-passes 1 --cov=jina --cov-report=xml -n 1 --timeout=240 -v --ignore-glob='tests/integration/hub_usage/dummyhub*' tests/integration
           mv coverage.xml integration-test-coverage.xml
         timeout-minutes: 30
         env:

--- a/Dockerfiles/alpinex.Dockerfile
+++ b/Dockerfiles/alpinex.Dockerfile
@@ -22,9 +22,9 @@ ADD setup.py MANIFEST.in requirements.txt extra-requirements.txt README.md ./
 ADD cli ./cli/
 ADD jina ./jina/
 
-ENV PYTHONPATH=$PYTHONPATH:/usr/lib/python3.8/dist-packages:/usr/local/lib/python3.8/site-packages:/usr/lib/python3/dist-packages:/usr/local/lib/python3/site-packages
-ENV PIP_NO_CACHE_DIR=1
-ENV PIP_DISABLE_PIP_VERSION_CHECK=1
+ENV PYTHONPATH=$PYTHONPATH:/usr/lib/python3.8/dist-packages:/usr/local/lib/python3.8/site-packages:/usr/lib/python3/dist-packages:/usr/local/lib/python3/site-packages \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1
 
 # py3-scipy
 RUN apk add --no-cache py3-pyzmq py3-numpy grpc && \
@@ -39,7 +39,7 @@ RUN apk add --no-cache py3-pyzmq py3-numpy grpc && \
 
 WORKDIR /
 
-ENV JINA_VCS_VERSION=$VCS_REF
-ENV JINA_BUILD_DATE=$BUILD_DATE
+ENV JINA_VCS_VERSION=$VCS_REF \
+    JINA_BUILD_DATE=$BUILD_DATE
 
 ENTRYPOINT ["jina"]

--- a/Dockerfiles/alpinex.Dockerfile
+++ b/Dockerfiles/alpinex.Dockerfile
@@ -23,11 +23,13 @@ ADD cli ./cli/
 ADD jina ./jina/
 
 ENV PYTHONPATH=$PYTHONPATH:/usr/lib/python3.8/dist-packages:/usr/local/lib/python3.8/site-packages:/usr/lib/python3/dist-packages:/usr/local/lib/python3/site-packages
+ENV PIP_NO_CACHE_DIR=1
+ENV PIP_DISABLE_PIP_VERSION_CHECK=1
 
 # py3-scipy
 RUN apk add --no-cache py3-pyzmq py3-numpy grpc && \
     ln -s locale.h /usr/include/xlocale.h && \
-    pip install . --no-cache-dir --compile && \
+    pip install . --compile && \
     find /usr/lib/python3.8/ -name 'tests' -exec rm -r '{}' + && \
     find /usr/lib/python3.8/site-packages/ -name '*.so' -print -exec sh -c 'file "{}" | grep -q "not stripped" && strip -s "{}"' \; && \
     rm /usr/include/xlocale.h && \

--- a/Dockerfiles/debianx.Dockerfile
+++ b/Dockerfiles/debianx.Dockerfile
@@ -29,6 +29,8 @@ ENV PYTHONPATH=$PYTHONPATH:/usr/lib/python3.7/dist-packages:/usr/local/lib/pytho
 ENV JINA_VERSION=$JINA_VERSION
 ENV JINA_VCS_VERSION=$VCS_REF
 ENV JINA_BUILD_DATE=$BUILD_DATE
+ENV PIP_NO_CACHE_DIR=1
+ENV PIP_DISABLE_PIP_VERSION_CHECK=1
 
 WORKDIR /jina/
 
@@ -37,8 +39,8 @@ ADD cli ./cli/
 ADD jina ./jina/
 
 RUN ln -s locale.h /usr/include/xlocale.h && \
-    pip install . --no-cache-dir --compile && \
-    if [ -n "$INSTALL_DEV" ]; then pip install .[devel] --no-cache-dir --compile; fi && \
+    pip install . --compile && \
+    if [ -n "$INSTALL_DEV" ]; then pip install .[devel] --compile; fi && \
     rm -rf /tmp/* && rm -rf /jina && \
     rm /usr/include/xlocale.h
 

--- a/Dockerfiles/debianx.Dockerfile
+++ b/Dockerfiles/debianx.Dockerfile
@@ -17,20 +17,19 @@ LABEL org.opencontainers.image.created=$BUILD_DATE \
       org.opencontainers.image.title="Jina" \
       org.opencontainers.image.description="Jina is the cloud-native neural search solution powered by state-of-the-art AI and deep learning technology"
 
-ENV JINA_BUILD_BASE_DEP="python3-numpy python3-zmq python3-protobuf python3-grpcio python3-tornado python3-uvloop python3-lz4"
-ENV JINA_BUILD_DEVEL_DEP="gcc libc-dev python3-gevent libmagic1"
+ENV JINA_BUILD_BASE_DEP="python3-numpy python3-zmq python3-protobuf python3-grpcio python3-tornado python3-uvloop python3-lz4" \
+    JINA_BUILD_DEVEL_DEP="gcc libc-dev python3-gevent libmagic1"
 
 RUN apt-get update && apt-get install --no-install-recommends -y $JINA_BUILD_BASE_DEP && \
     if [ -n "$INSTALL_DEV" ]; then apt-get install --no-install-recommends -y $JINA_BUILD_DEVEL_DEP; fi && \
     apt-get autoremove && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-ENV PYTHONPATH=$PYTHONPATH:/usr/lib/python3.7/dist-packages:/usr/local/lib/python3.7/site-packages:/usr/lib/python3/dist-packages:/usr/local/lib/python3/site-packages
-
-ENV JINA_VERSION=$JINA_VERSION
-ENV JINA_VCS_VERSION=$VCS_REF
-ENV JINA_BUILD_DATE=$BUILD_DATE
-ENV PIP_NO_CACHE_DIR=1
-ENV PIP_DISABLE_PIP_VERSION_CHECK=1
+ENV PYTHONPATH=$PYTHONPATH:/usr/lib/python3.7/dist-packages:/usr/local/lib/python3.7/site-packages:/usr/lib/python3/dist-packages:/usr/local/lib/python3/site-packages \
+    JINA_VERSION=$JINA_VERSION \
+    JINA_VCS_VERSION=$VCS_REF \
+    JINA_BUILD_DATE=$BUILD_DATE \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1
 
 WORKDIR /jina/
 


### PR DESCRIPTION
Describe the bug
All of our hub docker containers contain pip cache which increases its size. This cache is useless.

Describe how you solve it
Add these to our jina dockerfiles. This will lead to smaller jina and hub images especially those with big dependencies like tensorflow and torch. This way we don't need to use flag `--no-cache-dir` in pip installs everywhere.
I also suggest disabling pip version check.

```
ENV PIP_NO_CACHE_DIR=1
ENV PIP_DISABLE_PIP_VERSION_CHECK=1
```

resolved #1167 