### PR TITLE
fix: failure not combinable

### DIFF
--- a/.github/workflows/code-formatting.yml
+++ b/.github/workflows/code-formatting.yml
@@ -25,10 +25,9 @@ jobs:
       - name: Install Black
         run: pip install black
       - name: Run black --check .
-        id: black_check
         run: black --check -S jina/drivers/__init__.py
       - name: If needed, commit black changes to master
-        if: "failure() && (steps.black_check.outputs.exit_code != 0)"
+        if: failure()
         run: |
           black -S jina/drivers/__init__.py
           git add -u


### PR DESCRIPTION
Sorry for the first try in a row. But `failure()` is not combinable @JoanFM . Anyhow, if any step before the `black --check...` fails, the last one will fail as well and nothing bad will be committed.