### PR TITLE
fix: check jina version in hub modules when pushing

### DIFF
--- a/jina/docker/hubio.py
+++ b/jina/docker/hubio.py
@@ -16,7 +16,7 @@ from .helper import credentials_file
 from .hubapi import _list, _register_to_mongodb, _list_local
 from ..clients.python import ProgressBar
 from ..enums import BuildTestLevel
-from ..excepts import DockerLoginFailed, HubBuilderError, HubBuilderBuildError, HubBuilderTestError
+from ..excepts import DockerLoginFailed, HubBuilderError, HubBuilderBuildError, HubBuilderTestError, ImageAlreadyExists
 from ..executors import BaseExecutor
 from ..flow import Flow
 from ..helper import colored, get_readable_size, get_now_timestamp, get_full_version, random_name, expand_dict, \
@@ -32,7 +32,7 @@ if False:
 
 _allowed = {'name', 'description', 'author', 'url',
             'documentation', 'version', 'vendor', 'license', 'avatar',
-            'platform', 'update', 'keywords'}
+            'jina_version', 'platform', 'update', 'keywords'}
 
 _label_prefix = 'ai.jina.hub.'
 
@@ -171,16 +171,15 @@ class HubIO:
         - Writes to the db
         """
         name = name or self.args.name
-
         try:
             # check if image exists
             # fail if it does
-            if self._image_version_exists(
+            if self.args.no_overwrite and self._image_version_exists(
                     build_result['manifest_info']['name'],
                     build_result['manifest_info']['version'],
                     jina_version
             ):
-                raise Exception(f'Image with name {name} already exists. Will NOT overwrite.')
+                raise ImageAlreadyExists(f'Image with name {name} already exists. Will NOT overwrite.')
             else:
                 self.logger.debug(f'Image with name {name} does not exist. Pushing now...')
             self._push_docker_hub(name, readme_path)
@@ -200,9 +199,10 @@ class HubIO:
                     _register_to_mongodb(logger=self.logger, summary=build_result)
                 if build_result.get('details', None) and build_result.get('build_history', None):
                     self._write_slack_message(build_result, build_result['details'], build_result['build_history'])
-
-        except Exception as ex:
-            self.logger.error(f'can not complete the push due to {repr(ex)}')
+        except Exception as e:
+            self.logger.error(f'Error when trying to push image {name}: {repr(e)}')
+            if isinstance(e, ImageAlreadyExists):
+                raise e
 
     def _push_docker_hub(self, name: str = None, readme_path: str = None) -> None:
         """ Helper push function """
@@ -265,7 +265,7 @@ class HubIO:
             if f'{_label_prefix}{r}' not in image.labels.keys():
                 self.logger.warning(f'{r} is missing in your docker image labels, you may want to check it')
         try:
-            image.labels['jina_version'] = jina_version
+            image.labels['ai.jina.hub.jina_version'] = jina_version
             if name != safe_url_name(
                     f'{self.args.repository}/' + '{type}.{kind}.{name}:{version}-{jina_version}'.format(
                         **{k.replace(_label_prefix, ''): v for k, v in image.labels.items()})):
@@ -501,6 +501,7 @@ class HubIO:
             raise FileNotFoundError('Dockerfile or manifest.yml is not given, can not build')
 
         self.manifest = self._read_manifest(self.manifest_path)
+        self.manifest['jina_version'] = jina_version
         self.dockerfile_path_revised = self._get_revised_dockerfile(self.dockerfile_path, self.manifest)
         tag_name = safe_url_name(
             f'{self.args.repository}/' + f'{self.manifest["type"]}.{self.manifest["kind"]}.{self.manifest["name"]}:{self.manifest["version"]}-{jina_version}')
@@ -606,8 +607,8 @@ class HubIO:
             matching = [
                 m for m in manifests
                 if m['version'] == module_version
-                and 'jina_version' in m.keys()
-                and m['jina_version'] == req_jina_version
+                   and 'jina_version' in m.keys()
+                   and m['jina_version'] == req_jina_version
             ]
             return len(matching) > 0
-        return True
+        return False

--- a/jina/excepts.py
+++ b/jina/excepts.py
@@ -173,3 +173,7 @@ class RemotePodClosed(Exception):
 
 class LengthMismatchException(Exception):
     """ Exception when length of two items should be identical while not """
+
+
+class ImageAlreadyExists(Exception):
+    """ Exception when an image with the name, module version, and Jina version already exists on the Hub"""

--- a/jina/parser.py
+++ b/jina/parser.py
@@ -119,6 +119,8 @@ def set_hub_build_parser(parser=None):
                         help='store the host information during bookkeeping')
     parser.add_argument('--daemon', action='store_true', default=False,
                         help='run the test Pea/Pod as a daemon process, see "jina pea --help" for details')
+    parser.add_argument('--no-overwrite', action='store_true', default=False,
+                        help='Do not allow overwriting existing images (based on module version and jina version)')
     return parser
 
 

--- a/tests/unit/docker/test_hub_build.py
+++ b/tests/unit/docker/test_hub_build.py
@@ -92,10 +92,10 @@ def test_hub_build_push_push_again():
     assert len(manifests) >= 1
     assert manifests[0]['name'] == summary['manifest_info']['name']
 
-    # try and push same version again should fail
-    args = set_hub_build_parser().parse_args([str(cur_dir / 'hub-mwu'), '--push', '--host-info'])
-    summary = HubIO(args).build()
-    print(summary['is_build_success'])
+    with pytest.raises(Exception):
+        # try and push same version again should fail with `--no-overwrite`
+        args = set_hub_build_parser().parse_args([str(cur_dir / 'hub-mwu'), '--push', '--host-info', '--no-overwrite'])
+        HubIO(args).build()
 
 
 def test_hub_build_failures():

--- a/tests/unit/executors/indexers/test_binary_indexer.py
+++ b/tests/unit/executors/indexers/test_binary_indexer.py
@@ -4,10 +4,7 @@ import numpy as np
 import pytest
 
 from jina.flow import Flow
-from jina.proto import jina_pb2
-from jina.types.document import uid
 from jina.types.ndarray.generic import NdArray
-
 from tests import random_docs
 
 


### PR DESCRIPTION
+ Add `--no-overwrite` option to not allow pushing image with same module version and jina version