### PR TITLE
feat: add `env` to pea, pod, flow cli

### DIFF
--- a/jina/flow/__init__.py
+++ b/jina/flow/__init__.py
@@ -10,7 +10,7 @@ import threading
 import time
 from collections import OrderedDict, defaultdict
 from contextlib import ExitStack
-from typing import Optional, Union, Tuple, List, Set, Dict, Iterator, Callable, TextIO, Any
+from typing import Optional, Union, Tuple, List, Set, Dict, Iterator, Callable, TextIO
 from urllib.request import Request, urlopen
 
 import ruamel.yaml
@@ -21,7 +21,7 @@ from .. import JINA_GLOBAL
 from ..clients.python import InputFnType
 from ..enums import FlowBuildLevel, PodRoleType, FlowInspectType
 from ..excepts import FlowTopologyError, FlowMissingPodError
-from ..helper import yaml, expand_env_var, get_non_defaults_args, deprecated_alias, complete_path, colored, \
+from ..helper import yaml, get_non_defaults_args, deprecated_alias, complete_path, colored, \
     get_public_ip, get_internal_ip, typename
 from ..logging import JinaLogger
 from ..logging.sse import start_sse_logger
@@ -34,7 +34,7 @@ if False:
 
 
 class Flow(ExitStack):
-    def __init__(self, args: Optional['argparse.Namespace'] = None, env: Optional[Dict]=None, **kwargs):
+    def __init__(self, args: Optional['argparse.Namespace'] = None, env: Optional[Dict] = None, **kwargs):
         """Initialize a flow object
 
         :param kwargs: other keyword arguments that will be shared by all pods in this flow

--- a/jina/flow/yaml_parser/v1.py
+++ b/jina/flow/yaml_parser/v1.py
@@ -51,13 +51,14 @@ class V1Parser(VersionedYamlParser):
 
         :param data: flow yaml file loaded as python dict
         """
+        envs = data.get('env', {})  # type: Dict[str, str]
         p = data.get('with', {})  # type: Dict[str, Any]
         a = p.pop('args') if 'args' in p else ()
         k = p.pop('kwargs') if 'kwargs' in p else {}
         # maybe there are some hanging kwargs in "parameters"
         tmp_a = (expand_env_var(v) for v in a)
         tmp_p = {kk: expand_env_var(vv) for kk, vv in {**k, **p}.items()}
-        obj = Flow(*tmp_a, **tmp_p)
+        obj = Flow(*tmp_a, env=envs, **tmp_p)
 
         pp = data.get('pods', [])
         for pods in pp:
@@ -78,6 +79,9 @@ class V1Parser(VersionedYamlParser):
         r = {}
         if data._version:
             r['version'] = data._version
+
+        if data._env:
+            r['version'] = data._env
 
         if data._kwargs:
             r['with'] = data._kwargs

--- a/jina/flow/yaml_parser/v1.py
+++ b/jina/flow/yaml_parser/v1.py
@@ -81,7 +81,7 @@ class V1Parser(VersionedYamlParser):
             r['version'] = data._version
 
         if data._env:
-            r['version'] = data._env
+            r['env'] = data._env
 
         if data._kwargs:
             r['with'] = data._kwargs

--- a/jina/helper.py
+++ b/jina/helper.py
@@ -2,6 +2,7 @@ __copyright__ = "Copyright (c) 2020 Jina AI Limited. All rights reserved."
 __license__ = "Apache-2.0"
 
 import functools
+import json
 import math
 import os
 import random
@@ -391,6 +392,8 @@ def kwargs2list(kwargs: Dict) -> List[str]:
                     args.append(f'--{k}')
             elif isinstance(v, list):  # for nargs
                 args.extend([f'--{k}', *(str(vv) for vv in v)])
+            elif isinstance(v, dict):
+                args.extend([f'--{k}', json.dumps(v)])
             else:
                 args.extend([f'--{k}', str(v)])
     return args

--- a/jina/parser.py
+++ b/jina/parser.py
@@ -4,11 +4,34 @@ __license__ = "Apache-2.0"
 import argparse
 import os
 
+
 _SHOW_ALL_ARGS = 'JINA_FULL_CLI' in os.environ
 
 
 def add_arg_group(parser, title):
     return parser.add_argument_group(title)
+
+
+class KVAppendAction(argparse.Action):
+    """
+    argparse action to split an argument into KEY=VALUE form
+    on the first = and append to a dictionary.
+    This is used for setting up --env
+    """
+
+    def __call__(self, parser, args, values, option_string=None):
+        import json
+        d = getattr(args, self.dest) or {}
+        for value in values:
+            try:
+                d.update(json.loads(value))
+            except json.JSONDecodeError:
+                try:
+                    (k, v) = value.split('=', 2)
+                except ValueError:
+                    raise argparse.ArgumentError(f'could not parse argument \"{values[0]}\" as k=v format')
+                d[k] = v
+        setattr(args, self.dest, d)
 
 
 def set_base_parser():
@@ -142,7 +165,7 @@ def set_hub_list_parser(parser=None):
                         help='name of hub image')
     parser.add_argument('--kind', type=str,
                         help='kind of hub image')
-    parser.add_argument('--keywords', type=str, nargs='+',
+    parser.add_argument('--keywords', type=str, nargs='+', metavar='KEYWORD',
                         help='keywords for searching')
     parser.add_argument('--type', type=str, default='pod', choices=['pod', 'app'],
                         help='type of the hub image')
@@ -248,7 +271,8 @@ def set_pea_parser(parser=None):
     gp0.add_argument('--name', type=str,
                      help='the name of this pea, used to identify the pod and its logs.')
     gp0.add_argument('--identity', type=str, default=get_random_identity(),
-                     help='the identity of the sockets, default a random string (Important for load balancing messages')
+                     help='the identity of the sockets, default a random string (Important for load balancing messages'
+                     if _SHOW_ALL_ARGS else argparse.SUPPRESS)
     gp0.add_argument('--uses', type=str, default='_pass',
                      help='the config of the executor, it could be '
                           '> a YAML file path, '
@@ -256,9 +280,12 @@ def set_pea_parser(parser=None):
                           '> one of "_clear", "_pass", "_logforward" '
                           '> the content of YAML config (must starts with "!")'
                           '> a docker image')  # pod(no use) -> pea
-    gp0.add_argument('--py-modules', type=str, nargs='*',
+    gp0.add_argument('--py-modules', type=str, nargs='*', metavar='PATH',
                      help='the customized python modules need to be imported before loading the'
                           ' executor')
+    gp0.add_argument('--env', action=KVAppendAction,
+                     metavar='KEY=VALUE', nargs='*',
+                     help='a map of environment variables that are available to all peas in the pod.')
 
     gp1 = add_arg_group(parser, 'pea container arguments')
     gp1.add_argument('--uses-internal', type=str, default='BaseExecutor',
@@ -269,7 +296,7 @@ def set_pea_parser(parser=None):
                           'when not set then the docker image ENTRYPOINT takes effective.')
     gp1.add_argument('--pull-latest', action='store_true', default=False,
                      help='pull the latest image before running')
-    gp1.add_argument('--volumes', type=str, nargs='*',
+    gp1.add_argument('--volumes', type=str, nargs='*', metavar='DIR',
                      help='the path on the host to be mounted inside the container. '
                           'they will be mounted to the root path, i.e. /user/test/my-workspace will be mounted to '
                           '/my-workspace inside the container. all volumes are mounted with read-write mode.')
@@ -426,9 +453,9 @@ def set_export_api_parser(parser=None):
     if not parser:
         parser = set_base_parser()
 
-    parser.add_argument('--yaml-path', type=str, nargs='*',
+    parser.add_argument('--yaml-path', type=str, nargs='*', metavar='PATH',
                         help='the YAML file path for storing the exported API')
-    parser.add_argument('--json-path', type=str, nargs='*',
+    parser.add_argument('--json-path', type=str, nargs='*', metavar='PATH',
                         help='the JSON file path for storing the exported API')
     return parser
 

--- a/tests/unit/flow/yaml/flow-with-envs.yml
+++ b/tests/unit/flow/yaml/flow-with-envs.yml
@@ -1,0 +1,12 @@
+!Flow
+version: '1'
+env:
+  key_parent: value3  # all pods share this env var
+pods:
+  - name: pod0  # notice the change here, name is now an attribute
+    uses: EnvChecker1
+    env:
+      key1: value1
+      key2: value2
+  - name: pod0  # notice the change here, name is now an attribute
+    uses: EnvChecker2

--- a/tests/unit/flow/yaml/flow-with-envs.yml
+++ b/tests/unit/flow/yaml/flow-with-envs.yml
@@ -3,10 +3,8 @@ version: '1'
 env:
   key_parent: value3  # all pods share this env var
 pods:
-  - name: pod0  # notice the change here, name is now an attribute
-    uses: EnvChecker1
+  - uses: EnvChecker1
     env:
       key1: value1
       key2: value2
-  - name: pod0  # notice the change here, name is now an attribute
-    uses: EnvChecker2
+  - uses: EnvChecker2

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -2,6 +2,8 @@ import subprocess
 
 import pytest
 
+from jina.parser import set_pod_parser
+
 
 @pytest.mark.parametrize('cli', ['pod', 'pea', 'gateway', 'log',
                                  'check', 'ping', 'client', 'flow', 'hello-world', 'export-api'])
@@ -11,3 +13,12 @@ def test_cli(cli):
 
 def test_main_cli():
     subprocess.check_call(['jina'])
+
+
+def test_parse_env_map():
+    a = set_pod_parser().parse_args(['--env', 'key1=value1',
+                                     '--env', 'key2=value2'])
+    assert a.env == {'key1': 'value1', 'key2': 'value2'}
+
+    a = set_pod_parser().parse_args(['--env', 'key1=value1', 'key2=value2'])
+    assert a.env == {'key1': 'value1', 'key2': 'value2'}


### PR DESCRIPTION
## Feature

- `env` add for Flow and Pod level
- available from CLI and YAML

YAML usage:
```yaml
!Flow
version: '1'
env:
  key_parent: value3  # all pods share this env var
pods:
  - uses: EnvChecker1
    env:
      key1: value1
      key2: value2
  - uses: EnvChecker2
```

CLI usage: `jina pod --env key1=value1 key2=value2`

could be useful to #1414 

