### PR TITLE
docs: add reference check while build docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -121,6 +121,7 @@ nitpicky = True
 
 extensions = [
     'sphinx.ext.coverage',
+    'sphinx.ext.doctest',
 ]
 
 def setup(app):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -119,6 +119,7 @@ autoclass_content = 'both'
 set_type_checking_flag = False
 html_last_updated_fmt = ''
 nitpicky = True
+nitpick_ignore = [('py:class', 'type')]
 
 def setup(app):
     from sphinx.domains.python import PyField

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -84,6 +84,7 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx_autodoc_typehints',
     'sphinx.ext.viewcode',
+    'sphinx.ext.coverage',
     'sphinxcontrib.apidoc',
     'sphinxarg.ext',
     'sphinx_rtd_theme',
@@ -118,11 +119,6 @@ autoclass_content = 'both'
 set_type_checking_flag = False
 html_last_updated_fmt = ''
 nitpicky = True
-
-extensions = [
-    'sphinx.ext.coverage',
-    'sphinx.ext.doctest',
-]
 
 def setup(app):
     from sphinx.domains.python import PyField

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -119,6 +119,9 @@ set_type_checking_flag = False
 html_last_updated_fmt = ''
 nitpicky = True
 
+extensions = [
+    'sphinx.ext.coverage',
+]
 
 def setup(app):
     from sphinx.domains.python import PyField

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -117,6 +117,7 @@ autodoc_mock_imports = ['argparse', 'numpy', 'np', 'tensorflow', 'torch', 'scipy
 autoclass_content = 'both'
 set_type_checking_flag = False
 html_last_updated_fmt = ''
+nitpicky = True
 
 
 def setup(app):


### PR DESCRIPTION
Add cross-reference checker for sphinx.

with this PR, several options have been offered to make docstring more robust:

1. `make html` will show warnings if the internal referenced link is incorrect.
2. `make linkcheck` same as above, without generating html pages.
3. `make coverage` check the docstring coverage.

Some basic statistics:

**broken links**: Found 2724 broken links, ~2550 were broken links in CHANGELOG.md.
**coverage**:  ~40 undocumented methods & classes.
**warnings**: 2721 warnings, mostly are class or method reference not found.
