### PR TITLE
fix: test for hubio test build

### DIFF
--- a/tests/unit/docker/test_hub_build_level.py
+++ b/tests/unit/docker/test_hub_build_level.py
@@ -1,0 +1,40 @@
+import os
+
+import docker
+import pytest
+import mock
+from mock import Mock, patch
+
+from jina.docker.hubio import HubIO
+from jina.enums import BuildTestLevel
+from jina.peapods import Pod
+from jina.executors import BaseExecutor
+from jina.executors import AnyExecutor
+from jina.parsers.hub import set_hub_build_parser
+
+@pytest.fixture
+def mock_load_config():
+    return BaseExecutor
+
+cli = docker.APIClient(base_url='unix://var/run/docker.sock')
+
+def test_hub_build_level_pass(monkeypatch, mock_load_config):
+
+    monkeypatch.setattr(BaseExecutor, "load_config", mock_load_config)
+    args = set_hub_build_parser().parse_args(['path/hub-mwu', '--push', '--host-info', '--test-level', 'EXECUTOR'])
+
+    docker_image = cli.get_image('jinahub/pod.dummy_mwu_encoder')
+    p_names, failed_levels = HubIO._test_build(docker_image, BuildTestLevel.EXECUTOR, "sample/yaml.yaml", 60, True)
+    expected_failed_levels = []
+    assert expected_failed_levels == failed_levels
+
+
+def test_hub_build_level_fail(monkeypatch, mock_load_config):
+
+    monkeypatch.setattr(BaseExecutor, "load_config", mock_load_config)
+    args = set_hub_build_parser().parse_args(['path/hub-mwu', '--push', '--host-info', '--test-level', 'FLOW'])
+
+    docker_image = cli.get_image('jinahub/pod.dummy_mwu_encoder')
+    expected_failed_levels = [BuildTestLevel.POD_NONDOCKER, BuildTestLevel.POD_DOCKER, BuildTestLevel.FLOW]
+    p_names, failed_levels = HubIO(args)._test_build(docker_image, BuildTestLevel.FLOW, 'sampleconfig/yaml', 60, True)
+    assert expected_failed_levels == failed_levels

--- a/tests/unit/docker/test_hub_build_level.py
+++ b/tests/unit/docker/test_hub_build_level.py
@@ -2,39 +2,37 @@ import os
 
 import docker
 import pytest
-import mock
-from mock import Mock, patch
-
 from jina.docker.hubio import HubIO
 from jina.enums import BuildTestLevel
-from jina.peapods import Pod
 from jina.executors import BaseExecutor
-from jina.executors import AnyExecutor
 from jina.parsers.hub import set_hub_build_parser
 
-@pytest.fixture
-def mock_load_config():
-    return BaseExecutor
-
 cli = docker.APIClient(base_url='unix://var/run/docker.sock')
+cur_dir = os.path.dirname(os.path.abspath(__file__))
 
-def test_hub_build_level_pass(monkeypatch, mock_load_config):
+@pytest.fixture(scope='function')
+def test_workspace(tmpdir):
+    os.environ['JINA_TEST_JOINT'] = str(tmpdir)
+    workspace_path = os.environ['JINA_TEST_JOINT']
+    yield workspace_path
+    del os.environ['JINA_TEST_JOINT']
 
-    monkeypatch.setattr(BaseExecutor, "load_config", mock_load_config)
+
+def test_hub_build_level_pass(monkeypatch, test_workspace):
     args = set_hub_build_parser().parse_args(['path/hub-mwu', '--push', '--host-info', '--test-level', 'EXECUTOR'])
-
     docker_image = cli.get_image('jinahub/pod.dummy_mwu_encoder')
-    p_names, failed_levels = HubIO._test_build(docker_image, BuildTestLevel.EXECUTOR, "sample/yaml.yaml", 60, True)
     expected_failed_levels = []
+
+    _, failed_levels = HubIO(args)._test_build(docker_image, BuildTestLevel.EXECUTOR, os.path.join(cur_dir, 'yaml/test-joint.yml'), 60, True)
+
     assert expected_failed_levels == failed_levels
 
 
-def test_hub_build_level_fail(monkeypatch, mock_load_config):
-
-    monkeypatch.setattr(BaseExecutor, "load_config", mock_load_config)
+def test_hub_build_level_fail(monkeypatch, test_workspace):
     args = set_hub_build_parser().parse_args(['path/hub-mwu', '--push', '--host-info', '--test-level', 'FLOW'])
-
     docker_image = cli.get_image('jinahub/pod.dummy_mwu_encoder')
     expected_failed_levels = [BuildTestLevel.POD_NONDOCKER, BuildTestLevel.POD_DOCKER, BuildTestLevel.FLOW]
-    p_names, failed_levels = HubIO(args)._test_build(docker_image, BuildTestLevel.FLOW, 'sampleconfig/yaml', 60, True)
+
+    _, failed_levels = HubIO(args)._test_build(docker_image, BuildTestLevel.FLOW, os.path.join(cur_dir, 'yaml/test-joint.yml'), 60, True)
+
     assert expected_failed_levels == failed_levels

--- a/tests/unit/docker/yaml/test-joint.yml
+++ b/tests/unit/docker/yaml/test-joint.yml
@@ -1,0 +1,18 @@
+!CompoundIndexer
+components:
+  - !NumpyIndexer
+    with:
+      metric: euclidean
+      index_filename: vec.gz
+    metas:
+      name: vecidx  # a customized name
+      workspace: $JINA_TEST_JOINT
+  - !BinaryPbIndexer
+    with:
+      index_filename: chunk.gz
+    metas:
+      name: chunkidx
+      workspace: $JINA_TEST_JOINT
+metas:
+  name: chunk_compound_indexer
+  workspace: $JINA_TEST_JOINT


### PR DESCRIPTION
Fix for #1575 using `docker image` object instead of `string` argument for `test_build` in `hubio`