### PR TITLE
feat(evaluator): add average precision

### DIFF
--- a/jina/executors/evaluators/rank/average_precision.py
+++ b/jina/executors/evaluators/rank/average_precision.py
@@ -1,0 +1,38 @@
+from typing import Sequence, Any
+from ..rank import BaseRankingEvaluator
+import numpy as np
+
+
+class AveragePrecisionEvaluator(BaseRankingEvaluator):
+    """A :class:`AveragePrecisionEvaluator` evaluates the Average Precision of the search.
+       https://en.wikipedia.org/wiki/Evaluation_measures_(information_retrieval)#Average_precision
+    """
+
+    @property
+    def metric(self):
+        return 'AveragePrecision'
+
+    def evaluate(self, actual: Sequence[Any], desired: Sequence[Any], *args, **kwargs) -> float:
+        """"
+        :param actual: the matched document identifiers from the request as matched by jina indexers and rankers
+        :param desired: the expected documents matches ids sorted as they are expected
+        :return the evaluation metric value for the request document
+        """
+        matches = []
+        for idx, doc_id in enumerate(desired):
+            matches.append(doc_id in actual[:idx+1])
+        matches = np.array(matches)
+        cumsum = np.cumsum(matches)
+        precision = cumsum / np.arange(1, len(matches) + 1)
+
+        # Does not match behaviour in
+        # https://github.com/jina-ai/jina/blob/master/tests/unit/executors/evaluators/rank/test_precision.py#L10
+        precision = np.insert(precision, 0, 1.)
+
+        recall = cumsum / len(matches)
+        # copy behaviour as in
+        # https://github.com/jina-ai/jina/blob/master/tests/unit/executors/evaluators/rank/test_recall.py#L10
+        recall = np.insert(recall, 0, 0.)
+
+        ap = np.sum(np.diff(recall) * ((precision[1:] + precision[:-1]) / 2))
+        return ap

--- a/tests/unit/executors/evaluators/rank/test_average_precision.py
+++ b/tests/unit/executors/evaluators/rank/test_average_precision.py
@@ -1,0 +1,43 @@
+import numpy as np
+import pytest
+
+from jina.executors.evaluators.rank.average_precision import AveragePrecisionEvaluator
+
+
+@pytest.mark.parametrize(
+    'matches_ids, desired_ids, expected',
+    [
+        ([0, 1, 2, 3], [0, 1, 2, 3], 1.0),
+        ([0, 1, 4, 5], [0, 1, 2, 3], 0.5),
+        ([4, 5, 6, 7], [0, 1, 2, 3], 0.0),
+        ([0, 1, 1, 1], [0, 1, 2, 3], 0.5),
+        ([0, 1], [0, 1, 2, 3], 0.5),
+        ([0, 1, 4, 2], [0, 1, 2, 3], 0.5),
+        ([0, 1, 3], [0, 1, 2, 3], 0.677083),
+        ([0, 1, 3, 2], [0, 1, 2, 3], 0.677083),
+    ]
+)
+def test_average_precision_evaluator(matches_ids, desired_ids, expected):
+
+    # TODO eval_at keyword argument has no meaning for AP
+    evaluator = AveragePrecisionEvaluator(eval_at=-1)
+    output = evaluator.evaluate(actual=matches_ids, desired=desired_ids)
+    np.testing.assert_array_almost_equal(output, expected)
+
+
+def test_precision_evaluator_no_groundtruth():
+    matches_ids = [0, 1, 2, 3, 4]
+    desired_ids = []
+
+    # TODO eval_at keyword argument has no meaning for AP
+    evaluator = AveragePrecisionEvaluator(eval_at=-1)
+    assert evaluator.evaluate(actual=matches_ids, desired=desired_ids) == 0.0
+
+
+def test_precision_evaluator_no_actuals():
+    matches_ids = []
+    desired_ids = [1, 2]
+
+    # TODO eval_at keyword argument has no meaning for AP
+    evaluator = AveragePrecisionEvaluator(eval_at=-1)
+    assert evaluator.evaluate(actual=matches_ids, desired=desired_ids) == 0.0


### PR DESCRIPTION
Adding Average Precision (AP) as an evaluator.
See tests for some sanity checks.

I considered adding this to jina-hub, but thought this can fit here as well as there is no other dependencies besides numpy.

The `BaseRankingEvaluator` class expects a eval_at argument which is not necessary for AP as it evaluates on the whole ranking.
It could be used to limit the AP to only consider the first x results though.