### PR TITLE
feat: support json print in loginfo

### DIFF
--- a/jina/drivers/control.py
+++ b/jina/drivers/control.py
@@ -3,6 +3,8 @@ __license__ = "Apache-2.0"
 
 import time
 
+from google.protobuf.json_format import MessageToJson
+
 from . import BaseDriver
 from .querylang.queryset.dunderkey import dunder_get
 from ..excepts import UnknownControlCommand, RuntimeTerminated, NoExplicitMessage
@@ -22,7 +24,7 @@ class BaseControlDriver(BaseDriver):
 class LogInfoDriver(BaseControlDriver):
     """Log output the request info"""
 
-    def __init__(self, key: str = 'request', *args, **kwargs):
+    def __init__(self, key: str = 'request', json: bool = True, *args, **kwargs):
         """
         :param key: (str) that represents a first level or nested key in the dict
         :param args:
@@ -30,9 +32,16 @@ class LogInfoDriver(BaseControlDriver):
         """
         super().__init__(*args, **kwargs)
         self.key = key
+        self.json = json
 
     def __call__(self, *args, **kwargs):
-        self.logger.info(dunder_get(self.msg.as_pb_object, self.key))
+        data = dunder_get(self.msg.as_pb_object, self.key)
+        if self.json:
+            self.logger.info(
+                MessageToJson(data)
+            )
+        else:
+            self.logger.info(data)
 
 
 class WaitDriver(BaseControlDriver):


### PR DESCRIPTION
I found this more useful when debugging. I can just copy-paste the output into a JSON tree viewer, and collapse/expand as needed during inspection.