### PR TITLE
fix: rely on control request to set ready docker pea

### DIFF
--- a/jina/peapods/container.py
+++ b/jina/peapods/container.py
@@ -5,6 +5,8 @@ import os
 from pathlib import Path
 
 from .pea import BasePea
+from .zmq import send_ctrl_message
+from ..proto import jina_pb2
 from .. import __ready_msg__, __unable_to_load_pretrained_model_msg__
 from ..helper import is_valid_local_config_source, kwargs2list, get_non_defaults_args
 from ..logging import JinaLogger
@@ -65,14 +67,13 @@ class ContainerPea(BasePea):
         _args = kwargs2list(non_defaults)
         self._container = self._client.containers.run(self.args.uses, _args,
                                                       detach=True, auto_remove=True,
-                                                      ports={'%d/tcp' % v: v for v in
+                                                      ports={f'{v}': v for v in
                                                              _expose_port},
                                                       name=self.name,
                                                       volumes=_volumes,
                                                       network_mode=net_mode,
                                                       entrypoint=self.args.entrypoint,
-                                                      # network='mynetwork',
-                                                      # publish_all_ports=True
+                                                      # publish_all_ports=True # This looks like something I would activate
                                                       )
         # wait until the container is ready
         self.logger.info('waiting ready signal from the container')
@@ -82,18 +83,20 @@ class ContainerPea(BasePea):
         import docker
 
         logger = JinaLogger('🐳', **vars(self.args))
+        ready = False
         with logger:
             try:
                 for line in self._container.logs(stream=True):
                     msg = line.strip().decode()
                     # this is shabby, but it seems the only easy way to detect is_ready signal meanwhile
                     # print all error message when fails
-                    if __ready_msg__ in msg:
+                    logger.info(line.strip().decode())
+                    if not ready and self.get_ready:
                         self.is_ready.set()
                         self.logger.success(__ready_msg__)
+                        ready = True
                     if __unable_to_load_pretrained_model_msg__ in msg:
                         self.is_pretrained_model_exception.set()
-                    logger.info(line.strip().decode())
             except docker.errors.NotFound:
                 self.logger.error('the container can not be started, check your arguments, entrypoint')
 
@@ -108,6 +111,18 @@ class ContainerPea(BasePea):
                     'the container is already shutdown (mostly because of some error inside the container)')
         if getattr(self, '_client', None):
             self._client.close()
+
+    @property
+    def status(self):
+        """Send the control signal ``STATUS`` to itself and return the status """
+        if getattr(self, 'ctrl_addr'):
+            return send_ctrl_message(self.ctrl_addr, jina_pb2.Request.ControlRequest.STATUS,
+                                     timeout=self.args.timeout_ctrl)
+
+    @property
+    def get_ready(self) -> bool:
+        status = self.status
+        return status and status.envelope.status.code == jina_pb2.Status.READY
 
     def close(self) -> None:
         self.send_terminate_signal()

--- a/jina/peapods/pod.py
+++ b/jina/peapods/pod.py
@@ -49,7 +49,7 @@ class BasePod(ExitStack):
     def is_idle(self) -> bool:
         """A Pod is idle when all its peas are idle, see also :attr:`jina.peapods.pea.Pea.is_idle`.
         """
-        return all(p.is_idle for p in self.peas if p.is_ready.is_set())
+        return all(p.is_idle for p in self.peas if p.is_ready_event.is_set())
 
     def close_if_idle(self):
         """Check every second if the pod is in idle, if yes, then close the pod"""
@@ -248,7 +248,7 @@ class BasePod(ExitStack):
 
     @property
     def is_shutdown(self) -> bool:
-        return all(not p.is_ready.is_set() for p in self.peas)
+        return all(not p.is_ready_event.is_set() for p in self.peas)
 
     def __enter__(self) -> Union['GatewayFlowPod', 'FlowPod']:
         return self.start()
@@ -261,10 +261,10 @@ class BasePod(ExitStack):
     def is_ready(self) -> bool:
         """Wait till the ready signal of this BasePod.
 
-        The pod is ready only when all the contained Peas returns is_ready
+        The pod is ready only when all the contained Peas returns is_ready_event
         """
         for p in self.peas:
-            p.is_ready.wait()
+            p.is_ready_event.wait()
         return True
 
     def __exit__(self, exc_type, exc_val, exc_tb) -> None:

--- a/tests/unit/peapods/test_container.py
+++ b/tests/unit/peapods/test_container.py
@@ -182,3 +182,14 @@ def test_tail_host_docker2local(docker_image_built):
     with f:
         assert getattr(f._pod_nodes['d12'].tail_args, 'host_out') == localhost
         f.dry_run()
+
+
+def test_container_status():
+    args = set_pea_parser().parse_args(['--uses', img_name,
+                                        '--uses-internal',
+                                        os.path.join(cur_dir, '../mwu-encoder/mwu_encoder_ext.yml')])
+    pea = ContainerPea(args)
+    assert not pea.get_ready
+    with pea:
+        time.sleep(1.)
+        assert pea.get_ready

--- a/tests/unit/peapods/test_container.py
+++ b/tests/unit/peapods/test_container.py
@@ -189,7 +189,7 @@ def test_container_status():
                                         '--uses-internal',
                                         os.path.join(cur_dir, '../mwu-encoder/mwu_encoder_ext.yml')])
     pea = ContainerPea(args)
-    assert not pea.get_ready
+    assert not pea.is_ready
     with pea:
         time.sleep(1.)
-        assert pea.get_ready
+        assert pea.is_ready


### PR DESCRIPTION
**Changes introduced**
Instead of relying on reading messages from the logs to set ready signal to the Pod, it relies in network connection with the Pea running inside docker.

To ensure that the PretrainedModelException is properly passed when building executors in the hub, we are still basing ourselves on reading log messages. Not sure if there is a solution for it

**Discussion**
Since there are 2 processes where the `ContainerPea` lives right now, if we start the `docker` container in a `detach=False` way, we may have better control on how its resources are used, and maybe we can avoid all this inner communication? I am not an expert but in non-detached mode we may be able to extract exceptions and errors?