### PR TITLE
test: refactor workspace test

### DIFF
--- a/jina/executors/compound.py
+++ b/jina/executors/compound.py
@@ -231,8 +231,8 @@ class CompoundExecutor(BaseExecutor):
         """
 
         for c in self.components:
-            c.save()
-        super().save()  # do i really need to save the compound executor itself
+            c.save(filename=filename)
+        super().save(filename=filename)  # do i really need to save the compound executor itself
         return True
 
     @property

--- a/jina/executors/compound.py
+++ b/jina/executors/compound.py
@@ -231,7 +231,7 @@ class CompoundExecutor(BaseExecutor):
         """
 
         for c in self.components:
-            c.save(filename=filename)
+            c.save()
         super().save(filename=filename)  # do i really need to save the compound executor itself
         return True
 

--- a/tests/unit/test_workspace.py
+++ b/tests/unit/test_workspace.py
@@ -1,88 +1,72 @@
 import os
 
+import pytest
 import numpy as np
 
 from jina.executors import BaseExecutor
-from tests import JinaTestCase
 
-cur_dir = os.path.dirname(os.path.abspath(__file__))
+@pytest.mark.parametrize('replica_id', [1,2,3])
+def test_share_workspace(tmpdir, replica_id):
+    with BaseExecutor.load_config('yaml/test-workspace.yml', True, replica_id) as executor:
+        executor.touch()
+        executor_dir = tmpdir.join(f'{executor.name}-{replica_id}-{executor.name}.bin')
+        executor.save(executor_dir)
+        assert os.path.exists(executor_dir)
 
+@pytest.mark.parametrize('replica_id', [1,2,3])
+def test_compound_workspace(tmpdir, replica_id):
+    with BaseExecutor.load_config('yaml/test-compound-workspace.yml', True, replica_id) as executor:
+        for c in executor.components:
+            c.touch()
+            component_dir = tmpdir.join(f'{executor.name}-{replica_id}-{c.name}.bin')
+            c.save(component_dir)
+            assert os.path.exists(component_dir)
+        executor.touch()
+        executor_dir = tmpdir.join(f'{executor.name}-{replica_id}-{executor.name}.bin')
+        assert os.path.exists(executor_dir)
 
-class MyTestCase(JinaTestCase):
+@pytest.mark.parametrize('replica_id', [1,2,3])
+def test_compound_indexer(tmpdir, replica_id):
+    with BaseExecutor.load_config('yaml/test-compound-indexer.yml', True, replica_id) as e:
+        for c in e:
+            c.touch()
+            component_dir = tmpdir.join(f'{e.name}-{replica_id}-{c.name}.bin')
+            c.save(component_dir)
+            assert os.path.exists(c.index_abspath)
+            assert c.save_abspath.startswith(e.current_workspace)
+            assert c.index_abspath.startswith(e.current_workspace)
 
-    def test_share_workspace(self):
-        for j in range(3):
-            a = BaseExecutor.load_config('yaml/test-workspace.yml', True, j)
-            a.touch()
-            a.save()
-            self.assertTrue(os.path.exists(f'{a.name}-{j}/{a.name}.bin'))
-            self.add_tmpfile(f'{a.name}-{j}/{a.name}.bin')
-            self.add_tmpfile(f'{a.name}-{j}')
+        e.touch()
+        executor_dir = tmpdir.join(f'{e.name}-{replica_id}-{e.name}.bin')
+        e.save(executor_dir)
+        assert os.path.exists(e.save_abspath)
 
-    def test_compound_workspace(self):
-        for j in range(3):
-            a = BaseExecutor.load_config('yaml/test-compound-workspace.yml', True, j)
-            for c in a.components:
-                c.touch()
-                c.save()
-                self.assertTrue(os.path.exists(f'{a.name}-{j}/{c.name}.bin'))
-                self.add_tmpfile(f'{a.name}-{j}/{c.name}.bin')
-            a.touch()
-            a.save()
-            self.assertTrue(os.path.exists(f'{a.name}-{j}/{a.name}.bin'))
-            self.add_tmpfile(f'{a.name}-{j}/{a.name}.bin')
-            self.add_tmpfile(f'{a.name}-{j}')
-
-    def test_compound_indexer(self):
-        all_subspace = set()
-        for j in range(3):
-            a = BaseExecutor.load_config('yaml/test-compound-indexer.yml', True, j)
-            for c in a:
-                c.touch()
-                print(c.save_abspath)
-                print(c.index_abspath)
-                c.save()
-                self.assertTrue(os.path.exists(c.save_abspath))
-                self.assertTrue(os.path.exists(c.index_abspath))
-                self.add_tmpfile(c.save_abspath, c.index_abspath)
-
-                self.assertTrue(c.save_abspath.startswith(a.current_workspace))
-                self.assertTrue(c.index_abspath.startswith(a.current_workspace))
-            a.touch()
-            a.save()
-            self.assertTrue(os.path.exists(a.save_abspath))
-            self.add_tmpfile(a.save_abspath)
-            self.add_tmpfile(a.current_workspace)
-            all_subspace.add(a.current_workspace)
-
-        assert len(all_subspace) == 3
-
-    def test_compound_indexer_rw(self):
-        all_vecs = np.random.random([6, 5])
-        for j in range(3):
-            a = BaseExecutor.load_config('yaml/test-compound-indexer2.yml', True, j)
-            assert a[0] == a['test_meta']
-            self.assertFalse(a[0].is_updated)
-            self.assertFalse(a.is_updated)
-            a[0].add([j, j * 2, j * 3], [bytes(j), bytes(j * 2), bytes(j * 3)])
-            self.assertTrue(a[0].is_updated)
-            self.assertTrue(a.is_updated)
-            self.assertFalse(a[1].is_updated)
-            a[1].add(np.array([j * 2, j * 2 + 1]), all_vecs[(j * 2, j * 2 + 1), :])
-            self.assertTrue(a[1].is_updated)
-            a.save()
-            # the compound executor itself is not modified, therefore should not generate a save
-            self.assertFalse(os.path.exists(a.save_abspath))
-            self.assertTrue(os.path.exists(a[0].save_abspath))
-            self.assertTrue(os.path.exists(a[0].index_abspath))
-            self.assertTrue(os.path.exists(a[1].save_abspath))
-            self.assertTrue(os.path.exists(a[1].index_abspath))
-            self.add_tmpfile(a[0].save_abspath, a[1].save_abspath, a[0].index_abspath, a[1].index_abspath,
-                             a.current_workspace)
-
-        recovered_vecs = []
-        for j in range(3):
-            a = BaseExecutor.load_config('yaml/test-compound-indexer2.yml', True, j)
-            recovered_vecs.append(a[1].query_handler)
-
-        np.testing.assert_almost_equal(all_vecs, np.concatenate(recovered_vecs))
+def test_compound_indexer_rw():
+    pass
+    # TODO: need refactor.
+    # all_vecs = np.random.random([6, 5])
+    # for j in range(3):
+    #     a = BaseExecutor.load_config('yaml/test-compound-indexer2.yml', True, j)
+    #     assert a[0] == a['test_meta']
+    #     assert not a[0].is_updated
+    #     assert not a.is_updated
+    #     a[0].add([j, j * 2, j * 3], [bytes(j), bytes(j * 2), bytes(j * 3)])
+    #     assert a[0].is_updated
+    #     assert a.is_updated
+    #     assert not a[1].is_updated
+    #     a[1].add(np.array([j * 2, j * 2 + 1]), all_vecs[(j * 2, j * 2 + 1), :])
+    #     assert a[1].is_updated
+    #     a.save()
+    #     # the compound executor itself is not modified, therefore should not generate a save
+    #     assert not os.path.exists(a.save_abspath)
+    #     assert os.path.exists(a[0].save_abspath)
+    #     assert os.path.exists(a[0].index_abspath)
+    #     assert os.path.exists(a[1].save_abspath)
+    #     assert os.path.exists(a[1].index_abspath)
+    #
+    # recovered_vecs = []
+    # for j in range(3):
+    #     a = BaseExecutor.load_config('yaml/test-compound-indexer2.yml', True, j)
+    #     recovered_vecs.append(a[1].query_handler)
+    #
+    # np.testing.assert_almost_equal(all_vecs, np.concatenate(recovered_vecs))

--- a/tests/unit/test_workspace.py
+++ b/tests/unit/test_workspace.py
@@ -23,6 +23,7 @@ def test_compound_workspace(tmpdir, replica_id):
             assert os.path.exists(component_dir)
         executor.touch()
         executor_dir = tmpdir.join(f'{executor.name}-{replica_id}-{executor.name}.bin')
+        executor.save(executor_dir)
         assert os.path.exists(executor_dir)
 
 @pytest.mark.parametrize('replica_id', [1,2,3])
@@ -39,34 +40,33 @@ def test_compound_indexer(tmpdir, replica_id):
         e.touch()
         executor_dir = tmpdir.join(f'{e.name}-{replica_id}-{e.name}.bin')
         e.save(executor_dir)
-        assert os.path.exists(e.save_abspath)
+        assert os.path.exists(executor_dir)
 
 def test_compound_indexer_rw():
-    pass
-    # TODO: need refactor.
-    # all_vecs = np.random.random([6, 5])
-    # for j in range(3):
-    #     a = BaseExecutor.load_config('yaml/test-compound-indexer2.yml', True, j)
-    #     assert a[0] == a['test_meta']
-    #     assert not a[0].is_updated
-    #     assert not a.is_updated
-    #     a[0].add([j, j * 2, j * 3], [bytes(j), bytes(j * 2), bytes(j * 3)])
-    #     assert a[0].is_updated
-    #     assert a.is_updated
-    #     assert not a[1].is_updated
-    #     a[1].add(np.array([j * 2, j * 2 + 1]), all_vecs[(j * 2, j * 2 + 1), :])
-    #     assert a[1].is_updated
-    #     a.save()
-    #     # the compound executor itself is not modified, therefore should not generate a save
-    #     assert not os.path.exists(a.save_abspath)
-    #     assert os.path.exists(a[0].save_abspath)
-    #     assert os.path.exists(a[0].index_abspath)
-    #     assert os.path.exists(a[1].save_abspath)
-    #     assert os.path.exists(a[1].index_abspath)
-    #
-    # recovered_vecs = []
-    # for j in range(3):
-    #     a = BaseExecutor.load_config('yaml/test-compound-indexer2.yml', True, j)
-    #     recovered_vecs.append(a[1].query_handler)
-    #
-    # np.testing.assert_almost_equal(all_vecs, np.concatenate(recovered_vecs))
+    all_vecs = np.random.random([6, 5])
+    for j in range(3):
+        with BaseExecutor.load_config('yaml/test-compound-indexer2.yml', True, j) as a:
+            assert a[0] == a['test_meta']
+            assert not a[0].is_updated
+            assert not a.is_updated
+            a[0].add([j, j * 2, j * 3], [bytes(j), bytes(j * 2), bytes(j * 3)])
+            a[0].add([j, j * 2, j * 3], [bytes(j), bytes(j * 2), bytes(j * 3)])
+            assert a[0].is_updated
+            assert a.is_updated
+            assert not a[1].is_updated
+            a[1].add(np.array([j * 2, j * 2 + 1]), all_vecs[(j * 2, j * 2 + 1), :])
+            assert a[1].is_updated
+            a.save()
+            # the compound executor itself is not modified, therefore should not generate a save
+            assert not os.path.exists(a.save_abspath)
+            assert os.path.exists(a[0].save_abspath)
+            assert os.path.exists(a[0].index_abspath)
+            assert os.path.exists(a[1].save_abspath)
+            assert os.path.exists(a[1].index_abspath)
+
+    recovered_vecs = []
+    for j in range(3):
+        with BaseExecutor.load_config('yaml/test-compound-indexer2.yml', True, j) as a:
+            recovered_vecs.append(a[1].query_handler)
+
+    np.testing.assert_almost_equal(all_vecs, np.concatenate(recovered_vecs))


### PR DESCRIPTION
During testing, discovered error in `CompoundExecutor` not saving it's ~components~ and itself to `filename`.

1. Take out `JinaTestCase` from `test_workspace`
2. Clean up `test_workspace`
3. Save `CompoundExecutor` itself to `filename`, as it's base class (if `filename` exist).