### PR TITLE
feat: revert pathlib changes

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,15 +1,14 @@
 import os
 import sys
 import shutil
-from pathlib import Path
 from typing import Iterator
 
 import numpy as np
 
 from jina import Document
 
-file_dir = Path(__file__).parent
-sys.path.append(str(file_dir.parent))
+file_dir = os.path.dirname(__file__)
+sys.path.append(os.path.dirname(file_dir))
 
 
 def random_docs(num_docs, chunks_per_doc=5, embed_dim=10, jitter=1, start_id=0, embedding=True) -> Iterator['Document']:
@@ -42,9 +41,9 @@ def random_docs(num_docs, chunks_per_doc=5, embed_dim=10, jitter=1, start_id=0, 
 
 def rm_files(file_paths):
     for file_path in file_paths:
-        file_path = Path(file_path)
-        if file_path.exists():
-            if file_path.is_file():
+        if os.path.exists(file_path):
+            if os.path.isfile(file_path):
                 os.remove(file_path)
-            elif file_path.is_dir():
+            elif os.path.isdir(file_path):
                 shutil.rmtree(file_path, ignore_errors=False, onerror=None)
+

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,5 +1,5 @@
+import os
 import sys
-from pathlib import Path
 
-file_dir = Path(__file__).parent
-sys.path.append(str(file_dir.parent))
+file_dir = os.path.dirname(__file__)
+sys.path.append(os.path.dirname(file_dir))

--- a/tests/unit/clients/python/test_io.py
+++ b/tests/unit/clients/python/test_io.py
@@ -1,4 +1,4 @@
-from pathlib import Path
+import os
 
 import numpy as np
 import pytest
@@ -11,7 +11,7 @@ from jina.excepts import BadClientInput
 
 @pytest.fixture(scope='function')
 def filepath(tmpdir):
-    input_filepath = Path(tmpdir) / 'input_file.csv'
+    input_filepath = os.path.join(tmpdir, 'input_file.csv')
     with open(input_filepath, 'w') as input_file:
         input_file.writelines(["1\n", "2\n", "3\n"])
     return input_filepath

--- a/tests/unit/docker/test_hub_build.py
+++ b/tests/unit/docker/test_hub_build.py
@@ -1,22 +1,16 @@
-from pathlib import Path
-
-import pytest
 import os
 
-from jina.docker.hubio import HubIO
-from jina.docker import hubapi
-from jina.excepts import ImageAlreadyExists
-from jina.jaml import JAML
-from jina.helper import expand_dict
-from jina.docker.helper import credentials_file
-from jina.parser import set_hub_build_parser, set_hub_list_parser, set_hub_pushpull_parser
+import pytest
 
-cur_dir = Path(__file__).parent
+from jina.docker.hubio import HubIO
+from jina.parser import set_hub_build_parser, set_hub_pushpull_parser
+
+cur_dir = os.path.dirname(os.path.abspath(__file__))
 
 @pytest.mark.timeout(360)
 def test_hub_build_pull():
     args = set_hub_build_parser().parse_args(
-        [str(cur_dir / 'hub-mwu'), '--push', '--test-uses', '--raise-error'])
+        [os.path.join(cur_dir, 'hub-mwu'), '--push', '--test-uses', '--raise-error'])
     HubIO(args).build()
 
     args = set_hub_pushpull_parser().parse_args(['jinahub/pod.dummy_mwu_encoder'])
@@ -29,13 +23,13 @@ def test_hub_build_pull():
 @pytest.mark.timeout(360)
 def test_hub_build_uses():
     args = set_hub_build_parser().parse_args(
-        [str(cur_dir / 'hub-mwu'), '--test-uses', '--raise-error'])
+        [os.path.join(cur_dir, 'hub-mwu'), '--test-uses', '--raise-error'])
     HubIO(args).build()
     # build again it shall not fail
     HubIO(args).build()
 
     args = set_hub_build_parser().parse_args(
-        [str(cur_dir / 'hub-mwu'), '--test-uses', '--daemon', '--raise-error'])
+        [os.path.join(cur_dir, 'hub-mwu'), '--test-uses', '--daemon', '--raise-error'])
     HubIO(args).build()
     # build again it shall not fail
     HubIO(args).build()
@@ -44,15 +38,15 @@ def test_hub_build_uses():
 def test_hub_build_failures():
     for j in ['bad-dockerfile', 'bad-pythonfile', 'missing-dockerfile', 'missing-manifest']:
         args = set_hub_build_parser().parse_args(
-            [str(cur_dir / 'hub-mwu-bad' / j)])
+            [os.path.join(cur_dir, 'hub-mwu-bad', j)])
         assert not HubIO(args).build()['is_build_success']
 
 
 def test_hub_build_no_pymodules():
     args = set_hub_build_parser().parse_args(
-        [str(cur_dir / 'hub-mwu-bad' / 'fail-to-start')])
+        [os.path.join(cur_dir, 'hub-mwu-bad', 'fail-to-start')])
     assert HubIO(args).build()['is_build_success']
 
     args = set_hub_build_parser().parse_args(
-        [str(cur_dir / 'hub-mwu-bad' / 'fail-to-start'), '--test-uses'])
+        [os.path.join(cur_dir, 'hub-mwu-bad', 'fail-to-start'), '--test-uses'])
     assert not HubIO(args).build()['is_build_success']

--- a/tests/unit/drivers/test_cache_driver.py
+++ b/tests/unit/drivers/test_cache_driver.py
@@ -89,7 +89,7 @@ def test_cache_driver_from_file(tmp_path):
         driver._traverse_apply(docs)
 
     # check persistence
-    assert Path(executor.save_abspath).exists()
+    assert os.path.exists(executor.save_abspath)
 
 
 class MockBaseCacheDriver(BaseCacheDriver):

--- a/tests/unit/drivers/test_cache_driver.py
+++ b/tests/unit/drivers/test_cache_driver.py
@@ -1,5 +1,5 @@
+import os
 import pickle
-from pathlib import Path
 from typing import Any
 
 import pytest
@@ -46,7 +46,7 @@ def test_cache_driver_twice(tmpdir):
         filename = executor.save_abspath
 
     # check persistence
-    assert Path(filename).exists()
+    assert os.path.exists(filename)
 
 
 def test_cache_driver_tmpfile():
@@ -66,7 +66,7 @@ def test_cache_driver_tmpfile():
         docs = list(random_docs(10, start_id=100, embedding=False))
         driver._traverse_apply(docs)
 
-    assert Path(executor.index_abspath).exists()
+    assert os.path.exists(executor.index_abspath)
 
 
 def test_cache_driver_from_file(tmp_path):

--- a/tests/unit/drivers/test_reduce_all_driver.py
+++ b/tests/unit/drivers/test_reduce_all_driver.py
@@ -1,4 +1,4 @@
-from pathlib import Path
+import os
 from typing import List, Dict
 
 import numpy as np
@@ -8,7 +8,7 @@ from jina.executors.encoders import BaseEncoder
 from jina.flow import Flow
 from jina.proto.jina_pb2 import DocumentProto
 
-cur_dir = Path(__file__).parent
+cur_dir = os.path.dirname(os.path.abspath(__file__))
 
 
 class MockSegmenterReduce(BaseSegmenter):
@@ -53,8 +53,8 @@ def test_merge_chunks_with_different_modality(mocker):
     response_mock = mocker.Mock(wrap=validate)
 
     flow = Flow().add(name='crafter', uses='MockSegmenterReduce'). \
-        add(name='encoder1', uses=str(cur_dir / 'yaml/mockencoder-mode1.yml')). \
-        add(name='encoder2', uses=str(cur_dir / 'yaml/mockencoder-mode2.yml'), needs=['crafter']). \
+        add(name='encoder1', uses=os.path.join(cur_dir, 'yaml/mockencoder-mode1.yml')). \
+        add(name='encoder2', uses=os.path.join(cur_dir, 'yaml/mockencoder-mode2.yml'), needs=['crafter']). \
         add(name='reducer', uses='- !ReduceAllDriver | {traversal_paths: [c]}',
             needs=['encoder1', 'encoder2'])
 

--- a/tests/unit/executors/indexers/test_numpyindexer.py
+++ b/tests/unit/executors/indexers/test_numpyindexer.py
@@ -1,4 +1,4 @@
-from pathlib import Path
+import os
 
 import numpy as np
 import pytest
@@ -25,7 +25,7 @@ def test_numpy_indexer(batch_size, compress_level, test_metas):
         indexer.batch_size = batch_size
         indexer.add(vec_idx, vec)
         indexer.save()
-        assert Path(indexer.index_abspath).exists()
+        assert os.path.exists(indexer.index_abspath)
         save_abspath = indexer.save_abspath
 
     with BaseIndexer.load(save_abspath) as indexer:
@@ -49,7 +49,7 @@ def test_numpy_indexer_known(batch_size, compress_level, test_metas):
         indexer.batch_size = batch_size
         indexer.add(keys, vectors)
         indexer.save()
-        assert Path(indexer.index_abspath).exists()
+        assert os.path.exists(indexer.index_abspath)
         save_abspath = indexer.save_abspath
 
     queries = np.array([[1, 1, 1],
@@ -74,7 +74,7 @@ def test_scipy_indexer(batch_size, compress_level, test_metas):
         indexer.batch_size = batch_size
         indexer.add(vec_idx, vec)
         indexer.save()
-        assert Path(indexer.index_abspath).exists()
+        assert os.path.exists(indexer.index_abspath)
         save_abspath = indexer.save_abspath
 
     with BaseIndexer.load(save_abspath) as indexer:
@@ -107,7 +107,7 @@ def test_numpy_indexer_known_big(batch_size, compress_level, test_metas):
                       metas=test_metas) as indexer:
         indexer.add(keys, vectors)
         indexer.save()
-        assert Path(indexer.index_abspath).exists()
+        assert os.path.exists(indexer.index_abspath)
         save_abspath = indexer.save_abspath
 
     with BaseIndexer.load(save_abspath) as indexer:
@@ -143,7 +143,7 @@ def test_scipy_indexer_known_big(batch_size, compress_level, test_metas):
                       metas=test_metas) as indexer:
         indexer.add(keys, vectors)
         indexer.save()
-        assert Path(indexer.index_abspath).exists()
+        assert os.path.exists(indexer.index_abspath)
         save_abspath = indexer.save_abspath
 
     with BaseIndexer.load(save_abspath) as indexer:
@@ -175,12 +175,12 @@ def test__get_sorted_top_k(batch_size, num_docs, top_k, test_metas):
 
 @pytest.mark.parametrize('batch_size, compress_level', [(None, 0), (None, 1), (2, 0), (2, 1)])
 def test_numpy_indexer_empty_data(batch_size, compress_level, test_metas):
-    idx_file_path = Path(test_metas['workspace']) / 'np.test.gz'
+    idx_file_path = os.path.join(test_metas['workspace'], 'np.test.gz')
     with NumpyIndexer(index_filename=str(idx_file_path), compress_level=compress_level, metas=test_metas) as indexer:
         indexer.batch_size = batch_size
         indexer.touch()
         indexer.save()
-        assert Path(indexer.index_abspath).exists()
+        assert os.path.exists(indexer.index_abspath)
         save_abspath = indexer.save_abspath
 
     with BaseIndexer.load(save_abspath) as indexer:
@@ -201,7 +201,7 @@ def test_indexer_one_dimensional(metric, test_metas):
         indexer.add(add_vec_idx, add_vec)
 
         indexer.save()
-        assert Path(indexer.index_abspath).exists()
+        assert os.path.exists(indexer.index_abspath)
         save_abspath = indexer.save_abspath
 
     with BaseIndexer.load(save_abspath) as indexer:
@@ -223,7 +223,7 @@ def test_indexer_zeros(metric, dimension, test_metas):
                       metas=test_metas) as indexer:
         indexer.add(add_vec_idx, add_vec)
         indexer.save()
-        assert Path(indexer.index_abspath).exists()
+        assert os.path.exists(indexer.index_abspath)
         save_abspath = indexer.save_abspath
 
     with BaseIndexer.load(save_abspath) as indexer:

--- a/tests/unit/executors/test_comp_exec.py
+++ b/tests/unit/executors/test_comp_exec.py
@@ -1,4 +1,4 @@
-from pathlib import Path
+import os
 
 import pytest
 
@@ -6,7 +6,7 @@ from jina.executors import BaseExecutor
 from jina.executors.compound import CompoundExecutor
 from tests import rm_files
 
-cur_dir = Path(__file__).parent
+cur_dir = os.path.dirname(os.path.abspath(__file__))
 
 
 class DummyA(BaseExecutor):
@@ -37,7 +37,7 @@ def test_compositional_route(monkeypatch):
     b.add_route('say', db.name, 'say')
     assert b.say() == 'b'
     b.save_config()
-    assert Path(b.config_abspath).exists()
+    assert os.path.exists(b.config_abspath)
 
     c = BaseExecutor.load_config(b.config_abspath)
     assert c.say_all() == ['a', 'b']
@@ -51,7 +51,7 @@ def test_compositional_route(monkeypatch):
 
     b.touch()
     b.save()
-    assert Path(b.save_abspath).exists()
+    assert os.path.exists(b.save_abspath)
 
     d = BaseExecutor.load(b.save_abspath)
     assert d.say_all() == ['a', 'b']
@@ -67,13 +67,13 @@ def test_compositional_dump():
     a.touch()
     a.save()
     a.save_config()
-    assert Path(a.save_abspath).exists()
-    assert Path(a.config_abspath).exists()
+    assert os.path.exists(a.save_abspath)
+    assert os.path.exists(a.config_abspath)
     rm_files([a.save_abspath, a.config_abspath])
 
 
 def test_compound_from_yaml():
-    a = BaseExecutor.load_config(str(cur_dir / 'yaml/npvec.yml'))
+    a = BaseExecutor.load_config(os.path.join(cur_dir, 'yaml/npvec.yml'))
     assert isinstance(a, CompoundExecutor)
     assert callable(getattr(a, 'add'))
     assert callable(getattr(a, 'query'))

--- a/tests/unit/executors/test_decorators.py
+++ b/tests/unit/executors/test_decorators.py
@@ -1,4 +1,4 @@
-from pathlib import Path
+import os
 
 import numpy as np
 import pytest
@@ -154,7 +154,7 @@ def test_batching_slice_on():
 
 
 def test_batching_ordinal_idx_arg(tmpdir):
-    path = Path(tmpdir) / 'vec.gz'
+    path = os.path.join(str(tmpdir), 'vec.gz')
     vec = np.random.random([10, 10])
     with open(path, 'wb') as f:
         f.write(vec.tobytes())
@@ -170,7 +170,7 @@ def test_batching_ordinal_idx_arg(tmpdir):
             return list(range(ord_idx.start, ord_idx.stop))
 
     instance = A(2)
-    result = instance.f(np.memmap(str(path), dtype=vec.dtype.name, mode='r', shape=vec.shape), vec.shape[0])
+    result = instance.f(np.memmap(path, dtype=vec.dtype.name, mode='r', shape=vec.shape), vec.shape[0])
     assert len(instance.ord_idx) == 5
     assert instance.ord_idx[0].start == 0
     assert instance.ord_idx[0].stop == 2

--- a/tests/unit/executors/test_route_exec.py
+++ b/tests/unit/executors/test_route_exec.py
@@ -1,4 +1,4 @@
-from pathlib import Path
+import os
 from pprint import pprint
 
 import pytest
@@ -7,11 +7,11 @@ from jina.executors import BaseExecutor
 from jina.flow import Flow
 from tests import random_docs
 
-cur_dir = Path(__file__).parent
+cur_dir = os.path.dirname(os.path.abspath(__file__))
 
 
 def test_load_driver():
-    b = BaseExecutor.load_config(str(cur_dir / 'yaml/route.yml'))
+    b = BaseExecutor.load_config(os.path.join(cur_dir, 'yaml/route.yml'))
     pprint(b._drivers)
 
     c = BaseExecutor.load_config('_pass')
@@ -24,7 +24,7 @@ def test_route():
     docs = random_docs(num_docs=2, chunks_per_doc=2)
     f = (Flow()
         .add(
-        uses_before=str(cur_dir / 'yaml' / 'route.yml'),
+        uses_before=os.path.join(cur_dir, 'yaml', 'route.yml'),
         shards=2))
 
     with f:

--- a/tests/unit/flow/test_flow.py
+++ b/tests/unit/flow/test_flow.py
@@ -139,7 +139,7 @@ def test_simple_flow():
 
 
 def test_flow_identical():
-    with open(cur_dir.parent / 'yaml' / 'test-flow.yml') as fp:
+    with open(os.path.join(cur_dir, '../yaml/test-flow.yml')) as fp:
         a = Flow.load_config(fp)
 
     b = (Flow()
@@ -199,15 +199,16 @@ def test_pod_status():
 
 
 def test_flow_no_container():
+
     f = (Flow()
-         .add(name='dummyEncoder', uses=str(cur_dir.parent / 'mwu-encoder' / 'mwu_encoder.yml')))
+         .add(name='dummyEncoder', uses=os.path.join(cur_dir, '../mwu-encoder/mwu_encoder.yml')))
 
     with f:
         f.index(input_fn=random_docs(10))
 
 
 def test_flow_log_server():
-    f = Flow.load_config(str(cur_dir.parent / 'yaml' / 'test_log_server.yml'))
+    f = Flow.load_config(os.path.join(cur_dir, '../yaml/test_log_server.yml'))
     with f:
         assert hasattr(JINA_GLOBAL.logserver, 'ready')
 

--- a/tests/unit/flow/test_flow.py
+++ b/tests/unit/flow/test_flow.py
@@ -1,5 +1,4 @@
 import os
-from pathlib import Path
 
 import numpy as np
 import pytest
@@ -17,7 +16,7 @@ from jina.proto.jina_pb2 import DocumentProto
 from jina.types.request import Response
 from tests import random_docs, rm_files
 
-cur_dir = Path(__file__).parent
+cur_dir = os.path.dirname(os.path.abspath(__file__))
 
 
 def test_ping():
@@ -251,7 +250,7 @@ def test_flow_log_server():
 
 
 def test_shards():
-    f = Flow().add(name='doc_pb', uses=str(cur_dir.parent / 'yaml' / 'test-docpb.yml'), parallel=3,
+    f = Flow().add(name='doc_pb', uses=os.path.join(cur_dir, '../yaml/test-docpb.yml'), parallel=3,
                    separated_workspace=True)
     with f:
         f.index(input_fn=random_docs(1000), random_doc_id=False)
@@ -451,7 +450,7 @@ def test_index_text_files(mocker):
 
     response_mock = mocker.Mock(wrap=validate)
 
-    f = (Flow(read_only=True).add(uses=str(cur_dir.parent / 'yaml' / 'datauriindex.yml'), timeout_ready=-1))
+    f = (Flow(read_only=True).add(uses=os.path.join(cur_dir, '../yaml/datauriindex.yml'), timeout_ready=-1))
 
     with f:
         f.index_files('*.py', on_done=response_mock, callback_on='body')

--- a/tests/unit/flow/test_flow_example_face.py
+++ b/tests/unit/flow/test_flow_example_face.py
@@ -1,13 +1,13 @@
-from pathlib import Path
+import os
 
 from jina.enums import SocketType
 from jina.flow import Flow
 
-cur_dir = Path(__file__).parent
+cur_dir = os.path.dirname(os.path.abspath(__file__))
 
 
 def test_index():
-    f = Flow.load_config(str(cur_dir.parent / 'yaml' / 'examples' / 'faces' / 'flow-index.yml'))
+    f = Flow.load_config(os.path.join(cur_dir, '../yaml/examples/faces/flow-index.yml'))
     with f:
         node = f._pod_nodes['gateway']
         assert node.head_args.socket_in == SocketType.PULL_CONNECT
@@ -76,7 +76,7 @@ def test_index():
 
 
 def test_query():
-    f = Flow.load_config(str(cur_dir.parent / 'yaml' / 'examples' / 'faces' / 'flow-query.yml'))
+    f = Flow.load_config(os.path.join(cur_dir, '../yaml/examples/faces/flow-query.yml'))
     with f:
         node = f._pod_nodes['gateway']
         assert node.head_args.socket_in == SocketType.PULL_CONNECT

--- a/tests/unit/flow/test_flow_example_faiss.py
+++ b/tests/unit/flow/test_flow_example_faiss.py
@@ -1,13 +1,13 @@
-from pathlib import Path
+import os
 
 from jina.enums import SocketType
 from jina.flow import Flow
 
-cur_dir = Path(__file__).parent
+cur_dir = os.path.dirname(os.path.abspath(__file__))
 
 
 def test_index():
-    f = Flow.load_config(str(cur_dir.parent / 'yaml' / 'examples' / 'faiss' / 'flow-index.yml'))
+    f = Flow.load_config(os.path.join(cur_dir, '../yaml/examples/faiss/flow-index.yml'))
     with f:
         node = f._pod_nodes['gateway']
         assert node.head_args.socket_in == SocketType.PULL_CONNECT
@@ -58,7 +58,7 @@ def test_index():
 
 
 def test_query():
-    f = Flow.load_config(str(cur_dir.parent / 'yaml' / 'examples' / 'faiss' / 'flow-query.yml'))
+    f = Flow.load_config(os.path.join(cur_dir, '../yaml/examples/faiss/flow-query.yml'))
     with f:
         node = f._pod_nodes['gateway']
         assert node.head_args.socket_in == SocketType.PULL_CONNECT

--- a/tests/unit/flow/test_flow_index.py
+++ b/tests/unit/flow/test_flow_index.py
@@ -1,6 +1,5 @@
 import os
 import time
-from pathlib import Path
 
 import pytest
 
@@ -9,7 +8,7 @@ from jina.proto import jina_pb2
 from jina.types.document.uid import UniqueId
 from tests import random_docs, rm_files
 
-cur_dir = Path(__file__).parent
+cur_dir = os.path.dirname(os.path.abspath(__file__))
 
 
 def random_queries(num_docs, chunks_per_doc=5):
@@ -41,7 +40,7 @@ def test_shards_insufficient_data():
             assert d.meta_info == b'hello world'
 
     f = Flow().add(name='doc_pb',
-                   uses=str(cur_dir.parent / 'yaml' / 'test-docpb.yml'),
+                   uses=os.path.join(cur_dir, '../yaml/test-docpb.yml'),
                    parallel=parallel,
                    separated_workspace=True)
     with f:
@@ -52,7 +51,7 @@ def test_shards_insufficient_data():
         pass
     time.sleep(2)
     f = Flow().add(name='doc_pb',
-                   uses=str(cur_dir.parent / 'yaml' / 'test-docpb.yml'),
+                   uses=os.path.join(cur_dir, '../yaml/test-docpb.yml'),
                    parallel=parallel,
                    separated_workspace=True, polling='all', uses_after='_merge_chunks')
     with f:

--- a/tests/unit/flow/test_flow_multimode.py
+++ b/tests/unit/flow/test_flow_multimode.py
@@ -1,5 +1,4 @@
 import os
-from pathlib import Path
 from typing import List, Dict
 
 import numpy as np
@@ -11,9 +10,7 @@ from jina.flow import Flow
 from jina.proto import jina_pb2
 from jina.types.document.uid import UniqueId
 
-# import DocumentProto
-
-cur_dir = Path(__file__).parent
+cur_dir = os.path.dirname(os.path.abspath(__file__))
 
 
 class MockSegmenter(BaseSegmenter):
@@ -57,10 +54,10 @@ def test_flow_with_modalities(tmpdir):
         return [doc1, doc2, doc3]
 
     flow = Flow().add(name='crafter', uses='!MockSegmenter'). \
-        add(name='encoder1', uses=str(cur_dir / 'yaml' / 'mockencoder-mode1.yml')). \
-        add(name='indexer1', uses=str(cur_dir / 'yaml' / 'numpy-indexer-1.yml'), needs=['encoder1']). \
-        add(name='encoder2', uses=str(cur_dir / 'yaml' / 'mockencoder-mode2.yml'), needs=['crafter']). \
-        add(name='indexer2', uses=str(cur_dir / 'yaml' / 'numpy-indexer-2.yml')). \
+        add(name='encoder1', uses=os.path.join(cur_dir, 'yaml/mockencoder-mode1.yml')). \
+        add(name='indexer1', uses=os.path.join(cur_dir, 'yaml/numpy-indexer-1.yml'), needs=['encoder1']). \
+        add(name='encoder2', uses=os.path.join(cur_dir, 'yaml/mockencoder-mode2.yml'), needs=['crafter']). \
+        add(name='indexer2', uses=os.path.join(cur_dir, 'yaml/numpy-indexer-2.yml')). \
         join(['indexer1', 'indexer2'])
 
     with flow:

--- a/tests/unit/flow/test_flow_visualization.py
+++ b/tests/unit/flow/test_flow_visualization.py
@@ -1,67 +1,58 @@
-from pathlib import Path
+import os
 
 from jina.flow import Flow
 
-cur_dir = Path(__file__).parent
+cur_dir = os.path.dirname(os.path.abspath(__file__))
 
 
 def test_visualization_with_yml_file_img(tmpdir):
-    output_file = Path(tmpdir) / 'flow.svg'
-    Flow.load_config(str(cur_dir.parent / 'yaml' / 'test_flow_visualization.yml')).plot(
-        output=str(output_file))
-    assert output_file.exists()
+    Flow.load_config(os.path.join(cur_dir, '../yaml/test_flow_visualization.yml')).plot(
+        output=os.path.join(tmpdir, 'flow.svg'))
+    assert os.path.exists(os.path.join(tmpdir, 'flow.svg'))
 
 
 def test_visualization_with_yml_file_jpg(tmpdir):
-    output_file = Path(tmpdir) / 'flow.jpg'
-    Flow.load_config(str(cur_dir.parent / 'yaml' / 'test_flow_visualization.yml')).plot(
-        output=str(output_file))
-    assert output_file.exists()
+    Flow.load_config(os.path.join(cur_dir, '../yaml/test_flow_visualization.yml')).plot(
+        output=os.path.join(tmpdir, 'flow.jpg'))
+    assert os.path.exists(os.path.join(tmpdir, 'flow.jpg'))
 
 
 def test_visualization_with_yml_file_jpg_lr(tmpdir):
-    output_file = Path(tmpdir) / 'flow-hor.jpg'
-    Flow.load_config(str(cur_dir.parent / 'yaml' / 'test_flow_visualization.yml')).plot(
-        output=str(output_file),
+    Flow.load_config(os.path.join(cur_dir, '../yaml/test_flow_visualization.yml')).plot(
+        output=os.path.join(tmpdir, 'flow-hor.jpg'),
         vertical_layout=False)
-    assert output_file.exists()
+    assert os.path.exists(os.path.join(tmpdir, 'flow-hor.jpg'))
 
 
 def test_visualization_plot_twice(tmpdir):
-    output_file1 = Path(tmpdir) / 'flow1.svg'
-    output_file2 = Path(tmpdir) / 'flow2.svg'
     (Flow().add(name='pod_a')
-     .plot(output=str(output_file1))
+     .plot(output=os.path.join(tmpdir, 'flow1.svg'))
      .add(name='pod_b', needs='gateway')
-     .join(needs=['pod_a', 'pod_b']).plot(output=str(output_file2)))
+     .join(needs=['pod_a', 'pod_b']).plot(output=os.path.join(tmpdir, 'flow2.svg')))
 
-    assert output_file1.exists()
-    assert output_file2.exists()
+    assert os.path.exists(os.path.join(tmpdir, 'flow1.svg'))
+    assert os.path.exists(os.path.join(tmpdir, 'flow2.svg'))
 
 
 def test_visualization_plot_in_middle(tmpdir):
-    output_file = Path(tmpdir) / 'flow3.svg'
     (Flow().add(name='pod_a')
-     .plot(output=str(output_file))
+     .plot(output=os.path.join(tmpdir, 'flow3.svg'))
      .add(name='pod_b', needs='gateway')
      .join(needs=['pod_a', 'pod_b']))
 
-    assert output_file.exists()
+    assert os.path.exists(os.path.join(tmpdir, 'flow3.svg'))
 
 
 def test_flow_before_after_plot(tmpdir):
-    output_file = Path(tmpdir) / 'flow.svg'
-    Flow().add(uses_before='_pass', uses_after='_pass', name='p1').plot(str(output_file))
-    assert output_file.exists()
+    Flow().add(uses_before='_pass', uses_after='_pass', name='p1').plot(os.path.join(tmpdir, 'flow.svg'))
+    assert os.path.exists(os.path.join(tmpdir, 'flow.svg'))
 
 
 def test_flow_before_plot(tmpdir):
-    output_file = Path(tmpdir) / 'flow.svg'
-    Flow().add(uses_before='_pass', name='p1').plot(str(output_file))
-    assert output_file.exists()
+    Flow().add(uses_before='_pass', name='p1').plot(os.path.join(tmpdir, 'flow.svg'))
+    assert os.path.exists(os.path.join(tmpdir, 'flow.svg'))
 
 
 def test_flow_after_plot(tmpdir):
-    output_file = Path(tmpdir) / 'flow.svg'
-    Flow().add(uses_after='_pass', name='p1').plot(str(output_file))
-    assert output_file.exists()
+    Flow().add(uses_after='_pass', name='p1').plot(os.path.join(tmpdir, 'flow.svg'))
+    assert os.path.exists(os.path.join(tmpdir, 'flow.svg'))

--- a/tests/unit/logging/test_logging.py
+++ b/tests/unit/logging/test_logging.py
@@ -1,12 +1,11 @@
 import os
-from pathlib import Path
 
 import pytest
 
 from jina import __uptime__
 from jina.logging import JinaLogger
 
-cur_dir = Path(__file__).parent
+cur_dir = os.path.dirname(os.path.abspath(__file__))
 
 
 def log(logger):
@@ -40,11 +39,11 @@ def test_logging_default():
 
 def test_logging_file():
     fn = f'jina-{__uptime__}.log'
-    if Path(fn).exists():
+    if os.path.exists(fn):
         os.remove(fn)
-    with JinaLogger('test_logger', log_config=str(cur_dir / 'yaml' / 'file.yml')) as logger:
+    with JinaLogger('test_logger', log_config=os.path.join(cur_dir, 'yaml/file.yml')) as logger:
         log(logger)
-    assert Path(fn).exists()
+    assert os.path.exists(fn)
     with open(fn) as fp:
         assert len(fp.readlines()) == 7
     os.remove(fn)

--- a/tests/unit/logging/test_logging.py
+++ b/tests/unit/logging/test_logging.py
@@ -21,7 +21,7 @@ def log(logger):
 
 
 def test_logging_syslog():
-    with JinaLogger('test_logger', log_config=str(cur_dir / 'yaml' / 'syslog.yml')) as logger:
+    with JinaLogger('test_logger', log_config=os.path.join(cur_dir, 'yaml/syslog.yml')) as logger:
         log(logger)
         assert len(logger.handlers) == 1
 
@@ -49,7 +49,7 @@ def test_logging_file():
     os.remove(fn)
 
 
-@pytest.mark.parametrize('log_config', [str(cur_dir / 'yaml/fluent.yml'), None])
+@pytest.mark.parametrize('log_config', [os.path.join(cur_dir, 'yaml/fluent.yml'), None])
 def test_logging_fluentd(monkeypatch, log_config):
     from fluent import asynchandler as fluentasynchandler
     with JinaLogger('test_logger', log_config=log_config, log_id='test_log_id') as logger:

--- a/tests/unit/peapods/runtimes/container/test_container_runtime.py
+++ b/tests/unit/peapods/runtimes/container/test_container_runtime.py
@@ -23,7 +23,7 @@ localhost = defaulthost if (platform == "linux" or platform == "linux2") else 'h
 def docker_image_built():
     import docker
     client = docker.from_env()
-    client.images.build(path=os.path.join(cur_dir, '../mwu-encoder/'), tag=img_name)
+    client.images.build(path=os.path.join(cur_dir, '../../../mwu-encoder/'), tag=img_name)
     client.close()
     yield
     time.sleep(2)
@@ -44,7 +44,7 @@ def test_simple_container(docker_image_built):
 def test_simple_container_with_ext_yaml(docker_image_built):
     args = set_pea_parser().parse_args(['--uses', img_name,
                                         '--uses-internal',
-                                        os.path.join(cur_dir, '../mwu-encoder/mwu_encoder_ext.yml')])
+                                        os.path.join(cur_dir, '../../../mwu-encoder/mwu_encoder_ext.yml')])
 
     with ContainerRuntime(args):
         time.sleep(2)
@@ -61,7 +61,7 @@ def test_flow_with_one_container_pod(docker_image_built):
 def test_flow_with_one_container_ext_yaml(docker_image_built):
     f = (Flow()
          .add(name='dummyEncoder2', uses=img_name,
-              uses_internal=str(cur_dir.parent.parent.parent / 'mwu-encoder' / 'mwu_encoder_ext.yml')))
+              uses_internal=os.path.join(cur_dir, '../../../mwu-encoder/mwu_encoder_ext.yml')))
 
     with f:
         f.index(input_fn=random_docs(10))
@@ -71,7 +71,7 @@ def test_flow_with_replica_container_ext_yaml(docker_image_built):
     f = (Flow()
          .add(name='dummyEncoder3',
               uses=img_name,
-              uses_internal=os.path.join(cur_dir, '../mwu-encoder/mwu_encoder_ext.yml'),
+              uses_internal=os.path.join(cur_dir, '../../../mwu-encoder/mwu_encoder_ext.yml'),
               parallel=3))
 
     with f:
@@ -117,18 +117,15 @@ def test_flow_topo_parallel(docker_image_built):
 
 
 def test_container_volume(docker_image_built, tmpdir):
-    tmpdir = Path(tmpdir)
-    abc_path = tmpdir / 'abc'
+    abc_path = os.path.join(tmpdir, 'abc')
     f = (Flow()
          .add(name=random_name(), uses=img_name, volumes=str(abc_path),
-              uses_internal=str(cur_dir.parent.parent.parent / 'mwu-encoder' / 'mwu_encoder_upd.yml')))
+              uses_internal=os.path.join(cur_dir, '../../../mwu-encoder/mwu_encoder_upd.yml')))
 
     with f:
         f.index(random_docs(10))
 
-    out_file = abc_path / 'ext-mwu-encoder.bin'
-
-    assert out_file.exists()
+    assert os.path.exists(os.path.join(abc_path, '/ext-mwu-encoder.bin'))
 
 
 def test_container_ping(docker_image_built):
@@ -162,7 +159,7 @@ def test_tail_host_docker2local(docker_image_built):
 def test_container_status():
     args = set_pea_parser().parse_args(['--uses', img_name,
                                         '--uses-internal',
-                                        str(cur_dir.parent.parent.parent / 'mwu-encoder' / 'mwu_encoder_ext.yml')])
+                                        os.path.join(cur_dir, '../../../mwu-encoder/mwu_encoder_ext.yml')])
     runtime = ContainerRuntime(args)
     assert not runtime.is_ready
     with runtime:

--- a/tests/unit/peapods/runtimes/container/test_container_runtime.py
+++ b/tests/unit/peapods/runtimes/container/test_container_runtime.py
@@ -119,13 +119,13 @@ def test_flow_topo_parallel(docker_image_built):
 def test_container_volume(docker_image_built, tmpdir):
     abc_path = os.path.join(tmpdir, 'abc')
     f = (Flow()
-         .add(name=random_name(), uses=img_name, volumes=str(abc_path),
+         .add(name=random_name(), uses=img_name, volumes=abc_path,
               uses_internal=os.path.join(cur_dir, '../../../mwu-encoder/mwu_encoder_upd.yml')))
 
     with f:
         f.index(random_docs(10))
 
-    assert os.path.exists(os.path.join(abc_path, '/ext-mwu-encoder.bin'))
+    assert os.path.exists(os.path.join(abc_path, 'ext-mwu-encoder.bin'))
 
 
 def test_container_ping(docker_image_built):

--- a/tests/unit/peapods/runtimes/container/test_container_runtime.py
+++ b/tests/unit/peapods/runtimes/container/test_container_runtime.py
@@ -1,6 +1,5 @@
 import os
 import time
-from pathlib import Path
 from sys import platform
 
 import pytest
@@ -12,7 +11,7 @@ from jina.parser import set_pea_parser, set_ping_parser
 from jina.peapods.runtimes.container import ContainerRuntime
 from tests import random_docs
 
-cur_dir = Path(__file__).parent
+cur_dir = os.path.dirname(os.path.abspath(__file__))
 
 img_name = 'jina/mwu-encoder'
 
@@ -24,7 +23,7 @@ localhost = defaulthost if (platform == "linux" or platform == "linux2") else 'h
 def docker_image_built():
     import docker
     client = docker.from_env()
-    client.images.build(path=str(cur_dir.parent.parent.parent / 'mwu-encoder'), tag=img_name)
+    client.images.build(path=os.path.join(cur_dir, '../mwu-encoder/'), tag=img_name)
     client.close()
     yield
     time.sleep(2)
@@ -45,7 +44,7 @@ def test_simple_container(docker_image_built):
 def test_simple_container_with_ext_yaml(docker_image_built):
     args = set_pea_parser().parse_args(['--uses', img_name,
                                         '--uses-internal',
-                                        str(cur_dir.parent.parent.parent / 'mwu-encoder' / 'mwu_encoder_ext.yml')])
+                                        os.path.join(cur_dir, '../mwu-encoder/mwu_encoder_ext.yml')])
 
     with ContainerRuntime(args):
         time.sleep(2)
@@ -72,7 +71,7 @@ def test_flow_with_replica_container_ext_yaml(docker_image_built):
     f = (Flow()
          .add(name='dummyEncoder3',
               uses=img_name,
-              uses_internal=str(cur_dir.parent.parent.parent / 'mwu-encoder' / 'mwu_encoder_ext.yml'),
+              uses_internal=os.path.join(cur_dir, '../mwu-encoder/mwu_encoder_ext.yml'),
               parallel=3))
 
     with f:

--- a/tests/unit/peapods/runtimes/remote/jinad/test_api.py
+++ b/tests/unit/peapods/runtimes/remote/jinad/test_api.py
@@ -1,11 +1,11 @@
-from pathlib import Path
+import os
 
 import mock
 from jina.logging import JinaLogger
 from jina.peapods.runtimes.remote.jinad.api import JinadAPI, PodJinadAPI, PeaJinadAPI, fetch_files_from_yaml
 
 logger = JinaLogger(context='test-remote')
-yaml_path = Path(__file__).parent
+yaml_path = os.path.dirname(os.path.realpath(__file__))
 relative_pymodules_path = 'tests/unit/peapods/runtimes/remote/jinad'
 jinad_api = JinadAPI(host='0.0.0.0', port=8000, logger=logger)
 pod_api = PodJinadAPI(host='0.0.0.0', port=8000, logger=logger)

--- a/tests/unit/test_driver_yaml.py
+++ b/tests/unit/test_driver_yaml.py
@@ -1,4 +1,4 @@
-from pathlib import Path
+import os
 
 import pytest
 from pkg_resources import resource_filename
@@ -11,22 +11,21 @@ from jina.jaml import JAML
 from jina.parser import set_pod_parser
 from jina.peapods import Pod
 
-cur_dir = Path(__file__).parent
+cur_dir = os.path.dirname(os.path.abspath(__file__))
 
 
 def test_load_yaml1(tmpdir):
-    tmpdir = Path(tmpdir)
-    with open(cur_dir / 'yaml/test-driver.yml', encoding='utf8') as fp:
+    with open(os.path.join(cur_dir, 'yaml/test-driver.yml'), encoding='utf8') as fp:
         a = JAML.load(fp)
 
     assert isinstance(a[0], KVSearchDriver)
     assert isinstance(a[1], ControlReqDriver)
     assert isinstance(a[2], BaseDriver)
 
-    with open(tmpdir / 'test_driver.yml', 'w', encoding='utf8') as fp:
+    with open(os.path.join(tmpdir, 'test_driver.yml'), 'w', encoding='utf8') as fp:
         JAML.dump(a[0], fp)
 
-    with open(tmpdir / 'test_driver.yml', encoding='utf8') as fp:
+    with open(os.path.join(tmpdir, 'test_driver.yml'), encoding='utf8') as fp:
         b = JAML.load(fp)
 
     assert isinstance(b, KVSearchDriver)
@@ -34,26 +33,26 @@ def test_load_yaml1(tmpdir):
 
 
 def test_load_cust_with_driver():
-    a = BaseExecutor.load_config(str(cur_dir / 'mwu-encoder/mwu_encoder_driver.yml'))
+    a = BaseExecutor.load_config(os.path.join(cur_dir, 'mwu-encoder/mwu_encoder_driver.yml'))
     assert a._drivers['ControlRequest'][0].__class__.__name__ == 'MyAwesomeDriver'
-    p = set_pod_parser().parse_args(['--uses', str(cur_dir / 'mwu-encoder/mwu_encoder_driver.yml')])
+    p = set_pod_parser().parse_args(['--uses', os.path.join(cur_dir, 'mwu-encoder/mwu_encoder_driver.yml')])
     with Pod(p):
         # will print a cust task_name from the driver when terminate
         pass
 
 
 def test_pod_new_api_from_kwargs():
-    a = BaseExecutor.load_config(str(cur_dir / 'mwu-encoder/mwu_encoder_driver.yml'))
+    a = BaseExecutor.load_config(os.path.join(cur_dir, 'mwu-encoder/mwu_encoder_driver.yml'))
     assert a._drivers['ControlRequest'][0].__class__.__name__ == 'MyAwesomeDriver'
 
-    with Pod(uses=str(cur_dir / 'mwu-encoder/mwu_encoder_driver.yml')):
+    with Pod(uses=os.path.join(cur_dir, 'mwu-encoder/mwu_encoder_driver.yml')):
         # will print a cust task_name from the driver when terminate
         pass
 
 
 @pytest.mark.parametrize('random_workspace_name', ['JINA_TEST_EXEC_WITH_DRIVER'])
 def test_load_yaml2(test_metas):
-    a = BaseExecutor.load_config(str(cur_dir / 'yaml/test-exec-with-driver.yml'))
+    a = BaseExecutor.load_config(os.path.join(cur_dir, 'yaml/test-exec-with-driver.yml'))
     assert len(a._drivers) == 2
     # should be able to auto fill in ControlRequest
     assert 'ControlRequest' in a._drivers

--- a/tests/unit/test_exectype.py
+++ b/tests/unit/test_exectype.py
@@ -1,4 +1,4 @@
-from pathlib import Path
+import os
 
 import pytest
 
@@ -8,21 +8,20 @@ from jina.jaml import JAML
 
 
 def test_exec_type(tmpdir):
-    tmpdir = Path(tmpdir)
     from jina.executors.indexers import BaseIndexer
     assert 'BaseIndexer' in BaseExecutor._registered_class
 
     # init from YAML should be okay as well
     BaseExecutor.load_config('BaseIndexer')
 
-    BaseIndexer().save_config(str(tmpdir / 'tmp.yml'))
-    with open(tmpdir / 'tmp.yml') as fp:
+    BaseIndexer().save_config(os.path.join(tmpdir, 'tmp.yml'))
+    with open(os.path.join(tmpdir, 'tmp.yml')) as fp:
         s = JAML.load(fp)
 
     def assert_bi():
         b = BaseIndexer(1)
-        b.save_config(str(tmpdir / 'tmp.yml'))
-        with open(tmpdir / 'tmp.yml') as fp:
+        b.save_config(os.path.join(tmpdir, 'tmp.yml'))
+        with open(os.path.join(tmpdir, 'tmp.yml')) as fp:
             b = JAML.load(fp)
             assert b.a == 1
 

--- a/tests/unit/test_index.py
+++ b/tests/unit/test_index.py
@@ -1,6 +1,5 @@
 import os
 import multiprocessing as mp
-from pathlib import Path
 
 import pytest
 import numpy as np
@@ -13,7 +12,7 @@ from jina.proto import jina_pb2
 from jina import Document
 from tests import random_docs
 
-cur_dir = Path(__file__).parent
+cur_dir = os.path.dirname(os.path.abspath(__file__))
 
 
 @pytest.fixture(scope='function')
@@ -91,21 +90,21 @@ def test_simple_route():
 def test_update_method(test_metas):
     with DummyIndexer(index_filename='testa.bin', metas=test_metas) as indexer:
         indexer.save()
-        assert not Path(indexer.save_abspath).exists()
-        assert not Path(indexer.index_abspath).exists()
+        assert not os.path.exists(indexer.save_abspath)
+        assert not os.path.exists(indexer.index_abspath)
         indexer.add()
         indexer.save()
-        assert Path(indexer.save_abspath).exists()
-        assert Path(indexer.index_abspath).exists()
+        assert os.path.exists(indexer.save_abspath)
+        assert os.path.exists(indexer.index_abspath)
 
     with DummyIndexer2(index_filename='testb.bin', metas=test_metas) as indexer:
         indexer.save()
-        assert not Path(indexer.save_abspath).exists()
-        assert not Path(indexer.index_abspath).exists()
+        assert not os.path.exists(indexer.save_abspath)
+        assert not os.path.exists(indexer.index_abspath)
         indexer.add(np.array([1, 2, 3]), np.array([[1, 1, 1], [2, 2, 2]]))
         indexer.save()
-        assert Path(indexer.save_abspath).exists()
-        assert Path(indexer.index_abspath).exists()
+        assert os.path.exists(indexer.save_abspath)
+        assert os.path.exists(indexer.index_abspath)
 
 
 @pytest.mark.skipif('GITHUB_WORKFLOW' in os.environ, reason='skip the network test on github workflow')
@@ -155,13 +154,13 @@ def test_two_client_route():
 
 
 def test_index(test_workspace_index):
-    f = Flow().add(uses=str(cur_dir / 'yaml' / 'test-index.yml'), parallel=3, separated_workspace=True)
+    f = Flow().add(uses=os.path.join(cur_dir, 'yaml/test-index.yml'), parallel=3, separated_workspace=True)
     with f:
         f.index(input_fn=random_docs(50))
 
     for j in range(3):
-        assert Path(test_workspace_index) / f'test2-{j + 1}/test2.bin'
-        assert (Path(test_workspace_index) / f'test2-{j + 1}/tmp2').exists()
+        assert os.path.join(test_workspace_index, f'test2-{j + 1}/test2.bin')
+        assert os.path.exists(os.path.join(test_workspace_index, f'test2-{j + 1}/tmp2'))
 
 
 def test_compound_idx(test_workspace_joint, mocker):
@@ -169,11 +168,11 @@ def test_compound_idx(test_workspace_joint, mocker):
         assert req.status.code < jina_pb2.StatusProto.ERROR
         assert req.search.docs[0].matches[0].score.op_name == 'NumpyIndexer'
 
-    with Flow().add(uses=str(cur_dir / 'yaml' / 'test-joint.yml')) as f:
+    with Flow().add(uses=os.path.join(cur_dir, 'yaml/test-joint.yml')) as f:
         f.index(random_docs(100, chunks_per_doc=0))
 
     response_mock = mocker.Mock(wrap=validate)
-    with Flow().add(uses=str(cur_dir / 'yaml' / 'test-joint.yml')) as g:
+    with Flow().add(uses=os.path.join(cur_dir, 'yaml/test-joint.yml')) as g:
         g.search(random_docs(10, chunks_per_doc=0), on_done=response_mock)
 
     response_mock.assert_called()

--- a/tests/unit/test_index_remote.py
+++ b/tests/unit/test_index_remote.py
@@ -1,7 +1,6 @@
 import os
 import time
 import multiprocessing as mp
-from pathlib import Path
 
 import pytest
 import numpy as np
@@ -14,7 +13,7 @@ from jina.parser import set_gateway_parser
 from jina.executors.indexers.vector import NumpyIndexer
 from tests import random_docs
 
-cur_dir = Path(__file__).parent
+cur_dir = os.path.dirname(os.path.abspath(__file__))
 
 
 def get_result(resp):
@@ -83,7 +82,7 @@ def test_index_remote(test_workspace):
     t.start()
 
     f = Flow().add(
-        uses=str(cur_dir / 'yaml/test-index-remote.yml'),
+        uses=os.path.join(cur_dir, 'yaml/test-index-remote.yml'),
         parallel=3,
         separated_workspace=True,
         host='0.0.0.0',
@@ -95,10 +94,10 @@ def test_index_remote(test_workspace):
 
     time.sleep(3)
     for j in range(3):
-        bin_path = Path(test_workspace) / f'test2-{j + 1}/test2.bin'
-        index_filename_path = Path(test_workspace) / f'test2-{j + 1}/tmp2'
-        assert bin_path.exists()
-        assert index_filename_path.exists()
+        bin_path = os.path.join(test_workspace, f'test2-{j + 1}/test2.bin')
+        index_filename_path = os.path.join(test_workspace, f'test2-{j + 1}/tmp2')
+        assert os.path.exists(bin_path)
+        assert os.path.exists(index_filename_path)
 
 
 @pytest.mark.skipif('GITHUB_WORKFLOW' in os.environ, reason='skip the network test on github workflow')
@@ -114,7 +113,7 @@ def test_index_remote_rpi(test_workspace):
     t.start()
 
     f = Flow(optimize_level=FlowOptimizeLevel.IGNORE_GATEWAY).add(
-        uses=str(cur_dir / 'yaml/test-index-remote.yml'),
+        uses=os.path.join(cur_dir, 'yaml/test-index-remote.yml'),
         parallel=3,
         separated_workspace=True,
         host='0.0.0.0',

--- a/tests/unit/test_workspace.py
+++ b/tests/unit/test_workspace.py
@@ -1,5 +1,4 @@
 import os
-from pathlib import Path
 
 import numpy as np
 import pytest
@@ -11,44 +10,42 @@ from jina.executors import BaseExecutor
 def test_share_workspace(tmpdir, pea_id):
     with BaseExecutor.load_config('yaml/test-workspace.yml', separated_workspace=True, pea_id=pea_id) as executor:
         executor.touch()
-        executor_dir = Path(tmpdir) / f'{executor.name}-{pea_id}-{executor.name}.bin'
-        executor.save(str(executor_dir))
-        assert executor_dir.exists()
+        executor_dir = tmpdir.join(f'{executor.name}-{pea_id}-{executor.name}.bin')
+        executor.save(executor_dir)
+        assert os.path.exists(executor_dir)
 
 
 @pytest.mark.parametrize('pea_id', [1, 2, 3])
 def test_compound_workspace(tmpdir, pea_id):
-    tmpdir = Path(tmpdir)
     with BaseExecutor.load_config('yaml/test-compound-workspace.yml', separated_workspace=True,
                                   pea_id=pea_id) as executor:
         for c in executor.components:
             c.touch()
-            component_dir = tmpdir / f'{executor.name}-{pea_id}-{c.name}.bin'
-            c.save(str(component_dir))
-            assert component_dir.exists()
+            component_dir = tmpdir.join(f'{executor.name}-{pea_id}-{c.name}.bin')
+            c.save(component_dir)
+            assert os.path.exists(component_dir)
         executor.touch()
-        executor_dir = tmpdir / f'{executor.name}-{pea_id}-{executor.name}.bin'
-        executor.save(str(executor_dir))
-        assert executor_dir.exists()
+        executor_dir = tmpdir.join(f'{executor.name}-{pea_id}-{executor.name}.bin')
+        executor.save(executor_dir)
+        assert os.path.exists(executor_dir)
 
 
 @pytest.mark.parametrize('pea_id', [1, 2, 3])
 def test_compound_indexer(tmpdir, pea_id):
-    tmpdir = Path(tmpdir)
     with BaseExecutor.load_config('yaml/test-compound-indexer.yml',
                                   separated_workspace=True, pea_id=pea_id) as e:
         for c in e:
             c.touch()
-            component_dir = tmpdir / f'{e.name}-{pea_id}-{c.name}.bin'
-            c.save(str(component_dir))
-            assert Path(c.index_abspath).exists()
+            component_dir = tmpdir.join(f'{e.name}-{pea_id}-{c.name}.bin')
+            c.save(component_dir)
+            assert os.path.exists(c.index_abspath)
             assert c.save_abspath.startswith(e.current_workspace)
             assert c.index_abspath.startswith(e.current_workspace)
 
         e.touch()
-        executor_dir = tmpdir / f'{e.name}-{pea_id}-{e.name}.bin'
-        e.save(str(executor_dir))
-        assert executor_dir.exists()
+        executor_dir = tmpdir.join(f'{e.name}-{pea_id}-{e.name}.bin')
+        e.save(executor_dir)
+        assert os.path.exists(executor_dir)
 
 
 def test_compound_indexer_rw(tmpdir):
@@ -67,11 +64,11 @@ def test_compound_indexer_rw(tmpdir):
             assert a[1].is_updated
             a.save()
             # the compound executor itself is not modified, therefore should not generate a save
-            assert not Path(a.save_abspath).exists()
-            assert Path(a[0].save_abspath).exists()
-            assert Path(a[0].index_abspath).exists()
-            assert Path(a[1].save_abspath).exists()
-            assert Path(a[1].index_abspath).exists()
+            assert not os.path.exists(a.save_abspath)
+            assert os.path.exists(a[0].save_abspath)
+            assert os.path.exists(a[0].index_abspath)
+            assert os.path.exists(a[1].save_abspath)
+            assert os.path.exists(a[1].index_abspath)
 
     recovered_vecs = []
     for j in range(3):

--- a/tests/unit/test_yamlparser.py
+++ b/tests/unit/test_yamlparser.py
@@ -63,7 +63,7 @@ def test_yaml_expand3():
 
 def test_yaml_expand4():
     os.environ['ENV1'] = 'a'
-    with open(os.path.join(cur_dir / 'yaml/test-expand4.yml')) as fp:
+    with open(os.path.join(cur_dir, 'yaml/test-expand4.yml')) as fp:
         b = JAML.load(fp, substitute=True,
                       context={'context_var': 3.14,
                                'context_var2': 'hello-world'})

--- a/tests/unit/test_yamlparser.py
+++ b/tests/unit/test_yamlparser.py
@@ -1,5 +1,4 @@
 import os
-from pathlib import Path
 
 import pytest
 import yaml
@@ -15,7 +14,7 @@ from jina.jaml import JAML
 from jina.parser import set_pea_parser
 from jina.peapods.peas import BasePea
 
-cur_dir = Path(__file__).parent
+cur_dir = os.path.dirname(os.path.abspath(__file__))
 
 
 @pytest.fixture(scope='function')
@@ -27,7 +26,7 @@ def test_workspace(tmpdir):
 
 
 def test_yaml_expand():
-    with open(cur_dir / 'yaml/test-expand.yml') as fp:
+    with open(os.path.join(cur_dir, 'yaml/test-expand.yml')) as fp:
         a = JAML.load(fp)
     b = expand_dict(a)
     assert b['quote_dict'] == {}
@@ -41,7 +40,7 @@ def test_yaml_expand():
 
 
 def test_yaml_expand2():
-    with open(cur_dir / 'yaml/test-expand2.yml') as fp:
+    with open(os.path.join(cur_dir, 'yaml/test-expand2.yml')) as fp:
         a = JAML.load(fp)
     os.environ['ENV1'] = 'a'
     b = expand_dict(a)
@@ -54,7 +53,7 @@ def test_yaml_expand2():
 
 
 def test_yaml_expand3():
-    with open(cur_dir / 'yaml/test-expand3.yml') as fp:
+    with open(os.path.join(cur_dir, 'yaml/test-expand3.yml')) as fp:
         a = JAML.load(fp)
 
     b = expand_dict(a)
@@ -64,7 +63,7 @@ def test_yaml_expand3():
 
 def test_yaml_expand4():
     os.environ['ENV1'] = 'a'
-    with open(cur_dir / 'yaml/test-expand4.yml') as fp:
+    with open(os.path.join(cur_dir / 'yaml/test-expand4.yml')) as fp:
         b = JAML.load(fp, substitute=True,
                       context={'context_var': 3.14,
                                'context_var2': 'hello-world'})
@@ -91,7 +90,7 @@ def test_attr_dict():
 
 
 def test_yaml_fill():
-    with open(cur_dir / 'yaml/test-expand2.yml') as fp:
+    with open(os.path.join(cur_dir, 'yaml/test-expand2.yml')) as fp:
         a = JAML.load(fp)
     print(fill_metas_with_defaults(a))
 
@@ -123,7 +122,7 @@ def test_class_yaml3():
 
 
 def test_joint_indexer(test_workspace):
-    b = BaseExecutor.load_config(str(cur_dir / 'yaml/test-joint.yml'))
+    b = BaseExecutor.load_config(os.path.join(cur_dir, 'yaml/test-joint.yml'))
     b.attach(pea=None)
     assert b._drivers['SearchRequest'][0]._exec == b[0]
     assert b._drivers['SearchRequest'][-1]._exec == b[1]


### PR DESCRIPTION
Revert #1400 in #1349

Reason:

> please do not do any pathlib refactoring anymore. Not worth it, as none of our methods accepts Path-like object as arg. As a consequence, I observe this pattern str->Path->str in a lot of places in the tests. What's the purpose of doing this if you eventually have to convert it into str? for just saving +'/'+?