### PR TITLE
fix(docker): include submodule when building devel images

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -61,6 +61,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          submodules: true  # this job build devel image, devel image includes hub submodule
       - name: Set up Docker Buildx
         id: buildx
         uses: crazy-max/ghaction-docker-buildx@v1

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          submodules: true  # this job build devel image, devel image includes hub submodule
       - name: Set up Docker Buildx
         id: buildx
         uses: crazy-max/ghaction-docker-buildx@v1


### PR DESCRIPTION
`devel` image is generated in two places:
- `cd.yml` on master merging, building x64 image
- `nightly.yml` midnight on building multi-arch devel images

Fixing these two places solves #1171 