### PR TITLE
refactor chunkset and matchset append method

### DIFF
--- a/jina/types/sets/chunk_set.py
+++ b/jina/types/sets/chunk_set.py
@@ -37,7 +37,9 @@ class ChunkSet(DocumentSet):
         chunk.set_attrs(parent_id=self._ref_doc.id,
                         granularity=self._ref_doc.granularity + 1,
                         **kwargs)
+
         if not chunk.mime_type:
             chunk.mime_type = self._ref_doc.mime_type
+        chunk.update_id()
 
         return chunk

--- a/jina/types/sets/chunk_set.py
+++ b/jina/types/sets/chunk_set.py
@@ -31,5 +31,5 @@ class ChunkSet(DocumentSet):
         if not chunk.mime_type:
             chunk.mime_type = self._ref_doc.mime_type
 
-        self._docs_proto.append(chunk)
+        self._docs_proto.append(chunk.as_pb_object)
         return chunk

--- a/jina/types/sets/chunk_set.py
+++ b/jina/types/sets/chunk_set.py
@@ -32,7 +32,7 @@ class ChunkSet(DocumentSet):
             chunk = Document()
             if document:
                 chunk.CopyFrom(document)
-            self._docs_proto.append(chunk.as_pb_object)
+            self._docs_proto.append(chunk)
 
         chunk.set_attrs(parent_id=self._ref_doc.id,
                         granularity=self._ref_doc.granularity + 1,

--- a/jina/types/sets/chunk_set.py
+++ b/jina/types/sets/chunk_set.py
@@ -20,15 +20,16 @@ class ChunkSet(DocumentSet):
             Comparing to :attr:`DocumentSet.append()`, this method adds more safeguard to
             make sure the added chunk is legit.
         """
-        c = self._docs_proto.add()
-        if document is not None:
-            c.CopyFrom(document.as_pb_object)
-
         from ..document import Document
-        with Document(c) as chunk:
-            chunk.set_attrs(parent_id=self._ref_doc.id,
-                            granularity=self._ref_doc.granularity + 1,
-                            **kwargs)
-            if not chunk.mime_type:
-                chunk.mime_type = self._ref_doc.mime_type
-            return chunk
+        chunk = Document()
+        if document:
+            chunk.CopyFrom(document)
+
+        chunk.set_attrs(parent_id=self._ref_doc.id,
+                        granularity=self._ref_doc.granularity + 1,
+                        **kwargs)
+        if not chunk.mime_type:
+            chunk.mime_type = self._ref_doc.mime_type
+
+        self._docs_proto.append(chunk)
+        return chunk

--- a/jina/types/sets/chunk_set.py
+++ b/jina/types/sets/chunk_set.py
@@ -21,15 +21,16 @@ class ChunkSet(DocumentSet):
             make sure the added chunk is legit.
         """
         from ..document import Document
-        chunk = Document()
-        if document:
-            chunk.CopyFrom(document)
+        with Document() as chunk:
+            if document:
+                chunk.CopyFrom(document)
 
-        chunk.set_attrs(parent_id=self._ref_doc.id,
-                        granularity=self._ref_doc.granularity + 1,
-                        **kwargs)
-        if not chunk.mime_type:
-            chunk.mime_type = self._ref_doc.mime_type
+            chunk.set_attrs(parent_id=self._ref_doc.id,
+                            granularity=self._ref_doc.granularity + 1,
+                            **kwargs)
 
-        self._docs_proto.append(chunk.as_pb_object)
-        return chunk
+            if not chunk.mime_type:
+                chunk.mime_type = self._ref_doc.mime_type
+
+            self._docs_proto.append(chunk.as_pb_object)
+            return chunk

--- a/jina/types/sets/match_set.py
+++ b/jina/types/sets/match_set.py
@@ -33,7 +33,7 @@ class MatchSet(DocumentSet):
         match.set_attrs(parent_id=self._ref_doc.id,
                         granularity=self._ref_doc.granularity + 1,
                         **kwargs)
+        match.score.ref_id = self._ref_doc.id
         if not match.mime_type:
             match.mime_type = self._ref_doc.mime_type
-
         return match

--- a/jina/types/sets/match_set.py
+++ b/jina/types/sets/match_set.py
@@ -30,9 +30,9 @@ class MatchSet(DocumentSet):
                 match.CopyFrom(document)
             self._docs_proto.append(match)
 
-        match.set_attrs(parent_id=self._ref_doc.id,
-                        granularity=self._ref_doc.granularity + 1,
-                        **kwargs)
+        match.set_attrs(granularity=self._ref_doc.granularity,
+                    adjacency=self._ref_doc.adjacency + 1,
+                    **kwargs)
         match.score.ref_id = self._ref_doc.id
         if not match.mime_type:
             match.mime_type = self._ref_doc.mime_type

--- a/jina/types/sets/match_set.py
+++ b/jina/types/sets/match_set.py
@@ -28,7 +28,7 @@ class MatchSet(DocumentSet):
             match = Document()
             if document:
                 match.CopyFrom(document)
-            self._docs_proto.append(match.as_pb_object)
+            self._docs_proto.append(match)
 
         match.set_attrs(parent_id=self._ref_doc.id,
                         granularity=self._ref_doc.granularity + 1,

--- a/jina/types/sets/match_set.py
+++ b/jina/types/sets/match_set.py
@@ -2,6 +2,8 @@ from typing import Optional
 
 from .document_set import DocumentSet
 
+from google.protobuf.pyext._message import RepeatedCompositeContainer
+
 if False:
     from ..document import Document
 
@@ -16,17 +18,22 @@ class MatchSet(DocumentSet):
 
         :return: the newly added sub-document in :class:`Document` view
         """
-        c = self._docs_proto.add()
-        if document is not None:
-            c.CopyFrom(document.as_pb_object)
-
         from ..document import Document
-        m = Document(c)
-        m.set_attrs(granularity=self._ref_doc.granularity,
-                    adjacency=self._ref_doc.adjacency + 1,
-                    **kwargs)
+        if isinstance(self._docs_proto, RepeatedCompositeContainer):
+            m = self._docs_proto.add()
+            if document:
+                m.CopyFrom(document.as_pb_object)
+            match = Document(m)
+        else:
+            match = Document()
+            if document:
+                match.CopyFrom(document)
+            self._docs_proto.append(match.as_pb_object)
 
-        m.score.ref_id = self._ref_doc.id
-        if not m.mime_type:
-            m.mime_type = self._ref_doc.mime_type
-        return m
+        match.set_attrs(parent_id=self._ref_doc.id,
+                        granularity=self._ref_doc.granularity + 1,
+                        **kwargs)
+        if not match.mime_type:
+            match.mime_type = self._ref_doc.mime_type
+
+        return match

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -6,7 +6,7 @@ from os.path import dirname
 
 import numpy as np
 
-from jina.types.document import uid, Document
+from jina.types.document import Document
 
 
 file_dir = os.path.dirname(__file__)

--- a/tests/unit/types/test_chunkset.py
+++ b/tests/unit/types/test_chunkset.py
@@ -6,17 +6,18 @@ from jina.types.sets.chunk_set import ChunkSet
 @pytest.fixture(scope='function')
 def document_factory():
     class DocumentFactory(object):
-        def create(self, idx, text, ):
+        def create(self, idx, text, mime_type=None):
             with Document() as d:
                 d.tags['id'] = idx
                 d.text = text
+                d.mime_type = mime_type
             return d
 
     return DocumentFactory()
 
 @pytest.fixture
 def reference_doc(document_factory):
-    return document_factory.create(0, 'test ref')
+    return document_factory.create(0, 'test ref', 'text/plain')
 
 @pytest.fixture
 def chunks(document_factory):
@@ -38,3 +39,4 @@ def test_append_from_documents(chunkset, document_factory, reference_doc):
     assert rv.text == chunk.text
     assert rv.parent_id == reference_doc.id
     assert rv.granularity == reference_doc.granularity + 1
+    assert rv.mime_type == 'text/plain'

--- a/tests/unit/types/test_chunkset.py
+++ b/tests/unit/types/test_chunkset.py
@@ -1,0 +1,39 @@
+import pytest
+
+from jina.types.document import Document
+from jina.types.sets.chunk_set import ChunkSet
+
+@pytest.fixture(scope='function')
+def document_factory():
+    class DocumentFactory(object):
+        def create(self, idx, text, ):
+            with Document() as d:
+                d.tags['id'] = idx
+                d.text = text
+            return d
+
+    return DocumentFactory()
+
+@pytest.fixture
+def reference_doc(document_factory):
+    return document_factory.create(0, 'test ref')
+
+@pytest.fixture
+def docs(document_factory):
+    return [
+        document_factory.create(1, 'test 1'),
+        document_factory.create(2, 'test 1'),
+        document_factory.create(3, 'test 3')
+    ]
+
+@pytest.fixture
+def chunkset(docs, reference_doc):
+    return ChunkSet(docs_proto=docs, reference_doc=reference_doc)
+
+def test_append_from_documents(chunkset, document_factory):
+    chunk = document_factory.create(4, 'test 4')
+    rv = chunkset.append(chunk)
+    assert len(chunkset) == 4
+    assert chunkset[-1].text == 'test 4'
+    assert rv.text == chunk.text
+    assert rv.id == chunk.id

--- a/tests/unit/types/test_chunkset.py
+++ b/tests/unit/types/test_chunkset.py
@@ -30,10 +30,12 @@ def docs(document_factory):
 def chunkset(docs, reference_doc):
     return ChunkSet(docs_proto=docs, reference_doc=reference_doc)
 
-def test_append_from_documents(chunkset, document_factory):
+def test_append_from_documents(chunkset, document_factory, reference_doc):
     chunk = document_factory.create(4, 'test 4')
     rv = chunkset.append(chunk)
     assert len(chunkset) == 4
     assert chunkset[-1].text == 'test 4'
     assert rv.text == chunk.text
     assert rv.id == chunk.id
+    assert rv.parent_id == reference_doc.id
+    assert rv.granularity == reference_doc.granularity + 1

--- a/tests/unit/types/test_chunkset.py
+++ b/tests/unit/types/test_chunkset.py
@@ -36,6 +36,5 @@ def test_append_from_documents(chunkset, document_factory, reference_doc):
     assert len(chunkset) == 4
     assert chunkset[-1].text == 'test 4'
     assert rv.text == chunk.text
-    assert rv.id == chunk.id
     assert rv.parent_id == reference_doc.id
     assert rv.granularity == reference_doc.granularity + 1

--- a/tests/unit/types/test_documentset.py
+++ b/tests/unit/types/test_documentset.py
@@ -6,7 +6,7 @@ from jina.types.sets import DocumentSet
 @pytest.fixture(scope='function')
 def document_factory():
     class DocumentFactory(object):
-        def create(self, idx, text, ):
+        def create(self, idx, text):
             with Document() as d:
                 d.tags['id'] = idx
                 d.text = text

--- a/tests/unit/types/test_matchset.py
+++ b/tests/unit/types/test_matchset.py
@@ -37,7 +37,7 @@ def test_append_from_documents(matchset, document_factory, reference_doc):
     assert len(matchset) == 4
     assert matchset[-1].text == 'test 4'
     assert rv.text == match.text
-    assert rv.parent_id == reference_doc.id
-    assert rv.granularity == reference_doc.granularity + 1
+    assert rv.granularity == reference_doc.granularity
+    assert rv.adjacency == reference_doc.adjacency + 1
     assert rv.mime_type == 'text/plain'
     assert rv.score.ref_id == reference_doc.id

--- a/tests/unit/types/test_matchset.py
+++ b/tests/unit/types/test_matchset.py
@@ -1,7 +1,7 @@
 import pytest
 
 from jina.types.document import Document
-from jina.types.sets.chunk_set import ChunkSet
+from jina.types.sets.match_set import MatchSet
 
 @pytest.fixture(scope='function')
 def document_factory():
@@ -19,7 +19,7 @@ def reference_doc(document_factory):
     return document_factory.create(0, 'test ref')
 
 @pytest.fixture
-def chunks(document_factory):
+def matches(document_factory):
     return [
         document_factory.create(1, 'test 1'),
         document_factory.create(2, 'test 1'),
@@ -27,14 +27,14 @@ def chunks(document_factory):
     ]
 
 @pytest.fixture
-def chunkset(chunks, reference_doc):
-    return ChunkSet(docs_proto=chunks, reference_doc=reference_doc)
+def matchset(matches, reference_doc):
+    return MatchSet(docs_proto=matches, reference_doc=reference_doc)
 
-def test_append_from_documents(chunkset, document_factory, reference_doc):
-    chunk = document_factory.create(4, 'test 4')
-    rv = chunkset.append(chunk)
-    assert len(chunkset) == 4
-    assert chunkset[-1].text == 'test 4'
-    assert rv.text == chunk.text
+def test_append_from_documents(matchset, document_factory, reference_doc):
+    match = document_factory.create(4, 'test 4')
+    rv = matchset.append(match)
+    assert len(matchset) == 4
+    assert matchset[-1].text == 'test 4'
+    assert rv.text == match.text
     assert rv.parent_id == reference_doc.id
     assert rv.granularity == reference_doc.granularity + 1

--- a/tests/unit/types/test_matchset.py
+++ b/tests/unit/types/test_matchset.py
@@ -6,17 +6,18 @@ from jina.types.sets.match_set import MatchSet
 @pytest.fixture(scope='function')
 def document_factory():
     class DocumentFactory(object):
-        def create(self, idx, text, ):
+        def create(self, idx, text, mime_type=None):
             with Document() as d:
                 d.tags['id'] = idx
                 d.text = text
+                d.mime_type = mime_type
             return d
 
     return DocumentFactory()
 
 @pytest.fixture
 def reference_doc(document_factory):
-    return document_factory.create(0, 'test ref')
+    return document_factory.create(0, 'test ref', 'text/plain')
 
 @pytest.fixture
 def matches(document_factory):
@@ -38,3 +39,5 @@ def test_append_from_documents(matchset, document_factory, reference_doc):
     assert rv.text == match.text
     assert rv.parent_id == reference_doc.id
     assert rv.granularity == reference_doc.granularity + 1
+    assert rv.mime_type == 'text/plain'
+    assert rv.score.ref_id == reference_doc.id


### PR DESCRIPTION
blocking #1368 .
When refactoring `traverse_apply`, need a lot of chunk level test cases. While `ChunkSet.append` is not working when append document on `Sequence[Document]`. 
![image](https://user-images.githubusercontent.com/9794489/100542799-ae69ba80-324c-11eb-8cf9-6ce65af6ab24.png)

Why?
`docs_proto` was defined as `Union['RepeatedCompositeContainer', Sequence['Document']]`, the current implementation does not support operations on sequence of documents.

What has been changed?
1. Refactored `MatchSet` and `ChunkSet` , allow `append` operation on a list of document.
2. Add tests.

Didn't add unit test case to initialise a `DocumentSet` or `MatchSet` when `self._docs_proto`  is `RepeatedCompositeContainer`. (I was not able to initialise `RepeatedCompositeContainer` manually, while it has been covered when testing a driver).