### PR TITLE
[not to be merged] test: bad iterator 

### DIFF
--- a/tests/unit/clients/python/test_async_client.py
+++ b/tests/unit/clients/python/test_async_client.py
@@ -1,0 +1,9 @@
+from jina.flow import Flow
+
+f = Flow().add()
+
+def test_bad_iterator():
+    # This will get stuck as iterator is bad
+    # This is the reason, we had added a timeout to request_iterator in the servicer
+    with f:
+        f.index([1, 2, 3])


### PR DESCRIPTION
- This should get stuck
- This is to show why we'd added a timeout to `request_iterator.__anext__()` in servicer (which was the reason for segmentation faults). The `wait_for` was removed in #1450 
- The way to solve this can be call `Client.check_input()` on the req_iter before calling servicer. 