### PR TITLE
fix: ignore parent id in content hash

### DIFF
--- a/jina/types/document/__init__.py
+++ b/jina/types/document/__init__.py
@@ -188,7 +188,8 @@ class Document:
         return self._document.content_hash
 
     def update_content_hash(self,
-                            exclude_fields: Optional[Tuple[str]] = ('id', 'chunks', 'matches', 'content_hash'),
+                            exclude_fields: Optional[Tuple[str]] = (
+                            'id', 'chunks', 'matches', 'content_hash', 'parent_id'),
                             include_fields: Optional[Tuple[str]] = None) -> None:
         """Update the document hash according to its content.
 


### PR DESCRIPTION
Stumbled upon this while working on #1613 