### PR TITLE
refactor: ranking evaluator inherit from field evaluator

### DIFF
--- a/jina/drivers/evaluate.py
+++ b/jina/drivers/evaluate.py
@@ -80,28 +80,25 @@ class FieldEvaluateDriver(BaseEvaluateDriver):
         return r
 
 
-class RankEvaluateDriver(BaseEvaluateDriver):
+class RankEvaluateDriver(FieldEvaluateDriver):
     """Drivers used to pass `matches` from documents and groundtruths to an executor and add the evaluation value
+
+        - Example fields:
+        ['tags__id', 'id', 'score__value]
     """
 
     def __init__(self,
-                 id_tag: str = 'id',
+                 field: str = 'tags__id',
                  *args,
                  **kwargs):
         """
-
-        :param id_tag: the name of the tag to be extracted, when not given then ``document.id`` is used.
         :param args:
         :param kwargs:
         """
-        super().__init__(*args, **kwargs)
-        self.id_tag = id_tag
+        super().__init__(field, *args, **kwargs)
 
     def extract(self, doc: 'jina_pb2.Document'):
-        if self.id_tag:
-            return [x.tags[self.id_tag] for x in doc.matches]
-        else:
-            return [x.id for x in doc.matches]
+        return [dunder_get(x, self.field) for x in doc.matches]
 
 
 class NDArrayEvaluateDriver(FieldEvaluateDriver):

--- a/jina/executors/evaluators/rank/precision.py
+++ b/jina/executors/evaluators/rank/precision.py
@@ -24,8 +24,4 @@ class PrecisionEvaluator(BaseRankingEvaluator):
                 ret += 1.0
 
         divisor = min(self.eval_at, len(desired))
-        if divisor == 0.0:
-            """TODO: Agree on a behavior"""
-            return 0.0
-        else:
-            return ret / divisor
+        return ret / divisor if divisor != 0.0 else 0.0

--- a/tests/integration/evaluation/rank/yaml/evaluate.yml
+++ b/tests/integration/evaluation/rank/yaml/evaluate.yml
@@ -3,25 +3,21 @@ components:
   - !PrecisionEvaluator
     with:
       eval_at: 1
-      id_tag: 'id'
     metas:
       name: precision-1
   - !PrecisionEvaluator
     with:
       eval_at: 2
-      id_tag: 'id'
     metas:
       name: precision-2
   - !RecallEvaluator
     with:
       eval_at: 1
-      id_tag: 'id'
     metas:
       name: recall-1
   - !RecallEvaluator
     with:
       eval_at: 2
-      id_tag: 'id'
     metas:
       name: recall-2
 metas:


### PR DESCRIPTION
**Changes introduced**
Inheriting `RankEvaluateDriver` from `FieldEvaluateDriver` makes it more flexible and specially allows the user to evaluate based on `score__value` field that is filled by the `Search` and `Rank` drivers. (See NDCG Evaluator for instance)