### PR TITLE
fix: pod argument overriden by flow

### DIFF
--- a/jina/flow/__init__.py
+++ b/jina/flow/__init__.py
@@ -293,7 +293,10 @@ class Flow(ExitStack):
 
         needs = op_flow._parse_endpoints(op_flow, pod_name, needs, connect_to_last_pod=True)
 
-        kwargs.update(op_flow._common_kwargs)
+        for key, value in op_flow._common_kwargs.items():
+            if key not in kwargs:
+                kwargs[key] = value
+
         kwargs['name'] = pod_name
 
         op_flow._pod_nodes[pod_name] = self._invoke_flowpod(kwargs, needs, pod_role)

--- a/tests/unit/flow/test_flow.py
+++ b/tests/unit/flow/test_flow.py
@@ -534,3 +534,13 @@ def test_load_flow_from_cli():
     f = Flow.load_config(a.uses)
     with f:
         assert f.port_expose == 12345
+
+
+def test_flow_arguments_priorities():
+    f = Flow(port_expose=12345).add(name='test', port_expose=23456)
+    assert f._pod_nodes["test"].cli_args[-1] == '23456'
+
+
+def test_flow_default_argument_passing():
+    f = Flow(port_expose=12345).add(name='test')
+    assert f._pod_nodes["test"].cli_args[-1] == '12345'


### PR DESCRIPTION
The explicitly defined values on pod level should have higher priority, then the ones on flow level.