### PR TITLE
fix: adapt log info after lazy reading

### DIFF
--- a/jina/drivers/control.py
+++ b/jina/drivers/control.py
@@ -3,7 +3,8 @@ __license__ = "Apache-2.0"
 
 import time
 
-from . import BaseDriver, BaseRecursiveDriver
+from . import BaseDriver
+from .querylang.queryset.dunderkey import dunder_get
 from ..excepts import UnknownControlCommand, RequestLoopEnd, NoExplicitMessage
 from ..proto import jina_pb2
 
@@ -11,12 +12,17 @@ from ..proto import jina_pb2
 class LogInfoDriver(BaseDriver):
     """Log output the request info"""
 
-    def __init__(self, field: str = 'msg', *args, **kwargs):
+    def __init__(self, key: str = 'request', *args, **kwargs):
+        """
+        :param key: (str) that represents a first level or nested key in the dict
+        :param args:
+        :param kwargs:
+        """
         super().__init__(*args, **kwargs)
-        self.field = field
+        self.key = key
 
     def __call__(self, *args, **kwargs):
-        self.logger.info(getattr(self, self.field, 'msg'))
+        self.logger.info(dunder_get(self.msg.as_pb_object, self.key))
 
 
 class WaitDriver(BaseDriver):

--- a/jina/drivers/querylang/queryset/dunderkey.py
+++ b/jina/drivers/querylang/queryset/dunderkey.py
@@ -116,7 +116,6 @@ def dunder_get(_dict: Any, key: str) -> Any:
 
     """
 
-
     try:
         part1, part2 = key.split('__', 1)
     except ValueError:
@@ -138,6 +137,7 @@ def dunder_get(_dict: Any, key: str) -> Any:
         result = getattr(_dict, part1)
 
     return dunder_get(result, part2) if part2 else result
+
 
 def undunder_keys(_dict: Dict) -> Dict:
     """Returns dict with the dunder keys converted back to nested dicts
@@ -164,7 +164,7 @@ def undunder_keys(_dict: Dict) -> Dict:
             dict1[key] = val
 
     result = {}
-    for k,v in _dict.items():
+    for k, v in _dict.items():
         merge(result, f(k.split('__'), v))
 
     return result


### PR DESCRIPTION
**Changes introduced**
Since #1210 the `LogInfoDriver` is broken and here I fix it and allow to extract the wanted fields of a message via `dunder_get`