### PR TITLE
feat(remote): add ssh remote peapod

### DIFF
--- a/jina/enums.py
+++ b/jina/enums.py
@@ -299,3 +299,10 @@ class CallbackOnType(BetterEnum):
     BODY = 1  # the body of the request, `status`, `routes` and `queryset` are removed
     DOCS = 2  # the documents inside the request body
     GROUNDTRUTHS = 3  # the groundtruths inside the request body
+
+
+class RemoteAccessType(BetterEnum):
+    """Remote access type when connect to the host """
+
+    SSH = 0  # ssh connection
+    JINAD = 1  # using rest api via jinad

--- a/jina/parser.py
+++ b/jina/parser.py
@@ -214,7 +214,7 @@ def set_flow_parser(parser=None):
                                               '/'.join(('resources', 'logserver.default.yml'))),
                     help='the yaml config of the log server')
     gp.add_argument('--log-id', type=str, default=get_random_identity(),
-                     help='the log id used to aggregate logs by fluentd' if _SHOW_ALL_ARGS else argparse.SUPPRESS)
+                    help='the log id used to aggregate logs by fluentd' if _SHOW_ALL_ARGS else argparse.SUPPRESS)
     gp.add_argument('--optimize-level', type=FlowOptimizeLevel.from_string, default=FlowOptimizeLevel.NONE,
                     help='removing redundant routers from the flow. Note, this may change the gateway zmq socket to BIND \
                             and hence not allow multiple clients connected to the gateway at the same time.'
@@ -243,8 +243,6 @@ def set_pea_parser(parser=None):
                      help='the name of this pea, used to identify the pod and its logs.')
     gp0.add_argument('--identity', type=str, default=get_random_identity(),
                      help='the identity of the sockets, default a random string (Important for load balancing messages')
-    gp0.add_argument('--log-id', type=str, default=get_random_identity(),
-                     help='the log id used to aggregate logs by fluentd' if _SHOW_ALL_ARGS else argparse.SUPPRESS)
     gp0.add_argument('--uses', type=str, default='_pass',
                      help='the config of the executor, it could be '
                           '> a YAML file path, '
@@ -344,6 +342,8 @@ def set_pea_parser(parser=None):
     gp7.add_argument('--log-remote', action='store_true', default=False,
                      help='turn on remote logging, this should not be set manually'
                      if _SHOW_ALL_ARGS else argparse.SUPPRESS)
+    gp7.add_argument('--log-id', type=str, default=get_random_identity(),
+                     help='the log id used to aggregate logs by fluentd' if _SHOW_ALL_ARGS else argparse.SUPPRESS)
 
     gp8 = add_arg_group(parser, 'ssh tunneling arguments')
     gp8.add_argument('--ssh-server', type=str, default=None,
@@ -431,6 +431,7 @@ def _set_grpc_parser(parser=None):
         parser = set_base_parser()
     from .helper import random_port
     from . import __default_host__
+    from .enums import RemoteAccessType
     gp1 = add_arg_group(parser, 'grpc and remote arguments')
     gp1.add_argument('--host', type=str, default=__default_host__,
                      help=f'host address of the pea/gateway, by default it is {__default_host__}.')
@@ -444,6 +445,10 @@ def _set_grpc_parser(parser=None):
                      help='respect the http_proxy and https_proxy environment variables. '
                           'otherwise, it will unset these proxy variables before start. '
                           'gRPC seems to prefer no proxy')
+    gp1.add_argument('--remote-access', choices=list(RemoteAccessType),
+                     default=RemoteAccessType.SSH,
+                     type=RemoteAccessType.from_string,
+                     help=f'host address of the pea/gateway, by default it is {__default_host__}.')
     return parser
 
 

--- a/jina/peapods/__init__.py
+++ b/jina/peapods/__init__.py
@@ -13,10 +13,10 @@ if False:
 
 
 def Pea(args: 'argparse.Namespace' = None, allow_remote: bool = True, **kwargs):
-    """Initialize a :class:`BasePea`, :class:`RemotePea` or :class:`ContainerPea`
+    """Initialize a :class:`BasePea`, :class:`RemoteSSHPea` or :class:`ContainerPea`
 
     :param args: arguments from CLI
-    :param allow_remote: allow start a :class:`RemotePea`
+    :param allow_remote: allow start a :class:`RemoteSSHPea`
     :param kwargs: all supported arguments from CLI
 
     """
@@ -48,10 +48,10 @@ def Pea(args: 'argparse.Namespace' = None, allow_remote: bool = True, **kwargs):
 
 
 def Pod(args: Union['argparse.Namespace', Dict] = None, allow_remote: bool = True, **kwargs):
-    """Initialize a :class:`BasePod`, :class:`RemotePod`, :class:`MutablePod` or :class:`RemoteMutablePod`
+    """Initialize a :class:`BasePod`, :class:`RemoteSSHPod`, :class:`MutablePod` or :class:`RemoteSSHMutablePod`
 
     :param args: arguments from CLI
-    :param allow_remote: allow start a :class:`RemotePod`
+    :param allow_remote: allow start a :class:`RemoteSSHPod`
     :param kwargs: all supported arguments from CLI
     """
 
@@ -87,11 +87,13 @@ def Pod(args: Union['argparse.Namespace', Dict] = None, allow_remote: bool = Tru
     if args.host != __default_host__:
         if args.remote == RemoteAccessType.JINAD:
             from .remote import RemotePod
+            return RemotePod(args)
         elif args.remote == RemoteAccessType.SSH:
-            from .ssh import RemotePod
+            from .ssh import RemoteSSHPod
+            return RemoteSSHPod(args)
         else:
             raise ValueError(f'{args.remote} is not supported')
-        return RemotePod(args)
+
     else:
         from .pod import BasePod
         return BasePod(args)

--- a/jina/peapods/__init__.py
+++ b/jina/peapods/__init__.py
@@ -4,9 +4,9 @@ __license__ = "Apache-2.0"
 from typing import Dict, Union
 
 from .. import __default_host__
-from ..enums import PeaRoleType
-from ..logging import default_logger
+from ..enums import PeaRoleType, RemoteAccessType
 from ..helper import is_valid_local_config_source
+from ..logging import default_logger
 
 if False:
     import argparse
@@ -54,6 +54,7 @@ def Pod(args: Union['argparse.Namespace', Dict] = None, allow_remote: bool = Tru
     :param allow_remote: allow start a :class:`RemotePod`
     :param kwargs: all supported arguments from CLI
     """
+
     if args is None:
         from ..parser import set_pod_parser
         from ..helper import get_parsed_args
@@ -75,6 +76,7 @@ def Pod(args: Union['argparse.Namespace', Dict] = None, allow_remote: bool = Tru
                 from .pod import MutablePod
                 return MutablePod(args)
             else:
+                # TODO: this part needs to be refactored
                 from .remote import RemoteMutablePod
                 return RemoteMutablePod(args)
 
@@ -83,7 +85,12 @@ def Pod(args: Union['argparse.Namespace', Dict] = None, allow_remote: bool = Tru
         default_logger.warning(f'host is reset to {__default_host__} as allow_remote=False')
 
     if args.host != __default_host__:
-        from .remote import RemotePod
+        if args.remote == RemoteAccessType.JINAD:
+            from .remote import RemotePod
+        elif args.remote == RemoteAccessType.SSH:
+            from .ssh import RemotePod
+        else:
+            raise ValueError(f'{args.remote} is not supported')
         return RemotePod(args)
     else:
         from .pod import BasePod

--- a/jina/peapods/container.py
+++ b/jina/peapods/container.py
@@ -2,13 +2,9 @@ __copyright__ = "Copyright (c) 2020 Jina AI Limited. All rights reserved."
 __license__ = "Apache-2.0"
 
 import os
-import asyncio
-
 from pathlib import Path
 
 from .pea import BasePea
-from .zmq import send_ctrl_message
-from ..proto import jina_pb2
 from .. import __ready_msg__, __unable_to_load_pretrained_model_msg__
 from ..helper import is_valid_local_config_source, kwargs2list, get_non_defaults_args
 from ..logging import JinaLogger

--- a/jina/peapods/pea.py
+++ b/jina/peapods/pea.py
@@ -8,7 +8,6 @@ import threading
 import time
 from collections import defaultdict
 from multiprocessing.synchronize import Event
-from queue import Empty
 from typing import Dict, Optional, Union, List
 
 import zmq
@@ -352,6 +351,8 @@ class BasePea(metaclass=PeaMeta):
             Class inherited from :class:`BasePea` must override this function. And add
             :meth:`set_ready` when your loop body is started
         """
+        os.environ['JINA_POD_NAME'] = self.name
+        os.environ['JINA_LOG_ID'] = self.args.log_id
         self.load_plugins()
         self.load_executor()
         self.zmqlet = ZmqStreamlet(self.args, logger=self.logger)
@@ -372,9 +373,6 @@ class BasePea(metaclass=PeaMeta):
         """Start the request loop of this BasePea. It will listen to the network protobuf message via ZeroMQ. """
         try:
             # Every logger created in this process will be identified by the `Pod Id` and use the same name
-            if self.args.name:
-                os.environ['JINA_POD_NAME'] = self.args.name
-            os.environ['JINA_LOG_ID'] = self.args.log_id
             self.post_init()
             self.loop_body()
         except ExecutorFailToLoad:

--- a/jina/peapods/pod.py
+++ b/jina/peapods/pod.py
@@ -369,12 +369,13 @@ class FlowPod(BasePod):
         else:
             if self._args.remote_access == RemoteAccessType.JINAD:
                 from .remote import RemoteMutablePod
+                _remote_pod = RemoteMutablePod(self.peas_args)
             elif self._args.remote_access == RemoteAccessType.SSH:
-                from .ssh import RemoteMutablePod
+                from .ssh import RemoteSSHMutablePod
+                _remote_pod = RemoteSSHMutablePod(self.peas_args)
             else:
                 raise ValueError(f'{self._args.remote_access} is unsupported')
 
-            _remote_pod = RemoteMutablePod(self.peas_args)
             self.enter_context(_remote_pod)
             self.start_sentinels()
             return self

--- a/jina/peapods/pod.py
+++ b/jina/peapods/pod.py
@@ -367,7 +367,13 @@ class FlowPod(BasePod):
         if self._args.host == __default_host__:
             return super().start()
         else:
-            from .remote import RemoteMutablePod
+            if self._args.remote_access == RemoteAccessType.JINAD:
+                from .remote import RemoteMutablePod
+            elif self._args.remote_access == RemoteAccessType.SSH:
+                from .ssh import RemoteMutablePod
+            else:
+                raise ValueError(f'{self._args.remote_access} is unsupported')
+
             _remote_pod = RemoteMutablePod(self.peas_args)
             self.enter_context(_remote_pod)
             self.start_sentinels()

--- a/jina/peapods/ssh.py
+++ b/jina/peapods/ssh.py
@@ -1,0 +1,67 @@
+from subprocess import Popen, PIPE
+
+from .. import __ready_msg__, __stop_msg__
+from ..helper import get_non_defaults_args, kwargs2list
+from ..logging import JinaLogger
+from ..peapods.pea import BasePea
+
+
+class RemotePea(BasePea):
+    """Simple SSH based RemotePea for remote Pea management
+
+    .. note::
+        It requires one to upload host public key to the remote
+        1. ssh-keygen -b 4096
+        2. scp ~/.ssh/id_rsa.pub username@hostname:~/.ssh/authorized_keys
+    """
+
+    @property
+    def remote_command(self) -> str:
+        from ..parser import set_pea_parser
+        non_defaults = get_non_defaults_args(self.args, set_pea_parser(), taboo={'host'})
+        _args = kwargs2list(non_defaults)
+        return f'jina pea {" ".join(_args)}'
+
+    def spawn_remote(self, ssh_proc: 'Popen') -> None:
+        ssh_proc.stdin.write(self.remote_command + '\n')
+
+    def loop_body(self):
+        logger = JinaLogger('🌏', **vars(self.args))
+        with Popen(['ssh', self.args.host], stdout=PIPE, stdin=PIPE, bufsize=0, universal_newlines=True) as p:
+            self.spawn_remote(p)
+            with logger:
+                for line in p.stdout:
+                    msg = line.strip()
+                    logger.info(msg)
+                    if __ready_msg__ in msg:
+                        self.is_ready_event.set()
+                        self.logger.success(__ready_msg__)
+                    if __stop_msg__ in msg:
+                        break
+            # after the pod receive TERMINATE control signal it should jump out from the loop
+            p.stdin.write('logout\n')
+            p.stdin.close()
+            p.stdout.close()
+        self.is_shutdown.set()
+
+
+class RemotePod(RemotePea):
+    """SSH based pod to be used while invoking remote Pod
+    """
+
+    @property
+    def remote_command(self) -> str:
+        from ..parser import set_pod_parser
+        non_defaults = get_non_defaults_args(self.args, set_pod_parser(), taboo={'host'})
+        _args = kwargs2list(non_defaults)
+        return f'jina pod {" ".join(_args)}'
+
+
+class RemoteMutablePod(RemotePod):
+    """
+    SSH based mutable pod, internally it has to maintain the context of multiple separated peas.
+    Subprocess-based simple ssh session is probably no good for that, but simple ssh remotepod is
+    """
+
+    def spawn_remote(self, ssh_proc: 'Popen') -> None:
+        raise NotImplementedError

--- a/jina/peapods/ssh.py
+++ b/jina/peapods/ssh.py
@@ -6,13 +6,18 @@ from ..logging import JinaLogger
 from ..peapods.pea import BasePea
 
 
-class RemotePea(BasePea):
-    """Simple SSH based RemotePea for remote Pea management
+class RemoteSSHPea(BasePea):
+    """Simple SSH based RemoteSSHPea for remote Pea management
 
     .. note::
         It requires one to upload host public key to the remote
         1. ssh-keygen -b 4096
         2. scp ~/.ssh/id_rsa.pub username@hostname:~/.ssh/authorized_keys
+
+    .. note::
+        As the terminal signal is sent via :meth:`send_terminate_signal` from
+        :class:`BasePea`, there is no need to override/implement :meth:`close`
+        method. Lifecycle is handled by :class:`BasePea`.
     """
 
     @property
@@ -45,7 +50,7 @@ class RemotePea(BasePea):
         self.is_shutdown.set()
 
 
-class RemotePod(RemotePea):
+class RemoteSSHPod(RemoteSSHPea):
     """SSH based pod to be used while invoking remote Pod
     """
 
@@ -57,7 +62,7 @@ class RemotePod(RemotePea):
         return f'jina pod {" ".join(_args)}'
 
 
-class RemoteMutablePod(RemotePod):
+class RemoteSSHMutablePod(RemoteSSHPod):
     """
     SSH based mutable pod, internally it has to maintain the context of multiple separated peas.
     Subprocess-based simple ssh session is probably no good for that, but simple ssh remotepod is

--- a/jina/peapods/zmq.py
+++ b/jina/peapods/zmq.py
@@ -88,7 +88,12 @@ class Zmqlet:
         if ctrl_with_ipc:
             return _get_random_ipc(), ctrl_with_ipc
         else:
-            return f'tcp://{args.host}:{args.port_ctrl}', ctrl_with_ipc
+            if '@' in args.host:
+                # user@hostname
+                host = args.host.split('@')[-1]
+            else:
+                host = args.host
+            return f'tcp://{host}:{args.port_ctrl}', ctrl_with_ipc
 
     def _pull(self, interval: int = 1):
         socks = dict(self.poller.poll(interval))
@@ -143,7 +148,9 @@ class Zmqlet:
             self.logger.debug(f'output {self.args.host_out}:{colored(self.args.port_out, "yellow")}')
 
             self.logger.info(
-                f'input {colored(in_addr, "yellow")} ({self.args.socket_in}) \t output {colored(out_addr, "yellow")} ({self.args.socket_out})\t control over {colored(ctrl_addr, "yellow")} ({SocketType.PAIR_BIND})')
+                f'input {colored(in_addr, "yellow")} ({self.args.socket_in.name}) \t '
+                f'output {colored(out_addr, "yellow")} ({self.args.socket_out.name})\t '
+                f'control over {colored(ctrl_addr, "yellow")} ({SocketType.PAIR_BIND.name})')
 
             self.in_sock_type = in_sock.type
             self.out_sock_type = out_sock.type

--- a/tests/unit/peapods/test_ssh_remote.py
+++ b/tests/unit/peapods/test_ssh_remote.py
@@ -1,0 +1,44 @@
+import pytest
+
+from jina.enums import RemoteAccessType
+from jina.flow import Flow
+from jina.parser import set_pea_parser, set_pod_parser
+from jina.peapods.pod import BasePod
+from jina.peapods.ssh import RemotePea, RemotePod, RemoteMutablePod
+from jina.proto import jina_pb2
+
+
+@pytest.mark.skip('works locally, but until I findout how to mock ssh, this has to be skipped')
+def test_ssh_pea():
+    p = set_pea_parser().parse_args(['--host', 'pi@172.16.1.110', '--timeout', '5000'])
+
+    with RemotePea(p) as pp:
+        assert pp.status.envelope.status.code == jina_pb2.Status.READY
+
+    assert pp.status is None
+
+
+@pytest.mark.skip('works locally, but until I findout how to mock ssh, this has to be skipped')
+def test_ssh_pod():
+    p = set_pod_parser().parse_args(['--host', 'pi@172.16.1.110', '--timeout', '5000'])
+    with RemotePod(p) as pp:
+        assert pp.status.envelope.status.code == jina_pb2.Status.READY
+
+    assert pp.status is None
+
+
+@pytest.mark.skip('not implemented yet')
+def test_ssh_mutable_pod():
+    p = set_pod_parser().parse_args(['--host', 'pi@172.16.1.110', '--timeout', '5000'])
+    p = BasePod(p)
+    with RemoteMutablePod(p.peas_args) as pp:
+        assert pp.status.envelope.status.code == jina_pb2.Status.READY
+
+    assert pp.status is None
+
+
+@pytest.mark.skip('not implemented yet')
+def test_flow():
+    f = Flow().add().add(host='pi@172.16.1.110', remote_access=RemoteAccessType.SSH)
+    with f:
+        pass

--- a/tests/unit/peapods/test_ssh_remote.py
+++ b/tests/unit/peapods/test_ssh_remote.py
@@ -4,7 +4,7 @@ from jina.enums import RemoteAccessType
 from jina.flow import Flow
 from jina.parser import set_pea_parser, set_pod_parser
 from jina.peapods.pod import BasePod
-from jina.peapods.ssh import RemotePea, RemotePod, RemoteMutablePod
+from jina.peapods.ssh import RemoteSSHPea, RemoteSSHPod, RemoteSSHMutablePod
 from jina.proto import jina_pb2
 
 
@@ -12,7 +12,7 @@ from jina.proto import jina_pb2
 def test_ssh_pea():
     p = set_pea_parser().parse_args(['--host', 'pi@172.16.1.110', '--timeout', '5000'])
 
-    with RemotePea(p) as pp:
+    with RemoteSSHPea(p) as pp:
         assert pp.status.envelope.status.code == jina_pb2.Status.READY
 
     assert pp.status is None
@@ -21,7 +21,7 @@ def test_ssh_pea():
 @pytest.mark.skip('works locally, but until I findout how to mock ssh, this has to be skipped')
 def test_ssh_pod():
     p = set_pod_parser().parse_args(['--host', 'pi@172.16.1.110', '--timeout', '5000'])
-    with RemotePod(p) as pp:
+    with RemoteSSHPod(p) as pp:
         assert pp.status.envelope.status.code == jina_pb2.Status.READY
 
     assert pp.status is None
@@ -31,7 +31,7 @@ def test_ssh_pod():
 def test_ssh_mutable_pod():
     p = set_pod_parser().parse_args(['--host', 'pi@172.16.1.110', '--timeout', '5000'])
     p = BasePod(p)
-    with RemoteMutablePod(p.peas_args) as pp:
+    with RemoteSSHMutablePod(p.peas_args) as pp:
         assert pp.status.envelope.status.code == jina_pb2.Status.READY
 
     assert pp.status is None

--- a/tests/unit/test_zmq_addr.py
+++ b/tests/unit/test_zmq_addr.py
@@ -1,0 +1,10 @@
+import pytest
+
+from jina.parser import set_pea_parser
+from jina.peapods.zmq import Zmqlet
+
+
+@pytest.mark.parametrize('host', ['pi@192.0.0.1', '192.0.0.1'])
+def test_get_ctrl_addr(host):
+    p = set_pea_parser().parse_args(['--host', 'pi@192.0.0.1', '--port-ctrl', '56789'])
+    assert Zmqlet.get_ctrl_address(p)[0] == 'tcp://192.0.0.1:56789'


### PR DESCRIPTION
Reason for this PR:
- we can have multiple remote access methods
- having an SSH-based remote peapod requires no extra dependency, long-term: ssh peapod is a poorman solution for novice
- help us to design better RemotePea/Pod lifecycle

Not trying to overengineer anything at the moment.