### PR TITLE
chore dummyhub 004

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -99,3 +99,14 @@ jobs:
           dockerfile: Dockerfiles/debianx.Dockerfile
           buildargs: BUILD_DATE, VCS_REF, JINA_VERSION
           tags: "latest, ${{env.JINA_VERSION}}"
+
+  update-jina-hub:
+    needs: update-docker
+    runs-on: ubuntu-latest
+    steps:
+      - name: handle jina hub
+        run: |
+          git clone git@github.com:jina-ai/jina-hub.git --depth=1
+          python scripts/jina-hub-update.py
+
+

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -106,7 +106,7 @@ jobs:
     steps:
       - name: handle jina hub
         run: |
-          git clone git@github.com:jina-ai/jina-hub.git --depth=1
+          git clone https://github.com/jina-ai/jina-hub.git --depth=1
           python scripts/jina-hub-update.py
 
 

--- a/.github/workflows/update_hub.yml
+++ b/.github/workflows/update_hub.yml
@@ -1,0 +1,14 @@
+name: Update hub
+
+on:
+  workflow_dispatch:
+
+jobs:
+  update-jina-hub:
+    runs-on: ubuntu-latest
+    steps:
+      - name: handle jina hub
+        run: |
+          git clone https://github.com/jina-ai/jina-hub.git --depth=1
+          python scripts/jina-hub-update.py
+

--- a/scripts/jina-hub-update.py
+++ b/scripts/jina-hub-update.py
@@ -1,0 +1,21 @@
+import os
+from glob import glob
+
+
+def handle_module_update(module_dir):
+    print(f'handing module {module_dir}')
+    pass
+
+
+def main():
+    manifest_ymls = glob('**/manifest.yml')
+    print(f'Got {len(manifest_ymls)} manifests/modules to handle')
+    # TODO limited to 1 for dev/testing
+    manifest_ymls = manifest_ymls[:1]
+    for manifest_path in manifest_ymls:
+        module_dir = os.path.sep.join(manifest_path.split(os.path.sep)[:-1])
+        handle_module_update(module_dir)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/jina-hub-update.py
+++ b/scripts/jina-hub-update.py
@@ -1,3 +1,6 @@
+"""
+updates all modules from JinaHub with latest version of Jina
+"""
 import os
 from glob import glob
 

--- a/tests/integration/hub_usage/dummyhub/manifest.yml
+++ b/tests/integration/hub_usage/dummyhub/manifest.yml
@@ -7,6 +7,7 @@ author: Jina AI Dev-Team (dev-team@jina.ai)
 url: https://jina.ai
 vendor: Jina AI Limited
 documentation: https://github.com/jina-ai/jina-hub
-version: 0.0.0
+version: 0.0.4
 license: apache-2.0
 keywords: [Some keywords to describe the executor, separated by commas]
+jina-version: 0.7.8


### PR DESCRIPTION
- ci: handling updating jina hub modules
- ci: handling updating jina hub modules
- ci: handling updating jina hub modules
- chore: bump dummyhub version to 0.0.4
