### PR TITLE
refactor(num_part): rewrite num_part logic at pea, driver and proto

### DIFF
--- a/.github/i18n/README.de.md
+++ b/.github/i18n/README.de.md
@@ -170,7 +170,7 @@ pods:
     replicas: $SHARDS
     separated_workspace: true
   join_all:
-    uses: _merge
+    uses: _pass
     needs: [doc_idx, chunk_idx]
     read_only: true
 ```

--- a/.github/i18n/README.fr.md
+++ b/.github/i18n/README.fr.md
@@ -171,7 +171,7 @@ pods:
     replicas: $SHARDS
     separated_workspace: true
   join_all:
-    uses: _merge
+    uses: _pass
     needs: [doc_idx, chunk_idx]
     read_only: true
 ```

--- a/.github/i18n/README.ja.md
+++ b/.github/i18n/README.ja.md
@@ -170,7 +170,7 @@ pods:
     replicas: $SHARDS
     separated_workspace: true
   join_all:
-    uses: _merge
+    uses: _pass
     needs: [doc_idx, chunk_idx]
     read_only: true
 ```

--- a/.github/i18n/README.ru.md
+++ b/.github/i18n/README.ru.md
@@ -170,7 +170,7 @@ pods:
     replicas: $SHARDS
     separated_workspace: true
   join_all:
-    uses: _merge
+    uses: _pass
     needs: [doc_idx, chunk_idx]
     read_only: true
 ```

--- a/.github/i18n/README.zh.md
+++ b/.github/i18n/README.zh.md
@@ -172,7 +172,7 @@ pods:
     replicas: $SHARDS
     separated_workspace: true
   join_all:
-    uses: _merge
+    uses: _pass
     needs: [doc_idx, chunk_idx]
     read_only: true
 ```

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -138,6 +138,7 @@ jobs:
           docker ps
           jina check
           export JINA_LOG_VERBOSITY="ERROR"
+          export JINA_RAISE_ERROR_EARLY=1
           pip install .[test]
           pytest --force-flaky --min-passes 1 --max-runs 5 --cov=jina --cov-report=xml -n 1 --timeout=120 -v tests/unit
           mv coverage.xml unit-test-coverage.xml
@@ -179,6 +180,7 @@ jobs:
           jina check
           docker build  -f Dockerfiles/pip.Dockerfile -t jinaai/jina:test-pip .
           export JINA_LOG_VERBOSITY="ERROR"
+          export JINA_RAISE_ERROR_EARLY=1
           pip install .[test]
           pytest --force-flaky --min-passes 1 --max-runs 5 --cov=jina --cov-report=xml -n 1 --timeout=120 --ignore-glob='tests/integration/hub_usage/dummyhub*' -v tests/integration
           mv coverage.xml integration-test-coverage.xml

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -138,7 +138,6 @@ jobs:
           docker ps
           jina check
           export JINA_LOG_VERBOSITY="ERROR"
-          export JINA_RAISE_ERROR_EARLY=1
           pip install .[test]
           pytest --force-flaky --min-passes 1 --max-runs 5 --cov=jina --cov-report=xml -n 1 --timeout=120 -v tests/unit
           mv coverage.xml unit-test-coverage.xml
@@ -180,7 +179,6 @@ jobs:
           jina check
           docker build  -f Dockerfiles/pip.Dockerfile -t jinaai/jina:test-pip .
           export JINA_LOG_VERBOSITY="ERROR"
-          export JINA_RAISE_ERROR_EARLY=1
           pip install .[test]
           pytest --force-flaky --min-passes 1 --max-runs 5 --cov=jina --cov-report=xml -n 1 --timeout=120 --ignore-glob='tests/integration/hub_usage/dummyhub*' -v tests/integration
           mv coverage.xml integration-test-coverage.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,7 @@ jobs:
           docker ps
           jina check
           export JINA_LOG_VERBOSITY="ERROR"
+          export JINA_RAISE_ERROR_EARLY=1
           pip install .[test]
           pytest --force-flaky --min-passes 1 --max-runs 5 --cov=jina --cov-report=xml -n 1 --timeout=120 -v tests/unit
           mv coverage.xml unit-test-coverage.xml
@@ -101,6 +102,7 @@ jobs:
           docker run jinaai/jina:test-pip hello-world
           jina check
           export JINA_LOG_VERBOSITY="ERROR"
+          export JINA_RAISE_ERROR_EARLY=1
           pip install .[test]
           pytest --force-flaky --min-passes 1 --max-runs 5 --cov=jina --cov-report=xml -n 1 --timeout=120 -v --ignore-glob='tests/integration/hub_usage/dummyhub*' tests/integration
           mv coverage.xml integration-test-coverage.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,6 @@ jobs:
           docker ps
           jina check
           export JINA_LOG_VERBOSITY="ERROR"
-          export JINA_RAISE_ERROR_EARLY=1
           pip install .[test]
           pytest --force-flaky --min-passes 1 --max-runs 5 --cov=jina --cov-report=xml -n 1 --timeout=120 -v tests/unit
           mv coverage.xml unit-test-coverage.xml
@@ -102,7 +101,6 @@ jobs:
           docker run jinaai/jina:test-pip hello-world
           jina check
           export JINA_LOG_VERBOSITY="ERROR"
-          export JINA_RAISE_ERROR_EARLY=1
           pip install .[test]
           pytest --force-flaky --min-passes 1 --max-runs 5 --cov=jina --cov-report=xml -n 1 --timeout=120 -v --ignore-glob='tests/integration/hub_usage/dummyhub*' tests/integration
           mv coverage.xml integration-test-coverage.xml

--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -39,6 +39,7 @@ jobs:
         run: |
           jina check
           export JINA_LOG_VERBOSITY="ERROR"
+          export JINA_RAISE_ERROR_EARLY=1
           cd examples/${{ matrix.path }}
           pip install -r requirements.txt --no-cache-dir
           pytest -s -v .

--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -39,7 +39,6 @@ jobs:
         run: |
           jina check
           export JINA_LOG_VERBOSITY="ERROR"
-          export JINA_RAISE_ERROR_EARLY=1
           cd examples/${{ matrix.path }}
           pip install -r requirements.txt --no-cache-dir
           pytest -s -v .

--- a/docs/chapters/envs.rst
+++ b/docs/chapters/envs.rst
@@ -155,3 +155,9 @@ Here is the list of environment variables that ``jina`` respects during runtime.
     ``uvloop`` is ultra fast implementation of the asyncio event loop on top of libuv. Since Jina 0.3.6, Jina relies on ``uvloop`` to manage the sockets and streams.
 
     :default: unset
+
+.. confval:: JINA_RAISE_ERROR_EARLY
+
+    Raise exception immedidately instead of passing it forward in the flow. Useful in debugging
+
+    :default: unset

--- a/docs/chapters/flow/index.md
+++ b/docs/chapters/flow/index.md
@@ -271,7 +271,7 @@ pods:
     replicas: $SHARDS
     separated_workspace: true
   join_all:
-    uses: _merge
+    uses: _pass
     needs: [doc_idx, chunk_idx]
     read_only: true
 ```
@@ -394,7 +394,7 @@ pods:
     uses: BinaryPbIndexer
     needs: gateway
   join_all:
-    uses: _merge
+    uses: _pass
     needs: [doc_indexer, chunk_indexer]
 ```
 

--- a/docs/chapters/simple_exec.md
+++ b/docs/chapters/simple_exec.md
@@ -25,7 +25,7 @@ requests:
 
 It uses `ReqPruneDriver` to prune the request. That's it.
 
-Another example, in Flow API the `join` method (waiting multiple Pods to finish) is implemented with `_merge` Simple Executor, which is specified by 
+Another example, in Flow API the `join` method (waiting multiple Pods to finish) is implemented with `_pass` Simple Executor, which is specified by 
 ```yaml
 !BaseExecutor
 with: {}
@@ -51,7 +51,7 @@ def join(self, needs: Union[Tuple[str], List[str]], *args, **kwargs) -> 'Flow':
     """
     if len(needs) <= 1:
         raise FlowTopologyError('no need to wait for a single service, need len(needs) > 1')
-    return self.add(name='joiner', uses='_merge', needs=needs, *args, **kwargs)
+    return self.add(name='joiner', uses='_pass', needs=needs, *args, **kwargs)
 
 ```
 
@@ -66,7 +66,7 @@ To help users quickly use these patterns, we reserved the following keywords for
 | `_forward` | Forward the message to the downstream |
 | `_route` | Use load-balancing algorithm to route message to the downstream |
 | `_logforward` | Like `_forward`, but print the message |
-| `_merge` | Merge the envelope of all collected messages, often used in the tail of a Pod |
+| `_pass` | Merge the envelope of all collected messages, often used in the tail of a Pod |
 | `_merge_topk` | Merge the top-k search results (both doc and chunk level) of all collected messages, often used in the tail of a Pod |
 | `_merge_topk_chunks` | Merge the top-k search results (chunk level only) of all collected messages, often used in the tail of a Pod |
 | `_merge_topk_docs` | Merge the top-k search results (doc level only) of all collected messages, often used in the tail of a Pod |

--- a/docs/chapters/simple_exec.md
+++ b/docs/chapters/simple_exec.md
@@ -63,10 +63,8 @@ To help users quickly use these patterns, we reserved the following keywords for
 | Reserved Name | Description |
 | --- | --- |
 | `_clear` | Clear request body from a message |
-| `_forward` | Forward the message to the downstream |
-| `_route` | Use load-balancing algorithm to route message to the downstream |
-| `_logforward` | Like `_forward`, but print the message |
-| `_pass` | Merge the envelope of all collected messages, often used in the tail of a Pod |
+| `_logforward` | Like `_pass`, but print the message |
+| `_pass` | Pass the message to the downstream |
 | `_merge_topk` | Merge the top-k search results (both doc and chunk level) of all collected messages, often used in the tail of a Pod |
 | `_merge_topk_chunks` | Merge the top-k search results (chunk level only) of all collected messages, often used in the tail of a Pod |
 | `_merge_topk_docs` | Merge the top-k search results (doc level only) of all collected messages, often used in the tail of a Pod |

--- a/jina/drivers/__init__.py
+++ b/jina/drivers/__init__.py
@@ -173,7 +173,16 @@ class BaseDriver(metaclass=DriverType):
     @property
     def partial_reqs(self) -> Sequence['LazyRequest']:
         """The collected partial requests under the current ``request_id`` """
-        return self.pea.partial_requests
+        if self.expect_parts > 1:
+            return self.pea.partial_requests
+        else:
+            raise ValueError(f'trying to access all partial requests, '
+                             f'but {self.pea} has only one message')
+
+    @property
+    def expect_parts(self) -> int:
+        """The expected number of partial messages """
+        return self.pea.expect_parts
 
     @property
     def msg(self) -> 'ProtoMessage':
@@ -267,7 +276,7 @@ class BaseRecursiveDriver(BaseDriver):
 
     @property
     def docs(self):
-        if len(self.partial_reqs) > 1:
+        if self.expect_parts > 1:
             return (d for r in reversed(self.partial_reqs) for d in r.docs)
         else:
             return self.req.docs

--- a/jina/drivers/__init__.py
+++ b/jina/drivers/__init__.py
@@ -2,7 +2,6 @@ __copyright__ = "Copyright (c) 2020 Jina AI Limited. All rights reserved."
 __license__ = "Apache-2.0"
 
 import inspect
-from collections import defaultdict
 from functools import wraps
 from typing import (
     Any,
@@ -11,7 +10,6 @@ from typing import (
     Tuple,
     Iterable,
     Iterator,
-    List,
     Optional,
     Sequence,
 )
@@ -21,7 +19,7 @@ from google.protobuf.struct_pb2 import Struct
 
 from ..enums import SkipOnErrorType
 from ..executors.compound import CompoundExecutor
-from ..executors.decorators import as_reduce_method, wrap_func
+from ..executors.decorators import wrap_func
 from ..helper import yaml
 from ..proto import jina_pb2
 from ..proto.message import ProtoMessage, LazyRequest
@@ -98,10 +96,10 @@ class QuerySetReader:
         if getattr(self, 'queryset', None):
             for q in self.queryset:
                 if (
-                    not q.disabled
-                    and self.__class__.__name__ == q.name
-                    and q.priority > self._priority
-                    and key in q.parameters
+                        not q.disabled
+                        and self.__class__.__name__ == q.name
+                        and q.priority > self._priority
+                        and key in q.parameters
                 ):
                     ret = q.parameters[key]
                     return dict(ret) if isinstance(ret, Struct) else ret
@@ -127,7 +125,7 @@ class DriverType(type):
         reg_cls_set = getattr(cls, '_registered_class', set())
         if cls.__name__ not in reg_cls_set or getattr(cls, 'force_register', False):
             wrap_func(cls, ['__init__'], store_init_kwargs)
-            wrap_func(cls, ['__call__'], as_reduce_method)
+            # wrap_func(cls, ['__call__'], as_reduce_method)
 
             reg_cls_set.add(cls.__name__)
             setattr(cls, '_registered_class', reg_cls_set)
@@ -148,7 +146,7 @@ class BaseDriver(metaclass=DriverType):
     store_args_kwargs = False  #: set this to ``True`` to save ``args`` (in a list) and ``kwargs`` (in a map) in YAML config
 
     def __init__(
-        self, priority: int = 0, expect_parts: Optional[int] = 1, *args, **kwargs
+            self, priority: int = 0, *args, **kwargs
     ):
         """
 
@@ -158,18 +156,6 @@ class BaseDriver(metaclass=DriverType):
         self.attached = False  #: represent if this driver is attached to a :class:`jina.peapods.pea.BasePea` (& :class:`jina.executors.BaseExecutor`)
         self.pea = None  # type: Optional['BasePea']
         self._priority = priority
-        self._expect_parts = expect_parts
-
-        # all pending messages collected so far, key is the request id
-        self._pending_msgs = defaultdict(list)  # type: Dict[str, List['ProtoMessage']]
-
-        # all pointers of the docs, provide the weak ref to all docs in partial reqs
-        self.doc_pointers = {}  # type: Dict[str, Any]
-
-    @property
-    def expect_parts(self) -> int:
-        """The expected number of partial messages before trigger :meth:`__call__` """
-        return self._expect_parts or self.msg.num_part
 
     def attach(self, pea: 'BasePea', *args, **kwargs) -> None:
         """Attach this driver to a :class:`jina.peapods.pea.BasePea`
@@ -187,13 +173,7 @@ class BaseDriver(metaclass=DriverType):
     @property
     def partial_reqs(self) -> Sequence['LazyRequest']:
         """The collected partial requests under the current ``request_id`` """
-        if self.expect_parts <= 1:
-            raise ValueError(
-                f'trying to get collected requests even though expect_parts={self.expect_parts},'
-                f'maybe you want to use self.req instead?'
-            )
-
-        return [v.request for v in self._pending_msgs[self.envelope.request_id]]
+        return self.pea.partial_requests
 
     @property
     def msg(self) -> 'ProtoMessage':
@@ -271,12 +251,12 @@ class BaseRecursiveDriver(BaseDriver):
         self._traversal_paths = [path.lower() for path in traversal_paths]
 
     def _apply_all(
-        self,
-        docs: Iterable['jina_pb2.Document'],
-        context_doc: 'jina_pb2.Document',
-        field: str,
-        *args,
-        **kwargs,
+            self,
+            docs: Iterable['jina_pb2.Document'],
+            context_doc: 'jina_pb2.Document',
+            field: str,
+            *args,
+            **kwargs,
     ) -> None:
         """Apply function works on a list of docs, modify the docs in-place
 
@@ -287,7 +267,7 @@ class BaseRecursiveDriver(BaseDriver):
 
     @property
     def docs(self):
-        if self.expect_parts > 1:
+        if len(self.partial_reqs) > 1:
             return (d for r in reversed(self.partial_reqs) for d in r.docs)
         else:
             return self.req.docs
@@ -296,7 +276,7 @@ class BaseRecursiveDriver(BaseDriver):
         self._traverse_apply(self.docs, *args, **kwargs)
 
     def _traverse_apply(
-        self, docs: Iterable['jina_pb2.Document'], *args, **kwargs
+            self, docs: Iterable['jina_pb2.Document'], *args, **kwargs
     ) -> None:
         for path in self._traversal_paths:
             if path[0] == 'r':
@@ -359,8 +339,8 @@ class BaseExecutableDriver(BaseRecursiveDriver):
     def exec_fn(self) -> Callable:
         """the function of :func:`jina.executors.BaseExecutor` to call """
         if (
-            self.envelope.status.code != jina_pb2.Status.ERROR
-            or self.pea.args.skip_on_error < SkipOnErrorType.EXECUTOR
+                self.envelope.status.code != jina_pb2.Status.ERROR
+                or self.pea.args.skip_on_error < SkipOnErrorType.EXECUTOR
         ):
             return self._exec_fn
         else:
@@ -375,7 +355,7 @@ class BaseExecutableDriver(BaseRecursiveDriver):
             else:
                 for c in executor.components:
                     if any(
-                        t.__name__ == self._executor_name for t in type.mro(c.__class__)
+                            t.__name__ == self._executor_name for t in type.mro(c.__class__)
                     ):
                         self._exec = c
                         break

--- a/jina/drivers/control.py
+++ b/jina/drivers/control.py
@@ -44,7 +44,7 @@ class ControlReqDriver(BaseDriver):
             for k, v in vars(self.pea.args).items():
                 self.req.args[k] = str(v)
         else:
-            raise UnknownControlCommand('don\'t know how to handle %s' % self.req)
+            raise UnknownControlCommand(f'don\'t know how to handle {self.req.command}')
 
 
 class RouteDriver(ControlReqDriver):

--- a/jina/drivers/control.py
+++ b/jina/drivers/control.py
@@ -109,3 +109,7 @@ class RouteDriver(ControlReqDriver):
 
 class ForwardDriver(RouteDriver):
     """Alias to :class:`RouteDriver`"""
+
+
+class ReduceDriver(RouteDriver):
+    """Alias to :class:`RouteDriver`"""

--- a/jina/drivers/reduce.py
+++ b/jina/drivers/reduce.py
@@ -10,12 +10,6 @@ from ..proto import jina_pb2
 from ..proto.ndarray.generic import GenericNdArray
 
 
-class ReduceDriver(BaseRecursiveDriver):
-
-    def __call__(self, *args, **kwargs):
-        """Intentionally override traverse_apply with empty function"""
-
-
 class ReduceAllDriver(BaseRecursiveDriver):
     """:class:`ReduceAllDriver` merges chunks/matches from all requests, recursively.
 

--- a/jina/excepts.py
+++ b/jina/excepts.py
@@ -137,5 +137,9 @@ class CompressionRateTooLow(Exception):
     """
 
 
+class DryRunException(Exception):
+    """Dryrun is not successful on the given flow"""
+
+
 class BadDocID(Exception):
     """ Exception when user give a non-hex string as the doc id """

--- a/jina/flow/__init__.py
+++ b/jina/flow/__init__.py
@@ -298,7 +298,7 @@ class Flow(ExitStack):
                 kwargs[key] = value
 
         kwargs['name'] = pod_name
-        kwargs['num_part_expect'] = len(needs)
+        kwargs['num_part'] = len(needs)
 
         op_flow._pod_nodes[pod_name] = self._invoke_flowpod(kwargs, needs, pod_role)
         op_flow.last_pod = pod_name

--- a/jina/flow/__init__.py
+++ b/jina/flow/__init__.py
@@ -16,7 +16,7 @@ from urllib.request import Request, urlopen
 import ruamel.yaml
 from ruamel.yaml import StringIO
 
-from .builder import build_required, _build_flow, _optimize_flow
+from .builder import build_required, _build_flow, _optimize_flow, _hanging_pods
 from .. import JINA_GLOBAL
 from ..enums import FlowBuildLevel, PodRoleType, FlowInspectType
 from ..excepts import FlowTopologyError, FlowMissingPodError
@@ -442,6 +442,10 @@ class Flow(ExitStack):
 
         op_flow = _build_flow(op_flow, _outgoing_map)
         op_flow = _optimize_flow(op_flow, _outgoing_map, _pod_edges)
+        hanging_pods = _hanging_pods(op_flow)
+        if hanging_pods:
+            self.logger.warning(f'{hanging_pods} are hanging in this flow with no pod receiving from them, '
+                                f'you may want to double check if it is intentional or some mistake')
         op_flow._build_level = FlowBuildLevel.GRAPH
         return op_flow
 

--- a/jina/flow/__init__.py
+++ b/jina/flow/__init__.py
@@ -298,6 +298,7 @@ class Flow(ExitStack):
                 kwargs[key] = value
 
         kwargs['name'] = pod_name
+        kwargs['num_part_expect'] = len(needs)
 
         op_flow._pod_nodes[pod_name] = self._invoke_flowpod(kwargs, needs, pod_role)
         op_flow.last_pod = pod_name

--- a/jina/flow/__init__.py
+++ b/jina/flow/__init__.py
@@ -241,18 +241,17 @@ class Flow(ExitStack):
         self._pod_nodes[pod_name] = GatewayFlowPod(kwargs, needs)
 
     def needs(self, needs: Union[Tuple[str], List[str]],
-              uses: str = '_pass', name: str = 'joiner', *args, **kwargs) -> 'Flow':
+              name: str = 'joiner', *args, **kwargs) -> 'Flow':
         """
         Add a blocker to the flow, wait until all peas defined in **needs** completed.
 
         :param needs: list of service names to wait
-        :param uses: the config of the executor, by default is ``_pass``
         :param name: the name of this joiner, by default is ``joiner``
         :return: the modified flow
         """
         if len(needs) <= 1:
             raise FlowTopologyError('no need to wait for a single service, need len(needs) > 1')
-        return self.add(name=name, uses=uses, needs=needs, pod_role=PodRoleType.JOIN, *args, **kwargs)
+        return self.add(name=name, needs=needs, pod_role=PodRoleType.JOIN, *args, **kwargs)
 
     def add(self,
             needs: Union[str, Tuple[str], List[str]] = None,
@@ -340,7 +339,7 @@ class Flow(ExitStack):
         # now remove uses and add an auxiliary Pod
         if 'uses' in kwargs:
             kwargs.pop('uses')
-        op_flow = op_flow.add(name=f'_aux_{name}', uses='_pass', needs=_last_pod,
+        op_flow = op_flow.add(name=f'_aux_{name}', needs=_last_pod,
                               pod_role=PodRoleType.INSPECT_AUX_PASS, *args, **kwargs)
 
         # register any future connection to _last_pod by the auxiliary pod

--- a/jina/flow/__init__.py
+++ b/jina/flow/__init__.py
@@ -241,12 +241,12 @@ class Flow(ExitStack):
         self._pod_nodes[pod_name] = GatewayFlowPod(kwargs, needs)
 
     def needs(self, needs: Union[Tuple[str], List[str]],
-              uses: str = '_merge', name: str = 'joiner', *args, **kwargs) -> 'Flow':
+              uses: str = '_pass', name: str = 'joiner', *args, **kwargs) -> 'Flow':
         """
         Add a blocker to the flow, wait until all peas defined in **needs** completed.
 
         :param needs: list of service names to wait
-        :param uses: the config of the executor, by default is ``_merge``
+        :param uses: the config of the executor, by default is ``_pass``
         :param name: the name of this joiner, by default is ``joiner``
         :return: the modified flow
         """
@@ -359,7 +359,7 @@ class Flow(ExitStack):
             in general you don't need to manually call :meth:`gather_inspect`.
 
         :param name: the name of the gather pod
-        :param uses: the config of the executor, by default is ``_merge``
+        :param uses: the config of the executor, by default is ``_pass``
         :param include_last_pod: if to include the last modified pod in the flow
         :param args:
         :param kwargs:

--- a/jina/flow/builder.py
+++ b/jina/flow/builder.py
@@ -83,14 +83,21 @@ def _build_flow(op_flow: 'Flow', outgoing_map: Dict[str, List[str]]) -> 'Flow':
         elif end_node_name == 'gateway':
             first_socket_type = SocketType.PUSH_BIND
         FlowPod.connect(start_node, end_node, first_socket_type=first_socket_type)
-        flow.logger.debug(f'Connect {start_node_name} ({start_node.tail_args.num_part}) '
-                          f'with {end_node_name} {str(end_node.role)} {end_node.head_args.num_part}')
+        # flow.logger.debug(f'Connect {start_node_name} ({start_node.tail_args.num_part}) '
+        #                   f'with {end_node_name} {str(end_node.role)} {end_node.head_args.num_part}')
 
     return _traverse_graph(op_flow, outgoing_map, _build_two_connections)
 
 
 def _optimize_flow(op_flow, outgoing_map: Dict[str, List[str]], pod_edges: {str, str}) -> 'Flow':
     def _optimize_two_connections(flow: 'Flow', start_node_name: str, end_node_name: str):
+        """ THIS CODE IS NEVER TESTED AND THE LOGIC MAY NOT APPLIED ANYMORE
+
+        :param flow:
+        :param start_node_name:
+        :param end_node_name:
+        :return:
+        """
         start_node = flow._pod_nodes[start_node_name]
         end_node = flow._pod_nodes[end_node_name]
         edges_with_same_start = [ed for ed in pod_edges if ed[0].startswith(start_node_name)]
@@ -104,6 +111,7 @@ def _optimize_flow(op_flow, outgoing_map: Dict[str, List[str]], pod_edges: {str,
                         f'Node {end_node_name} connects to tail of {start_node_name}')
                     end_node.connect_to_tail_of(start_node)
             elif end_node.role == PodRoleType.GATEWAY:
+                # TODO: this part of the code is never executed given the current optimization level. Never tested.
                 if flow.args.optimize_level > FlowOptimizeLevel.IGNORE_GATEWAY and \
                         start_node.is_tail_router and start_node.tail_args.num_part <= 1:
                     # connect gateway directly to peas only if this is unblock router

--- a/jina/flow/builder.py
+++ b/jina/flow/builder.py
@@ -91,8 +91,8 @@ def _build_flow(op_flow: 'Flow', outgoing_map: Dict[str, List[str]]) -> 'Flow':
         elif end_node_name == 'gateway':
             first_socket_type = SocketType.PUSH_BIND
         FlowPod.connect(start_node, end_node, first_socket_type=first_socket_type)
-        # flow.logger.debug(f'Connect {start_node_name} ({start_node.tail_args.num_part}) '
-        #                   f'with {end_node_name} {str(end_node.role)} {end_node.head_args.num_part}')
+        flow.logger.debug(f'Connect {start_node_name} '
+                          f'with {end_node_name} {str(end_node.role)} require {end_node.head_args.num_part} messages')
 
     return _traverse_graph(op_flow, outgoing_map, _build_two_connections)
 

--- a/jina/flow/builder.py
+++ b/jina/flow/builder.py
@@ -65,6 +65,14 @@ def _traverse_graph(op_flow: 'Flow', outgoing_map: Dict[str, List[str]],
     return op_flow
 
 
+def _hanging_pods(op_flow: 'Flow') -> List[str]:
+    """Return the names of hanging pods (nobody recv from them) in the flow"""
+    all_needs = {v for p in op_flow._pod_nodes.values() for v in p.needs}
+    all_names = {p for p in op_flow._pod_nodes.keys()}
+    # all_names is always a superset of all_needs
+    return list(all_names.difference(all_needs))
+
+
 def _build_flow(op_flow: 'Flow', outgoing_map: Dict[str, List[str]]) -> 'Flow':
     def _build_two_connections(flow: 'Flow', start_node_name: str, end_node_name: str):
         # Rule

--- a/jina/parser.py
+++ b/jina/parser.py
@@ -244,7 +244,7 @@ def set_pea_parser(parser=None):
                      help='the config of the executor, it could be '
                           '> a YAML file path, '
                           '> a supported executor\'s class name, '
-                          '> one of "_clear", "_route", "_pass", "_logforward", "_merge" '
+                          '> one of "_clear", "_pass", "_logforward" '
                           '> the content of YAML config (must starts with "!")'
                           '> a docker image')  # pod(no use) -> pea
     gp0.add_argument('--py-modules', type=str, nargs='*',

--- a/jina/parser.py
+++ b/jina/parser.py
@@ -308,7 +308,10 @@ def set_pea_parser(parser=None):
 
     gp5 = add_arg_group(parser, 'pea messaging arguments')
     gp5.add_argument('--num-part', type=int, default=0,
-                     help='the number of replicated message sent to the next Pod, 0 and 1 means single part'
+                     help='the number of replicated messages sent to the downstream, 0 and 1 means single part'
+                     if _SHOW_ALL_ARGS else argparse.SUPPRESS)
+    gp5.add_argument('--num-part-expect', type=int, default=1,
+                     help='the number of messages expected from upstream, 0 and 1 means single part'
                      if _SHOW_ALL_ARGS else argparse.SUPPRESS)
     gp5.add_argument('--role', type=PeaRoleType.from_string, choices=list(PeaRoleType),
                      help='the role of this pea in a pod' if _SHOW_ALL_ARGS else argparse.SUPPRESS)

--- a/jina/parser.py
+++ b/jina/parser.py
@@ -307,8 +307,8 @@ def set_pea_parser(parser=None):
                      if _SHOW_ALL_ARGS else argparse.SUPPRESS)
 
     gp5 = add_arg_group(parser, 'pea messaging arguments')
-    gp5.add_argument('--num-part', type=int, default=0,
-                     help='the number of replicated messages sent to the downstream, 0 and 1 means single part'
+    gp5.add_argument('--num-part', type=int, default=0, nargs='+',
+                     help='the number of messages sent to the downstream, 0 and 1 means single part'
                      if _SHOW_ALL_ARGS else argparse.SUPPRESS)
     gp5.add_argument('--num-part-expect', type=int, default=1,
                      help='the number of messages expected from upstream, 0 and 1 means single part'

--- a/jina/parser.py
+++ b/jina/parser.py
@@ -214,7 +214,8 @@ def set_flow_parser(parser=None):
                     help='the yaml config of the log server')
     gp.add_argument('--optimize-level', type=FlowOptimizeLevel.from_string, default=FlowOptimizeLevel.NONE,
                     help='removing redundant routers from the flow. Note, this may change the gateway zmq socket to BIND \
-                            and hence not allow multiple clients connected to the gateway at the same time.')
+                            and hence not allow multiple clients connected to the gateway at the same time.'
+                    if _SHOW_ALL_ARGS else argparse.SUPPRESS)
     gp.add_argument('--output-type', type=FlowOutputType.from_string,
                     choices=list(FlowOutputType), default=FlowOutputType.SHELL_PROC,
                     help='type of the output')
@@ -307,10 +308,7 @@ def set_pea_parser(parser=None):
                      if _SHOW_ALL_ARGS else argparse.SUPPRESS)
 
     gp5 = add_arg_group(parser, 'pea messaging arguments')
-    gp5.add_argument('--num-part', type=int, default=0, nargs='+',
-                     help='the number of messages sent to the downstream, 0 and 1 means single part'
-                     if _SHOW_ALL_ARGS else argparse.SUPPRESS)
-    gp5.add_argument('--num-part-expect', type=int, default=1,
+    gp5.add_argument('--num-part', type=int, default=0,
                      help='the number of messages expected from upstream, 0 and 1 means single part'
                      if _SHOW_ALL_ARGS else argparse.SUPPRESS)
     gp5.add_argument('--role', type=PeaRoleType.from_string, choices=list(PeaRoleType),

--- a/jina/peapods/gateway.py
+++ b/jina/peapods/gateway.py
@@ -103,9 +103,6 @@ class GatewayPea:
             :return:
             """
             msg.add_route(self.name, self.args.identity)
-            if not msg.is_complete:
-                msg.add_exception(GatewayPartialMessage(f'gateway can not handle message '
-                                                        f'with num_part={msg.envelope.num_part}'))
             return msg.response
 
         async def CallUnary(self, request, context):

--- a/jina/peapods/gateway.py
+++ b/jina/peapods/gateway.py
@@ -104,7 +104,8 @@ class GatewayPea:
             """
             msg.add_route(self.name, self.args.identity)
             if not msg.is_complete:
-                msg.add_exception(GatewayPartialMessage(f'gateway can not handle message with num_part={msg.envelope.num_part}'))
+                msg.add_exception(GatewayPartialMessage(f'gateway can not handle message '
+                                                        f'with num_part={msg.envelope.num_part}'))
             return msg.response
 
         async def CallUnary(self, request, context):

--- a/jina/peapods/pea.py
+++ b/jina/peapods/pea.py
@@ -297,8 +297,7 @@ class BasePea(metaclass=PeaMeta):
             pass
 
         # tell downstream a new reduce work
-        if self.args.num_part > 1:
-            msg.num_part = self.args.num_part
+        msg.num_part = self.args.num_part
 
         msg.update_timestamp()
         return self

--- a/jina/peapods/pea.py
+++ b/jina/peapods/pea.py
@@ -354,7 +354,7 @@ class BasePea(metaclass=PeaMeta):
                 msg.add_exception(ex, executor=getattr(self, 'executor'))
                 self.logger.error(repr(ex))
             if 'JINA_RAISE_ERROR_EARLY' in os.environ:
-                self.logger.error(ex, exc_info=True)
+                raise
             self.zmqlet.send_message(msg)
 
     def loop_body(self):

--- a/jina/peapods/pod.py
+++ b/jina/peapods/pod.py
@@ -444,7 +444,7 @@ def _copy_to_head_args(args: Namespace, is_push: bool, as_router: bool = True) -
         elif args.scheduling == SchedulerType.LOAD_BALANCE:
             _head_args.socket_out = SocketType.ROUTER_BIND
             if as_router:
-                _head_args.uses = args.uses_before or '_route'
+                _head_args.uses = args.uses_before or '_pass'
     else:
         _head_args.socket_out = SocketType.PUB_BIND
         if as_router:
@@ -467,7 +467,7 @@ def _copy_to_tail_args(args: Namespace, as_router: bool = True) -> Namespace:
     _tail_args.uses = None
 
     if as_router:
-        _tail_args.uses = args.uses_after or '_merge'
+        _tail_args.uses = args.uses_after or '_pass'
         _tail_args.name = args.name or ''
         _tail_args.role = PeaRoleType.TAIL
         _tail_args.num_part = 1 if args.polling.is_push else args.parallel

--- a/jina/peapods/pod.py
+++ b/jina/peapods/pod.py
@@ -454,6 +454,10 @@ def _copy_to_head_args(args: Namespace, is_push: bool, as_router: bool = True) -
         _head_args.name = args.name or ''
         _head_args.role = PeaRoleType.HEAD
 
+    # in any case, if header is present, it represent this Pod to consume `num_part`
+    # the following peas inside the pod will have num_part=1
+    args.num_part = 1
+
     return _head_args
 
 

--- a/jina/peapods/pod.py
+++ b/jina/peapods/pod.py
@@ -341,8 +341,6 @@ class FlowPod(BasePod):
             second.head_args.host_in = __default_host__
             first.tail_args.port_out = second.head_args.port_in
         elif first_socket_type == SocketType.PUB_BIND:
-            if not second.role.is_inspect:
-                first.tail_args.num_part += 1
             first.tail_args.host_out = __default_host__  # bind always get default 0.0.0.0
             second.head_args.host_in = _fill_in_host(bind_args=first.tail_args,
                                                      connect_args=second.head_args)  # the hostname of s_pod
@@ -449,7 +447,6 @@ def _copy_to_head_args(args: Namespace, is_push: bool, as_router: bool = True) -
                 _head_args.uses = args.uses_before or '_route'
     else:
         _head_args.socket_out = SocketType.PUB_BIND
-        _head_args.num_part = args.parallel
         if as_router:
             _head_args.uses = args.uses_before or '_pass'
 
@@ -473,7 +470,7 @@ def _copy_to_tail_args(args: Namespace, as_router: bool = True) -> Namespace:
         _tail_args.uses = args.uses_after or '_merge'
         _tail_args.name = args.name or ''
         _tail_args.role = PeaRoleType.TAIL
-        _tail_args.num_part_expect = 1 if args.polling.is_push else args.parallel
+        _tail_args.num_part = 1 if args.polling.is_push else args.parallel
 
     return _tail_args
 

--- a/jina/peapods/pod.py
+++ b/jina/peapods/pod.py
@@ -103,7 +103,6 @@ class BasePod(ExitStack):
             self.is_tail_router = False
             peas_args['peas'] = [args]
 
-
         # note that peas_args['peas'][0] exist either way and carries the original property
         return peas_args
 
@@ -474,6 +473,7 @@ def _copy_to_tail_args(args: Namespace, as_router: bool = True) -> Namespace:
         _tail_args.uses = args.uses_after or '_merge'
         _tail_args.name = args.name or ''
         _tail_args.role = PeaRoleType.TAIL
+        _tail_args.num_part_expect = 1 if args.polling.is_push else args.parallel
 
     return _tail_args
 

--- a/jina/proto/jina.proto
+++ b/jina/proto/jina.proto
@@ -183,8 +183,6 @@ message Envelope {
 
     Status status = 7; // status info, when present, it is the first exception that routes carry
 
-    repeated uint32 num_part = 8; // the number of partial messages
-
     string request_type = 9; // type of the request: TrainRequest, IndexRequest, SearchRequest, ControlRequest
 
     bool check_version = 10; // check local Protobuf version on every Pod that this message flows to

--- a/jina/proto/jina_pb2.py
+++ b/jina/proto/jina_pb2.py
@@ -21,7 +21,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   syntax='proto3',
   serialized_options=None,
   create_key=_descriptor._internal_create_key,
-  serialized_pb=b'\n\njina.proto\x12\x04jina\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1cgoogle/protobuf/struct.proto\"\xf3\x01\n\x0c\x44\x65nseNdArray\x12\x0e\n\x06\x62uffer\x18\x01 \x01(\x0c\x12\r\n\x05shape\x18\x02 \x03(\r\x12\r\n\x05\x64type\x18\x03 \x01(\t\x12\x39\n\x0cquantization\x18\x04 \x01(\x0e\x32#.jina.DenseNdArray.QuantizationMode\x12\x0f\n\x07max_val\x18\x05 \x01(\x02\x12\x0f\n\x07min_val\x18\x06 \x01(\x02\x12\r\n\x05scale\x18\x07 \x01(\x02\x12\x16\n\x0eoriginal_dtype\x18\x08 \x01(\t\"1\n\x10QuantizationMode\x12\x08\n\x04NONE\x10\x00\x12\x08\n\x04\x46P16\x10\x01\x12\t\n\x05UINT8\x10\x02\"`\n\x07NdArray\x12#\n\x05\x64\x65nse\x18\x01 \x01(\x0b\x32\x12.jina.DenseNdArrayH\x00\x12%\n\x06sparse\x18\x02 \x01(\x0b\x32\x13.jina.SparseNdArrayH\x00\x42\t\n\x07\x63ontent\"m\n\rSparseNdArray\x12#\n\x07indices\x18\x01 \x01(\x0b\x32\x12.jina.DenseNdArray\x12\"\n\x06values\x18\x02 \x01(\x0b\x32\x12.jina.DenseNdArray\x12\x13\n\x0b\x64\x65nse_shape\x18\x03 \x03(\x03\"u\n\nNamedScore\x12\r\n\x05value\x18\x01 \x01(\x02\x12\x0f\n\x07op_name\x18\x02 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x03 \x01(\t\x12\"\n\x08operands\x18\x04 \x03(\x0b\x32\x10.jina.NamedScore\x12\x0e\n\x06ref_id\x18\x05 \x01(\t\"\x8a\x04\n\x08\x44ocument\x12\n\n\x02id\x18\x01 \x01(\t\x12\x13\n\x0bgranularity\x18\x0e \x01(\r\x12\x11\n\tadjacency\x18\x16 \x01(\r\x12\x12\n\nlevel_name\x18\x0f \x01(\t\x12\x11\n\tparent_id\x18\x10 \x01(\t\x12\x10\n\x06\x62uffer\x18\x03 \x01(\x0cH\x00\x12\x1d\n\x04\x62lob\x18\x0c \x01(\x0b\x32\r.jina.NdArrayH\x00\x12\x0e\n\x04text\x18\r \x01(\tH\x00\x12\x1e\n\x06\x63hunks\x18\x04 \x03(\x0b\x32\x0e.jina.Document\x12\x0e\n\x06weight\x18\x05 \x01(\x02\x12\x0e\n\x06length\x18\x06 \x01(\r\x12\x11\n\tmeta_info\x18\x07 \x01(\x0c\x12\x1f\n\x07matches\x18\x08 \x03(\x0b\x32\x0e.jina.Document\x12\x11\n\tmime_type\x18\n \x01(\t\x12\x0b\n\x03uri\x18\t \x01(\t\x12%\n\x04tags\x18\x0b \x01(\x0b\x32\x17.google.protobuf.Struct\x12\x10\n\x08location\x18\x11 \x03(\r\x12\x0e\n\x06offset\x18\x12 \x01(\r\x12 \n\tembedding\x18\x13 \x01(\x0b\x32\r.jina.NdArray\x12\x1f\n\x05score\x18\x14 \x01(\x0b\x32\x10.jina.NamedScore\x12\x10\n\x08modality\x18\x15 \x01(\t\x12%\n\x0b\x65valuations\x18\x17 \x03(\x0b\x32\x10.jina.NamedScoreB\t\n\x07\x63ontent\"\xa0\x01\n\x05Route\x12\x0b\n\x03pod\x18\x01 \x01(\t\x12\x0e\n\x06pod_id\x18\x02 \x01(\t\x12.\n\nstart_time\x18\x03 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12,\n\x08\x65nd_time\x18\x04 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x1c\n\x06status\x18\x05 \x01(\x0b\x32\x0c.jina.Status\"\xda\x02\n\x08\x45nvelope\x12\x11\n\tsender_id\x18\x01 \x01(\t\x12\x13\n\x0breceiver_id\x18\x02 \x01(\t\x12\x12\n\nrequest_id\x18\x03 \x01(\t\x12\x0f\n\x07timeout\x18\x04 \x01(\r\x12\x1b\n\x06routes\x18\x05 \x03(\x0b\x32\x0b.jina.Route\x12\'\n\x07version\x18\x06 \x01(\x0b\x32\x16.jina.Envelope.Version\x12\x1c\n\x06status\x18\x07 \x01(\x0b\x32\x0c.jina.Status\x12\x10\n\x08num_part\x18\x08 \x03(\r\x12\x14\n\x0crequest_type\x18\t \x01(\t\x12\x15\n\rcheck_version\x18\n \x01(\x08\x12)\n\x0b\x63ompression\x18\x0b \x01(\x0b\x32\x14.jina.CompressConfig\x1a\x33\n\x07Version\x12\x0c\n\x04jina\x18\x01 \x01(\t\x12\r\n\x05proto\x18\x02 \x01(\t\x12\x0b\n\x03vcs\x18\x03 \x01(\t\"\x7f\n\x0e\x43ompressConfig\x12\x11\n\talgorithm\x18\x01 \x01(\t\x12\x16\n\x0ehigh_watermark\x18\x02 \x01(\x04\x12\x15\n\rlow_watermark\x18\x03 \x01(\x02\x12+\n\nparameters\x18\x04 \x01(\x0b\x32\x17.google.protobuf.Struct\"\xc6\x02\n\x06Status\x12%\n\x04\x63ode\x18\x01 \x01(\x0e\x32\x17.jina.Status.StatusCode\x12\x13\n\x0b\x64\x65scription\x18\x02 \x01(\t\x12)\n\texception\x18\x03 \x01(\x0b\x32\x16.jina.Status.Exception\x1aY\n\tException\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0c\n\x04\x61rgs\x18\x02 \x03(\t\x12\x0e\n\x06stacks\x18\x03 \x03(\t\x12\x10\n\x08\x65xecutor\x18\x04 \x01(\t\x12\x0e\n\x06\x64river\x18\x05 \x01(\t\"z\n\nStatusCode\x12\x0b\n\x07SUCCESS\x10\x00\x12\x0b\n\x07PENDING\x10\x01\x12\t\n\x05READY\x10\x02\x12\t\n\x05\x45RROR\x10\x03\x12\x13\n\x0f\x45RROR_DUPLICATE\x10\x04\x12\x14\n\x10\x45RROR_NOTALLOWED\x10\x05\x12\x11\n\rERROR_CHAINED\x10\x06\"K\n\x07Message\x12 \n\x08\x65nvelope\x18\x01 \x01(\x0b\x32\x0e.jina.Envelope\x12\x1e\n\x07request\x18\x02 \x01(\x0b\x32\r.jina.Request\"\xa6\x06\n\x07Request\x12\x12\n\nrequest_id\x18\x01 \x01(\t\x12+\n\x05train\x18\x02 \x01(\x0b\x32\x1a.jina.Request.TrainRequestH\x00\x12+\n\x05index\x18\x03 \x01(\x0b\x32\x1a.jina.Request.IndexRequestH\x00\x12-\n\x06search\x18\x04 \x01(\x0b\x32\x1b.jina.Request.SearchRequestH\x00\x12/\n\x07\x63ontrol\x18\x05 \x01(\x0b\x32\x1c.jina.Request.ControlRequestH\x00\x12\x1c\n\x06status\x18\x06 \x01(\x0b\x32\x0c.jina.Status\x12\x1b\n\x06routes\x18\x08 \x03(\x0b\x32\x0b.jina.Route\x12!\n\x08queryset\x18\x07 \x03(\x0b\x32\x0f.jina.QueryLang\x1a\x61\n\x0cTrainRequest\x12\x1c\n\x04\x64ocs\x18\x01 \x03(\x0b\x32\x0e.jina.Document\x12$\n\x0cgroundtruths\x18\x02 \x03(\x0b\x32\x0e.jina.Document\x12\r\n\x05\x66lush\x18\x03 \x01(\x08\x1aR\n\x0cIndexRequest\x12\x1c\n\x04\x64ocs\x18\x01 \x03(\x0b\x32\x0e.jina.Document\x12$\n\x0cgroundtruths\x18\x02 \x03(\x0b\x32\x0e.jina.Document\x1aS\n\rSearchRequest\x12\x1c\n\x04\x64ocs\x18\x01 \x03(\x0b\x32\x0e.jina.Document\x12$\n\x0cgroundtruths\x18\x02 \x03(\x0b\x32\x0e.jina.Document\x1a\xda\x01\n\x0e\x43ontrolRequest\x12\x35\n\x07\x63ommand\x18\x01 \x01(\x0e\x32$.jina.Request.ControlRequest.Command\x12\x34\n\x04\x61rgs\x18\x02 \x03(\x0b\x32&.jina.Request.ControlRequest.ArgsEntry\x1a+\n\tArgsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\".\n\x07\x43ommand\x12\r\n\tTERMINATE\x10\x00\x12\n\n\x06STATUS\x10\x01\x12\x08\n\x04IDLE\x10\x03\x42\x06\n\x04\x62ody\"j\n\tQueryLang\x12\x0c\n\x04name\x18\x01 \x01(\t\x12+\n\nparameters\x18\x02 \x01(\x0b\x32\x17.google.protobuf.Struct\x12\x10\n\x08\x64isabled\x18\x03 \x01(\x08\x12\x10\n\x08priority\x18\x04 \x01(\x05\"\xe3\x03\n\x0cSpawnRequest\x12\x31\n\x03pea\x18\x01 \x01(\x0b\x32\".jina.SpawnRequest.PeaSpawnRequestH\x00\x12\x31\n\x03pod\x18\x02 \x01(\x0b\x32\".jina.SpawnRequest.PodSpawnRequestH\x00\x12@\n\x0bmutable_pod\x18\x03 \x01(\x0b\x32).jina.SpawnRequest.MutablepodSpawnRequestH\x00\x12\x12\n\nlog_record\x18\x04 \x01(\t\x12\x1c\n\x06status\x18\x05 \x01(\x0b\x32\x0c.jina.Status\x1a\x1f\n\x0fPeaSpawnRequest\x12\x0c\n\x04\x61rgs\x18\x01 \x03(\t\x1a\x1f\n\x0fPodSpawnRequest\x12\x0c\n\x04\x61rgs\x18\x01 \x03(\t\x1a\xae\x01\n\x16MutablepodSpawnRequest\x12\x30\n\x04head\x18\x01 \x01(\x0b\x32\".jina.SpawnRequest.PeaSpawnRequest\x12\x30\n\x04tail\x18\x02 \x01(\x0b\x32\".jina.SpawnRequest.PeaSpawnRequest\x12\x30\n\x04peas\x18\x03 \x03(\x0b\x32\".jina.SpawnRequest.PeaSpawnRequestB\x06\n\x04\x62ody2\x97\x01\n\x07JinaRPC\x12*\n\x04\x43\x61ll\x12\r.jina.Request\x1a\r.jina.Request\"\x00(\x01\x30\x01\x12+\n\tCallUnary\x12\r.jina.Request\x1a\r.jina.Request\"\x00\x12\x33\n\x05Spawn\x12\x12.jina.SpawnRequest\x1a\x12.jina.SpawnRequest\"\x00\x30\x01\x62\x06proto3'
+  serialized_pb=b'\n\njina.proto\x12\x04jina\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1cgoogle/protobuf/struct.proto\"\xf3\x01\n\x0c\x44\x65nseNdArray\x12\x0e\n\x06\x62uffer\x18\x01 \x01(\x0c\x12\r\n\x05shape\x18\x02 \x03(\r\x12\r\n\x05\x64type\x18\x03 \x01(\t\x12\x39\n\x0cquantization\x18\x04 \x01(\x0e\x32#.jina.DenseNdArray.QuantizationMode\x12\x0f\n\x07max_val\x18\x05 \x01(\x02\x12\x0f\n\x07min_val\x18\x06 \x01(\x02\x12\r\n\x05scale\x18\x07 \x01(\x02\x12\x16\n\x0eoriginal_dtype\x18\x08 \x01(\t\"1\n\x10QuantizationMode\x12\x08\n\x04NONE\x10\x00\x12\x08\n\x04\x46P16\x10\x01\x12\t\n\x05UINT8\x10\x02\"`\n\x07NdArray\x12#\n\x05\x64\x65nse\x18\x01 \x01(\x0b\x32\x12.jina.DenseNdArrayH\x00\x12%\n\x06sparse\x18\x02 \x01(\x0b\x32\x13.jina.SparseNdArrayH\x00\x42\t\n\x07\x63ontent\"m\n\rSparseNdArray\x12#\n\x07indices\x18\x01 \x01(\x0b\x32\x12.jina.DenseNdArray\x12\"\n\x06values\x18\x02 \x01(\x0b\x32\x12.jina.DenseNdArray\x12\x13\n\x0b\x64\x65nse_shape\x18\x03 \x03(\x03\"u\n\nNamedScore\x12\r\n\x05value\x18\x01 \x01(\x02\x12\x0f\n\x07op_name\x18\x02 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x03 \x01(\t\x12\"\n\x08operands\x18\x04 \x03(\x0b\x32\x10.jina.NamedScore\x12\x0e\n\x06ref_id\x18\x05 \x01(\t\"\x8a\x04\n\x08\x44ocument\x12\n\n\x02id\x18\x01 \x01(\t\x12\x13\n\x0bgranularity\x18\x0e \x01(\r\x12\x11\n\tadjacency\x18\x16 \x01(\r\x12\x12\n\nlevel_name\x18\x0f \x01(\t\x12\x11\n\tparent_id\x18\x10 \x01(\t\x12\x10\n\x06\x62uffer\x18\x03 \x01(\x0cH\x00\x12\x1d\n\x04\x62lob\x18\x0c \x01(\x0b\x32\r.jina.NdArrayH\x00\x12\x0e\n\x04text\x18\r \x01(\tH\x00\x12\x1e\n\x06\x63hunks\x18\x04 \x03(\x0b\x32\x0e.jina.Document\x12\x0e\n\x06weight\x18\x05 \x01(\x02\x12\x0e\n\x06length\x18\x06 \x01(\r\x12\x11\n\tmeta_info\x18\x07 \x01(\x0c\x12\x1f\n\x07matches\x18\x08 \x03(\x0b\x32\x0e.jina.Document\x12\x11\n\tmime_type\x18\n \x01(\t\x12\x0b\n\x03uri\x18\t \x01(\t\x12%\n\x04tags\x18\x0b \x01(\x0b\x32\x17.google.protobuf.Struct\x12\x10\n\x08location\x18\x11 \x03(\r\x12\x0e\n\x06offset\x18\x12 \x01(\r\x12 \n\tembedding\x18\x13 \x01(\x0b\x32\r.jina.NdArray\x12\x1f\n\x05score\x18\x14 \x01(\x0b\x32\x10.jina.NamedScore\x12\x10\n\x08modality\x18\x15 \x01(\t\x12%\n\x0b\x65valuations\x18\x17 \x03(\x0b\x32\x10.jina.NamedScoreB\t\n\x07\x63ontent\"\xa0\x01\n\x05Route\x12\x0b\n\x03pod\x18\x01 \x01(\t\x12\x0e\n\x06pod_id\x18\x02 \x01(\t\x12.\n\nstart_time\x18\x03 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12,\n\x08\x65nd_time\x18\x04 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x1c\n\x06status\x18\x05 \x01(\x0b\x32\x0c.jina.Status\"\xc8\x02\n\x08\x45nvelope\x12\x11\n\tsender_id\x18\x01 \x01(\t\x12\x13\n\x0breceiver_id\x18\x02 \x01(\t\x12\x12\n\nrequest_id\x18\x03 \x01(\t\x12\x0f\n\x07timeout\x18\x04 \x01(\r\x12\x1b\n\x06routes\x18\x05 \x03(\x0b\x32\x0b.jina.Route\x12\'\n\x07version\x18\x06 \x01(\x0b\x32\x16.jina.Envelope.Version\x12\x1c\n\x06status\x18\x07 \x01(\x0b\x32\x0c.jina.Status\x12\x14\n\x0crequest_type\x18\t \x01(\t\x12\x15\n\rcheck_version\x18\n \x01(\x08\x12)\n\x0b\x63ompression\x18\x0b \x01(\x0b\x32\x14.jina.CompressConfig\x1a\x33\n\x07Version\x12\x0c\n\x04jina\x18\x01 \x01(\t\x12\r\n\x05proto\x18\x02 \x01(\t\x12\x0b\n\x03vcs\x18\x03 \x01(\t\"\x7f\n\x0e\x43ompressConfig\x12\x11\n\talgorithm\x18\x01 \x01(\t\x12\x16\n\x0ehigh_watermark\x18\x02 \x01(\x04\x12\x15\n\rlow_watermark\x18\x03 \x01(\x02\x12+\n\nparameters\x18\x04 \x01(\x0b\x32\x17.google.protobuf.Struct\"\xc6\x02\n\x06Status\x12%\n\x04\x63ode\x18\x01 \x01(\x0e\x32\x17.jina.Status.StatusCode\x12\x13\n\x0b\x64\x65scription\x18\x02 \x01(\t\x12)\n\texception\x18\x03 \x01(\x0b\x32\x16.jina.Status.Exception\x1aY\n\tException\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0c\n\x04\x61rgs\x18\x02 \x03(\t\x12\x0e\n\x06stacks\x18\x03 \x03(\t\x12\x10\n\x08\x65xecutor\x18\x04 \x01(\t\x12\x0e\n\x06\x64river\x18\x05 \x01(\t\"z\n\nStatusCode\x12\x0b\n\x07SUCCESS\x10\x00\x12\x0b\n\x07PENDING\x10\x01\x12\t\n\x05READY\x10\x02\x12\t\n\x05\x45RROR\x10\x03\x12\x13\n\x0f\x45RROR_DUPLICATE\x10\x04\x12\x14\n\x10\x45RROR_NOTALLOWED\x10\x05\x12\x11\n\rERROR_CHAINED\x10\x06\"K\n\x07Message\x12 \n\x08\x65nvelope\x18\x01 \x01(\x0b\x32\x0e.jina.Envelope\x12\x1e\n\x07request\x18\x02 \x01(\x0b\x32\r.jina.Request\"\xa6\x06\n\x07Request\x12\x12\n\nrequest_id\x18\x01 \x01(\t\x12+\n\x05train\x18\x02 \x01(\x0b\x32\x1a.jina.Request.TrainRequestH\x00\x12+\n\x05index\x18\x03 \x01(\x0b\x32\x1a.jina.Request.IndexRequestH\x00\x12-\n\x06search\x18\x04 \x01(\x0b\x32\x1b.jina.Request.SearchRequestH\x00\x12/\n\x07\x63ontrol\x18\x05 \x01(\x0b\x32\x1c.jina.Request.ControlRequestH\x00\x12\x1c\n\x06status\x18\x06 \x01(\x0b\x32\x0c.jina.Status\x12\x1b\n\x06routes\x18\x08 \x03(\x0b\x32\x0b.jina.Route\x12!\n\x08queryset\x18\x07 \x03(\x0b\x32\x0f.jina.QueryLang\x1a\x61\n\x0cTrainRequest\x12\x1c\n\x04\x64ocs\x18\x01 \x03(\x0b\x32\x0e.jina.Document\x12$\n\x0cgroundtruths\x18\x02 \x03(\x0b\x32\x0e.jina.Document\x12\r\n\x05\x66lush\x18\x03 \x01(\x08\x1aR\n\x0cIndexRequest\x12\x1c\n\x04\x64ocs\x18\x01 \x03(\x0b\x32\x0e.jina.Document\x12$\n\x0cgroundtruths\x18\x02 \x03(\x0b\x32\x0e.jina.Document\x1aS\n\rSearchRequest\x12\x1c\n\x04\x64ocs\x18\x01 \x03(\x0b\x32\x0e.jina.Document\x12$\n\x0cgroundtruths\x18\x02 \x03(\x0b\x32\x0e.jina.Document\x1a\xda\x01\n\x0e\x43ontrolRequest\x12\x35\n\x07\x63ommand\x18\x01 \x01(\x0e\x32$.jina.Request.ControlRequest.Command\x12\x34\n\x04\x61rgs\x18\x02 \x03(\x0b\x32&.jina.Request.ControlRequest.ArgsEntry\x1a+\n\tArgsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\".\n\x07\x43ommand\x12\r\n\tTERMINATE\x10\x00\x12\n\n\x06STATUS\x10\x01\x12\x08\n\x04IDLE\x10\x03\x42\x06\n\x04\x62ody\"j\n\tQueryLang\x12\x0c\n\x04name\x18\x01 \x01(\t\x12+\n\nparameters\x18\x02 \x01(\x0b\x32\x17.google.protobuf.Struct\x12\x10\n\x08\x64isabled\x18\x03 \x01(\x08\x12\x10\n\x08priority\x18\x04 \x01(\x05\"\xe3\x03\n\x0cSpawnRequest\x12\x31\n\x03pea\x18\x01 \x01(\x0b\x32\".jina.SpawnRequest.PeaSpawnRequestH\x00\x12\x31\n\x03pod\x18\x02 \x01(\x0b\x32\".jina.SpawnRequest.PodSpawnRequestH\x00\x12@\n\x0bmutable_pod\x18\x03 \x01(\x0b\x32).jina.SpawnRequest.MutablepodSpawnRequestH\x00\x12\x12\n\nlog_record\x18\x04 \x01(\t\x12\x1c\n\x06status\x18\x05 \x01(\x0b\x32\x0c.jina.Status\x1a\x1f\n\x0fPeaSpawnRequest\x12\x0c\n\x04\x61rgs\x18\x01 \x03(\t\x1a\x1f\n\x0fPodSpawnRequest\x12\x0c\n\x04\x61rgs\x18\x01 \x03(\t\x1a\xae\x01\n\x16MutablepodSpawnRequest\x12\x30\n\x04head\x18\x01 \x01(\x0b\x32\".jina.SpawnRequest.PeaSpawnRequest\x12\x30\n\x04tail\x18\x02 \x01(\x0b\x32\".jina.SpawnRequest.PeaSpawnRequest\x12\x30\n\x04peas\x18\x03 \x03(\x0b\x32\".jina.SpawnRequest.PeaSpawnRequestB\x06\n\x04\x62ody2\x97\x01\n\x07JinaRPC\x12*\n\x04\x43\x61ll\x12\r.jina.Request\x1a\r.jina.Request\"\x00(\x01\x30\x01\x12+\n\tCallUnary\x12\r.jina.Request\x1a\r.jina.Request\"\x00\x12\x33\n\x05Spawn\x12\x12.jina.SpawnRequest\x1a\x12.jina.SpawnRequest\"\x00\x30\x01\x62\x06proto3'
   ,
   dependencies=[google_dot_protobuf_dot_timestamp__pb2.DESCRIPTOR,google_dot_protobuf_dot_struct__pb2.DESCRIPTOR,])
 
@@ -102,8 +102,8 @@ _STATUS_STATUSCODE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=2028,
-  serialized_end=2150,
+  serialized_start=2010,
+  serialized_end=2132,
 )
 _sym_db.RegisterEnumDescriptor(_STATUS_STATUSCODE)
 
@@ -132,8 +132,8 @@ _REQUEST_CONTROLREQUEST_COMMAND = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=2982,
-  serialized_end=3028,
+  serialized_start=2964,
+  serialized_end=3010,
 )
 _sym_db.RegisterEnumDescriptor(_REQUEST_CONTROLREQUEST_COMMAND)
 
@@ -655,8 +655,8 @@ _ENVELOPE_VERSION = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1641,
-  serialized_end=1692,
+  serialized_start=1623,
+  serialized_end=1674,
 )
 
 _ENVELOPE = _descriptor.Descriptor(
@@ -717,28 +717,21 @@ _ENVELOPE = _descriptor.Descriptor(
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
     _descriptor.FieldDescriptor(
-      name='num_part', full_name='jina.Envelope.num_part', index=7,
-      number=8, type=13, cpp_type=3, label=3,
-      has_default_value=False, default_value=[],
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    _descriptor.FieldDescriptor(
-      name='request_type', full_name='jina.Envelope.request_type', index=8,
+      name='request_type', full_name='jina.Envelope.request_type', index=7,
       number=9, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=b"".decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
     _descriptor.FieldDescriptor(
-      name='check_version', full_name='jina.Envelope.check_version', index=9,
+      name='check_version', full_name='jina.Envelope.check_version', index=8,
       number=10, type=8, cpp_type=7, label=1,
       has_default_value=False, default_value=False,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
     _descriptor.FieldDescriptor(
-      name='compression', full_name='jina.Envelope.compression', index=10,
+      name='compression', full_name='jina.Envelope.compression', index=9,
       number=11, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
@@ -757,7 +750,7 @@ _ENVELOPE = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=1346,
-  serialized_end=1692,
+  serialized_end=1674,
 )
 
 
@@ -809,8 +802,8 @@ _COMPRESSCONFIG = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1694,
-  serialized_end=1821,
+  serialized_start=1676,
+  serialized_end=1803,
 )
 
 
@@ -869,8 +862,8 @@ _STATUS_EXCEPTION = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1937,
-  serialized_end=2026,
+  serialized_start=1919,
+  serialized_end=2008,
 )
 
 _STATUS = _descriptor.Descriptor(
@@ -915,8 +908,8 @@ _STATUS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1824,
-  serialized_end=2150,
+  serialized_start=1806,
+  serialized_end=2132,
 )
 
 
@@ -954,8 +947,8 @@ _MESSAGE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2152,
-  serialized_end=2227,
+  serialized_start=2134,
+  serialized_end=2209,
 )
 
 
@@ -1000,8 +993,8 @@ _REQUEST_TRAINREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2541,
-  serialized_end=2638,
+  serialized_start=2523,
+  serialized_end=2620,
 )
 
 _REQUEST_INDEXREQUEST = _descriptor.Descriptor(
@@ -1038,8 +1031,8 @@ _REQUEST_INDEXREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2640,
-  serialized_end=2722,
+  serialized_start=2622,
+  serialized_end=2704,
 )
 
 _REQUEST_SEARCHREQUEST = _descriptor.Descriptor(
@@ -1076,8 +1069,8 @@ _REQUEST_SEARCHREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2724,
-  serialized_end=2807,
+  serialized_start=2706,
+  serialized_end=2789,
 )
 
 _REQUEST_CONTROLREQUEST_ARGSENTRY = _descriptor.Descriptor(
@@ -1114,8 +1107,8 @@ _REQUEST_CONTROLREQUEST_ARGSENTRY = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2937,
-  serialized_end=2980,
+  serialized_start=2919,
+  serialized_end=2962,
 )
 
 _REQUEST_CONTROLREQUEST = _descriptor.Descriptor(
@@ -1153,8 +1146,8 @@ _REQUEST_CONTROLREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2810,
-  serialized_end=3028,
+  serialized_start=2792,
+  serialized_end=3010,
 )
 
 _REQUEST = _descriptor.Descriptor(
@@ -1238,8 +1231,8 @@ _REQUEST = _descriptor.Descriptor(
       create_key=_descriptor._internal_create_key,
     fields=[]),
   ],
-  serialized_start=2230,
-  serialized_end=3036,
+  serialized_start=2212,
+  serialized_end=3018,
 )
 
 
@@ -1291,8 +1284,8 @@ _QUERYLANG = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3038,
-  serialized_end=3144,
+  serialized_start=3020,
+  serialized_end=3126,
 )
 
 
@@ -1323,8 +1316,8 @@ _SPAWNREQUEST_PEASPAWNREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3381,
-  serialized_end=3412,
+  serialized_start=3363,
+  serialized_end=3394,
 )
 
 _SPAWNREQUEST_PODSPAWNREQUEST = _descriptor.Descriptor(
@@ -1354,8 +1347,8 @@ _SPAWNREQUEST_PODSPAWNREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3414,
-  serialized_end=3445,
+  serialized_start=3396,
+  serialized_end=3427,
 )
 
 _SPAWNREQUEST_MUTABLEPODSPAWNREQUEST = _descriptor.Descriptor(
@@ -1399,8 +1392,8 @@ _SPAWNREQUEST_MUTABLEPODSPAWNREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3448,
-  serialized_end=3622,
+  serialized_start=3430,
+  serialized_end=3604,
 )
 
 _SPAWNREQUEST = _descriptor.Descriptor(
@@ -1463,8 +1456,8 @@ _SPAWNREQUEST = _descriptor.Descriptor(
       create_key=_descriptor._internal_create_key,
     fields=[]),
   ],
-  serialized_start=3147,
-  serialized_end=3630,
+  serialized_start=3129,
+  serialized_end=3612,
 )
 
 _DENSENDARRAY.fields_by_name['quantization'].enum_type = _DENSENDARRAY_QUANTIZATIONMODE
@@ -1760,8 +1753,8 @@ _JINARPC = _descriptor.ServiceDescriptor(
   index=0,
   serialized_options=None,
   create_key=_descriptor._internal_create_key,
-  serialized_start=3633,
-  serialized_end=3784,
+  serialized_start=3615,
+  serialized_end=3766,
   methods=[
   _descriptor.MethodDescriptor(
     name='Call',

--- a/jina/proto/message/__init__.py
+++ b/jina/proto/message/__init__.py
@@ -292,9 +292,13 @@ class ProtoMessage:
         return self.envelope.num_part[-1]
 
     @num_part.setter
-    def num_part(self, expect: int):
+    def num_part(self, expect: Union[int, List]):
         """Add new expected parts to the message"""
-        self.envelope.num_part.append(expect)
+        if isinstance(expect, int) and expect>1:
+            self.envelope.num_part.append(expect)
+        elif isinstance(expect, list):
+            self.envelope.ClearField('num_part')
+            self.envelope.num_part.extend(expect)
 
     def complete_last_part(self):
         """Mark the last expected parts as complete"""

--- a/jina/resources/executors._pass.yml
+++ b/jina/resources/executors._pass.yml
@@ -4,7 +4,5 @@ metas:
   name: forward
 requests:
   on:
-    [SearchRequest, TrainRequest, IndexRequest]:
-      - !ForwardDriver {}
-    ControlRequest:
-      - !ControlReqDriver {}
+    [ SearchRequest, TrainRequest, IndexRequest, ControlRequest ]:
+      - !RouteDriver { }

--- a/tests/integration/incremental_indexing/test_incremental_indexing.py
+++ b/tests/integration/incremental_indexing/test_incremental_indexing.py
@@ -43,7 +43,7 @@ def test_incremental_indexing_parallel_indexers(random_workspace):
          .add(uses=os.path.join(cur_dir, 'uniq_docindexer.yml'),
               name='inc_doc',
               needs=['gateway'])
-         .add(uses='_merge', needs=['inc_vec', 'inc_doc']))
+         .add(uses='_pass', needs=['inc_vec', 'inc_doc']))
     with f:
         f.index(duplicate_docs[:500])
         f.index(duplicate_docs)
@@ -111,7 +111,7 @@ def test_incremental_indexing_parallel_indexers_with_shards(random_workspace):
               name='inc_doc',
               needs=['gateway'],
               separated_workspace=True)
-         .add(uses='_merge',
+         .add(uses='_pass',
               needs=['inc_vec', 'inc_doc']))
 
     with f:

--- a/tests/integration/incremental_indexing/test_incremental_indexing.py
+++ b/tests/integration/incremental_indexing/test_incremental_indexing.py
@@ -43,7 +43,7 @@ def test_incremental_indexing_parallel_indexers(random_workspace):
          .add(uses=os.path.join(cur_dir, 'uniq_docindexer.yml'),
               name='inc_doc',
               needs=['gateway'])
-         .add(uses='_pass', needs=['inc_vec', 'inc_doc']))
+         .add(needs=['inc_vec', 'inc_doc']))
     with f:
         f.index(duplicate_docs[:500])
         f.index(duplicate_docs)
@@ -100,19 +100,19 @@ def test_incremental_indexing_parallel_indexers_with_shards(random_workspace):
     num_shards = 4
 
     f = (Flow()
-         .add(uses=os.path.join(cur_dir, 'vectorindexer.yml'),
-              uses_before='_unique',
-              shards=num_shards,
-              name='inc_vec',
-              separated_workspace=True)
-         .add(uses=os.path.join(cur_dir, 'docindexer.yml'),
-              uses_before='_unique',
-              shards=num_shards,
-              name='inc_doc',
-              needs=['gateway'],
-              separated_workspace=True)
-         .add(uses='_pass',
-              needs=['inc_vec', 'inc_doc']))
+        .add(uses=os.path.join(cur_dir, 'vectorindexer.yml'),
+             uses_before='_unique',
+             shards=num_shards,
+             name='inc_vec',
+             separated_workspace=True)
+        .add(uses=os.path.join(cur_dir, 'docindexer.yml'),
+             uses_before='_unique',
+             shards=num_shards,
+             name='inc_doc',
+             needs=['gateway'],
+             separated_workspace=True)
+        .add(
+        needs=['inc_vec', 'inc_doc']))
 
     with f:
         f.index(duplicate_docs[:500])

--- a/tests/integration/issues/github_936/test_flow_with_sse_no_deadlock.py
+++ b/tests/integration/issues/github_936/test_flow_with_sse_no_deadlock.py
@@ -22,7 +22,7 @@ def test_flow_with_sse_no_deadlock():
         add(uses='BaseExecutor', parallel=2, name='crafter').add(uses='BaseExecutor', parallel=2, name='encoder'). \
         add(uses='BaseExecutor', parallel=2, name='vec_idx').add(uses='BaseExecutor', parallel=2, needs=['gateway'],
                                                                  name='doc_idx'). \
-        add(uses='_merge', needs=['vec_idx', 'doc_idx'])
+        add(uses='_pass', needs=['vec_idx', 'doc_idx'])
     with f:
         assert hasattr(f, '_sse_logger')
         pass

--- a/tests/integration/issues/github_936/test_flow_with_sse_no_deadlock.py
+++ b/tests/integration/issues/github_936/test_flow_with_sse_no_deadlock.py
@@ -22,7 +22,7 @@ def test_flow_with_sse_no_deadlock():
         add(uses='BaseExecutor', parallel=2, name='crafter').add(uses='BaseExecutor', parallel=2, name='encoder'). \
         add(uses='BaseExecutor', parallel=2, name='vec_idx').add(uses='BaseExecutor', parallel=2, needs=['gateway'],
                                                                  name='doc_idx'). \
-        add(uses='_pass', needs=['vec_idx', 'doc_idx'])
+        add(needs=['vec_idx', 'doc_idx'])
     with f:
         assert hasattr(f, '_sse_logger')
         pass

--- a/tests/integration/issues/github_969/test_messages_different_types.py
+++ b/tests/integration/issues/github_969/test_messages_different_types.py
@@ -44,7 +44,7 @@ def test_message_docs_different_chunk_types():
         assert int(chunk2.tags['id']) == 30
         assert chunk2.buffer == buffer
 
-    with Flow().add(uses='_pass') as f:
+    with Flow().add() as f:
         f.search(input_fn=[input_doc()], output_fn=validate_fn)
 
 
@@ -83,7 +83,7 @@ def test_message_docs_different_chunk_types_without_optimization():
         assert int(chunk2.tags['id']) == 30
         assert chunk2.buffer == buffer
 
-    with Flow().add(uses='_pass') as f:
+    with Flow().add() as f:
         f.search(input_fn=[input_doc()], output_fn=validate_fn)
 
 
@@ -122,7 +122,7 @@ def test_message_docs_different_matches_types():
         assert int(match2.tags['id']) == 30
         assert match2.buffer == buffer
 
-    with Flow().add(uses='_pass') as f:
+    with Flow().add() as f:
         f.search(input_fn=[input_doc()], output_fn=validate_fn)
 
 
@@ -161,7 +161,7 @@ def test_message_docs_different_matches_types_without_optimization():
         assert int(match2.tags['id']) == 30
         assert match2.buffer == buffer
 
-    with Flow().add(uses='_pass') as f:
+    with Flow().add() as f:
         f.search(input_fn=[input_doc()], output_fn=validate_fn)
 
 
@@ -225,7 +225,7 @@ def test_message_docs_different_chunks_and_matches_types():
         assert int(match2.tags['id']) == 30
         assert match2.buffer == buffer
 
-    with Flow().add(uses='_pass') as f:
+    with Flow().add() as f:
         f.search(input_fn=[input_doc()], output_fn=validate_fn)
 
 
@@ -289,5 +289,5 @@ def test_message_docs_different_chunks_and_matches_types_without_optimization():
         assert int(match2.tags['id']) == 30
         assert match2.buffer == buffer
 
-    with Flow().add(uses='_pass') as f:
+    with Flow().add() as f:
         f.search(input_fn=[input_doc()], output_fn=validate_fn)

--- a/tests/integration/issues/github_976/test_topk_rest_api.py
+++ b/tests/integration/issues/github_976/test_topk_rest_api.py
@@ -16,7 +16,7 @@ def query_dict():
 
 
 def test_top_k_with_rest_api(query_dict):
-    with Flow(rest_api=True, port_expose=PORT).add(uses='_pass'):
+    with Flow(rest_api=True, port_expose=PORT).add():
         query = json.dumps(query_dict).encode('utf-8')
         req = request.Request(f'http://0.0.0.0:{PORT}/api/search', data=query,
                               headers={'content-type': 'application/json'})

--- a/tests/integration/level_depth/flow-index.yml
+++ b/tests/integration/level_depth/flow-index.yml
@@ -13,6 +13,6 @@ pods:
     uses: yaml/index-doc.yml
     needs: gateway
   join_all:
-    uses: _merge
+    uses: _pass
     needs: [doc_indexer, chunk_indexer]
     read_only: true

--- a/tests/integration/mime/test_mime.py
+++ b/tests/integration/mime/test_mime.py
@@ -69,7 +69,7 @@ def test_text2datauri():
 
 
 def test_gateway_dataui():
-    f = (Flow().add(uses='_pass'))
+    f = (Flow().add())
 
     with f:
         f.index_lines(lines=['abc', '123', 'hello, world'])

--- a/tests/integration/multimodal/test_multimodal_parallel.py
+++ b/tests/integration/multimodal/test_multimodal_parallel.py
@@ -43,7 +43,7 @@ def test_multimodal_embedding_parallel(multimodal_documents):
         for idx, doc in enumerate(resp.index.docs):
             np.testing.assert_almost_equal(GenericNdArray(doc.embedding).value, np.array([idx, idx, idx, idx, idx]))
 
-    with Flow().load_config(os.path.join(cur_dir, 'flow-embedding-multimodal-parallel.yml')) as index_gt_flow:
+    with Flow.load_config(os.path.join(cur_dir, 'flow-embedding-multimodal-parallel.yml')) as index_gt_flow:
         index_gt_flow.index(input_fn=multimodal_documents,
                             output_fn=validate_response)
 
@@ -87,6 +87,6 @@ def test_multimodal_all_types_parallel(multimodal_all_types_documents):
             np.testing.assert_almost_equal(GenericNdArray(doc.embedding).value,
                                            np.array([idx, idx, idx, idx, idx, 3, 3, 4, 4]))
 
-    with Flow().load_config(os.path.join(cur_dir, 'flow-multimodal-all-types-parallel.yml')) as index_gt_flow:
+    with Flow.load_config(os.path.join(cur_dir, 'flow-multimodal-all-types-parallel.yml')) as index_gt_flow:
         index_gt_flow.index(input_fn=multimodal_all_types_documents,
                             output_fn=validate_response)

--- a/tests/unit/clients/python/test_client.py
+++ b/tests/unit/clients/python/test_client.py
@@ -14,12 +14,12 @@ from jina.proto.jina_pb2 import Document
 
 @pytest.fixture(scope='function')
 def flow():
-    return Flow(rest_api=False).add(uses='_pass')
+    return Flow(rest_api=False).add()
 
 
 @pytest.fixture(scope='function')
 def flow_with_rest_api_enabled():
-    return Flow(rest_api=True).add(uses='_pass')
+    return Flow(rest_api=True).add()
 
 
 @pytest.fixture(scope='function')

--- a/tests/unit/drivers/test_reduce_all_driver.py
+++ b/tests/unit/drivers/test_reduce_all_driver.py
@@ -2,18 +2,11 @@ import os
 from typing import List, Dict
 
 import numpy as np
-import pytest
 
-from jina.drivers.reduce import CollectEvaluationDriver
-from jina.excepts import NoExplicitMessage
-from jina.executors import BaseExecutor
 from jina.executors.crafters import BaseSegmenter
 from jina.executors.encoders import BaseEncoder
 from jina.flow import Flow
-from jina.logging import default_logger
-from jina.proto import jina_pb2
-from jina.proto.jina_pb2 import Document, Envelope
-from jina.proto.message import ProtoMessage
+from jina.proto.jina_pb2 import Document
 
 cur_dir = os.path.dirname(os.path.abspath(__file__))
 
@@ -66,69 +59,3 @@ def test_merge_chunks_with_different_modality():
     with flow:
         flow.index(input_fn=input_fn, output_fn=validate)
 
-
-def get_prev_reqs():
-    # three requests, each with the SAME doc, but diff evaluations
-    result = []
-    for j in range(3):
-        r = jina_pb2.Request()
-        d = r.index.docs.add()
-        d.id = 'SAME DOC THEY ARE'  # same doc id
-        ev1 = d.evaluations.add()
-        ev1.value = j  # diff eval
-        ev1.op_name = f'op{j}'  # diff eval
-        result.append(r)
-    return result
-
-
-prev_reqs = list(get_prev_reqs())
-ev = Envelope()
-ev.num_part.extend([1, 3])
-prev_msgs = [ProtoMessage(ev, r.SerializeToString(), 'test', 'placeholder') for r in prev_reqs]
-
-
-class MockCollectEvalDriver(CollectEvaluationDriver):
-
-    @property
-    def exec_fn(self):
-        return self._exec_fn
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self._num_call = -1
-
-    @property
-    def expect_parts(self) -> int:
-        return 3
-
-    @property
-    def msg(self) -> 'ProtoMessage':
-        r = prev_msgs[self._num_call]
-        return r
-
-    @property
-    def logger(self) -> 'JinaLogger':
-        return default_logger
-
-
-def test_collect_evals():
-    driver = MockCollectEvalDriver()
-    executor = BaseExecutor()
-    driver.attach(executor=executor, pea=None)
-    # before
-    for q in prev_reqs:
-        assert len(q.index.docs[0].evaluations) == 1
-
-    # reduce to last request, aka current request
-    for j in range(2):
-        with pytest.raises(NoExplicitMessage):
-            driver._num_call += 1
-            driver()
-
-    driver._num_call += 1
-    driver()
-
-    # after
-    assert len(prev_msgs[0].request.docs[0].evaluations) == 1
-    assert len(prev_msgs[1].request.docs[0].evaluations) == 1
-    assert len(prev_msgs[2].request.docs[0].evaluations) == 3

--- a/tests/unit/executors/test_route_exec.py
+++ b/tests/unit/executors/test_route_exec.py
@@ -23,9 +23,9 @@ def test_load_driver():
 def test_route():
     docs = random_docs(num_docs=2, chunks_per_doc=2)
     f = (Flow()
-         .add(uses='_pass',
-              uses_before=os.path.join(cur_dir, 'yaml', 'route.yml'),
-              shards=2))
+        .add(
+        uses_before=os.path.join(cur_dir, 'yaml', 'route.yml'),
+        shards=2))
 
     with f:
         f.index(docs)

--- a/tests/unit/executors/test_route_exec.py
+++ b/tests/unit/executors/test_route_exec.py
@@ -14,7 +14,7 @@ def test_load_driver():
     b = BaseExecutor.load_config(os.path.join(cur_dir, 'yaml/route.yml'))
     pprint(b._drivers)
 
-    c = BaseExecutor.load_config('_route')
+    c = BaseExecutor.load_config('_pass')
     assert len(b._drivers['ControlRequest']) == len(c._drivers['ControlRequest'])
     pprint(c._drivers)
 

--- a/tests/unit/flow/test_flow.py
+++ b/tests/unit/flow/test_flow.py
@@ -554,7 +554,7 @@ def test_flow_arbitrary_needs():
          .add(name='p5', needs='gateway')
          .needs(['p2', 'p4'], name='r1', num_part=[3, 1])
          .needs(['p3', 'p5'], name='r2', num_part=[3, 1])
-         .needs(['p1', 'r1', 'r2']))
+         .needs(['p1', 'r1', 'r2'], name='r3'))
 
     with f:
         f.index_lines(['abc', 'def'])

--- a/tests/unit/flow/test_flow.py
+++ b/tests/unit/flow/test_flow.py
@@ -538,9 +538,10 @@ def test_load_flow_from_cli():
 
 def test_flow_arguments_priorities():
     f = Flow(port_expose=12345).add(name='test', port_expose=23456)
-    assert f._pod_nodes["test"].cli_args[-1] == '23456'
+    assert '23456' in f._pod_nodes['test'].cli_args
+    assert '12345' not in f._pod_nodes['test'].cli_args
 
 
 def test_flow_default_argument_passing():
     f = Flow(port_expose=12345).add(name='test')
-    assert f._pod_nodes["test"].cli_args[-1] == '12345'
+    assert '12345' in f._pod_nodes['test'].cli_args

--- a/tests/unit/flow/test_flow.py
+++ b/tests/unit/flow/test_flow.py
@@ -36,15 +36,15 @@ def test_ping():
 
 
 def test_flow_with_jump():
-    f = (Flow().add(name='r1', uses='_pass')
-         .add(name='r2', uses='_pass')
-         .add(name='r3', uses='_pass', needs='r1')
-         .add(name='r4', uses='_pass', needs='r2')
-         .add(name='r5', uses='_pass', needs='r3')
-         .add(name='r6', uses='_pass', needs='r4')
-         .add(name='r8', uses='_pass', needs='r6')
-         .add(name='r9', uses='_pass', needs='r5')
-         .add(name='r10', uses='_pass', needs=['r9', 'r8']))
+    f = (Flow().add(name='r1')
+         .add(name='r2')
+         .add(name='r3', needs='r1')
+         .add(name='r4', needs='r2')
+         .add(name='r5', needs='r3')
+         .add(name='r6', needs='r4')
+         .add(name='r8', needs='r6')
+         .add(name='r9', needs='r5')
+         .add(name='r10', needs=['r9', 'r8']))
 
     with f:
         f.dry_run()
@@ -110,7 +110,7 @@ def test_simple_flow():
             yield b'aaa'
 
     f = (Flow()
-         .add(uses='_pass'))
+         .add())
 
     with f:
         f.index(input_fn=bytes_gen)
@@ -285,15 +285,15 @@ def test_shards():
 
 
 def test_py_client():
-    f = (Flow().add(name='r1', uses='_pass')
-         .add(name='r2', uses='_pass')
-         .add(name='r3', uses='_pass', needs='r1')
-         .add(name='r4', uses='_pass', needs='r2')
-         .add(name='r5', uses='_pass', needs='r3')
-         .add(name='r6', uses='_pass', needs='r4')
-         .add(name='r8', uses='_pass', needs='r6')
-         .add(name='r9', uses='_pass', needs='r5')
-         .add(name='r10', uses='_pass', needs=['r9', 'r8']))
+    f = (Flow().add(name='r1')
+         .add(name='r2')
+         .add(name='r3', needs='r1')
+         .add(name='r4', needs='r2')
+         .add(name='r5', needs='r3')
+         .add(name='r6', needs='r4')
+         .add(name='r8', needs='r6')
+         .add(name='r9', needs='r5')
+         .add(name='r10', needs=['r9', 'r8']))
 
     with f:
         f.dry_run()
@@ -347,8 +347,8 @@ def test_py_client():
 
 
 def test_dry_run_with_two_pathways_diverging_at_gateway():
-    f = (Flow().add(name='r2', uses='_pass')
-         .add(name='r3', uses='_pass', needs='gateway')
+    f = (Flow().add(name='r2', )
+         .add(name='r3', needs='gateway')
          .join(['r2', 'r3']))
 
     with f:
@@ -372,9 +372,9 @@ def test_dry_run_with_two_pathways_diverging_at_gateway():
 
 
 def test_dry_run_with_two_pathways_diverging_at_non_gateway():
-    f = (Flow().add(name='r1', uses='_pass')
-         .add(name='r2', uses='_pass')
-         .add(name='r3', uses='_pass', needs='r1')
+    f = (Flow().add(name='r1', )
+         .add(name='r2', )
+         .add(name='r3', needs='r1')
          .join(['r2', 'r3']))
 
     with f:
@@ -516,7 +516,7 @@ def test_flow_with_modalitys_simple():
         doc3.modality = 'mode1'
         return [doc1, doc2, doc3]
 
-    flow = Flow().add(name='chunk_seg', parallel=3, uses='_pass'). \
+    flow = Flow().add(name='chunk_seg', parallel=3). \
         add(name='encoder12', parallel=2,
             uses='- !FilterQL | {lookups: {modality__in: [mode1, mode2]}, traversal_paths: [c]}')
     with flow:

--- a/tests/unit/flow/test_flow.py
+++ b/tests/unit/flow/test_flow.py
@@ -545,3 +545,16 @@ def test_flow_arguments_priorities():
 def test_flow_default_argument_passing():
     f = Flow(port_expose=12345).add(name='test')
     assert '12345' in f._pod_nodes['test'].cli_args
+
+
+def test_flow_arbitrary_needs():
+    f = (Flow().add(name='p1').add(name='p2', needs='gateway')
+         .add(name='p3', needs='gateway')
+         .add(name='p4', needs='gateway')
+         .add(name='p5', needs='gateway')
+         .needs(['p2', 'p4'], name='r1', num_part=[3, 1])
+         .needs(['p3', 'p5'], name='r2', num_part=[3, 1])
+         .needs(['r1', 'r2', 'p1']))
+
+    with f:
+        f.index_lines(['abc', 'def'])

--- a/tests/unit/flow/test_flow.py
+++ b/tests/unit/flow/test_flow.py
@@ -44,7 +44,7 @@ def test_flow_with_jump():
          .add(name='r6', uses='_pass', needs='r4')
          .add(name='r8', uses='_pass', needs='r6')
          .add(name='r9', uses='_pass', needs='r5')
-         .add(name='r10', uses='_merge', needs=['r9', 'r8']))
+         .add(name='r10', uses='_pass', needs=['r9', 'r8']))
 
     with f:
         f.dry_run()
@@ -293,7 +293,7 @@ def test_py_client():
          .add(name='r6', uses='_pass', needs='r4')
          .add(name='r8', uses='_pass', needs='r6')
          .add(name='r9', uses='_pass', needs='r5')
-         .add(name='r10', uses='_merge', needs=['r9', 'r8']))
+         .add(name='r10', uses='_pass', needs=['r9', 'r8']))
 
     with f:
         f.dry_run()

--- a/tests/unit/flow/test_flow.py
+++ b/tests/unit/flow/test_flow.py
@@ -347,7 +347,7 @@ def test_py_client():
 
 
 def test_dry_run_with_two_pathways_diverging_at_gateway():
-    f = (Flow().add(name='r2', )
+    f = (Flow().add(name='r2')
          .add(name='r3', needs='gateway')
          .join(['r2', 'r3']))
 
@@ -372,8 +372,8 @@ def test_dry_run_with_two_pathways_diverging_at_gateway():
 
 
 def test_dry_run_with_two_pathways_diverging_at_non_gateway():
-    f = (Flow().add(name='r1', )
-         .add(name='r2', )
+    f = (Flow().add(name='r1')
+         .add(name='r2')
          .add(name='r3', needs='r1')
          .join(['r2', 'r3']))
 

--- a/tests/unit/flow/test_flow.py
+++ b/tests/unit/flow/test_flow.py
@@ -552,9 +552,10 @@ def test_flow_arbitrary_needs():
          .add(name='p3', needs='gateway')
          .add(name='p4', needs='gateway')
          .add(name='p5', needs='gateway')
-         .needs(['p2', 'p4'], name='r1', num_part=[3, 1])
-         .needs(['p3', 'p5'], name='r2', num_part=[3, 1])
-         .needs(['p1', 'r1', 'r2'], name='r3'))
+         .needs(['p2', 'p4'], name='r1')
+         .needs(['p3', 'p5'], name='r2')
+         .needs(['p1', 'r1'], name='r3')
+         .needs(['r2', 'r3'], name='r4'))
 
     with f:
         f.index_lines(['abc', 'def'])

--- a/tests/unit/flow/test_flow.py
+++ b/tests/unit/flow/test_flow.py
@@ -554,7 +554,7 @@ def test_flow_arbitrary_needs():
          .add(name='p5', needs='gateway')
          .needs(['p2', 'p4'], name='r1', num_part=[3, 1])
          .needs(['p3', 'p5'], name='r2', num_part=[3, 1])
-         .needs(['r1', 'r2', 'p1']))
+         .needs(['p1', 'r1', 'r2']))
 
     with f:
         f.index_lines(['abc', 'def'])

--- a/tests/unit/flow/test_flow_except.py
+++ b/tests/unit/flow/test_flow_except.py
@@ -40,7 +40,7 @@ def test_bad_flow_customized():
         assert bad_routes[0].pod == 'r2'
         assert bad_routes[0].status.exception.name == 'ZeroDivisionError'
 
-    f = (Flow().add(name='r1', uses='_pass')
+    f = (Flow().add(name='r1')
          .add(name='r2', uses='!DummyCrafter')
          .add(name='r3', uses='!BaseEncoder'))
 
@@ -63,7 +63,7 @@ def test_except_with_parallel():
         assert err_routes[0].exception.name == 'ZeroDivisionError'
         assert err_routes[1].exception.name == 'NotImplementedError'
 
-    f = (Flow().add(name='r1', uses='_pass')
+    f = (Flow().add(name='r1')
          .add(name='r2', uses='!DummyCrafter', parallel=3)
          .add(name='r3', uses='!BaseEncoder'))
 
@@ -90,7 +90,7 @@ def test_on_error_callback():
         badones = [r for r in x if r.status.code == jina_pb2.Status.ERROR]
         assert badones[0].pod == 'r3'
 
-    f = (Flow().add(name='r1', uses='_pass')
+    f = (Flow().add(name='r1')
          .add(name='r3', uses='!BaseEncoder'))
 
     with f:
@@ -104,8 +104,8 @@ def test_no_error_callback():
     def validate1(x, *args):
         pass
 
-    f = (Flow().add(name='r1', uses='_pass')
-         .add(name='r3', uses='_pass'))
+    f = (Flow().add(name='r1')
+         .add(name='r3'))
 
     with f:
         f.index_lines(lines=['abbcs', 'efgh'], output_fn=validate1, on_error=validate2)

--- a/tests/unit/flow/test_flow_merge.py
+++ b/tests/unit/flow/test_flow_merge.py
@@ -42,11 +42,11 @@ def test_this_will_fail():
 @pytest.mark.timeout(180)
 def test_this_should_work():
     f = (Flow()
-         .add(name='a1', uses='_pass')
+         .add(name='a1')
          .add(name='a11', uses='DummySegment', needs='a1')
          .add(name='a12', uses='DummySegment', needs='a1')
          .add(name='r1', uses='_merge_all', needs=['a11', 'a12'])
-         .add(name='a2', uses='_pass', needs='gateway')
+         .add(name='a2', needs='gateway')
          .add(name='a21', uses='DummySegment', needs='a2')
          .add(name='a22', uses='DummySegment', needs='a2')
          .add(name='r2', uses='_merge_all', needs=['a21', 'a22'])

--- a/tests/unit/peapods/remote/test_remote.py
+++ b/tests/unit/peapods/remote/test_remote.py
@@ -7,9 +7,9 @@ from jina.peapods.remote import namespace_to_dict
 def test_namespace_to_dict():
     _namespaces = {
         'head': Namespace(host='1.2.3.4', name='encoder', parallel=2, pea_id=-1, polling=PollingType.ANY,
-                          port_ctrl=39011, port_expose=8000, uses='_pass', uses_after='_pass', uses_before=None),
+                          port_ctrl=39011, port_expose=8000, uses_after='_pass', uses_before=None),
         'tail': Namespace(host='1.2.3.4', name='encoder', parallel=2, pea_id=-1, polling=PollingType.ANY,
-                          port_ctrl=46937, port_expose=8000, uses='_pass', uses_after='_pass', uses_before=None),
+                          port_ctrl=46937, port_expose=8000, uses_after='_pass', uses_before=None),
         'peas': [
             Namespace(host='1.2.3.4', name='encoder', parallel=2, pea_id=-1, polling=PollingType.ANY,
                       port_ctrl=44747, port_expose=8000, uses='helloworld.encoder.yml', uses_after='_pass',

--- a/tests/unit/peapods/remote/test_remote.py
+++ b/tests/unit/peapods/remote/test_remote.py
@@ -7,9 +7,9 @@ from jina.peapods.remote import namespace_to_dict
 def test_namespace_to_dict():
     _namespaces = {
         'head': Namespace(host='1.2.3.4', name='encoder', parallel=2, pea_id=-1, polling=PollingType.ANY,
-                          port_ctrl=39011, port_expose=8000, uses='_route', uses_after='_pass', uses_before=None),
+                          port_ctrl=39011, port_expose=8000, uses='_pass', uses_after='_pass', uses_before=None),
         'tail': Namespace(host='1.2.3.4', name='encoder', parallel=2, pea_id=-1, polling=PollingType.ANY,
-                          port_ctrl=46937, port_expose=8000, uses='_route', uses_after='_pass', uses_before=None),
+                          port_ctrl=46937, port_expose=8000, uses='_pass', uses_after='_pass', uses_before=None),
         'peas': [
             Namespace(host='1.2.3.4', name='encoder', parallel=2, pea_id=-1, polling=PollingType.ANY,
                       port_ctrl=44747, port_expose=8000, uses='helloworld.encoder.yml', uses_after='_pass',

--- a/tests/unit/peapods/test_container.py
+++ b/tests/unit/peapods/test_container.py
@@ -130,7 +130,7 @@ def test_flow_topo_mixed(docker_image_built):
 def test_flow_topo_parallel(docker_image_built):
     f = (Flow()
          .add(name='d7', uses='jinaai/jina:test-pip', entrypoint='jina pod', uses_internal='_pass', parallel=3)
-         .add(name='d8', uses='_pass', parallel=3)
+         .add(name='d8', parallel=3)
          .add(name='d9', uses='jinaai/jina:test-pip', entrypoint='jina pod', uses_internal='_pass',
               needs='d7')
          .join(['d9', 'd8']))
@@ -169,7 +169,7 @@ def test_container_ping(docker_image_built):
 def test_tail_host_docker2local_parallel(docker_image_built):
     f = (Flow()
          .add(name='d10', uses='jinaai/jina:test-pip', entrypoint='jina pod', uses_internal='_pass', parallel=3)
-         .add(name='d11', uses='_pass'))
+         .add(name='d11'))
     with f:
         assert getattr(f._pod_nodes['d10'].peas_args['tail'], 'host_out') == defaulthost
         f.dry_run()
@@ -178,7 +178,7 @@ def test_tail_host_docker2local_parallel(docker_image_built):
 def test_tail_host_docker2local(docker_image_built):
     f = (Flow()
          .add(name='d12', uses='jinaai/jina:test-pip', entrypoint='jina pod', uses_internal='_pass')
-         .add(name='d13', uses='_pass'))
+         .add(name='d13'))
     with f:
         assert getattr(f._pod_nodes['d12'].tail_args, 'host_out') == localhost
         f.dry_run()

--- a/tests/unit/test_driver_yaml.py
+++ b/tests/unit/test_driver_yaml.py
@@ -71,7 +71,7 @@ def test_load_yaml2(test_metas):
     [
         ('executors._route.yml', 'route', 4),
         ('executors._pass.yml', 'forward', 4),
-        ('executors._merge.yml', 'merge', 4),
+        ('executors._pass.yml', 'merge', 4),
         ('executors._clear.yml', 'clear', 4)
     ]
 )

--- a/tests/unit/test_driver_yaml.py
+++ b/tests/unit/test_driver_yaml.py
@@ -71,7 +71,7 @@ def test_load_yaml2(test_metas):
     [
         ('executors._route.yml', 'route', 4),
         ('executors._pass.yml', 'forward', 4),
-        ('executors._pass.yml', 'merge', 4),
+        ('executors._merge.yml', 'merge', 4),
         ('executors._clear.yml', 'clear', 4)
     ]
 )

--- a/tests/unit/test_echostream.py
+++ b/tests/unit/test_echostream.py
@@ -50,7 +50,7 @@ def test_flow_with_jump():
          .add(name='r6', uses='_pass', needs='r4')
          .add(name='r8', uses='_pass', needs='r6')
          .add(name='r9', uses='_pass', needs='r5')
-         .add(name='r10', uses='_merge', needs=['r9', 'r8']))
+         .add(name='r10', uses='_pass', needs=['r9', 'r8']))
 
     with f:
         f.index(random_docs(10))

--- a/tests/unit/test_echostream.py
+++ b/tests/unit/test_echostream.py
@@ -42,23 +42,23 @@ def test_simple_zmqlet():
 
 
 def test_flow_with_jump():
-    f = (Flow().add(name='r1', uses='_pass')
-         .add(name='r2', uses='_pass')
-         .add(name='r3', uses='_pass', needs='r1')
-         .add(name='r4', uses='_pass', needs='r2')
-         .add(name='r5', uses='_pass', needs='r3')
-         .add(name='r6', uses='_pass', needs='r4')
-         .add(name='r8', uses='_pass', needs='r6')
-         .add(name='r9', uses='_pass', needs='r5')
-         .add(name='r10', uses='_pass', needs=['r9', 'r8']))
+    f = (Flow().add(name='r1')
+         .add(name='r2')
+         .add(name='r3', needs='r1')
+         .add(name='r4', needs='r2')
+         .add(name='r5', needs='r3')
+         .add(name='r6', needs='r4')
+         .add(name='r8', needs='r6')
+         .add(name='r9', needs='r5')
+         .add(name='r10', needs=['r9', 'r8']))
 
     with f:
         f.index(random_docs(10))
 
 
 def test_flow_with_parallel():
-    f = (Flow().add(name='r1', uses='_pass')
-         .add(name='r2', uses='_pass', parallel=3))
+    f = (Flow().add(name='r1')
+         .add(name='r2', parallel=3))
 
     with f:
         f.index(random_docs(100))

--- a/tests/unit/test_gateway.py
+++ b/tests/unit/test_gateway.py
@@ -40,9 +40,7 @@ def test_rest_gateway_concurrency():
         durations[index] = resp.elapsed.total_seconds()
         status_codes[index] = resp.status_code
 
-    f = Flow(rest_api=True).add(
-        uses='_pass',
-        parallel=2)
+    f = Flow(rest_api=True).add(parallel=2)
     with f:
         concurrency = 50
         threads = []
@@ -96,9 +94,7 @@ def test_grpc_gateway_concurrency():
                 index=index
             ))
 
-    f = Flow().add(
-        uses='_pass',
-        parallel=2)
+    f = Flow().add(parallel=2)
     with f:
         threads = []
         status_codes = [None] * concurrency

--- a/tests/unit/test_index.py
+++ b/tests/unit/test_index.py
@@ -1,15 +1,14 @@
-import os
 import multiprocessing as mp
+import os
 
-import pytest
 import numpy as np
+import pytest
 
-
-from jina.flow import Flow
-from jina.proto import jina_pb2
-from jina.parser import set_flow_parser
 from jina.enums import FlowOptimizeLevel
 from jina.executors.indexers.vector import NumpyIndexer
+from jina.flow import Flow
+from jina.parser import set_flow_parser
+from jina.proto import jina_pb2
 from tests import random_docs
 
 cur_dir = os.path.dirname(os.path.abspath(__file__))
@@ -66,10 +65,12 @@ def test_doc_iters():
     for doc in docs:
         assert isinstance(doc, jina_pb2.Document)
 
+
 def test_simple_route():
-    f = Flow().add(uses='_pass')
+    f = Flow().add()
     with f:
         f.index(input_fn=random_docs(10))
+
 
 def test_update_method(test_metas):
     with DummyIndexer(index_filename='testa.bin', metas=test_metas) as indexer:
@@ -94,8 +95,8 @@ def test_update_method(test_metas):
 @pytest.mark.skipif('GITHUB_WORKFLOW' in os.environ, reason='skip the network test on github workflow')
 def test_two_client_route_parallel():
     fa1 = set_flow_parser().parse_args(['--optimize-level', str(FlowOptimizeLevel.NONE)])
-    f1 = Flow(fa1).add(uses='_pass', parallel=3)
-    f2 = Flow(optimize_level=FlowOptimizeLevel.IGNORE_GATEWAY).add(uses='_pass', parallel=3)
+    f1 = Flow(fa1).add(parallel=3)
+    f2 = Flow(optimize_level=FlowOptimizeLevel.IGNORE_GATEWAY).add(parallel=3)
 
     def start_client(fl):
         fl.index(input_fn=random_docs(10))
@@ -127,7 +128,7 @@ def test_two_client_route():
     def start_client(fl):
         fl.index(input_fn=random_docs(10))
 
-    with Flow().add(uses='_pass') as f:
+    with Flow().add() as f:
         t1 = mp.Process(target=start_client, args=(f,))
         t1.daemon = True
         t2 = mp.Process(target=start_client, args=(f,))

--- a/tests/unit/test_quant.py
+++ b/tests/unit/test_quant.py
@@ -36,7 +36,7 @@ def test_quant_f1(quant):
     np.random.seed(rseed)
     os.environ['JINA_ARRAY_QUANT'] = quant
 
-    f = Flow(callback_on_body=True).add(uses='_pass')
+    f = Flow(callback_on_body=True).add()
     with f as fl:
         fl.index(random_docs(num_docs, chunks_per_doc=chunks_per_doc, embed_dim=embed_dim), output_fn=get_output)
 
@@ -46,6 +46,6 @@ def test_quant_f2(quant):
     np.random.seed(rseed)
     os.environ['JINA_ARRAY_QUANT'] = quant
 
-    f = Flow(callback_on_body=True).add(uses='_pass')
+    f = Flow(callback_on_body=True).add()
     with f as fl:
         fl.index(random_docs(num_docs, chunks_per_doc=chunks_per_doc, embed_dim=embed_dim), output_fn=get_output)

--- a/tests/unit/yaml/examples/faces/flow-index.yml
+++ b/tests/unit/yaml/examples/faces/flow-index.yml
@@ -21,6 +21,6 @@ pods:
   doc_indexer:
     needs: loader
   join_all:
-    uses: _merge
+    uses: _pass
     needs: [doc_indexer, chunk_indexer]
     read_only: true

--- a/tests/unit/yaml/examples/faiss/flow-index.yml
+++ b/tests/unit/yaml/examples/faiss/flow-index.yml
@@ -11,6 +11,6 @@ pods:
   doc_indexer:
     needs: crafter
   join_all:
-    uses: _merge
+    uses: _pass
     needs: [doc_indexer, faiss_indexer]
     read_only: true

--- a/tests/unit/yaml/test-flow.yml
+++ b/tests/unit/yaml/test-flow.yml
@@ -11,5 +11,5 @@ pods:
     parallel: 2
     needs: chunk_seg
   joiner:
-    uses: _merge
+    uses: _pass
     needs: [wqncode1, encode2]

--- a/tests/unit/yaml/test_flow_visualization.yml
+++ b/tests/unit/yaml/test_flow_visualization.yml
@@ -19,6 +19,6 @@ pods:
   text_indexer:
     read_only: true
   join_all:
-    uses: _merge
+    uses: _pass
     needs: [image_vector_indexer, image_kv_indexer, text_indexer]
     read_only: true


### PR DESCRIPTION
## Background

This PR is motivated by #1215 

To understand the problem, the following Flow is not runnable at the current master.

```python
f = (Flow().add(name='p1').add(name='p2', needs='gateway')
         .add(name='p3', needs='gateway')
         .add(name='p4', needs='gateway')
         .add(name='p5', needs='gateway')
         .needs(['p2', 'p4'], name='r1')
         .needs(['p3', 'p5'], name='r2')
         .needs(['p1', 'r1'], name='r3')
         .needs(['r2', 'r3'], name='r4')).plot()
```


<img src="https://mermaid.ink/svg/JSV7aW5pdDogeyd0aGVtZSc6ICdiYXNlJywgJ3RoZW1lVmFyaWFibGVzJzogeyAncHJpbWFyeUNvbG9yJzogJyMzMkM4Q0QnLCAnZWRnZUxhYmVsQmFja2dyb3VuZCc6JyNmZmYnLCAnY2x1c3RlckJrZyc6ICcjRkZDQzY2J319fSUlCmdyYXBoIExSCmdhdGV3YXkoZ2F0ZXdheSk6OjpHQVRFV0FZIC0tPiB8UFVCLVNVQnxwMShwMSk6OjpQT0QKZ2F0ZXdheShnYXRld2F5KTo6OkdBVEVXQVkgLS0+IHxQVUItU1VCfHAyKHAyKTo6OlBPRApnYXRld2F5KGdhdGV3YXkpOjo6R0FURVdBWSAtLT4gfFBVQi1TVUJ8cDMocDMpOjo6UE9ECmdhdGV3YXkoZ2F0ZXdheSk6OjpHQVRFV0FZIC0tPiB8UFVCLVNVQnxwNChwNCk6OjpQT0QKZ2F0ZXdheShnYXRld2F5KTo6OkdBVEVXQVkgLS0+IHxQVUItU1VCfHA1KHA1KTo6OlBPRApwMihwMik6OjpQT0QgLS0+IHxQVVNILVBVTEx8cjEocjEpOjo6Sk9JTgpwNChwNCk6OjpQT0QgLS0+IHxQVVNILVBVTEx8cjEocjEpOjo6Sk9JTgpwMyhwMyk6OjpQT0QgLS0+IHxQVVNILVBVTEx8cjIocjIpOjo6Sk9JTgpwNShwNSk6OjpQT0QgLS0+IHxQVVNILVBVTEx8cjIocjIpOjo6Sk9JTgpwMShwMSk6OjpQT0QgLS0+IHxQVVNILVBVTEx8cjMocjMpOjo6Sk9JTgpyMShyMSk6OjpKT0lOIC0tPiB8UFVTSC1QVUxMfHIzKHIzKTo6OkpPSU4KcjIocjIpOjo6Sk9JTiAtLT4gfFBVU0gtUFVMTHxyNChyNCk6OjpKT0lOCnIzKHIzKTo6OkpPSU4gLS0+IHxQVVNILVBVTEx8cjQocjQpOjo6Sk9JTgpyNChyNCk6OjpKT0lOIC0tPiB8UFVTSC1QVUxMfGdhdGV3YXlfRU5EKGdhdGV3YXkpOjo6R0FURVdBWQpjbGFzc0RlZiBQT0QgZmlsbDojMzJDOENELHN0cm9rZTojMDA5OTk5CmNsYXNzRGVmIElOU1BFQ1QgZmlsbDojZmY2NjY2LGNvbG9yOiNmZmYKY2xhc3NEZWYgSk9JTl9JTlNQRUNUIGZpbGw6I2ZmNjY2Nixjb2xvcjojZmZmCmNsYXNzRGVmIEdBVEVXQVkgZmlsbDojNkU3Mjc4LGNvbG9yOiNmZmYKY2xhc3NEZWYgSU5TUEVDVF9BVVhfUEFTUyBmaWxsOiNmZmYsY29sb3I6IzAwMCxzdHJva2UtZGFzaGFycmF5OiA1IDUKY2xhc3NEZWYgcGVhIGZpbGw6IzAwOTk5OSxzdHJva2U6IzFFNkU3Mw=="/>

The reason:
- in the master, `num_part` is purely determined by the upstream. It works like a FILO queue. The downstream Pods has no control this `num_part` in `Flow.needs()` but following what is written in the envelope.
- when the flow has hanging pods (introduced in #1087 ), collecting pods at downstream requires flexibile control of `num_part`.

## Changes

The change is about letting downstream to decide how to collect. This affects the logic of `ReduceDriver`, `BasePea`, `Protobuf`, `Flow.needs`. **No breaking changes at the Flow-level user experience.**

- Change the semantic of `num_part` to `the number of messages expected from upstream` as written in the `parser.py`
- Remove `num_part` from envelope & FILO logic, not required anymore.
- Move `num_part` gather logic to `BasePea` so that `ReduceDriver` simplified to `_pass`. And all `Drivers` bind to that executor now have access to `partial_reqs`.
- `_merge` is now `_pass`. All basic routing such as prev `_merge`, `_route`, `_pass` are simply `_pass`.

