### PR TITLE
feat(flow): add needs, inspect, version to flow yaml

### DIFF
--- a/jina/excepts.py
+++ b/jina/excepts.py
@@ -177,3 +177,7 @@ class LengthMismatchException(Exception):
 
 class ImageAlreadyExists(Exception):
     """ Exception when an image with the name, module version, and Jina version already exists on the Hub"""
+
+
+class BadFlowYAMLVersion(Exception):
+    """ Exception when Flow YAML config specifies a wrong version number"""

--- a/jina/flow/__init__.py
+++ b/jina/flow/__init__.py
@@ -55,6 +55,7 @@ class Flow(ExitStack):
 
         """
         super().__init__()
+        self._version = ''  # YAML version number
         self._pod_nodes = OrderedDict()  # type: Dict[str, 'FlowPod']
         self._inspect_pods = {}  # type: Dict[str, str]
         self._build_level = FlowBuildLevel.EMPTY
@@ -86,30 +87,8 @@ class Flow(ExitStack):
     @staticmethod
     def _dump_instance_to_yaml(data):
         # note: we only save non-default property for the sake of clarity
-        r = {}
-
-        if data._kwargs:
-            r['with'] = data._kwargs
-
-        if data._pod_nodes:
-            r['pods'] = {}
-
-        if 'gateway' in data._pod_nodes:
-            # always dump gateway as the first pod, if exist
-            r['pods']['gateway'] = {}
-
-        for k, v in data._pod_nodes.items():
-            if k == 'gateway':
-                continue
-
-            kwargs = {'needs': list(v.needs)} if v.needs else {}
-            kwargs.update(v._kwargs)
-
-            if 'name' in kwargs:
-                kwargs.pop('name')
-
-            r['pods'][k] = kwargs
-        return r
+        from .parser import dump
+        return dump(data)
 
     @classmethod
     def from_yaml(cls, constructor, node):
@@ -164,27 +143,8 @@ class Flow(ExitStack):
         data = ruamel.yaml.constructor.SafeConstructor.construct_mapping(
             constructor, node, deep=True)
 
-        p = data.get('with', {})  # type: Dict[str, Any]
-        a = p.pop('args') if 'args' in p else ()
-        k = p.pop('kwargs') if 'kwargs' in p else {}
-        # maybe there are some hanging kwargs in "parameters"
-        tmp_a = (expand_env_var(v) for v in a)
-        tmp_p = {kk: expand_env_var(vv) for kk, vv in {**k, **p}.items()}
-        obj = cls(*tmp_a, **tmp_p)
-
-        pp = data.get('pods', {})
-        for pod_name, pod_attr in pp.items():
-            p_pod_attr = {kk: expand_env_var(vv) for kk, vv in pod_attr.items()}
-            if pod_name != 'gateway':
-                # ignore gateway when reading, it will be added during build()
-                obj.add(name=pod_name, **p_pod_attr, copy_flow=False)
-
-        obj.logger.success(f'successfully built {cls.__name__} from a yaml config')
-
-        # if node.tag in {'!CompoundExecutor'}:
-        #     os.environ['JINA_WARN_UNNAMED'] = 'YES'
-
-        return obj, data
+        from .parser import parse
+        return parse(data), data
 
     @staticmethod
     def _parse_endpoints(op_flow, pod_name, endpoint, connect_to_last_pod=False) -> Set:

--- a/jina/flow/parser/__init__.py
+++ b/jina/flow/parser/__init__.py
@@ -1,0 +1,63 @@
+import warnings
+from typing import Dict, List
+
+from ...excepts import BadFlowYAMLVersion
+
+if False:
+    from .. import Flow
+
+loader_prefix = 'load_v_'
+dumper_prefix = 'dump_v_'
+
+
+def parse(data: Dict) -> 'Flow':
+    """Return the Flow YAML parser given the syntax version number
+
+    :param data: flow yaml file loaded as python dict
+    """
+    from . import loader
+
+    version = data.get('version', 'legacy')
+    v = version.replace('.', '_')
+    p = getattr(loader, loader_prefix + v, None)
+    if not p:
+        p = getattr(loader, loader_prefix + v.split('_')[0], None)
+        warnings.warn(f'can not find the parser for {version}, '
+                      f'will use the parser for version: "{v.split("_")[0]}"', UserWarning)
+    if not p:
+        raise BadFlowYAMLVersion(f'{version} is not a valid version number')
+    obj = p(data)
+    obj._version = version
+    obj.logger.success(f'successfully built a Flow from a YAML version: {version}')
+    return obj
+
+
+def dump(data: 'Flow') -> Dict:
+    """Return the dictionary given a versioned flow object
+
+    :param data: versioned flow object
+    """
+    from . import dumper
+    version = data._version
+    v = version.replace('.', '_')
+    p = getattr(dumper, dumper_prefix + v, None)
+    if not p:
+        p = getattr(dumper, dumper_prefix + v.split('_')[0], None)
+        warnings.warn(f'can not find the dumper for {version}, '
+                      f'will use the dumper for version: "{v.split("_")[0]}"', UserWarning)
+    if not p:
+        raise BadFlowYAMLVersion(f'{version} is not a valid version number')
+    return p(data)
+
+
+def get_support_versions() -> List[str]:
+    """List all supported versions
+
+    :return: supported versions sorted alphabetically
+    """
+    from . import loader
+    result = []
+    for v in dir(loader):
+        if v.startswith(loader_prefix):
+            result.append(v.replace(loader_prefix, '').replace('_', '.'))
+    return list(sorted(result))

--- a/jina/flow/parser/dumper.py
+++ b/jina/flow/parser/dumper.py
@@ -1,0 +1,84 @@
+"""
+# loader function format
+
+    def dump_v_MAJOR[_MINOR](data)
+    e.g.
+        - def dump_v_1_1(data)
+        - def dump_v_1(data)
+
+# match priority
+    if version is available:
+        - dump_v_MAJOR_MINOR
+        - dump_v_MAJOR
+        - throw BadFlowYAMLVersion
+    otherwise:
+        - dump_v_legacy
+"""
+
+import argparse
+from typing import Dict, Any
+
+from .. import Flow
+from ...parser import set_pod_parser
+
+
+def _get_taboo():
+    """Get a set of keys that should not be dumped"""
+    return {k.dest for k in set_pod_parser()._actions if k.help == argparse.SUPPRESS}
+
+
+def dump_v_legacy(data: 'Flow') -> Dict[str, Any]:
+    r = {}
+    if data._version:
+        r['version'] = data._version
+
+    if data._kwargs:
+        r['with'] = data._kwargs
+
+    if data._pod_nodes:
+        r['pods'] = {}
+
+    if 'gateway' in data._pod_nodes:
+        # always dump gateway as the first pod, if exist
+        r['pods']['gateway'] = {}
+
+    for k, v in data._pod_nodes.items():
+        if k == 'gateway':
+            continue
+
+        kwargs = {'needs': list(v.needs)} if v.needs else {}
+        kwargs.update(v._kwargs)
+
+        if 'name' in kwargs:
+            kwargs.pop('name')
+
+        r['pods'][k] = kwargs
+    return r
+
+
+def dump_v_1(data: 'Flow') -> Dict[str, Any]:
+    r = {}
+    if data._version:
+        r['version'] = data._version
+
+    if data._kwargs:
+        r['with'] = data._kwargs
+
+    if data._pod_nodes:
+        r['pods'] = []
+
+    last_name = 'gateway'
+    for k, v in data._pod_nodes.items():
+        if k == 'gateway':
+            continue
+        kwargs = {}
+        # only add "needs" when the value is not the last pod name
+        if list(v.needs) != [last_name]:
+            kwargs = {'needs': list(v.needs)}
+        kwargs.update(v._kwargs)
+        for t in _get_taboo():
+            if t in kwargs:
+                kwargs.pop(t)
+        last_name = kwargs['name']
+        r['pods'].append(kwargs)
+    return r

--- a/jina/flow/parser/loader.py
+++ b/jina/flow/parser/loader.py
@@ -1,0 +1,62 @@
+"""
+# loader function format
+
+    def load_v_MAJOR[_MINOR](data)
+    e.g.
+        - def load_v_1_1(data)
+        - def load_v_1(data)
+
+# match priority
+    if version is available:
+        - load_v_MAJOR_MINOR
+        - load_v_MAJOR
+        - throw BadFlowYAMLVersion
+    otherwise:
+        - load_v_legacy
+"""
+
+from typing import Dict, Any
+
+from .. import Flow
+from ...helper import expand_env_var
+
+
+def load_v_legacy(data):
+    p = data.get('with', {})  # type: Dict[str, Any]
+    a = p.pop('args') if 'args' in p else ()
+    k = p.pop('kwargs') if 'kwargs' in p else {}
+    # maybe there are some hanging kwargs in "parameters"
+    tmp_a = (expand_env_var(v) for v in a)
+    tmp_p = {kk: expand_env_var(vv) for kk, vv in {**k, **p}.items()}
+    obj = Flow(*tmp_a, **tmp_p)
+
+    pp = data.get('pods', {})
+    for pod_name, pod_attr in pp.items():
+        p_pod_attr = {kk: expand_env_var(vv) for kk, vv in pod_attr.items()}
+        if pod_name != 'gateway':
+            # ignore gateway when reading, it will be added during build()
+            obj.add(name=pod_name, **p_pod_attr, copy_flow=False)
+    # if node.tag in {'!CompoundExecutor'}:
+    #     os.environ['JINA_WARN_UNNAMED'] = 'YES'
+    return obj
+
+
+def load_v_1(data):
+    p = data.get('with', {})  # type: Dict[str, Any]
+    a = p.pop('args') if 'args' in p else ()
+    k = p.pop('kwargs') if 'kwargs' in p else {}
+    # maybe there are some hanging kwargs in "parameters"
+    tmp_a = (expand_env_var(v) for v in a)
+    tmp_p = {kk: expand_env_var(vv) for kk, vv in {**k, **p}.items()}
+    obj = Flow(*tmp_a, **tmp_p)
+
+    pp = data.get('pods', [])
+    for pods in pp:
+        p_pod_attr = {kk: expand_env_var(vv) for kk, vv in pods.items()}
+        # in v1 YAML, flow is an optional argument
+        if p_pod_attr.get('name', None) != 'gateway':
+            # ignore gateway when reading, it will be added during build()
+            method = p_pod_attr.get('method', 'add')
+            # support methods: add, needs, inspect
+            getattr(obj, method)(**p_pod_attr, copy_flow=False)
+    return obj

--- a/jina/types/sets/document.py
+++ b/jina/types/sets/document.py
@@ -109,7 +109,7 @@ class DocumentSet(MutableSequence):
     def all_contents(self) -> Tuple['np.ndarray', 'DocumentSet', 'DocumentSet']:
         """Return all embeddings from every document in this set as a ndarray
 
-        :return a tuple of embedding in :class:`np.ndarray`,
+        :return: a tuple of embedding in :class:`np.ndarray`,
                 the corresponding documents in a :class:`DocumentSet`,
                 and the documents have no contents in a :class:`DocumentSet`.
         """

--- a/tests/unit/flow/test_flow_yaml_parser.py
+++ b/tests/unit/flow/test_flow_yaml_parser.py
@@ -1,0 +1,48 @@
+import filecmp
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from jina import Flow
+from jina.excepts import BadFlowYAMLVersion
+from jina.flow.parser import get_support_versions
+
+
+def test_support_versions():
+    assert get_support_versions() == ['1', 'legacy']
+
+
+def test_load_legacy_and_v1():
+    Flow.load_config('yaml/flow-legacy-syntax.yml')
+    Flow.load_config('yaml/flow-v1-syntax.yml')
+
+    # this should fallback to v1
+    Flow.load_config('yaml/flow-v1.0-syntax.yml')
+
+    with pytest.raises(BadFlowYAMLVersion):
+        Flow.load_config('yaml/flow-v99-syntax.yml')
+
+
+def test_add_needs_inspect(tmpdir):
+    f1 = (Flow().add(name='pod0', needs='gateway').add(name='pod1', needs='gateway').inspect().needs(['pod0', 'pod1']))
+    f1.plot(Path(tmpdir) / 'from_python.jpg')
+    with f1:
+        f1.index_ndarray(np.random.random([5, 5]), output_fn=print)
+
+    f2 = Flow.load_config('yaml/flow-v1.0-syntax.yml')
+    f2.plot(Path(tmpdir) / 'from_yaml.jpg')
+    assert filecmp.cmp(Path(tmpdir) / 'from_python.jpg',
+                       Path(tmpdir) / 'from_yaml.jpg')
+
+    with f2:
+        f2.index_ndarray(np.random.random([5, 5]), output_fn=print)
+
+    assert f1 == f2
+
+
+def test_load_dump_load(tmpdir):
+    f1 = Flow.load_config('yaml/flow-legacy-syntax.yml')
+    f1.save_config(Path(tmpdir) / 'a0.yml')
+    f2 = Flow.load_config('yaml/flow-v1.0-syntax.yml')
+    f2.save_config(Path(tmpdir) / 'a1.yml')

--- a/tests/unit/flow/yaml/flow-legacy-syntax.yml
+++ b/tests/unit/flow/yaml/flow-legacy-syntax.yml
@@ -1,0 +1,12 @@
+!Flow
+pods:
+  pod0:
+    uses: _pass
+    needs: gateway
+  pod1:
+    uses: _pass
+    needs: gateway
+  pod2:
+    uses: _merge
+    needs: [pod1, pod0]
+

--- a/tests/unit/flow/yaml/flow-v1-syntax.yml
+++ b/tests/unit/flow/yaml/flow-v1-syntax.yml
@@ -1,0 +1,13 @@
+!Flow
+version: '1'
+pods:
+  - name: pod0  # notice the change here, name is now an attribute
+    method: add  # by default method is always add, available: add, needs, inspect
+    uses: _pass
+    needs: gateway
+  - name: pod1  # notice the change here, name is now an attribute
+    method: add  # by default method is always add, available: add, needs, inspect
+    uses: _pass
+    needs: gateway
+  - method: needs  # let's try something new in Flow YAML v1: needs
+    needs: [pod1, pod0]

--- a/tests/unit/flow/yaml/flow-v1.0-syntax.yml
+++ b/tests/unit/flow/yaml/flow-v1.0-syntax.yml
@@ -1,0 +1,14 @@
+!Flow
+version: '1.0'
+pods:
+  - name: pod0  # notice the change here, name is now an attribute
+    method: add  # by default method is always add, available: add, needs, inspect
+    uses: _pass
+    needs: gateway
+  - name: pod1  # notice the change here, name is now an attribute
+    method: add  # by default method is always add, available: add, needs, inspect
+    uses: _pass
+    needs: gateway
+  - method: inspect  # add an inspect node on pod1
+  - method: needs  # let's try something new in Flow YAML v1: needs
+    needs: [pod1, pod0]

--- a/tests/unit/flow/yaml/flow-v99-syntax.yml
+++ b/tests/unit/flow/yaml/flow-v99-syntax.yml
@@ -1,0 +1,13 @@
+!Flow
+version: '99.99'
+pods:
+  - name: pod0  # notice the change here, name is now an attribute
+    method: add  # by default method is always add, available: add, needs, inspect
+    uses: _pass
+    needs: gateway
+  - name: pod1  # notice the change here, name is now an attribute
+    method: add  # by default method is always add, available: add, needs, inspect
+    uses: _pass
+    needs: gateway
+  - method: needs  # let's try something new in Flow YAML v1: needs
+    needs: [pod1, pod0]


### PR DESCRIPTION
# Feature
- Flow YAML now supports versioning. The current master is considered as `version: legacy`.
- Flow YAML now supports `needs`, `inspect` as constructor beyond `add`, they can be specified via `method`:
```yaml
!Flow
version: '1.0'
pods:
  - name: pod0  # notice the change here, name is now an attribute
    method: add  # by default method is always add, available: add, needs, inspect
    uses: _pass
    needs: gateway
  - name: pod1  # notice the change here, name is now an attribute
    method: add  # by default method is always add, available: add, needs, inspect
    uses: _pass
    needs: gateway
  - method: inspect  # add an inspect node on pod1
  - method: needs  # let's try something new in Flow YAML v1: needs
    needs: [pod1, pod0]
```
-  `dumper` & `loader` can be specified for each version, see `jina.flow.parser` for details
