### PR TITLE
fix: change numpy metric cosine

### DIFF
--- a/jina/executors/indexers/vector.py
+++ b/jina/executors/indexers/vector.py
@@ -220,7 +220,7 @@ class NumpyIndexer(BaseNumpyIndexer):
 
     batch_size = 512
 
-    def __init__(self, metric: str = 'euclidean',
+    def __init__(self, metric: str = 'cosine',
                  backend: str = 'numpy',
                  compress_level: int = 0,
                  *args, **kwargs):

--- a/jina/resources/helloworld.indexer.yml
+++ b/jina/resources/helloworld.indexer.yml
@@ -3,6 +3,7 @@ components:
   - !NumpyIndexer
     with:
       index_filename: vec.gz
+      metric: euclidean
     metas:
       name: vecidx  # a customized name
       workspace: $HW_WORKDIR

--- a/tests/integration/high_order_matches/test-adjacency-integrated.yml
+++ b/tests/integration/high_order_matches/test-adjacency-integrated.yml
@@ -1,6 +1,7 @@
 !NumpyIndexer
 with:
   index_filename: tmp2
+  metric: euclidean
 metas:
   name: test2
   workspace: test-index-file

--- a/tests/integration/high_order_matches/test-adjacency.yml
+++ b/tests/integration/high_order_matches/test-adjacency.yml
@@ -1,6 +1,7 @@
 !NumpyIndexer
 with:
   index_filename: tmp2
+  metric: euclidean
 metas:
   name: test2
   workspace: test-index-file

--- a/tests/integration/incremental_indexing/uniq_vectorindexer.yml
+++ b/tests/integration/incremental_indexing/uniq_vectorindexer.yml
@@ -7,6 +7,7 @@ components:
   - !NumpyIndexer
     with:
       index_filename: vec.gz
+      metric: euclidean
     metas:
       workspace: $JINA_TEST_INCREMENTAL_INDEX_WORKSPACE
       name: vec_idx

--- a/tests/integration/incremental_indexing/vectorindexer.yml
+++ b/tests/integration/incremental_indexing/vectorindexer.yml
@@ -1,6 +1,7 @@
 !NumpyIndexer
 with:
   index_filename: vec.gz
+  metric: euclidean
 metas:
   workspace: $JINA_TEST_INCREMENTAL_INDEX_WORKSPACE
   name: vec_idx

--- a/tests/integration/jinad/test_index_query/pods/index.yml
+++ b/tests/integration/jinad/test_index_query/pods/index.yml
@@ -3,6 +3,7 @@ components:
   - !NumpyIndexer
     with:
       index_filename: vec.gz
+      metric: euclidean
     metas:
       name: vecidx
       workspace: $JINA_WORKSPACE

--- a/tests/integration/jinad/test_index_query_with_shards/pods/index.yml
+++ b/tests/integration/jinad/test_index_query_with_shards/pods/index.yml
@@ -3,6 +3,7 @@ components:
   - !NumpyIndexer
     with:
       index_filename: vec.gz
+      metric: euclidean
     metas:
       name: vecidx
       workspace: $JINA_WORKSPACE

--- a/tests/unit/executors/indexers/test_numpyindexer.py
+++ b/tests/unit/executors/indexers/test_numpyindexer.py
@@ -21,7 +21,7 @@ cur_dir = os.path.dirname(os.path.abspath(__file__))
 
 @pytest.mark.parametrize('batch_size, compress_level', [(None, 0), (None, 1), (2, 0), (2, 1)])
 def test_numpy_indexer(batch_size, compress_level, test_metas):
-    with NumpyIndexer(index_filename='np.test.gz', compress_level=compress_level, metas=test_metas) as indexer:
+    with NumpyIndexer(metric='euclidean', index_filename='np.test.gz', compress_level=compress_level, metas=test_metas) as indexer:
         indexer.batch_size = batch_size
         indexer.add(vec_idx, vec)
         indexer.save()
@@ -42,7 +42,7 @@ def test_numpy_indexer_known(batch_size, compress_level, test_metas):
                         [100, 100, 100],
                         [1000, 1000, 1000]])
     keys = np.array([4, 5, 6, 7]).reshape(-1, 1)
-    with NumpyIndexer(index_filename='np.test.gz', compress_level=compress_level, metas=test_metas) as indexer:
+    with NumpyIndexer(metric='euclidean', index_filename='np.test.gz', compress_level=compress_level, metas=test_metas) as indexer:
         indexer.batch_size = batch_size
         indexer.add(keys, vectors)
         indexer.save()
@@ -64,7 +64,7 @@ def test_numpy_indexer_known(batch_size, compress_level, test_metas):
 
 @pytest.mark.parametrize('batch_size, compress_level', [(None, 0), (None, 1), (16, 0), (16, 1)])
 def test_scipy_indexer(batch_size, compress_level, test_metas):
-    with NumpyIndexer(index_filename='np.test.gz', backend='scipy', compress_level=compress_level,
+    with NumpyIndexer(metric='euclidean', index_filename='np.test.gz', backend='scipy', compress_level=compress_level,
                       metas=test_metas) as indexer:
         indexer.batch_size = batch_size
         indexer.add(vec_idx, vec)
@@ -96,7 +96,7 @@ def test_numpy_indexer_known_big(batch_size, compress_level, test_metas):
 
     keys = np.arange(10000, 20000).reshape(-1, 1)
 
-    with NumpyIndexer(index_filename='np.test.gz', compress_level=compress_level,
+    with NumpyIndexer(metric='euclidean', index_filename='np.test.gz', compress_level=compress_level,
                       metas=test_metas) as indexer:
         indexer.add(keys, vectors)
         indexer.save()
@@ -130,7 +130,7 @@ def test_scipy_indexer_known_big(batch_size, compress_level, test_metas):
 
     keys = np.arange(10000, 20000).reshape(-1, 1)
 
-    with NumpyIndexer(index_filename='np.test.gz', backend='scipy', compress_level=compress_level,
+    with NumpyIndexer(metric='euclidean', index_filename='np.test.gz', backend='scipy', compress_level=compress_level,
                       metas=test_metas) as indexer:
         indexer.add(keys, vectors)
         indexer.save()
@@ -155,7 +155,7 @@ def test__get_sorted_top_k(batch_size, num_docs, top_k):
     expected_idx = np.argsort(dist)[:, :top_k]
     expected_dist = np.sort(dist)[:, :top_k]
 
-    with NumpyIndexer() as indexer:
+    with NumpyIndexer(metric='euclidean') as indexer:
         idx, dist = indexer._get_sorted_top_k(dist, top_k=top_k)
 
         np.testing.assert_equal(idx, expected_idx)

--- a/tests/unit/executors/yaml/npvec.yml
+++ b/tests/unit/executors/yaml/npvec.yml
@@ -2,6 +2,7 @@
 components:
   - !NumpyIndexer
     with:
+      metric: euclidean
       num_dim: -1
       index_key: HNSW32
       index_filename: vec.idx

--- a/tests/unit/flow/yaml/numpy-indexer-1.yml
+++ b/tests/unit/flow/yaml/numpy-indexer-1.yml
@@ -4,6 +4,7 @@ metas:
 components:
   - !NumpyIndexer
     with:
+      metric: euclidean
       index_filename: vec1.gz
     metas:
       name: vecidx1  # a customized name

--- a/tests/unit/flow/yaml/numpy-indexer-2.yml
+++ b/tests/unit/flow/yaml/numpy-indexer-2.yml
@@ -4,6 +4,7 @@ metas:
 components:
   - !NumpyIndexer
     with:
+      metric: euclidean
       index_filename: vec2.gz
     metas:
       name: vecidx2  # a customized name

--- a/tests/unit/peapods/remote/yamls/indexer.yml
+++ b/tests/unit/peapods/remote/yamls/indexer.yml
@@ -2,6 +2,7 @@
 components:
   - !NumpyIndexer
     with:
+      metric: euclidean
       index_filename: vec.gz
     metas:
       name: vecidx

--- a/tests/unit/yaml/dummy_exec1.yml
+++ b/tests/unit/yaml/dummy_exec1.yml
@@ -1,3 +1,4 @@
 !NumpyIndexer
 with:
+  metric: euclidean
   index_filename: 'test.gzip'

--- a/tests/unit/yaml/test-compound-indexer2.yml
+++ b/tests/unit/yaml/test-compound-indexer2.yml
@@ -7,6 +7,7 @@ components:
       name: test_meta
   - !NumpyIndexer
     with:
+      metric: euclidean
       index_filename: npidx
     metas:
       name: test_numpy

--- a/tests/unit/yaml/test-index-remote.yml
+++ b/tests/unit/yaml/test-index-remote.yml
@@ -1,5 +1,6 @@
 !NumpyIndexer
 with:
+  metric: euclidean
   index_filename: tmp2
 metas:
   name: test2

--- a/tests/unit/yaml/test-index.yml
+++ b/tests/unit/yaml/test-index.yml
@@ -1,5 +1,6 @@
 !NumpyIndexer
 with:
+  metric: euclidean
   index_filename: tmp2
 metas:
   name: test2

--- a/tests/unit/yaml/test-joint-wrap.yml
+++ b/tests/unit/yaml/test-joint-wrap.yml
@@ -5,6 +5,7 @@ components:
       ref_indexer:
         !NumpyIndexer
         with:
+          metric: euclidean
           index_filename: vec.gz
         metas:
           name: vecidx  # a customized name

--- a/tests/unit/yaml/test-joint.yml
+++ b/tests/unit/yaml/test-joint.yml
@@ -2,6 +2,7 @@
 components:
   - !NumpyIndexer
     with:
+      metric: euclidean
       index_filename: vec.gz
     metas:
       name: vecidx  # a customized name

--- a/tests/unit/yaml/test-multifield-indexer-2.yml
+++ b/tests/unit/yaml/test-multifield-indexer-2.yml
@@ -4,6 +4,7 @@ metas:
 components:
   - !NumpyIndexer
     with:
+      metric: euclidean
       index_filename: vec.gz
     metas:
       name: vecidx  # a customized name

--- a/tests/unit/yaml/test-multifield-indexer.yml
+++ b/tests/unit/yaml/test-multifield-indexer.yml
@@ -4,6 +4,7 @@ metas:
 components:
   - !NumpyIndexer
     with:
+      metric: euclidean
       index_filename: vec.gz
     metas:
       name: vecidx  # a customized name

--- a/tests/unit/yaml/test-query.yml
+++ b/tests/unit/yaml/test-query.yml
@@ -1,5 +1,6 @@
 !NumpyIndexer
 with:
+  metric: euclidean
   index_filename: tmp2
 metas:
   name: test2


### PR DESCRIPTION
Changed default `NumpyIndexer` metric to `cosine` for better `default`