### PR TITLE
Fixes CORS behavior for REST API.

### DIFF
--- a/jina/peapods/peas/gateway/rest/__init__.py
+++ b/jina/peapods/peas/gateway/rest/__init__.py
@@ -21,7 +21,13 @@ class RESTGatewayPea(GatewayPea):
             from fastapi.middleware.cors import CORSMiddleware
 
         app = FastAPI(title=self.__class__.__name__)
-        app.add_middleware(CORSMiddleware, allow_origins=['*'])
+        app.add_middleware(
+                CORSMiddleware, 
+                allow_origins=['*'], 
+                allow_credentials=True,
+                allow_methods=['*'],
+                allow_headers=['*'],
+                )
         servicer = AsyncPrefetchCall(self.args)
 
         def error(reason, status_code):


### PR DESCRIPTION
I was not able to connect form jinabox.js to my local machine running a REST endpoint (as given in the `multires-lyrics-search` example) on MacOS.
This fixes it by adding CORS flags that are recommended by fastAPI.