### PR TITLE
docs(contributing): fix link to commit style

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,7 @@ Right now we're working on a list of things we want help with and easy-to-fix bu
 1. Fork the Jina repo and clone onto your computer. By default, `git` won't clone `jina/hub` as it is a submodule maintained at [`jina-ai/jina-hub`](https://github.com/jina-ai/jina-hub). Please follow [the steps](#check-out-jina-hub-submodule) for details. 
 2. Create a [new branch](#naming-your-branch), for example `fix-jina-typo-1`.
 3. Work on this branch to do the fix/improvement.
-4. Commit the changes with the [correct commit style](#commit-message).
+4. Commit the changes with the [correct commit style](#writing-your-commit-message).
 5. Make a pull request. 
 6. Submit your pull request and wait for all checks to pass.
 7. Request reviews from one of [the code owners](.github/CODEOWNERS).


### PR DESCRIPTION
Otherwise in github the link doesn't work: [https://github.com/jina-ai/jina/blob/master/CONTRIBUTING.md#commit-message](https://github.com/jina-ai/jina/blob/master/CONTRIBUTING.md#commit-message)

After the fix the link works: [https://github.com/serge-m/jina/blob/docs-contributing-patch/CONTRIBUTING.md#writing-your-commit-message](https://github.com/serge-m/jina/blob/docs-contributing-patch/CONTRIBUTING.md#writing-your-commit-message)