### PR TITLE
docs(contributing): fix a broken link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ In this guide we're going to go through the steps for each kind of contribution,
 <a name="-before-you-start"></a>
 ## 🏁 Before you Start
 
-Make sure you've read through our [README](https://github.com/jina-ai/jina), [Jina 101](https://docs.jina.ai/chapters/101/index.html), and [example tutorials](https://github.com/jina-ai/examples) so you have a good understanding of what Jina is and how it works.
+Make sure you've read through our [README](https://github.com/jina-ai/jina), [Jina 101](https://101.jina.ai), and [example tutorials](https://learn.jina.ai) so you have a good understanding of what Jina is and how it works.
 
 ### Not a coder but still want to contribute?
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ In this guide we're going to go through the steps for each kind of contribution,
 <a name="-before-you-start"></a>
 ## 🏁 Before you Start
 
-Make sure you've read through our [README](https://github.com/jina-ai/jina), [Jina 101](https://github.com/jina-ai/jina/tree/master/docs/chapters/101), and [example tutorials](https://github.com/jina-ai/examples) so you have a good understanding of what Jina is and how it works.
+Make sure you've read through our [README](https://github.com/jina-ai/jina), [Jina 101](https://docs.jina.ai/chapters/101/index.html), and [example tutorials](https://github.com/jina-ai/examples) so you have a good understanding of what Jina is and how it works.
 
 ### Not a coder but still want to contribute?
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ In this guide we're going to go through the steps for each kind of contribution,
 <a name="-before-you-start"></a>
 ## 🏁 Before you Start
 
-Make sure you've read through our [README](https://github.com/jina-ai/jina), [Jina 101](./101/README.html), and [example tutorials](https://github.com/jina-ai/examples) so you have a good understanding of what Jina is and how it works.
+Make sure you've read through our [README](https://github.com/jina-ai/jina), [Jina 101](https://github.com/jina-ai/jina/tree/master/docs/chapters/101), and [example tutorials](https://github.com/jina-ai/examples) so you have a good understanding of what Jina is and how it works.
 
 ### Not a coder but still want to contribute?
 


### PR DESCRIPTION
In the contributing.md file, there is a broken link that needs to be changed:

![image](https://user-images.githubusercontent.com/22430520/103648160-b2c87800-4f5c-11eb-827f-7141b3f54690.png)

I will just change which link jina-101 is referring to: from "./101/README.html" to  "https://github.com/jina-ai/jina/tree/master/docs/chapters/101"