### PR TITLE
refactor: remove replica naming

### DIFF
--- a/jina/executors/compound.py
+++ b/jina/executors/compound.py
@@ -93,7 +93,7 @@ class CompoundExecutor(BaseExecutor):
         c[0].add(obj)
 
     .. note::
-        All components ``workspace`` and ``replica_workspace`` are overrided by their :class:`CompoundExecutor` counterparts.
+        All components ``workspace`` and ``pea_workspace`` are overrided by their :class:`CompoundExecutor` counterparts.
 
     .. warning::
 
@@ -265,7 +265,7 @@ class CompoundExecutor(BaseExecutor):
         for c in self.components:
             c.separated_workspace = self.separated_workspace
             c.workspace = self.workspace
-            c.replica_workspace = self.current_workspace
+            c.pea_workspace = self.current_workspace
 
     def _resolve_routes(self) -> None:
         if self._routes:

--- a/jina/executors/metas.py
+++ b/jina/executors/metas.py
@@ -71,28 +71,28 @@ Any executor inherited from :class:`BaseExecutor` always has the following **met
         :type: str/List[str]
         :default: ``None``
 
-    .. confval:: replica_id
+    .. confval:: pea_id
 
-        the integer index used for distinguish each replica of this executor, useful in :attr:`replica_workspace`
+        the integer index used for distinguish each parallel pea of this executor, useful in :attr:`pea_workspace`
 
         :type: int
-        :default: ``'{root.metas.replica_id}'``
+        :default: ``'{root.metas.pea_id}'``
 
     .. confval:: separated_workspace
 
-        whether to isolate the data of the parallel of this executor. If ``True``, then each replica works in its own
-        workspace specified in :attr:`replica_workspace`
+        whether to isolate the data of the parallel of this executor. If ``True``, then each parallel pea works in its own
+        workspace specified in :attr:`pea_workspace`
 
         :type: bool
         :default: ``'{root.metas.separated_workspace}'``
         
-    .. confval:: replica_workspace
+    .. confval:: pea_workspace
 
-        the workspace of each replica, useful when :attr:`separated_workspace` is set to True. All data and IO operations
-        related to this replica will be conducted under this workspace. It is often set as the sub-directory of :attr:`workspace`.
+        the workspace of each parallel pea, useful when :attr:`separated_workspace` is set to True. All data and IO operations
+        related to this parallel pea will be conducted under this workspace. It is often set as the sub-directory of :attr:`workspace`.
 
         :type: str
-        :default: ``'{root.metas.workspace}/{root.metas.name}-{root.metas.replica_id}'``
+        :default: ``'{root.metas.workspace}/{root.metas.name}-{root.metas.pea_id}'``
 
 
     .. warning::
@@ -100,7 +100,7 @@ Any executor inherited from :class:`BaseExecutor` always has the following **met
 
     .. note::
 
-        ``separated_workspace``, ``replica_workspace`` and ``replica_id`` is set in a way that when the executor ``A`` is used as
+        ``separated_workspace``, ``pea_workspace`` and ``pea_id`` is set in a way that when the executor ``A`` is used as
         a component of a :class:`jina.executors.compound.CompoundExecutor` ``B``, then ``A``'s setting will be overrided by B's counterpart.
 
     These **meta** fields can be accessed via `self.is_trained` or loaded from a YAML config via :func:`load_config`:

--- a/jina/logging/logger.py
+++ b/jina/logging/logger.py
@@ -8,6 +8,7 @@ import platform
 import re
 import sys
 
+from typing import Optional
 from pkg_resources import resource_filename
 
 from . import formatter
@@ -81,7 +82,7 @@ class SysLogHandlerWrapper(logging.handlers.SysLogHandler):
 class JinaLogger:
     supported = {'FileHandler', 'StreamHandler', 'SysLogHandler', 'FluentHandler'}
 
-    def __init__(self, context: str, log_config: str = None, **kwargs):
+    def __init__(self, context: str, log_config: Optional[str] = None, **kwargs):
         from .. import __uptime__
 
         if not log_config:

--- a/jina/resources/executors.metas.default.yml
+++ b/jina/resources/executors.metas.default.yml
@@ -7,6 +7,6 @@ on_gpu: false
 warn_unnamed: false
 max_snapshot: 0
 py_modules:
-replica_id: '{root.metas.replica_id}'  # this may result in self-referred
+pea_id: '{root.metas.pea_id}'  # this may result in self-referred
 separated_workspace: '{root.metas.separated_workspace}'  # this may result in self-referred
-replica_workspace: '{root.metas.workspace}/{root.metas.name}-{root.metas.replica_id}'
+pea_workspace: '{root.metas.workspace}/{root.metas.name}-{root.metas.pea_id}'

--- a/tests/unit/test_workspace.py
+++ b/tests/unit/test_workspace.py
@@ -5,40 +5,40 @@ import numpy as np
 
 from jina.executors import BaseExecutor
 
-@pytest.mark.parametrize('replica_id', [1,2,3])
-def test_share_workspace(tmpdir, replica_id):
-    with BaseExecutor.load_config('yaml/test-workspace.yml', True, replica_id) as executor:
+@pytest.mark.parametrize('pea_id', [1,2,3])
+def test_share_workspace(tmpdir, pea_id):
+    with BaseExecutor.load_config('yaml/test-workspace.yml', True, pea_id) as executor:
         executor.touch()
-        executor_dir = tmpdir.join(f'{executor.name}-{replica_id}-{executor.name}.bin')
+        executor_dir = tmpdir.join(f'{executor.name}-{pea_id}-{executor.name}.bin')
         executor.save(executor_dir)
         assert os.path.exists(executor_dir)
 
-@pytest.mark.parametrize('replica_id', [1,2,3])
-def test_compound_workspace(tmpdir, replica_id):
-    with BaseExecutor.load_config('yaml/test-compound-workspace.yml', True, replica_id) as executor:
+@pytest.mark.parametrize('pea_id', [1,2,3])
+def test_compound_workspace(tmpdir, pea_id):
+    with BaseExecutor.load_config('yaml/test-compound-workspace.yml', True, pea_id) as executor:
         for c in executor.components:
             c.touch()
-            component_dir = tmpdir.join(f'{executor.name}-{replica_id}-{c.name}.bin')
+            component_dir = tmpdir.join(f'{executor.name}-{pea_id}-{c.name}.bin')
             c.save(component_dir)
             assert os.path.exists(component_dir)
         executor.touch()
-        executor_dir = tmpdir.join(f'{executor.name}-{replica_id}-{executor.name}.bin')
+        executor_dir = tmpdir.join(f'{executor.name}-{pea_id}-{executor.name}.bin')
         executor.save(executor_dir)
         assert os.path.exists(executor_dir)
 
-@pytest.mark.parametrize('replica_id', [1,2,3])
-def test_compound_indexer(tmpdir, replica_id):
-    with BaseExecutor.load_config('yaml/test-compound-indexer.yml', True, replica_id) as e:
+@pytest.mark.parametrize('pea_id', [1,2,3])
+def test_compound_indexer(tmpdir, pea_id):
+    with BaseExecutor.load_config('yaml/test-compound-indexer.yml', True, pea_id) as e:
         for c in e:
             c.touch()
-            component_dir = tmpdir.join(f'{e.name}-{replica_id}-{c.name}.bin')
+            component_dir = tmpdir.join(f'{e.name}-{pea_id}-{c.name}.bin')
             c.save(component_dir)
             assert os.path.exists(c.index_abspath)
             assert c.save_abspath.startswith(e.current_workspace)
             assert c.index_abspath.startswith(e.current_workspace)
 
         e.touch()
-        executor_dir = tmpdir.join(f'{e.name}-{replica_id}-{e.name}.bin')
+        executor_dir = tmpdir.join(f'{e.name}-{pea_id}-{e.name}.bin')
         e.save(executor_dir)
         assert os.path.exists(executor_dir)
 

--- a/tests/unit/test_yamlparser.py
+++ b/tests/unit/test_yamlparser.py
@@ -43,7 +43,7 @@ def test_yaml_expand3():
     with open(os.path.join(cur_dir, 'yaml/test-expand3.yml')) as fp:
         a = yaml.load(fp)
     b = expand_dict(a)
-    assert b['replica_workspace'] != '{root.workspace}/{root.name}-{this.replica_id}'
+    assert b['pea_workspace'] != '{root.workspace}/{root.name}-{this.pea_id}'
 
 
 def test_attr_dict():

--- a/tests/unit/yaml/test-expand3.yml
+++ b/tests/unit/yaml/test-expand3.yml
@@ -7,6 +7,6 @@ on_gpu: false
 warn_unamed: false
 max_snapshot: 0
 py_modules:
-replica_id: 1
+pea_id: 1
 separated_workspace: false
-replica_workspace: '{root.workspace}/{root.name}-{this.replica_id}'
+pea_workspace: '{root.workspace}/{root.name}-{this.pea_id}'

--- a/tests/unit/yaml/test-workspace.yml
+++ b/tests/unit/yaml/test-workspace.yml
@@ -2,4 +2,4 @@
 metas:
   name: test1
   separated_workspace: true
-  replica_id: 0
+  pea_id: 0


### PR DESCRIPTION
**Changes introduced**
Changes `replica_id` to `pea_id` and `replica_workspace` to `pea_workspace`