### PR TITLE
refactor(types): move extract embeddings and contents into docset

### DIFF
--- a/jina/drivers/encode.py
+++ b/jina/drivers/encode.py
@@ -19,10 +19,10 @@ class EncodeDriver(BaseEncodeDriver):
     """
 
     def _apply_all(self, docs: 'DocumentSet', *args, **kwargs) -> None:
-        contents, docs_pts, bad_doc_ids = docs.all_contents
+        contents, docs_pts, bad_docs = docs.all_contents
 
-        if bad_doc_ids:
-            self.logger.warning(f'these bad docs can not be added: {bad_doc_ids} '
+        if bad_docs:
+            self.logger.warning(f'these bad docs can not be added: {bad_docs} '
                                 f'from level depth {docs_pts[0].granularity}')
 
         if docs_pts:

--- a/jina/drivers/encode.py
+++ b/jina/drivers/encode.py
@@ -2,7 +2,6 @@ __copyright__ = "Copyright (c) 2020 Jina AI Limited. All rights reserved."
 __license__ = "Apache-2.0"
 
 from . import BaseExecutableDriver
-from ..types.document.helper import extract_content
 
 if False:
     from ..types.sets import DocumentSet
@@ -20,7 +19,7 @@ class EncodeDriver(BaseEncodeDriver):
     """
 
     def _apply_all(self, docs: 'DocumentSet', *args, **kwargs) -> None:
-        contents, docs_pts, bad_doc_ids = extract_content(docs)
+        contents, docs_pts, bad_doc_ids = docs.all_contents
 
         if bad_doc_ids:
             self.logger.warning(f'these bad docs can not be added: {bad_doc_ids} '

--- a/jina/drivers/index.py
+++ b/jina/drivers/index.py
@@ -4,7 +4,6 @@ __license__ = "Apache-2.0"
 import numpy as np
 
 from . import BaseExecutableDriver
-from ..types.document.helper import extract_embedding
 
 if False:
     from ..types.sets import DocumentSet
@@ -22,7 +21,7 @@ class VectorIndexDriver(BaseIndexDriver):
     """
 
     def _apply_all(self, docs: 'DocumentSet', *args, **kwargs) -> None:
-        embed_vecs, docs_pts, bad_doc_ids = extract_embedding(docs)
+        embed_vecs, docs_pts, bad_doc_ids = docs.all_embeddings
 
         if bad_doc_ids:
             self.pea.logger.warning(f'these bad docs can not be added: {bad_doc_ids}')

--- a/jina/drivers/index.py
+++ b/jina/drivers/index.py
@@ -21,10 +21,10 @@ class VectorIndexDriver(BaseIndexDriver):
     """
 
     def _apply_all(self, docs: 'DocumentSet', *args, **kwargs) -> None:
-        embed_vecs, docs_pts, bad_doc_ids = docs.all_embeddings
+        embed_vecs, docs_pts, bad_docs = docs.all_embeddings
 
-        if bad_doc_ids:
-            self.pea.logger.warning(f'these bad docs can not be added: {bad_doc_ids}')
+        if bad_docs:
+            self.pea.logger.warning(f'these bad docs can not be added: {bad_docs}')
 
         if docs_pts:
             self.exec_fn(np.array([hash(doc.id) for doc in docs_pts]), np.stack(embed_vecs))

--- a/jina/drivers/predict.py
+++ b/jina/drivers/predict.py
@@ -5,7 +5,6 @@ import numpy as np
 from . import BaseExecutableDriver
 from ..helper import typename
 from ..types.document import Document
-from ..types.document.helper import extract_embedding
 
 if False:
     from ..types.sets import DocumentSet
@@ -38,7 +37,7 @@ class BaseLabelPredictDriver(BasePredictDriver):
             *args,
             **kwargs,
     ) -> None:
-        embed_vecs, docs_pts, bad_doc_ids = extract_embedding(docs)
+        embed_vecs, docs_pts, bad_doc_ids = docs.all_embeddings
 
         if bad_doc_ids:
             self.pea.logger.warning(f'these bad docs can not be added: {bad_doc_ids}')
@@ -153,7 +152,7 @@ class Prediction2DocBlobDriver(BasePredictDriver):
             *args,
             **kwargs,
     ) -> None:
-        embed_vecs, docs_pts, bad_doc_ids = extract_embedding(docs)
+        embed_vecs, docs_pts, bad_doc_ids = docs.all_embeddings
 
         if bad_doc_ids:
             self.pea.logger.warning(f'these bad docs can not be added: {bad_doc_ids}')

--- a/jina/drivers/predict.py
+++ b/jina/drivers/predict.py
@@ -37,10 +37,10 @@ class BaseLabelPredictDriver(BasePredictDriver):
             *args,
             **kwargs,
     ) -> None:
-        embed_vecs, docs_pts, bad_doc_ids = docs.all_embeddings
+        embed_vecs, docs_pts, bad_docs = docs.all_embeddings
 
-        if bad_doc_ids:
-            self.pea.logger.warning(f'these bad docs can not be added: {bad_doc_ids}')
+        if bad_docs:
+            self.pea.logger.warning(f'these bad docs can not be added: {bad_docs}')
 
         if docs_pts:
             prediction = self.exec_fn(embed_vecs)
@@ -152,10 +152,10 @@ class Prediction2DocBlobDriver(BasePredictDriver):
             *args,
             **kwargs,
     ) -> None:
-        embed_vecs, docs_pts, bad_doc_ids = docs.all_embeddings
+        embed_vecs, docs_pts, bad_docs = docs.all_embeddings
 
-        if bad_doc_ids:
-            self.pea.logger.warning(f'these bad docs can not be added: {bad_doc_ids}')
+        if bad_docs:
+            self.pea.logger.warning(f'these bad docs can not be added: {bad_docs}')
 
         if docs_pts:
             prediction = self.exec_fn(embed_vecs)

--- a/jina/drivers/search.py
+++ b/jina/drivers/search.py
@@ -107,7 +107,7 @@ class VectorSearchDriver(QuerySetReader, BaseSearchDriver):
         self._fill_embedding = fill_embedding
 
     def _apply_all(self, docs: 'DocumentSet', *args, **kwargs) -> None:
-        embed_vecs, doc_pts, bad_doc_ids = docs.all_embeddings
+        embed_vecs, doc_pts, bad_docs = docs.all_embeddings
 
         if not doc_pts:
             return
@@ -116,8 +116,8 @@ class VectorSearchDriver(QuerySetReader, BaseSearchDriver):
         if self._fill_embedding and not fill_fn:
             self.logger.warning(f'"fill_embedding=True" but {self.exec} does not have "query_by_id" method')
 
-        if bad_doc_ids:
-            self.logger.warning(f'these bad docs can not be added: {bad_doc_ids}')
+        if bad_docs:
+            self.logger.warning(f'these bad docs can not be added: {bad_docs}')
         idx, dist = self.exec_fn(embed_vecs, top_k=int(self.top_k))
         op_name = self.exec.__class__.__name__
         for doc, topks, scores in zip(doc_pts, idx, dist):

--- a/jina/drivers/search.py
+++ b/jina/drivers/search.py
@@ -4,8 +4,7 @@ __license__ = "Apache-2.0"
 from typing import Tuple
 
 from . import BaseExecutableDriver, QuerySetReader
-from ..types.document import uid, Document
-from ..types.document.helper import extract_embedding
+from ..types.document import Document
 
 if False:
     from ..types.sets import DocumentSet
@@ -108,7 +107,7 @@ class VectorSearchDriver(QuerySetReader, BaseSearchDriver):
         self._fill_embedding = fill_embedding
 
     def _apply_all(self, docs: 'DocumentSet', *args, **kwargs) -> None:
-        embed_vecs, doc_pts, bad_doc_ids = extract_embedding(docs)
+        embed_vecs, doc_pts, bad_doc_ids = docs.all_embeddings
 
         if not doc_pts:
             return

--- a/jina/types/document/helper.py
+++ b/jina/types/document/helper.py
@@ -1,51 +1,8 @@
-from typing import Iterable, Tuple, List
-
-import numpy as np
+from typing import Iterable
 
 from . import Document
 
-__all__ = ['extract_embedding', 'extract_content', 'DocGroundtruthPair']
-
-
-def extract_embedding(docs: Iterable['Document']) -> Tuple['np.ndarray',
-                                                           List['Document'], List[Tuple[str, str]]]:
-    return _extract_docs(docs, 'embedding')
-
-
-def extract_content(docs: Iterable['Document']) -> Tuple['np.ndarray',
-                                                         List['Document'], List[Tuple[str, str]]]:
-    return _extract_docs(docs, 'content')
-
-
-def _extract_docs(docs: Iterable['Document'], attr: str) -> Tuple['np.ndarray',
-                                                                  List['Document'], List[Tuple[str, str]]]:
-    """Iterate over a list of protobuf documents and extract chunk-level information from them
-
-    :param docs: an iterable of protobuf documents
-    :param embedding: an indicator of extracting embedding or not.
-                    If ``True`` then all doc-level embedding are extracted.
-                    If ``False`` then ``text``, ``buffer``, ``blob`` info of each doc are extracted
-    :return: A tuple of 3 pieces:
-
-            - a numpy ndarray of extracted info
-            - the corresponding doc references
-            - the doc_id list where the doc has no contents, useful for debugging
-    """
-    contents = []
-    docs_pts = []
-    bad_doc_ids = []
-
-    for doc in docs:
-        content = getattr(doc, attr)
-
-        if content is not None:
-            contents.append(content)
-            docs_pts.append(doc)
-        else:
-            bad_doc_ids.append((doc.id, doc.parent_id))
-
-    contents = np.stack(contents) if contents else None
-    return contents, docs_pts, bad_doc_ids
+__all__ = ['DocGroundtruthPair']
 
 
 class DocGroundtruthPair:

--- a/jina/types/sets/document_set.py
+++ b/jina/types/sets/document_set.py
@@ -1,6 +1,7 @@
 from collections.abc import MutableSequence
-from typing import Iterable, Union, Sequence
+from typing import Union, Sequence, Iterable, Tuple
 
+import numpy as np
 from google.protobuf.pyext._message import RepeatedCompositeContainer
 
 from ...proto.jina_pb2 import DocumentProto
@@ -88,3 +89,44 @@ class DocumentSet(MutableSequence):
 
     def sort(self, *args, **kwargs):
         self._docs_proto.sort(*args, **kwargs)
+
+    @property
+    def all_embeddings(self) -> Tuple['np.ndarray', 'DocumentSet', 'DocumentSet']:
+        """Return all embeddings from every document in this set as a ndarray
+
+        :return a tuple of embedding in :class:`np.ndarray`,
+                the corresponding documents in a :class:`DocumentSet`,
+                and the documents have no embedding in a :class:`DocumentSet`.
+        """
+        return self._extract_docs('embedding')
+
+    @property
+    def all_contents(self) -> Tuple['np.ndarray', 'DocumentSet', 'DocumentSet']:
+        """Return all embeddings from every document in this set as a ndarray
+
+        :return a tuple of embedding in :class:`np.ndarray`,
+                the corresponding documents in a :class:`DocumentSet`,
+                and the documents have no contents in a :class:`DocumentSet`.
+        """
+        return self._extract_docs('content')
+
+    def _extract_docs(self, attr: str) -> Tuple['np.ndarray', 'DocumentSet', 'DocumentSet']:
+        contents = []
+        docs_pts = []
+        bad_docs = []
+
+        for doc in self:
+            content = getattr(doc, attr)
+
+            if content is not None:
+                contents.append(content)
+                docs_pts.append(doc)
+            else:
+                bad_docs.append(doc)
+
+        contents = np.stack(contents) if contents else None
+        return contents, DocumentSet(docs_pts), DocumentSet(bad_docs)
+
+    def __bool__(self):
+        """To simulate ```l = []; if l: ...``` """
+        return bool(len(self))

--- a/tests/unit/drivers/test_encoder_driver.py
+++ b/tests/unit/drivers/test_encoder_driver.py
@@ -1,11 +1,9 @@
 from typing import Any
 
 import numpy as np
-
-from jina import Document
+from jina import Document, DocumentSet
 from jina.drivers.encode import EncodeDriver
 from jina.executors.encoders import BaseEncoder
-from jina.types.ndarray.generic import NdArray
 
 
 class MockEncoder(BaseEncoder):
@@ -33,7 +31,7 @@ def create_documents_to_encode(num_docs):
         doc = Document(content=np.array([idx]))
 
         docs.append(doc)
-    return docs
+    return DocumentSet(docs)
 
 
 def test_encode_driver():

--- a/tests/unit/drivers/test_helper.py
+++ b/tests/unit/drivers/test_helper.py
@@ -65,14 +65,14 @@ def test_add_route():
 def test_extract_docs():
     d = Document()
 
-    contents, docs_pts, bad_doc_ids = DocumentSet([d]).all_embeddings
-    assert len(bad_doc_ids) > 0
+    contents, docs_pts, bad_docs = DocumentSet([d]).all_embeddings
+    assert len(bad_docs) > 0
     assert contents is None
 
     vec = np.random.random([2, 2])
     d.embedding = vec
-    contents, docs_pts, bad_doc_ids = DocumentSet([d]).all_embeddings
-    assert len(bad_doc_ids) == 0
+    contents, docs_pts, bad_docs = DocumentSet([d]).all_embeddings
+    assert len(bad_docs) == 0
     np.testing.assert_equal(contents[0], vec)
 
 

--- a/tests/unit/drivers/test_helper.py
+++ b/tests/unit/drivers/test_helper.py
@@ -3,9 +3,9 @@ import random
 import numpy as np
 import pytest
 
-from jina import Document
+from jina import Document, DocumentSet
 from jina.proto import jina_pb2
-from jina.types.document.helper import extract_embedding, DocGroundtruthPair
+from jina.types.document.helper import DocGroundtruthPair
 from jina.types.message import Message
 from jina.types.ndarray.generic import NdArray
 
@@ -65,13 +65,13 @@ def test_add_route():
 def test_extract_docs():
     d = Document()
 
-    contents, docs_pts, bad_doc_ids = extract_embedding([d])
+    contents, docs_pts, bad_doc_ids = DocumentSet([d]).all_embeddings
     assert len(bad_doc_ids) > 0
     assert contents is None
 
     vec = np.random.random([2, 2])
     d.embedding = vec
-    contents, docs_pts, bad_doc_ids = extract_embedding([d])
+    contents, docs_pts, bad_doc_ids = DocumentSet([d]).all_embeddings
     assert len(bad_doc_ids) == 0
     np.testing.assert_equal(contents[0], vec)
 

--- a/tests/unit/drivers/test_predict_mock_driver.py
+++ b/tests/unit/drivers/test_predict_mock_driver.py
@@ -35,7 +35,7 @@ class MockPrediction2DocBlobDriver(Prediction2DocBlobDriver):
 
 
 def test_binary_predict_driver():
-    docs = list(random_docs(2))
+    docs = DocumentSet(random_docs(2))
     driver = MockBinaryPredictDriver()
     driver._traverse_apply(docs)
 
@@ -46,7 +46,7 @@ def test_binary_predict_driver():
 
 
 def test_one_hot_predict_driver():
-    docs = list(random_docs(2))
+    docs = DocumentSet(random_docs(2))
     driver = MockOneHotPredictDriver(labels=['cat', 'dog', 'human'])
     driver._traverse_apply(docs)
 
@@ -57,7 +57,7 @@ def test_one_hot_predict_driver():
 
 
 def test_multi_label_predict_driver():
-    docs = list(random_docs(2))
+    docs = DocumentSet(random_docs(2))
     driver = MockMultiLabelPredictDriver(labels=['cat', 'dog', 'human'])
     driver._traverse_apply(docs)
 
@@ -66,7 +66,7 @@ def test_multi_label_predict_driver():
         for t in d.tags['prediction']:
             assert t in {'cat', 'dog', 'human'}
 
-    docs = list(random_docs(2))
+    docs = DocumentSet(random_docs(2))
     driver = MockAllLabelPredictDriver(labels=['cat', 'dog', 'human'])
     driver._traverse_apply(docs)
 


### PR DESCRIPTION
Note: `__str__` and `__repr__` on Jina types are out of scope of this PR