### PR TITLE
feat: volumes can be mapped to arbitrary path in container

### DIFF
--- a/jina/parsers/peapods/runtimes/container.py
+++ b/jina/parsers/peapods/runtimes/container.py
@@ -16,8 +16,8 @@ def mixin_container_runtime_parser(parser):
                     help='pull the latest image before running')
     gp.add_argument('--volumes', type=str, nargs='*', metavar='DIR',
                     help='the path on the host to be mounted inside the container. '
-                         'if separated by ":" the first part will be considered as the local path and the second '
-                         'part, the path in the container system. '
-                         'If no split provided, they will be mounted to the root path, i.e. /user/test/my-workspace '
-                         'will be mounted to /my-workspace inside the container. all volumes are mounted with '
+                         'if separated by ":" the first part will be considered as the local host path and the second '
+                         'part is the path in the container system. '
+                         'If no split provided, then the basename of that directory will be mounted into container's root path, e.g. --volumes="/user/test/my-workspace" '
+                         'will be mounted into "/my-workspace" inside the container. all volumes are mounted with '
                          'read-write mode.')

--- a/jina/parsers/peapods/runtimes/container.py
+++ b/jina/parsers/peapods/runtimes/container.py
@@ -16,5 +16,8 @@ def mixin_container_runtime_parser(parser):
                     help='pull the latest image before running')
     gp.add_argument('--volumes', type=str, nargs='*', metavar='DIR',
                     help='the path on the host to be mounted inside the container. '
-                         'they will be mounted to the root path, i.e. /user/test/my-workspace will be mounted to '
-                         '/my-workspace inside the container. all volumes are mounted with read-write mode.')
+                         'if separated by ":" the first part will be considered as the local path and the second '
+                         'part, the path in the container system. '
+                         'If no split provided, they will be mounted to the root path, i.e. /user/test/my-workspace '
+                         'will be mounted to /my-workspace inside the container. all volumes are mounted with '
+                         'read-write mode.')

--- a/jina/parsers/peapods/runtimes/container.py
+++ b/jina/parsers/peapods/runtimes/container.py
@@ -18,6 +18,6 @@ def mixin_container_runtime_parser(parser):
                     help='the path on the host to be mounted inside the container. '
                          'if separated by ":" the first part will be considered as the local host path and the second '
                          'part is the path in the container system. '
-                         'If no split provided, then the basename of that directory will be mounted into container's root path, e.g. --volumes="/user/test/my-workspace" '
+                         'If no split provided, then the basename of that directory will be mounted into container\'s root path, e.g. --volumes="/user/test/my-workspace" '
                          'will be mounted into "/my-workspace" inside the container. all volumes are mounted with '
                          'read-write mode.')

--- a/tests/unit/mwu-encoder/mwu_encoder_volume_change.yml
+++ b/tests/unit/mwu-encoder/mwu_encoder_volume_change.yml
@@ -1,0 +1,7 @@
+!MWUUpdater
+with:
+  greetings: hello im from external yaml!
+metas:
+  name: ext-mwu-encoder
+  py_modules: mwu_encoder.py
+  workspace: '/mapped/here/abc'

--- a/tests/unit/peapods/runtimes/container/test_container_runtime.py
+++ b/tests/unit/peapods/runtimes/container/test_container_runtime.py
@@ -10,7 +10,6 @@ from jina.helper import random_name
 from jina.parsers import set_pea_parser
 from jina.parsers.ping import set_ping_parser
 from jina.peapods import Pea
-from jina.peapods.runtimes.container import ContainerRuntime
 from tests import random_docs
 
 cur_dir = os.path.dirname(os.path.abspath(__file__))
@@ -124,6 +123,18 @@ def test_container_volume(docker_image_built, tmpdir):
     f = (Flow()
          .add(name=random_name(), uses=f'docker://{img_name}', volumes=abc_path,
               uses_internal=os.path.join(cur_dir, '../../../mwu-encoder/mwu_encoder_upd.yml')))
+
+    with f:
+        f.index(random_docs(10))
+
+    assert os.path.exists(os.path.join(abc_path, 'ext-mwu-encoder.bin'))
+
+
+def test_container_volume_arbitrary(docker_image_built, tmpdir):
+    abc_path = os.path.join(tmpdir, 'abc')
+    f = (Flow()
+         .add(name=random_name(), uses=f'docker://{img_name}', volumes=abc_path + ':' + '/mapped/here/abc',
+              uses_internal=os.path.join(cur_dir, '../../../mwu-encoder/mwu_encoder_volume_change.yml')))
 
     with f:
         f.index(random_docs(10))


### PR DESCRIPTION
**Changes introduced**
Iteration to fix #1438 

It allows to have volumes mapped to arbitrary path in the container. This combined with #1595  can allow using `ref_indexer` inside Docker