### PR TITLE
fix: allow indexers to have workspace

### DIFF
--- a/jina/executors/__init__.py
+++ b/jina/executors/__init__.py
@@ -194,7 +194,7 @@ class BaseExecutor(metaclass=ExecutorType):
         if not getattr(self, 'name', None):
             _id = get_random_identity().split('-')[0]
             _name = f'{typename(self)}-{_id}'
-            if self.warn_unnamed:
+            if getattr(self, 'warn_unnamed', False):
                 self.logger.warning(
                     f'this executor is not named, i will call it "{_name}". '
                     'naming is important as it provides an unique identifier when '


### PR DESCRIPTION
We want to allow setting of `workspace` in Indexers without name. 

Brought up in #1380 , when tried setting `meta={'workspace': tmpdir}` but I get an error

like so
```    
with BinaryPbIndexer('pbdix.bin', metas={'workspace': tmpdir.strpath}) as idxer:
```

```
(<class 'AttributeError'>, AttributeError("'BinaryPbIndexer' object has no attribute 'warn_unnamed'"), <traceback object at 0x7f243731fec0>)
```

Copying the approach from here worked https://github.com/jina-ai/jina/blob/008638d3e61c20c585b376ea003be712123a6eb2/tests/unit/executors/indexers/test_numpyindexer.py#L39


```    
metas = {
        'is_trained': False,
        'is_updated': False,
        'batch_size': None,
        'workspace': f'{tmpdir}',
        'name': None,
        'on_gpu': False,
        'warn_unnamed': False,
        'max_snapshot': 0,
        'py_modules': None,
        'pea_id': '{root.metas.pea_id}',
        'separated_workspace': '{root.metas.separated_workspace}',
    }
    # FIXME how to open a specific file in a dir. os.path.join(tmpdir, file) doesn't work
    with BinaryPbIndexer('pbidx', metas=metas) as idxer:
```

Now the idx files are stored in the tmpdir, instead of the curdir.

Seems like the issue is with `        'warn_unnamed': False,`