### PR TITLE
fix: add jina version info to docker image name

### DIFF
--- a/jina/docker/checker.py
+++ b/jina/docker/checker.py
@@ -68,7 +68,7 @@ def remove_control_characters(s):
 
 
 def safe_url_name(s):
-    return s.lower().replace('-', '--').replace('_', '__').replace(' ', '_')
+    return s.lower().replace('_', '__').replace(' ', '_')
 
 
 def get_exist_path(directory, s):

--- a/jina/docker/hubio.py
+++ b/jina/docker/hubio.py
@@ -8,6 +8,7 @@ import urllib.request
 import webbrowser
 from typing import Dict, Any
 
+from jina import __version__ as jina_version
 from .checker import *
 from .helper import credentials_file
 from .hubapi import _list, _register_to_mongodb, _list_local
@@ -488,7 +489,8 @@ class HubIO:
 
         self.manifest = self._read_manifest(self.manifest_path)
         self.dockerfile_path_revised = self._get_revised_dockerfile(self.dockerfile_path, self.manifest)
-        self.tag = safe_url_name(f'{self.args.repository}/' + '{type}.{kind}.{name}:{version}'.format(**self.manifest))
+        self.manifest['jina_version'] = jina_version
+        self.tag = safe_url_name(f'{self.args.repository}/' + '{type}.{kind}.{name}:{version}-{jina_version}'.format(**self.manifest))
         self.canonical_name = safe_url_name(f'{self.args.repository}/' + '{type}.{kind}.{name}'.format(**self.manifest))
         return completeness
 

--- a/tests/integration/hub_usage/test_hub_usage.py
+++ b/tests/integration/hub_usage/test_hub_usage.py
@@ -3,6 +3,7 @@ import subprocess
 
 import pytest
 
+from jina import __version__ as jina_version
 from jina.docker.hubio import HubIO
 from jina.excepts import PeaFailToStart, HubBuilderError
 from jina.executors import BaseExecutor
@@ -51,8 +52,7 @@ def test_use_from_local_dir_flow_container_level():
     args = set_hub_build_parser().parse_args(
         [os.path.join(cur_dir, 'dummyhub'), '--test-uses', '--raise-error'])
     HubIO(args).build()
-
-    with Flow().add(uses='jinahub/pod.crafter.dummyhubexecutor:0.0.0'):
+    with Flow().add(uses=f'jinahub/pod.crafter.dummyhubexecutor:0.0.0-{jina_version}'):
         pass
 
 


### PR DESCRIPTION
- Add jina version to hub image name. Required for https://github.com/jina-ai/jina/pull/1298
- Fix unnecessary `-` being replaced with `--`