### PR TITLE
ci: add latency tracking

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -116,9 +116,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          if [ "${{ matrix.os }}" == "ubuntu-latest" ]; then
-            sudo apt-get install libsndfile1
-          fi
           python -m pip install --upgrade pip
           pip install .[cicd] --no-cache-dir
       - name: Lint with flake8

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,9 +37,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          if [ "${{ matrix.os }}" == "ubuntu-latest" ]; then
-            sudo apt-get install libsndfile1
-          fi
           python -m pip install --upgrade pip
           pip install .[cicd] --no-cache-dir
       - name: Lint with flake8

--- a/.github/workflows/latency-tracking.yml
+++ b/.github/workflows/latency-tracking.yml
@@ -28,6 +28,8 @@ jobs:
           cd latency
           docker build --build-arg JINA_VER=master . -t latency-tracking
           docker run -v $(pwd)/output:/workspace/output -v $(pwd)/original:/workspace/original latency-tracking
+          pwd
+          ls output/
       - name: Upload latency result
         uses: actions/upload-artifact@v1
         with:

--- a/.github/workflows/latency-tracking.yml
+++ b/.github/workflows/latency-tracking.yml
@@ -22,6 +22,9 @@ jobs:
           repository: jina-ai/latency-tracking
           path: latency
           token: ${{ secrets.JINA_DEV_BOT }}
+      - uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
       - name: Run current latency vs. last 3 versions
         run: |
           sudo apt-get install jq
@@ -29,6 +32,7 @@ jobs:
           docker build --build-arg JINA_VER=master . -t latency-tracking
           docker run -v $(pwd)/output:/workspace/output -v $(pwd)/original:/workspace/original latency-tracking
           bash batch.sh 3
+          pip install prettytable
           python ppstat.py > comment.txt
       - id: get-comment-body
         run: |

--- a/.github/workflows/latency-tracking.yml
+++ b/.github/workflows/latency-tracking.yml
@@ -32,4 +32,4 @@ jobs:
         uses: actions/upload-artifact@v1
         with:
           name: benchmark result
-          path: latency/benchmark.json
+          path: latency/output/benchmark.json

--- a/.github/workflows/latency-tracking.yml
+++ b/.github/workflows/latency-tracking.yml
@@ -32,4 +32,4 @@ jobs:
         uses: actions/upload-artifact@v1
         with:
           name: benchmark result
-          path: ./latency/benchmark.json
+          path: latency/benchmark.json

--- a/.github/workflows/latency-tracking.yml
+++ b/.github/workflows/latency-tracking.yml
@@ -29,8 +29,39 @@ jobs:
           docker build --build-arg JINA_VER=master . -t latency-tracking
           docker run -v $(pwd)/output:/workspace/output -v $(pwd)/original:/workspace/original latency-tracking
           bash batch.sh 3
-      - name: Upload latency result
-        uses: actions/upload-artifact@v1
+          python ppstat.py > comment.txt
+      - id: get-comment-body
+        run: |
+          body=$(cat latency/output/comment.txt)
+          body="${body//'%'/'%25'}"
+          body="${body//$'\n'/'%0A'}"
+          body="${body//$'\r'/'%0D'}"
+          echo ::set-output name=body::$body
+      - name: Find Comment
+        uses: peter-evans/find-comment@v1
+        id: fc
         with:
-          name: benchmark result
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: 'Backed by [latency-tracking]'
+
+      - name: Create comment
+        if: ${{ steps.fc.outputs.comment-id == 0 }}
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: ${{ steps.get-comment-body.outputs.body }}
+          reaction-type: "eyes"
+
+      - name: Update comment
+        if: ${{ steps.fc.outputs.comment-id != 0 }}
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          body: ${{ steps.get-comment-body.outputs.body }}
+          reaction-type: "rocket"
+      - name: Upload latency result
+        uses: actions/upload-artifact@v2
+        with:
+          name: stats.json.zip
           path: latency/output/stats.json

--- a/.github/workflows/latency-tracking.yml
+++ b/.github/workflows/latency-tracking.yml
@@ -36,7 +36,7 @@ jobs:
           python ppstat.py > comment.txt
       - id: get-comment-body
         run: |
-          body=$(cat latency/output/comment.txt)
+          body=$(cat latency/comment.txt)
           body="${body//'%'/'%25'}"
           body="${body//$'\n'/'%0A'}"
           body="${body//$'\r'/'%0D'}"

--- a/.github/workflows/latency-tracking.yml
+++ b/.github/workflows/latency-tracking.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           sudo apt-get install jq
           cd latency
-          docker build --build-arg JINA_VER=master . -t latency-tracking
+          docker build --build-arg JINA_VER=0.8.3 . -t latency-tracking
           docker run -v $(pwd)/output:/workspace/output -v $(pwd)/original:/workspace/original latency-tracking
       - name: Upload latency result
         uses: actions/upload-artifact@v1

--- a/.github/workflows/latency-tracking.yml
+++ b/.github/workflows/latency-tracking.yml
@@ -22,16 +22,15 @@ jobs:
           repository: jina-ai/latency-tracking
           path: latency
           token: ${{ secrets.JINA_DEV_BOT }}
-      - name: Run latency benchmark
+      - name: Run current latency vs. last 3 versions
         run: |
           sudo apt-get install jq
           cd latency
           docker build --build-arg JINA_VER=master . -t latency-tracking
           docker run -v $(pwd)/output:/workspace/output -v $(pwd)/original:/workspace/original latency-tracking
-          pwd
-          ls output/
+          bash batch.sh 3
       - name: Upload latency result
         uses: actions/upload-artifact@v1
         with:
           name: benchmark result
-          path: latency/output/benchmark.json
+          path: latency/output/stats.json

--- a/.github/workflows/latency-tracking.yml
+++ b/.github/workflows/latency-tracking.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           sudo apt-get install jq
           cd latency
-          docker build --build-arg JINA_VER=0.8.3 . -t latency-tracking
+          docker build --build-arg JINA_VER=master . -t latency-tracking
           docker run -v $(pwd)/output:/workspace/output -v $(pwd)/original:/workspace/original latency-tracking
       - name: Upload latency result
         uses: actions/upload-artifact@v1

--- a/.github/workflows/latency-tracking.yml
+++ b/.github/workflows/latency-tracking.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  pull_request:
+#    paths-ignore:
+#      - 'README.md'
+#      - '.all-contributorsrc'
+#      - 'docs/*'
+
+jobs:
+  latency-tracking:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Test docker install
+        run: |
+          docker build --build-arg PIP_TAG="[devel]" -f Dockerfiles/pip.Dockerfile -t jinaai/jina:master .
+      - uses: actions/checkout@v2
+        with:
+          repository: jina-ai/latency-tracking
+          path: latency
+          token: ${{ secrets.JINA_DEV_BOT }}
+      - name: Run latency benchmark
+        run: |
+          sudo apt-get install jq
+          cd latency
+          docker build --build-arg JINA_VER=master . -t latency-tracking
+          docker run -v $(pwd)/output:/workspace/output -v $(pwd)/original:/workspace/original latency-tracking
+      - name: Upload latency result
+        uses: actions/upload-artifact@v1
+        with:
+          name: benchmark result
+          path: ./latency/benchmark.json

--- a/.github/workflows/test-hubapp-hubpods.yml
+++ b/.github/workflows/test-hubapp-hubpods.yml
@@ -2,15 +2,9 @@ name: CI
 
 on:
   pull_request:
-    branches:
-      - master
 
 jobs:
   hubapp-hubpod-test:
-    if: |
-      !startsWith(github.event.head_commit.message, 'chore') &&
-      !startsWith(github.event.head_commit.message, 'build: hotfix') &&
-      !endsWith(github.event.head_commit.message, 'reformatted by jina-dev-bot')
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/test-jinad.yml
+++ b/.github/workflows/test-jinad.yml
@@ -2,15 +2,9 @@ name: CI
 
 on:
   pull_request:
-    branches:
-      - master
 
 jobs:
   jinad-test:
-    if: |
-      !startsWith(github.event.head_commit.message, 'chore') &&
-      !startsWith(github.event.head_commit.message, 'build: hotfix') &&
-      !endsWith(github.event.head_commit.message, 'reformatted by jina-dev-bot')
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:


### PR DESCRIPTION
🔴 changes in https://github.com/jina-ai/jina/pull/1348 seem to make https://github.com/jina-ai/latency-tracking unusable, which implies breaking changes that were not discovered.