### PR TITLE
chore(flow): no constructor for class method needed

### DIFF
--- a/docs/chapters/flow/index.md
+++ b/docs/chapters/flow/index.md
@@ -527,7 +527,7 @@ Passing `top_k_queryset` to `flow.search` will override `top_k` value of `10` wi
 Note that more than one `queryset` can be passed with any request.
 
 ```python
-    with Flow().load_config('flow.yml') as search_flow:
+    with Flow.load_config('flow.yml') as search_flow:
         search_flow.search(input_fn=docs, output_fn=print_results, queryset=[top_k_queryset])
 ```
 

--- a/tests/integration/evaluation/rank/test_evaluation.py
+++ b/tests/integration/evaluation/rank/test_evaluation.py
@@ -38,7 +38,7 @@ def test_evaluation(tmpdir):
 
         return [doc0, doc1, doc2]
 
-    with Flow().load_config('flow-index.yml') as index_flow:
+    with Flow.load_config('flow-index.yml') as index_flow:
         index_flow.index(input_fn=index_documents)
 
     def validate_evaluation_response(resp):
@@ -137,7 +137,7 @@ def test_evaluation(tmpdir):
 
         return [(doc0, groundtruth0), (doc1, groundtruth1)]
 
-    with Flow().load_config('flow-evaluate.yml') as evaluate_flow:
+    with Flow.load_config('flow-evaluate.yml') as evaluate_flow:
         evaluate_flow.search(
             input_fn=doc_groundtruth_evaluation_pairs,
             output_fn=validate_evaluation_response,

--- a/tests/integration/evaluation/test_evaluation_from_file.py
+++ b/tests/integration/evaluation/test_evaluation_from_file.py
@@ -68,7 +68,7 @@ def random_workspace(tmpdir):
                           ('flow-index-gt-parallel.yml', 'flow-parallel-evaluate-from-file-parallel.yml')
                           ])
 def test_evaluation_from_file(random_workspace, index_groundtruth, evaluate_docs, index_yaml, search_yaml):
-    with Flow().load_config(index_yaml) as index_gt_flow:
+    with Flow.load_config(index_yaml) as index_gt_flow:
         index_gt_flow.index(input_fn=index_groundtruth, override_doc_id=False)
 
     def validate_evaluation_response(resp):
@@ -81,7 +81,7 @@ def test_evaluation_from_file(random_workspace, index_groundtruth, evaluate_docs
         for gt in resp.groundtruths:
             assert gt.tags['groundtruth']
 
-    with Flow().load_config(search_yaml) as evaluate_flow:
+    with Flow.load_config(search_yaml) as evaluate_flow:
         evaluate_flow.search(
             input_fn=evaluate_docs,
             output_fn=validate_evaluation_response,

--- a/tests/integration/issues/github_976/test_topk.py
+++ b/tests/integration/issues/github_976/test_topk.py
@@ -34,9 +34,9 @@ def validate_results(resp):
 
 
 def test_topk(config):
-    with Flow().load_config('flow.yml') as index_flow:
+    with Flow.load_config('flow.yml') as index_flow:
         index_flow.index(input_fn=random_docs(100))
-    with Flow().load_config('flow.yml') as search_flow:
+    with Flow.load_config('flow.yml') as search_flow:
         search_flow.search(input_fn=random_docs(int(os.environ['JINA_NDOCS'])),
                            output_fn=validate_results)
 
@@ -51,8 +51,8 @@ def test_topk_override(config):
     # Making queryset
     top_k_queryset = QueryLang(VectorSearchDriver(top_k=int(os.environ['JINA_TOPK_OVERRIDE']), priority=1))
 
-    with Flow().load_config('flow.yml') as index_flow:
+    with Flow.load_config('flow.yml') as index_flow:
         index_flow.index(input_fn=random_docs(100))
-    with Flow().load_config('flow.yml') as search_flow:
+    with Flow.load_config('flow.yml') as search_flow:
         search_flow.search(input_fn=random_docs(int(os.environ['JINA_NDOCS'])),
                            output_fn=validate_override_results, queryset=[top_k_queryset])

--- a/tests/integration/level_depth/test_search_different_depths.py
+++ b/tests/integration/level_depth/test_search_different_depths.py
@@ -11,7 +11,7 @@ def test_index_depth_0_search_depth_1(tmpdir):
         'I am chunk 0 of doc 3, I am chunk 1 of doc 3, I am chunk 2 of doc 3, I am chunk 3 of doc 3',
     ]
 
-    index_flow = Flow().load_config('flow-index.yml')
+    index_flow = Flow.load_config('flow-index.yml')
     with index_flow:
         index_flow.index(index_data)
 
@@ -46,7 +46,7 @@ def test_index_depth_0_search_depth_1(tmpdir):
         ' I am chunk 3 of doc 3',
     ]
 
-    search_flow = Flow().load_config('flow-query.yml')
+    search_flow = Flow.load_config('flow-query.yml')
     with search_flow:
         search_flow.search(
             input_fn=search_data,


### PR DESCRIPTION
Since `load_config` is a `classmethod`, we don't need to call it on a Flow object. Instead we can call the `classmethod` directly.