### PR TITLE
refactor: remote default should be jinad

### DIFF
--- a/jina/parser.py
+++ b/jina/parser.py
@@ -450,7 +450,7 @@ def _set_grpc_parser(parser=None):
                           'otherwise, it will unset these proxy variables before start. '
                           'gRPC seems to prefer no proxy')
     gp1.add_argument('--remote-access', choices=list(RemoteAccessType),
-                     default=RemoteAccessType.SSH,
+                     default=RemoteAccessType.JINAD,
                      type=RemoteAccessType.from_string,
                      help=f'host address of the pea/gateway, by default it is {__default_host__}.')
     return parser


### PR DESCRIPTION
I think the remote default should be jinad.

SSHRemote does not handle proper closure of `pod` and executors, just finished the `ssh` connection ?