### PR TITLE
feat(jaml): enables loading config from dict

### DIFF
--- a/jina/jaml/__init__.py
+++ b/jina/jaml/__init__.py
@@ -91,7 +91,7 @@ class JAML:
     def load_no_tags(stream, **kwargs):
         """Load yaml object but ignore all customized tags, e.g. !Executor, !Driver, !Flow
         """
-        safe_yml = '\n'.join(v if not re.match(r'^[\s-]*?!\b', v) else v.replace('!', '!cls: ') for v in stream)
+        safe_yml = '\n'.join(v if not re.match(r'^[\s-]*?!\b', v) else v.replace('!', '__cls: ') for v in stream)
         return JAML.load(safe_yml, **kwargs)
 
     @staticmethod
@@ -390,7 +390,7 @@ class JAMLCompatible(metaclass=JAMLCompatibleType):
                 load_py_modules(no_tag_yml, extra_search_paths=(os.path.dirname(s_path),) if s_path else None)
 
             # revert yaml's tag and load again, this time with substitution
-            revert_tag_yml = JAML.dump(no_tag_yml).replace('\'!cls\': ', '!')
+            revert_tag_yml = JAML.dump(no_tag_yml).replace('__cls: ', '!')
 
             # load into object, no more substitute
             return JAML.load(revert_tag_yml, substitute=False)

--- a/jina/jaml/__init__.py
+++ b/jina/jaml/__init__.py
@@ -91,7 +91,7 @@ class JAML:
     def load_no_tags(stream, **kwargs):
         """Load yaml object but ignore all customized tags, e.g. !Executor, !Driver, !Flow
         """
-        safe_yml = '\n'.join(v if not re.match(r'^[\s-]*?!\b', v) else v.replace('!', '__tag: ') for v in stream)
+        safe_yml = '\n'.join(v if not re.match(r'^[\s-]*?!\b', v) else v.replace('!', '!cls: ') for v in stream)
         return JAML.load(safe_yml, **kwargs)
 
     @staticmethod
@@ -321,7 +321,7 @@ class JAMLCompatible(metaclass=JAMLCompatibleType):
 
     @classmethod
     def load_config(cls,
-                    source: Union[str, TextIO], *,
+                    source: Union[str, TextIO, Dict], *,
                     allow_py_modules: bool = True,
                     substitute: bool = True,
                     context: Dict[str, Any] = None,
@@ -390,7 +390,7 @@ class JAMLCompatible(metaclass=JAMLCompatibleType):
                 load_py_modules(no_tag_yml, extra_search_paths=(os.path.dirname(s_path),) if s_path else None)
 
             # revert yaml's tag and load again, this time with substitution
-            revert_tag_yml = JAML.dump(no_tag_yml).replace('__tag: ', '!')
+            revert_tag_yml = JAML.dump(no_tag_yml).replace('\'!cls\': ', '!')
 
             # load into object, no more substitute
             return JAML.load(revert_tag_yml, substitute=False)

--- a/tests/unit/flow/test_flow_yaml_parser.py
+++ b/tests/unit/flow/test_flow_yaml_parser.py
@@ -78,6 +78,7 @@ def test_load_flow_from_yaml():
     with open(cur_dir.parent / 'yaml' / 'test-flow.yml') as fp:
         a = Flow.load_config(fp)
 
+
 def test_flow_yaml_dump():
     f = Flow(logserver_config=str(cur_dir.parent / 'yaml' / 'test-server-config.yml'),
              optimize_level=FlowOptimizeLevel.IGNORE_GATEWAY,
@@ -88,3 +89,17 @@ def test_flow_yaml_dump():
     assert f.args.logserver_config == fl.args.logserver_config
     assert f.args.optimize_level == fl.args.optimize_level
     rm_files(['test1.yml'])
+
+
+def test_flow_yaml_from_string():
+    f1 = Flow.load_config('yaml/flow-v1.0-syntax.yml')
+    with open('yaml/flow-v1.0-syntax.yml') as fp:
+        str_yaml = fp.read()
+        assert isinstance(str_yaml, str)
+        f2 = Flow.load_config(str_yaml)
+        assert f1 == f2
+
+    f3 = Flow.load_config('!Flow\nversion: 1.0\npods: [{name: ppp0, uses: _merge}, name: aaa1]')
+    assert 'ppp0' in f3._pod_nodes.keys()
+    assert 'aaa1' in f3._pod_nodes.keys()
+    assert f3.num_pods == 2

--- a/tests/unit/flow/test_flow_yaml_parser.py
+++ b/tests/unit/flow/test_flow_yaml_parser.py
@@ -93,7 +93,7 @@ def test_flow_yaml_dump():
 
 def test_flow_yaml_from_string():
     f1 = Flow.load_config('yaml/flow-v1.0-syntax.yml')
-    with open('yaml/flow-v1.0-syntax.yml') as fp:
+    with open(str(cur_dir / 'yaml' / 'flow-v1.0-syntax.yml')) as fp:
         str_yaml = fp.read()
         assert isinstance(str_yaml, str)
         f2 = Flow.load_config(str_yaml)

--- a/tests/unit/flow/test_flow_yaml_parser.py
+++ b/tests/unit/flow/test_flow_yaml_parser.py
@@ -110,7 +110,7 @@ def test_flow_uses_from_dict():
     class DummyEncoder(BaseEncoder):
         pass
 
-    d1 = {'!cls': 'DummyEncoder',
+    d1 = {'__cls': 'DummyEncoder',
           'metas': {'name': 'dummy1'}}
     with Flow().add(uses=d1):
         pass

--- a/tests/unit/flow/test_flow_yaml_parser.py
+++ b/tests/unit/flow/test_flow_yaml_parser.py
@@ -6,6 +6,7 @@ import pytest
 from jina import Flow, AsyncFlow
 from jina.enums import FlowOptimizeLevel
 from jina.excepts import BadFlowYAMLVersion
+from jina.executors.encoders import BaseEncoder
 from jina.flow import BaseFlow
 from jina.jaml import JAML
 from jina.jaml.parsers import get_supported_versions
@@ -103,3 +104,13 @@ def test_flow_yaml_from_string():
     assert 'ppp0' in f3._pod_nodes.keys()
     assert 'aaa1' in f3._pod_nodes.keys()
     assert f3.num_pods == 2
+
+
+def test_flow_uses_from_dict():
+    class DummyEncoder(BaseEncoder):
+        pass
+
+    d1 = {'!cls': 'DummyEncoder',
+          'metas': {'name': 'dummy1'}}
+    with Flow().add(uses=d1):
+        pass

--- a/tests/unit/test_yamlparser.py
+++ b/tests/unit/test_yamlparser.py
@@ -6,11 +6,12 @@ from pkg_resources import resource_filename
 
 from jina.enums import SocketType
 from jina.executors import BaseExecutor
+from jina.executors.compound import CompoundExecutor
 from jina.executors.indexers.vector import NumpyIndexer
 from jina.executors.metas import fill_metas_with_defaults
 from jina.helper import expand_dict
 from jina.helper import expand_env_var
-from jina.jaml import JAML
+from jina.jaml import JAML, JAMLCompatible
 from jina.parsers import set_pea_parser
 from jina.peapods.peas import BasePea
 
@@ -178,3 +179,83 @@ def test_encoder_name_dict_replace():
 def test_encoder_inject_config_via_kwargs():
     with BaseExecutor.load_config('yaml/test-encoder-env.yml', pea_id=345) as be:
         assert be.pea_id == 345
+
+
+class TagDict(JAMLCompatible, dict):
+    def __init__(self, name):
+        super().__init__()
+        self._name = name
+
+
+def to_tag_dict(d):
+    if isinstance(d, dict):
+        for k, v in d.items():
+            if isinstance(k, str) and k.startswith('!') and isinstance(v, dict):
+                _v = TagDict(k)
+                _v.update(v)
+                d[k] = _v
+            to_tag_dict(d[k])
+    elif isinstance(d, list) or isinstance(d, tuple):
+        for dd in d:
+            to_tag_dict(dd)
+
+
+def dice_representer(dumper, data):
+    return dumper.represent_mapping(f'!abc', data)
+
+
+def test_load_from_dict():
+    # !BaseEncoder
+    # metas:
+    #   name: ${{BE_TEST_NAME}}
+    #   batch_size: ${{BATCH_SIZE}}
+    #   pea_id: ${{pea_id}}
+    #   workspace: ${{this.name}}-${{this.batch_size}}
+
+    d1 = {
+        '!cls': 'BaseEncoder',
+        'metas': {'name': '${{BE_TEST_NAME}}',
+                  'batch_size': '${{BATCH_SIZE}}',
+                  'pea_id': '${{pea_id}}',
+                  'workspace': '${{this.name}} -${{this.batch_size}}'}
+    }
+
+    # !CompoundExecutor
+    # components:
+    #   - !BinaryPbIndexer
+    #     with:
+    #       index_filename: tmp1
+    #     metas:
+    #       name: test1
+    #   - !BinaryPbIndexer
+    #     with:
+    #       index_filename: tmp2
+    #     metas:
+    #       name: test2
+    # metas:
+    #   name: compound1
+
+    d2 = {
+        '!cls': 'CompoundExecutor',
+        'components':
+            [
+                {
+                    '!cls': 'BinaryPbIndexer',
+                    'with': {'index_filename': 'tmp1'},
+                    'metas': {'name': 'test1'}
+                },
+                {
+                    '!cls': 'BinaryPbIndexer',
+                    'with': {'index_filename': 'tmp2'},
+                    'metas': {'name': 'test2'}
+                },
+            ]
+    }
+    d = {'BE_TEST_NAME': 'hello123', 'BATCH_SIZE': 256}
+    b1 = BaseExecutor.load_config(d1, context=d)
+    b2 = BaseExecutor.load_config(d2, context=d)
+    assert isinstance(b1, BaseExecutor)
+    assert isinstance(b2, CompoundExecutor)
+    assert b1.batch_size == 256
+    assert b1.name == 'hello123'
+


### PR DESCRIPTION
Enables loading config from dict. The class name must be labeled with the keyword `__cls`

# Examples

## At Flow-level
```python
class DummyEncoder(BaseEncoder):
    pass

d1 = {'__cls': 'DummyEncoder',
      'metas': {'name': 'dummy1'}}
with Flow().add(uses=d1):
    pass
```

## At Executor-level
```python
    d1 = {
        '__cls': 'BaseEncoder',
        'metas': {'name': '${{BE_TEST_NAME}}',
                  'batch_size': '${{BATCH_SIZE}}',
                  'pea_id': '${{pea_id}}',
                  'workspace': '${{this.name}} -${{this.batch_size}}'}
    }

    d = {'BE_TEST_NAME': 'hello123', 'BATCH_SIZE': 256}
    b1 = BaseExecutor.load_config(d1, context=d)
```
## Remarks

- Variable substitution works when loading from `dict`
- CompoundExecutor dict also works, e.g.
```python
d2 = {
        '__cls': 'CompoundExecutor',
        'components':
            [
                {
                    '__cls': 'BinaryPbIndexer',
                    'with': {'index_filename': 'tmp1'},
                    'metas': {'name': 'test1'}
                },
                {
                    '__cls': 'BinaryPbIndexer',
                    'with': {'index_filename': 'tmp2'},
                    'metas': {'name': 'test2'}
                },
            ]
    }
```

