### PR TITLE
chore: add jina version info to docker image name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -188,6 +188,14 @@ Jina is released on every Friday evening. The PyPi package and Docker Image will
 - [Release Note (`0.7.2`)](#release-note-072)
 - [Release Note (`0.7.3`)](#release-note-073)
 - [Release Note (`0.7.4`)](#release-note-074)
+- [Release Note (`0.7.5`)](#release-note-075)
+- [Release Note (`0.7.6`)](#release-note-076)
+- [Release Note (`0.7.7`)](#release-note-077)
+- [Release Note (`0.7.8`)](#release-note-078)
+- [Release Note (`0.7.10`)](#release-note-0710)
+- [Release Note (`0.7.11`)](#release-note-0711)
+- [Release Note (`0.7.12`)](#release-note-0712)
+- [Release Note (`0.8.0`)](#release-note-080)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,19 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [Installation](#installation)
+- [Jina "Hello, World!" 👋🌍](#jina-hello-world-)
+- [Get Started](#get-started)
+- [Learn](#learn)
+- [Documentation](#documentation)
+- [Contributing](#contributing)
+- [Community](#community)
+- [Open Governance](#open-governance)
+- [Join Us](#join-us)
+- [License](#license)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 <p align="center">
 <img src="https://github.com/jina-ai/jina/blob/master/.github/logo-only.gif?raw=true" alt="Jina banner" width="200px">
 </p>

--- a/jina/docker/hubio.py
+++ b/jina/docker/hubio.py
@@ -24,6 +24,8 @@ from ..logging.profile import TimeContext
 from ..parser import set_pod_parser
 from ..peapods import Pod
 
+from jina import __version__ as jina_version
+
 if False:
     import argparse
 
@@ -488,7 +490,8 @@ class HubIO:
 
         self.manifest = self._read_manifest(self.manifest_path)
         self.dockerfile_path_revised = self._get_revised_dockerfile(self.dockerfile_path, self.manifest)
-        self.tag = safe_url_name(f'{self.args.repository}/' + '{type}.{kind}.{name}:{version}'.format(**self.manifest))
+        self.manifest['jina_version'] = jina_version
+        self.tag = safe_url_name(f'{self.args.repository}/' + '{type}.{kind}.{name}:{version}-{jina_version}'.format(**self.manifest))
         self.canonical_name = safe_url_name(f'{self.args.repository}/' + '{type}.{kind}.{name}'.format(**self.manifest))
         return completeness
 


### PR DESCRIPTION
Ex. `self.tag` will look like `'jinahub/pod.crafter.dummyhubexecutor:0.0.0--0.8.1'`