### PR TITLE
fix: ci hub update missing python3-setuptools

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -105,11 +105,17 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
+          fetch-depth: 0
           submodules: true
           token: ${{ secrets.JINA_DEV_BOT }}
-      - run: |
+      - env:
+          GITHUB_TOKEN: ${{ secrets.JINA_DEV_BOT }}
+        run: |
           sudo apt-get update -y
-          sudo apt-get install python3.7 git python3-distutils python3-pip -y
-          pip3 install gitpython ruamel.yaml PyGithub semver
-          git clone --depth=1 https://$DEV_BOT_TOKEN@github.com/jina-ai/jina-hub.git
+          sudo apt-get install python3.7 git python3-distutils python3-pip python3-setuptools -y
+          echo `which python3.7`
+          echo `which pip3`
+          python3.7 -m pip install wheel --user
+          python3.7 -m pip install gitpython ruamel.yaml PyGithub semver --user
+          git clone --depth=1 https://$GITHUB_TOKEN@github.com/jina-ai/jina-hub.git
           python3.7 scripts/jina-hub-update.py

--- a/.github/workflows/update_hub.yml
+++ b/.github/workflows/update_hub.yml
@@ -9,11 +9,17 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
+          fetch-depth: 0
           submodules: true
           token: ${{ secrets.JINA_DEV_BOT }}
-      - run: |
+      - env:
+          GITHUB_TOKEN: ${{ secrets.JINA_DEV_BOT }}
+        run: |
           sudo apt-get update -y
-          sudo apt-get install python3.7 git python3-distutils python3-pip -y
-          pip3 install gitpython ruamel.yaml PyGithub semver
-          git clone --depth=1 https://$DEV_BOT_TOKEN@github.com/jina-ai/jina-hub.git
+          sudo apt-get install python3.7 git python3-distutils python3-pip python3-setuptools -y
+          echo `which python3.7`
+          echo `which pip3`
+          python3.7 -m pip install wheel --user
+          python3.7 -m pip install gitpython ruamel.yaml PyGithub semver --user
+          git clone --depth=1 https://$GITHUB_TOKEN@github.com/jina-ai/jina-hub.git
           python3.7 scripts/jina-hub-update.py

--- a/scripts/jina-hub-update.py
+++ b/scripts/jina-hub-update.py
@@ -12,7 +12,7 @@ from github import Github
 from ruamel.yaml import YAML
 
 # this one has PR push access
-g = Github(os.environ["DEV_BOT_TOKEN"])
+g = Github(os.environ["GITHUB_TOKEN"])
 
 yaml = YAML()
 
@@ -21,13 +21,15 @@ def main():
     hub_repo = git.Repo('jina-hub')
     hub_origin = hub_repo.remote(name='origin')
     hub_origin_url = list(hub_origin.urls)[0]
-    assert 'jina-hub' in hub_origin_url, f'hub repo was not initialized correctly'
+    assert 'jina-ai/jina-hub' in hub_origin_url, f'hub repo was not initialized correctly'
     gh_hub_repo = g.get_repo('jina-ai/jina-hub')
 
     jina_core_repo = git.Repo('.')
     core_origin_url = list(jina_core_repo.remote(name='origin').urls)[0]
-    assert 'jina.git' in core_origin_url, f'core repo was not initialized correctly'
+    assert 'jina-ai/jina' in core_origin_url, f'core repo was not initialized correctly'
 
+    print(f'tags = {jina_core_repo.tags}')
+    print(f'latest tag = {jina_core_repo.tags[-1].tag.tag}')
     jina_core_version = jina_core_repo.tags[-1].tag.tag[1:]  # remove leading 'v'
 
     print(f'cur. dir. is "{os.getcwd()}"')


### PR DESCRIPTION
Fixing difference between local run (via `act`) and GH environment.

**EDIT** Finished, workflow passed.
