### PR TITLE
test: add querylang set test

### DIFF
--- a/jina/types/sets/querylang.py
+++ b/jina/types/sets/querylang.py
@@ -31,7 +31,7 @@ class QueryLangSet(MutableSequence):
         if isinstance(key, int):
             self._querylangs_proto[key].CopyFrom(value.as_pb_object)
         elif isinstance(key, str):
-            return self._querylangs_map[key].CopyFrom(value.as_pb_object)
+            self._querylangs_map[key].CopyFrom(value.as_pb_object)
         else:
             raise IndexError(f'do not support this index {key}')
 
@@ -85,4 +85,5 @@ class QueryLangSet(MutableSequence):
         """Build a doc_id to doc mapping so one can later index a Document using
         doc_id as string key
         """
-        self._docs_map = {d.id: d for d in self._querylangs_proto}
+        # TODO This is a temp fix, QueryLangProto do not have an id field.
+        self._querylangs_map = {d.name: d for d in self._querylangs_proto}

--- a/jina/types/sets/querylang.py
+++ b/jina/types/sets/querylang.py
@@ -82,8 +82,8 @@ class QueryLangSet(MutableSequence):
             hi_idx -= 1
 
     def build(self):
-        """Build a doc_id to doc mapping so one can later index a Document using
-        doc_id as string key
+        """Build a name to QueryLang mapping so one can later index a QueryLang using
+        name as string key
         """
         # TODO This is a temp fix, QueryLangProto do not have an id field.
         self._querylangs_map = {d.name: d for d in self._querylangs_proto}

--- a/jina/types/sets/querylang.py
+++ b/jina/types/sets/querylang.py
@@ -86,4 +86,4 @@ class QueryLangSet(MutableSequence):
         name as string key
         """
         # TODO This is a temp fix, QueryLangProto do not have an id field.
-        self._querylangs_map = {d.name: d for d in self._querylangs_proto}
+        self._querylangs_map = {q.name: q for q in self._querylangs_proto}

--- a/tests/unit/types/sets/test_querylangset.py
+++ b/tests/unit/types/sets/test_querylangset.py
@@ -1,78 +1,138 @@
 import pytest
 
-def test_init():
+from jina.proto.jina_pb2 import RequestProto, QueryLangProto
+from jina.types.querylang import QueryLang
+from jina.types.sets.querylang import QueryLangSet
+
+@pytest.fixture(scope='function')
+def querylang_protos():
+    """:returns: A :class:`RepeatedCompositeContainer` consist list of :class:`QueryLangProto`."""
+    req = RequestProto()
+    for _ in range(3):
+        req.queryset.extend([QueryLangProto()])
+    return req.queryset
+
+
+@pytest.fixture(scope='function')
+def querylang_set(querylang_protos):
+    """:returns: A :class:`RepeatedCompositeContainer` consist list of :class:`QueryLangProto`."""
+    return QueryLangSet(querylang_protos=querylang_protos)
+
+
+@pytest.fixture(scope='function')
+def querylang_instance():
+    """:returns: An instance of :class:`QueryLang`."""
+    query_lang = QueryLang()
+    query_lang.name = 'test'
+    query_lang.priority = 5
+    return query_lang
+
+
+def test_init(querylang_protos):
     """The test function to initialize the :class:`QueryLangSet`"""
-    pass
+    assert QueryLangSet(querylang_protos=querylang_protos)
 
-def test_insert():
+
+def test_insert(querylang_set, querylang_instance):
     """Test insert :attr:`ql` to :class:`QueryLangSet` at :attr:`index`."""
-    pass
+    querylang_set.insert(index=0, ql=querylang_instance)
+    assert len(querylang_set) == 4
+    assert querylang_set[0].name == 'test'
+    assert querylang_set[0].priority == 5
 
-def test_get_set_success():
+
+def test_get_set_success(querylang_set, querylang_instance):
     """
     Test :meth:`__setitem__` and :meth:`__getitem__`  in :class`QueryLangSet`.
     :attr:`key` might blongs to type `int` or `str`.
-
-    .. note::
-            Please parameterize this test with pytest.mark.parameterize.
     """
-    pass
+    querylang_set[0] = querylang_instance
+    assert querylang_set[0].name == 'test'
+    assert querylang_set[0].priority == 5
+    querylang_set.build()
+    querylang_set['test'] = querylang_instance
+    assert querylang_set['test'].name == 'test'
+    assert querylang_set['test'].priority == 5
 
-def test_get_set_fail():
+
+def test_get_set_fail(querylang_set):
     """Test :meth:`__setitem__` and :meth:`__getitem__`  in :class`QueryLangSet`.
 
     .. note::
             Please assert pytest.rases `IndexError`
     """
-    pass
+    with pytest.raises(IndexError):
+        querylang_set[10]
+        querylang_set['not_exist']
 
-def test_delete():
+
+def test_delete(querylang_set):
     """Test :meth:`__del__`, should remove value from :class:`QueryLangSet` given an index."""
-    pass
+    del querylang_set[0]
+    assert len(querylang_set) == 2
 
-def test_length():
+
+def test_length(querylang_set):
     """Test :meth:`__len__`, should return the length of :class:`QueryLangSet`."""
-    pass
+    assert len(querylang_set) == 3
 
-def test_iter():
+
+def test_iter(querylang_set):
     """Test :meth:`__iter__`, should yield an instance of :class:`QueryLang`."""
-    pass
+    for querylang in querylang_set:
+        assert isinstance(querylang, QueryLang)
 
-def test_append_success():
+
+@pytest.mark.parametrize('querylang_item', [QueryLangProto(), QueryLang()])
+def test_append_success(querylang_set, querylang_item):
     """Test :meth:`append`. Expect test three cases depends on the type of :attr:`value`.
     Such as :class:`BaseDriver`, :class:`QueryLangProto` and :class:`QueryLang`.
 
     .. note::
             Please parameterize this test with pytest.mark.parameterize.
     """
-    pass
+    querylang_set.append(querylang_item)
+    assert len(querylang_set) == 4
 
-def test_append_fail():
+
+def test_append_fail(querylang_set):
     """Test :meth:`append` with an invalid input.
 
     .. note::
             Please assert pytest.rases `TypeError`
     """
-    pass
+    with pytest.raises(TypeError):
+        querylang_set.append('invalid type')
 
-def test_extend():
+
+def test_extend(querylang_set, querylang_instance):
     """Test :meth:`extend`, extend an iterable to :class:`QueryLangSet`."""
-    pass
+    querylang_set.extend([querylang_instance])
+    assert len(querylang_set) == 4
+    assert querylang_set[3].name == querylang_instance.name
 
-def test_clear():
+
+def test_clear(querylang_set):
     """Test :meth:`clear`, ensure length of :attr:`_querylangs_proto` is 0 after clear."""
-    pass
+    querylang_set.clear()
+    assert len(querylang_set) == 0
 
-def test_reverse():
+
+def test_reverse(querylang_set, querylang_instance):
     """Test :meth:`reverse`, reverse the items in :class:`QueryLangSet`.
 
     .. note::
         reverse the same :class:`QueryLangSet` twice and assert they're identical.
     """
-    pass
+    querylang_set.append(querylang_instance)
+    querylang_set.reverse()
+    assert querylang_set[0].name == querylang_instance.name
+    querylang_set.reverse()
+    assert querylang_set[3].name == querylang_instance.name
 
-def test_build():
+
+def test_build(querylang_set):
     """Test :meth:`build`.
     Ensure the built result :attr:`_docs_map` is `dict` and the values are correct.
     """
-    pass
+    querylang_set.build()


### PR DESCRIPTION
Add unit tests for QueryLangSet and minor bug fixing.

**What has been fixed**:
1. `__setitem__` expect set, not return
2. `self._docs_map` is not a valid variable in `QueryLangSet`.
3. `QueryLangProto` does not have an id field, while calling `build`.

Question: do we really need `build` method in `QueryLangSet`? the docstring was copied from `Document`