### PR TITLE
test: clean up driver test

### DIFF
--- a/tests/unit/drivers/querylang/queryset/test_dunderkeys.py
+++ b/tests/unit/drivers/querylang/queryset/test_dunderkeys.py
@@ -1,5 +1,6 @@
 import pytest
 
+from jina import Document
 from jina.drivers.querylang.queryset.dunderkey import (
     dunderkey,
     dunder_init,
@@ -8,7 +9,7 @@ from jina.drivers.querylang.queryset.dunderkey import (
     undunder_keys,
     dunder_truncate,
 )
-from jina import Document
+
 
 def test_dunderkey():
     assert dunderkey('a', 'b', 'c') == 'a__b__c'

--- a/tests/unit/drivers/querylang/queryset/test_lookup.py
+++ b/tests/unit/drivers/querylang/queryset/test_lookup.py
@@ -1,8 +1,7 @@
 import pytest
 
-from jina.types.document import Document
 from jina.drivers.querylang.queryset.lookup import LookupLeaf, Q, QuerySet
-
+from jina.types.document import Document
 from tests import random_docs
 
 

--- a/tests/unit/drivers/test_concat_driver.py
+++ b/tests/unit/drivers/test_concat_driver.py
@@ -8,9 +8,9 @@ from jina.types.document.uid import UniqueId
 from jina.types.ndarray.generic import NdArray
 
 e1 = np.random.random([7])
-e2 = np.random.random([7])
-e3 = np.random.random([7])
-e4 = np.random.random([7])
+e2 = np.random.random([5])
+e3 = np.random.random([3])
+e4 = np.random.random([9])
 
 
 def input_fn():

--- a/tests/unit/drivers/test_craft_driver.py
+++ b/tests/unit/drivers/test_craft_driver.py
@@ -8,6 +8,12 @@ from jina.drivers.craft import CraftDriver
 from jina.executors.crafters import BaseCrafter
 from jina.types.ndarray.generic import NdArray
 
+@pytest.fixture(scope='function')
+def docs():
+    doc1 = Document(content='valid')
+    doc2 = Document(content='invalid')
+    return [doc1, doc2]
+
 
 class MockCrafter(BaseCrafter):
     def __init__(self, *args, **kwargs):
@@ -31,14 +37,7 @@ class SimpleCraftDriver(CraftDriver):
         return self._exec_fn
 
 
-def create_documents_to_craft():
-    doc1 = Document(content='valid')
-    doc2 = Document(content='invalid')
-    return [doc1, doc2]
-
-
-def test_craft_driver():
-    docs = create_documents_to_craft()
+def test_craft_driver(docs):
     driver = SimpleCraftDriver()
     executor = MockCrafter()
     driver.attach(executor=executor, pea=None)

--- a/tests/unit/drivers/test_craft_driver.py
+++ b/tests/unit/drivers/test_craft_driver.py
@@ -8,6 +8,7 @@ from jina.drivers.craft import CraftDriver
 from jina.executors.crafters import BaseCrafter
 from jina.types.ndarray.generic import NdArray
 
+
 @pytest.fixture(scope='function')
 def docs():
     doc1 = Document(content='valid')

--- a/tests/unit/drivers/test_encoder_driver.py
+++ b/tests/unit/drivers/test_encoder_driver.py
@@ -12,6 +12,7 @@ from jina.executors.encoders import BaseEncoder
 def num_docs():
     return 10
 
+
 @pytest.fixture(scope='function')
 def docs_to_encode(num_docs):
     docs = []
@@ -19,6 +20,7 @@ def docs_to_encode(num_docs):
         doc = Document(content=np.array([idx]))
         docs.append(doc)
     return DocumentSet(docs)
+
 
 class MockEncoder(BaseEncoder):
     def __init__(self,

--- a/tests/unit/drivers/test_encoder_driver.py
+++ b/tests/unit/drivers/test_encoder_driver.py
@@ -1,7 +1,7 @@
 from typing import Any
 
-import pytest
 import numpy as np
+import pytest
 
 from jina import Document, DocumentSet
 from jina.drivers.encode import EncodeDriver

--- a/tests/unit/drivers/test_helper.py
+++ b/tests/unit/drivers/test_helper.py
@@ -5,9 +5,20 @@ import pytest
 
 from jina import Document, DocumentSet
 from jina.proto import jina_pb2
-from jina.types.document.helper import DocGroundtruthPair
 from jina.types.message import Message
 from jina.types.ndarray.generic import NdArray
+
+@pytest.fixture(scope='function')
+def document():
+    with Document() as doc:
+        doc.text = 'this is text'
+        doc.tags['id'] = 'id in tags'
+        doc.tags['inner_dict'] = {'id': 'id in inner_dict'}
+        with Document() as chunk:
+            chunk.text = 'text in chunk'
+            chunk.tags['id'] = 'id in chunk tags'
+        doc.chunks.add(chunk)
+    return doc
 
 
 @pytest.mark.parametrize(
@@ -32,15 +43,7 @@ def test_array_protobuf_conversions_with_quantize(quantize, type):
     np.testing.assert_almost_equal(d.value, random_array, decimal=2)
 
 
-def test_pb_obj2dict():
-    document = jina_pb2.DocumentProto()
-    document.text = 'this is text'
-    document.tags['id'] = 'id in tags'
-    document.tags['inner_dict'] = {'id': 'id in inner_dict'}
-    chunk = document.chunks.add()
-    chunk.text = 'text in chunk'
-    chunk.tags['id'] = 'id in chunk tags'
-    document = Document(document)
+def test_pb_obj2dict(document):
     res = document.get_attrs('text', 'tags', 'chunks')
     assert res['text'] == 'this is text'
     assert res['tags']['id'] == 'id in tags'
@@ -74,39 +77,3 @@ def test_extract_docs():
     contents, docs_pts, bad_docs = DocumentSet([d]).all_embeddings
     assert len(bad_docs) == 0
     np.testing.assert_equal(contents[0], vec)
-
-
-def test_docgroundtruth_pair():
-    def add_matches(doc: jina_pb2.DocumentProto, num_matches):
-        for idx in range(num_matches):
-            match = doc.matches.add()
-            match.adjacency = doc.adjacency + 1
-
-    def add_chunks(doc: jina_pb2.DocumentProto, num_chunks):
-        for idx in range(num_chunks):
-            chunk = doc.chunks.add()
-            chunk.granularity = doc.granularity + 1
-
-    doc = jina_pb2.DocumentProto()
-    gt = jina_pb2.DocumentProto()
-    add_matches(doc, 3)
-    add_matches(gt, 3)
-    add_chunks(doc, 3)
-    add_chunks(gt, 3)
-
-    pair = DocGroundtruthPair(doc, gt)
-
-    j = 0
-    for chunk_pair in pair.chunks:
-        assert chunk_pair.doc.granularity == 1
-        assert chunk_pair.groundtruth.granularity == 1
-        j += 1
-
-    k = 0
-    for match_pair in pair.matches:
-        assert match_pair.doc.adjacency == 1
-        assert match_pair.groundtruth.adjacency == 1
-        k += 1
-
-    assert j == 3
-    assert k == 3

--- a/tests/unit/drivers/test_helper.py
+++ b/tests/unit/drivers/test_helper.py
@@ -8,6 +8,7 @@ from jina.proto import jina_pb2
 from jina.types.message import Message
 from jina.types.ndarray.generic import NdArray
 
+
 @pytest.fixture(scope='function')
 def document():
     with Document() as doc:

--- a/tests/unit/drivers/test_kv_index_driver.py
+++ b/tests/unit/drivers/test_kv_index_driver.py
@@ -5,7 +5,7 @@ import pytest
 from jina.drivers.index import KVIndexDriver
 from jina.executors.indexers import BaseKVIndexer
 from jina.proto import jina_pb2
-from jina.types.document import uid, Document
+from jina.types.document import Document
 
 
 class MockGroundTruthIndexer(BaseKVIndexer):

--- a/tests/unit/drivers/test_kv_search_driver.py
+++ b/tests/unit/drivers/test_kv_search_driver.py
@@ -1,6 +1,7 @@
 from typing import Optional
 
 import numpy as np
+import pytest
 
 from jina import Document
 from jina.drivers.search import KVSearchDriver
@@ -31,24 +32,15 @@ class MockIndexer(BaseKVIndexer):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        doc1 = Document()
-        doc1.id = str(1) * 16
-        doc1.embedding = np.array([int(doc1.id)])
-        doc2 = Document()
-        doc2.id = str(2) * 16
-        doc2.embedding = np.array([int(doc2.id)])
-        doc3 = Document()
-        doc3.id = str(3) * 16
-        doc3.embedding = np.array([int(doc3.id)])
-        doc4 = Document()
-        doc4.id = str(4) * 16
-        doc4.embedding = np.array([int(doc4.id)])
-        self.db = {
-            int(doc1.id): doc1.SerializeToString(),
-            int(doc2.id): doc2.SerializeToString(),
-            int(doc3.id): doc3.SerializeToString(),
-            int(doc4.id): doc4.SerializeToString()
-        }
+        self.db = {}
+        doc_ids = ['1', '2', '3', '4']
+        doc_ids = [item * 16 for item in doc_ids]
+        for doc_id in doc_ids:
+            with Document() as doc:
+                doc.id = doc_id
+                doc.embedding = np.array([int(doc.id)])
+            self.db[int(doc.id)] = doc.SerializeToString()
+
 
 
 class SimpleKVSearchDriver(KVSearchDriver):
@@ -61,7 +53,8 @@ class SimpleKVSearchDriver(KVSearchDriver):
         return self._exec_fn
 
 
-def create_document_to_search():
+@pytest.fixture(scope='function')
+def document():
     # 1-D embedding
     # doc: 0
     #   - chunk: 1
@@ -72,12 +65,14 @@ def create_document_to_search():
     doc = Document()
     doc.id = '0' * 16
     for c in range(5):
-        chunk = doc.chunks.new()
-        chunk.id = str(c + 1) * 16
+        with Document() as chunk:
+            chunk.id = str(c + 1) * 16
+        doc.chunks.add(chunk)
     return doc
 
 
-def create_document_to_search_with_matches_on_chunks():
+@pytest.fixture(scope='function')
+def document_with_matches_on_chunks():
     # 1-D embedding
     # doc: 0
     #   - chunk: 1
@@ -86,32 +81,33 @@ def create_document_to_search_with_matches_on_chunks():
     #     - match: 4
     #     - match: 5 - will be missing from KV indexer
     #     - match: 6 - will be missing from KV indexer
-    doc = Document()
-    doc.id = '0' * 16
-    chunk = doc.chunks.new()
-    chunk.id = '1' * 16
-    for m in range(5):
-        d = Document(id=str(m + 2) * 16)
-        d.score.value = 1.
-        chunk.matches.append(d)
+    with Document() as doc:
+        doc.id = '0' * 16
+        with Document() as chunk:
+            chunk.id = '1' * 16
+            for m in range(5):
+                with Document() as match:
+                    match.id = str(m + 2) * 16
+                    match.score.value = 1.
+                chunk.matches.append(match)
+        doc.chunks.append(chunk)
     return doc
 
 
-def test_vectorsearch_driver_mock_indexer_apply_all():
-    doc = create_document_to_search()
+def test_vectorsearch_driver_mock_indexer_apply_all(document):
     driver = SimpleKVSearchDriver()
 
     executor = MockIndexer()
     driver.attach(executor=executor, pea=None)
 
-    dcs = list(doc.chunks)
+    dcs = list(document.chunks)
     assert len(dcs) == 5
     for chunk in dcs:
         assert chunk.embedding is None
 
-    driver._apply_all(doc.chunks)
+    driver._apply_all(document.chunks)
 
-    dcs = list(doc.chunks)
+    dcs = list(document.chunks)
 
     # chunk idx: 5 had no matched and is removed as missing idx
     assert len(dcs) == 4
@@ -121,22 +117,21 @@ def test_vectorsearch_driver_mock_indexer_apply_all():
         np.testing.assert_equal(embedding_array, np.array([int(chunk.id)]))
 
 
-def test_vectorsearch_driver_mock_indexer_traverse_apply():
-    doc = create_document_to_search()
+def test_vectorsearch_driver_mock_indexer_traverse_apply(document):
     driver = SimpleKVSearchDriver()
 
     executor = MockIndexer()
     driver.attach(executor=executor, pea=None)
 
-    dcs = list(doc.chunks)
+    dcs = list(document.chunks)
     assert len(dcs) == 5
     for chunk in dcs:
         assert chunk.embedding is None
 
-    driver._traverse_apply(doc.chunks)
+    driver._traverse_apply(document.chunks)
 
     # chunk idx: 5 had no matched and is removed as missing idx
-    dcs = list(doc.chunks)
+    dcs = list(document.chunks)
     assert len(dcs) == 4
     for chunk in dcs:
         assert chunk.embedding is not None
@@ -144,15 +139,14 @@ def test_vectorsearch_driver_mock_indexer_traverse_apply():
         np.testing.assert_equal(embedding_array, np.array([int(chunk.id)]))
 
 
-def test_vectorsearch_driver_mock_indexer_with_matches_on_chunks():
+def test_vectorsearch_driver_mock_indexer_with_matches_on_chunks(document_with_matches_on_chunks):
     driver = SimpleKVSearchDriver(traversal_paths=('cm',))
     executor = MockIndexer()
     driver.attach(executor=executor, pea=None)
-    doc = create_document_to_search_with_matches_on_chunks()
 
-    driver._traverse_apply([doc])
+    driver._traverse_apply([document_with_matches_on_chunks])
 
-    dcs = list(doc.chunks)
+    dcs = list(document_with_matches_on_chunks.chunks)
     assert len(dcs) == 1
     chunk = dcs[0]
     matches = list(chunk.matches)

--- a/tests/unit/drivers/test_multimodal_driver.py
+++ b/tests/unit/drivers/test_multimodal_driver.py
@@ -1,8 +1,8 @@
 import numpy as np
 import pytest
+
 from jina import Document, DocumentSet
 from jina.drivers.multimodal import MultiModalDriver
-from jina.excepts import LengthMismatchException
 from jina.executors.encoders.multimodal import BaseMultiModalEncoder
 from jina.types.document.multimodal import MultimodalDocument
 

--- a/tests/unit/drivers/test_reduce_all_driver.py
+++ b/tests/unit/drivers/test_reduce_all_driver.py
@@ -2,13 +2,24 @@ import os
 from typing import List, Dict
 
 import numpy as np
+import pytest
 
+from jina import Document
 from jina.executors.crafters import BaseSegmenter
 from jina.executors.encoders import BaseEncoder
 from jina.flow import Flow
-from jina.proto.jina_pb2 import DocumentProto
 
 cur_dir = os.path.dirname(os.path.abspath(__file__))
+
+
+@pytest.fixture(scope='function')
+def docs():
+    documents = []
+    for i in range(1, 4):
+        with Document() as doc:
+            doc.text = f'title: this is mode1 from doc{i}, body: this is mode2 from doc{i}'
+        documents.append(doc)
+    return documents
 
 
 class MockSegmenterReduce(BaseSegmenter):
@@ -33,15 +44,9 @@ class MockEncoderReduce(BaseEncoder):
         return np.array(output)
 
 
-def test_merge_chunks_with_different_modality(mocker):
+def test_merge_chunks_with_different_modality(mocker, docs):
     def input_fn():
-        doc1 = DocumentProto()
-        doc1.text = 'title: this is mode1 from doc1, body: this is mode2 from doc1'
-        doc2 = DocumentProto()
-        doc2.text = 'title: this is mode1 from doc2, body: this is mode2 from doc2'
-        doc3 = DocumentProto()
-        doc3.text = 'title: this is mode1 from doc3, body: this is mode2 from doc3'
-        return [doc1, doc2, doc3]
+        return docs
 
     def validate(req):
         assert len(req.index.docs) == 3

--- a/tests/unit/drivers/test_segmenter_driver.py
+++ b/tests/unit/drivers/test_segmenter_driver.py
@@ -3,9 +3,9 @@ from typing import Dict, List
 import numpy as np
 import pytest
 
+from jina import Document
 from jina.drivers.craft import SegmentDriver
 from jina.executors.crafters import BaseSegmenter
-from jina import Document
 from jina.types.sets import DocumentSet
 
 

--- a/tests/unit/drivers/test_vector_fill_driver.py
+++ b/tests/unit/drivers/test_vector_fill_driver.py
@@ -1,10 +1,25 @@
 from typing import Any
 
+import pytest
 import numpy as np
 
 from jina.drivers.search import VectorFillDriver
 from jina.executors.indexers import BaseIndexer
 from jina import Document
+
+
+@pytest.fixture(scope='function')
+def num_docs():
+    return 10
+
+
+@pytest.fixture(scope='function')
+def docs_to_encode(num_docs):
+    docs = []
+    for idx in range(num_docs):
+        doc = Document(content=np.array([idx]))
+        docs.append(doc)
+    return docs
 
 
 class MockIndexer(BaseIndexer):
@@ -20,23 +35,14 @@ class SimpleFillDriver(VectorFillDriver):
         return self._exec_fn
 
 
-def create_documents_to_encode(num_docs):
-    docs = []
-    for idx in range(num_docs):
-        doc = Document()
-        docs.append(doc)
-    return docs
-
-
-def test_index_driver():
-    docs = create_documents_to_encode(10)
+def test_index_driver(docs_to_encode, num_docs):
     driver = SimpleFillDriver()
     executor = MockIndexer()
     driver.attach(executor=executor, pea=None)
-    assert len(docs) == 10
-    for doc in docs:
+    assert len(docs_to_encode) == num_docs
+    for doc in docs_to_encode:
         assert doc.embedding is None
-    driver._apply_all(docs)
-    assert len(docs) == 10
-    for doc in docs:
+    driver._apply_all(docs_to_encode)
+    assert len(docs_to_encode) == num_docs
+    for doc in docs_to_encode:
         assert doc.embedding.shape == (5,)

--- a/tests/unit/drivers/test_vector_fill_driver.py
+++ b/tests/unit/drivers/test_vector_fill_driver.py
@@ -1,11 +1,11 @@
 from typing import Any
 
-import pytest
 import numpy as np
+import pytest
 
+from jina import Document
 from jina.drivers.search import VectorFillDriver
 from jina.executors.indexers import BaseIndexer
-from jina import Document
 
 
 @pytest.fixture(scope='function')

--- a/tests/unit/drivers/test_vector_search_driver.py
+++ b/tests/unit/drivers/test_vector_search_driver.py
@@ -3,9 +3,9 @@ from typing import Tuple
 import numpy as np
 import pytest
 
+from jina import Document, QueryLang
 from jina.drivers.search import VectorSearchDriver
 from jina.executors.indexers import BaseVectorIndexer
-from jina import Document, QueryLang
 
 
 class MockVectorSearchDriver(VectorSearchDriver):

--- a/tests/unit/drivers/test_vector_search_driver.py
+++ b/tests/unit/drivers/test_vector_search_driver.py
@@ -6,7 +6,6 @@ import pytest
 from jina.drivers.search import VectorSearchDriver
 from jina.executors.indexers import BaseVectorIndexer
 from jina import Document, QueryLang
-from jina.types.document import uid
 
 
 class MockVectorSearchDriver(VectorSearchDriver):


### PR DESCRIPTION
More test refactoring on driver module:

1. Replace protobuf with primitive data types.
2. More decoupling on entity creation using pytest fixtures from test cases.
3. Some minor changes, such as optimize imports, remove unused code.