### PR TITLE
feat: parse dict as document

### DIFF
--- a/tests/unit/clients/python/test_request.py
+++ b/tests/unit/clients/python/test_request.py
@@ -85,6 +85,82 @@ def test_request_generate_docs():
         assert doc.offset == 1000
 
 
+def test_request_generate_dict():
+    def random_docs(num_docs):
+        for j in range(1, num_docs + 1):
+            doc = {
+                'text': f'i\'m dummy doc {j}',
+                'offset': 1000,
+                'tags': {
+                    'id': 1000
+                },
+                'chunks': [
+                    {
+                        'text': f'i\'m chunk 1',
+                        'modality': 'text'
+                    },
+                    {
+                        'text': f'i\'m chunk 2',
+                        'modality': 'image'
+                    },
+                ]
+            }
+            yield doc
+
+    req = _generate(data=random_docs(100), batch_size=100)
+
+    request = next(req)
+    assert len(request.index.docs) == 100
+    for index, doc in enumerate(request.index.docs, 1):
+        assert doc.text == f'i\'m dummy doc {index}'
+        assert doc.offset == 1000
+        assert doc.tags['id'] == 1000
+        assert len(doc.chunks) == 2
+        assert doc.chunks[0].modality == 'text'
+        assert doc.chunks[0].text == f'i\'m chunk 1'
+        assert doc.chunks[1].modality == 'image'
+        assert doc.chunks[1].text == f'i\'m chunk 2'
+
+
+def test_request_generate_dict_str():
+    import json
+
+    def random_docs(num_docs):
+        for j in range(1, num_docs + 1):
+            doc = {
+                'text': f'i\'m dummy doc {j}',
+                'offset': 1000,
+                'tags': {
+                    'id': 1000
+                },
+                'chunks': [
+                    {
+                        'text': f'i\'m chunk 1',
+                        'modality': 'text'
+                    },
+                    {
+                        'text': f'i\'m chunk 2',
+                        'modality': 'image'
+                    },
+                ]
+            }
+            yield json.dumps(doc)
+
+    req = _generate(data=random_docs(100), batch_size=100)
+
+    request = next(req)
+    assert len(request.index.docs) == 100
+    for index, doc in enumerate(request.index.docs, 1):
+        assert doc.text == f'i\'m dummy doc {index}'
+        assert doc.offset == 1000
+        assert doc.tags['id'] == 1000
+        assert len(doc.chunks) == 2
+        assert doc.chunks[0].modality == 'text'
+        assert doc.chunks[0].text == f'i\'m chunk 1'
+        assert doc.chunks[1].modality == 'image'
+        assert doc.chunks[1].text == f'i\'m chunk 2'
+
+
 def test_request_generate_numpy_arrays():
     input_array = np.random.random([10, 10])
 


### PR DESCRIPTION
**Changes introduced**
To be able to receive complex `json-like` or `dict` representing documents (for instance from `jinabox`) we need to be able to interpret `dict` or `json-like str` directly into parsed documents.