### PR TITLE
fix: example requires numpy to be imported

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Let's create some random data and index it:
 
 ```python
 from jina import Document
+import numpy
 
 with Flow().add() as f:
     f.index((Document() for _ in range(10)))  # index raw Jina Documents

--- a/README.md
+++ b/README.md
@@ -133,8 +133,8 @@ To visualize the Flow, simply chain it with `.plot('my-flow.svg')`. If you are u
 Let's create some random data and index it:
 
 ```python
+import numpy 
 from jina import Document
-import numpy
 
 with Flow().add() as f:
     f.index((Document() for _ in range(10)))  # index raw Jina Documents


### PR DESCRIPTION
A user copying and pasting the existing sample will hit the following error. 
```
NameError: name 'numpy' is not defined
```

This is avoidable by including import numpy in the example.