### PR TITLE
fix: conditional args

### DIFF
--- a/jina/peapods/pods/__init__.py
+++ b/jina/peapods/pods/__init__.py
@@ -227,6 +227,8 @@ class BasePod(ExitStack):
                 args.runtime_cls = 'RESTRuntime'
             else:
                 args.runtime_cls = 'GRPCRuntime'
+        if 'parallel' in args and args.parallel == 1:
+            args.separated_workspace = False
 
     def connect_to_tail_of(self, pod: 'BasePod'):
         """Eliminate the head node by connecting prev_args node directly to peas """


### PR DESCRIPTION
In case we have a separated workspace and set shards to 1, search does not work.
We get rid of this case by forcing to have `separated_workspace=False` if `parallel==1`