### PR TITLE
docs(devices): improve TorchDevice docstring

### DIFF
--- a/jina/executors/devices.py
+++ b/jina/executors/devices.py
@@ -48,12 +48,11 @@ class TorchDevice(BaseDevice):
             def encode(self, data, *args, **kwargs):
                 # use your awesome model to encode/craft/score
                 import torch
-                _input = torch.from_numpy(data)
-                if self.on_gpu:
-                    _input = _input.cuda()
-                _output = self.model(_input).detach()
-                if self.on_gpu:
-                    _output = _output.cpu()
+                torch.set_grad_enabled(False)
+                
+                _input = torch.as_tensor(data, device=self.device)
+                _output = self.model(_input).cpu()
+
                 return _output.numpy()
 
     """


### PR DESCRIPTION
I improved the `TorchDevice` docs, namely:
- set `torch.set_grad_enabled(False)` as the example does not include any training/gradients - this is good practice as it saves memory and increases performance
- `_input` tensor created using `as_tensor` with the `device` parameter - no need to explicitly check for GPU, as if only CPU is available no in-memory copy will be made
-  `_output` tensor now calls the `cpu()` method without checking for GPU - as before, if there is no GPU, then this operation is a noop, i.e. no in-memory copy will be made.