### PR TITLE
test: help jinad integration

### DIFF
--- a/.github/workflows/test-jinad.yml
+++ b/.github/workflows/test-jinad.yml
@@ -31,21 +31,10 @@ jobs:
         with:
           repository: jina-ai/jinad
           path: jinad
-      - name: Install dependencies
+      - name: Build jina test-pip
         run: |
-          python -m pip install --upgrade pip
-          pip install .[cicd,test,http] requests --no-cache-dir
-      - name: Test jinad
-        run: |
-          jina check
-          export JINA_LOG_VERBOSITY="ERROR"
-          cd jinad/${{ matrix.path }}
-          pip install -r requirements.txt --no-cache-dir
-          pytest -s -v .
-        timeout-minutes: 30
-        env:
-          JINAHUB_USERNAME: ${{ secrets.JINAHUB_USERNAME }}
-          JINAHUB_PASSWORD: ${{ secrets.JINAHUB_PASSWORD }}
+          docker build -f Dockerfiles/pip.Dockerfile -t jinaai/jina:test-pip .
+          docker build --build-arg PIP_TAG="[devel]" -f Dockerfiles/pip.Dockerfile -t jinaai/jina:test-pip .
       - name: Test jinad
         run: |
           cd jinad/${{ matrix.path }}

--- a/jina/peapods/pod.py
+++ b/jina/peapods/pod.py
@@ -538,8 +538,7 @@ def _fill_in_host(bind_args: Namespace, connect_args: Namespace) -> str:
             return get_public_ip()
         else:
             return get_internal_ip()
-
-    if not bind_local and conn_local:
+    else:
         # in this case we (at local) need to know about remote the BIND address
         return bind_args.host
 

--- a/tests/integration/jinad/test_simple_distributed/Dockerfile
+++ b/tests/integration/jinad/test_simple_distributed/Dockerfile
@@ -1,5 +1,4 @@
-FROM python:3.7.6-slim
-FROM jinaai:jina:test-pip
+FROM jinaai/jina:test-pip
 
 WORKDIR /
 
@@ -7,13 +6,9 @@ RUN apt-get update && \
     apt-get install --no-install-recommends -y git \
                                                curl
 
-COPY tests/integration/jinad/test_simple_distributed/requirements.txt /requirements.txt
-
 RUN python -m pip install --no-cache-dir --upgrade pip && \
-    pip install --no-cache-dir -r tests/integration/jinad/test_simple_distributed/requirements.txt
-
-RUN git clone https://github.com/jina-ai/jinad.git && \
-    pip install --no-cache-dir --ignore-installed -r jinad/requirements.txt
+    git clone https://github.com/jina-ai/jinad.git && \
+    pip install $(grep -ivE "jina" jinad/requirements.txt)
 
 COPY . /
 

--- a/tests/integration/jinad/test_simple_distributed/docker-compose.yml
+++ b/tests/integration/jinad/test_simple_distributed/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.8"
+version: "3.3"
 services:
   flow:
     image: jinaai/jinad

--- a/tests/integration/jinad/test_simple_distributed/requirements.txt
+++ b/tests/integration/jinad/test_simple_distributed/requirements.txt
@@ -1,1 +1,0 @@
--e git+git://github.com/jina-ai/jina.git#egg=jina[scipy]


### PR DESCRIPTION
@rutujasurve94 I hope this one helps:

- Use test-pip image and build it in the yaml.

- Install jinad requirements avoiding it installing jina again.

- Remove requirements installation from jina since it uses the jina:test-pip image.

- To try locally, please build jina:test-pip locally by running in the jina root:

`docker build --build-arg PIP_TAG="[devel]" -f Dockerfiles/pip.Dockerfile -t jinaai/jina:test-pip .`

After that, u can run the bash or test manually to adapt properly the asserts