### PR TITLE
docs: fix deadlinks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -211,7 +211,7 @@ feat: add remote api
 
 #### What if I Mess Up?
 
-We all make mistakes. GitHub has a guide on [rewriting commit messages](https://help.github.com/en/github/committing-changes-to-your-project/changing-a-commit-message) to they can adhere to our standards.
+We all make mistakes. GitHub has a guide on [rewriting commit messages](https://docs.github.com/en/free-pro-team@latest/github/committing-changes-to-your-project/changing-a-commit-message) to they can adhere to our standards.
 
 You can also install [commitlint](https://commitlint.js.org/#/) onto your own machine and check your commit message by running:
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,7 +29,7 @@ version = __version__
 release = __version__
 
 templates_path = ['template']
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', 'tests']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', 'tests', 'CHANGELOG.md']
 pygments_style = 'rainbow_dash'
 html_theme = 'sphinx_rtd_theme'
 
@@ -120,6 +120,16 @@ set_type_checking_flag = False
 html_last_updated_fmt = ''
 nitpicky = True
 nitpick_ignore = [('py:class', 'type')]
+linkcheck_ignore = [
+    # Avoid link check on local uri
+    "http://0.0.0.0:*",
+    # Avoid errors due to GitHub rate limit
+    # https://github.com/sphinx-doc/sphinx/issues/7388
+    "https://github.com/jina-ai/jina/commit/*",
+]
+linkcheck_timeout = 20
+linkcheck_retries = 2
+linkcheck_anchors = False
 
 def setup(app):
     from sphinx.domains.python import PyField

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,7 +29,7 @@ version = __version__
 release = __version__
 
 templates_path = ['template']
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', 'tests', 'CHANGELOG.md']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', 'tests']
 pygments_style = 'rainbow_dash'
 html_theme = 'sphinx_rtd_theme'
 


### PR DESCRIPTION
This PR should fix all the deadlinks in docs:

1. Ignore unused links in `CHANGELOG.md`.
2. Ignore several local URIs, such as `0.0.0.0:[PORT]`.
3. Fix unreachable links.