### PR TITLE
fix: remote host_out None

### DIFF
--- a/jina/peapods/pod.py
+++ b/jina/peapods/pod.py
@@ -538,8 +538,7 @@ def _fill_in_host(bind_args: Namespace, connect_args: Namespace) -> str:
             return get_public_ip()
         else:
             return get_internal_ip()
-
-    if not bind_local and conn_local:
+    else:
         # in this case we (at local) need to know about remote the BIND address
         return bind_args.host
 

--- a/tests/unit/flow/test_remote_orchestrate.py
+++ b/tests/unit/flow/test_remote_orchestrate.py
@@ -54,3 +54,27 @@ def test_remote_pod_local_pod_remote_pod_local_gateway(local_ip, on_public):
     assert f['pod2'].host_out == __default_host__
     assert f['gateway'].host_in == remote2
     assert f['gateway'].host_out == remote1
+
+
+@pytest.mark.parametrize('local_ip, on_public', [(get_internal_ip(), False),
+                                                 (get_public_ip(), True)])
+def test_local_pod_remote_pod_remote_pod_local_gateway(local_ip, on_public):
+    remote1 = '111.111.111.111'
+    remote2 = '222.222.222.222'
+
+    f = Flow(expose_public=on_public).add().add(host=remote1).add(host=remote2)
+    f.build()
+
+    for k, v in f._pod_nodes.items():
+        print(f'{v.name}\tIN: {v.address_in}\t{v.address_out}')
+    assert f['pod0'].host_in == __default_host__
+    assert f['pod0'].host_out == remote1
+    assert f['pod1'].host_in == __default_host__
+    assert f['pod1'].host_out is None
+    assert f['pod2'].host_in == __default_host__
+    assert f['pod2'].host_out == __default_host__
+    assert f['gateway'].host_in == remote2
+    assert f['gateway'].host_out == __default_host__
+
+
+

--- a/tests/unit/flow/test_remote_orchestrate.py
+++ b/tests/unit/flow/test_remote_orchestrate.py
@@ -70,7 +70,7 @@ def test_local_pod_remote_pod_remote_pod_local_gateway(local_ip, on_public):
     assert f['pod0'].host_in == __default_host__
     assert f['pod0'].host_out == remote1
     assert f['pod1'].host_in == __default_host__
-    assert f['pod1'].host_out is None
+    assert f['pod1'].host_out == remote2
     assert f['pod2'].host_in == __default_host__
     assert f['pod2'].host_out == __default_host__
     assert f['gateway'].host_in == remote2

--- a/tests/unit/flow/test_remote_orchestrate.py
+++ b/tests/unit/flow/test_remote_orchestrate.py
@@ -65,7 +65,7 @@ def test_local_pod_remote_pod_remote_pod_local_gateway(local_ip, on_public):
     f = Flow(expose_public=on_public).add().add(host=remote1).add(host=remote2)
     f.build()
 
-    for k, v in f._pod_nodes.items():
+    for k, v in f:
         print(f'{v.name}\tIN: {v.address_in}\t{v.address_out}')
     assert f['pod0'].host_in == __default_host__
     assert f['pod0'].host_out == remote1
@@ -75,6 +75,5 @@ def test_local_pod_remote_pod_remote_pod_local_gateway(local_ip, on_public):
     assert f['pod2'].host_out == __default_host__
     assert f['gateway'].host_in == remote2
     assert f['gateway'].host_out == __default_host__
-
 
 


### PR DESCRIPTION
Without the change, in the test `assert f['pod1'].host_out == remote2` fails because it is None