### PR TITLE
fix: KVSearchDriver `is_merge` should be `False` by default

### DIFF
--- a/jina/drivers/search.py
+++ b/jina/drivers/search.py
@@ -47,7 +47,7 @@ class KVSearchDriver(BaseSearchDriver):
             - K is the top-k
     """
 
-    def __init__(self, is_merge: bool = True, *args, **kwargs):
+    def __init__(self, is_merge: bool = False, *args, **kwargs):
         """
 
         :param is_merge: when set to true the retrieved docs are merged into current message using :meth:`MergeFrom`,

--- a/tests/integration/level_depth/yaml/index-chunk.yml
+++ b/tests/integration/level_depth/yaml/index-chunk.yml
@@ -35,4 +35,5 @@ requests:
       - !KVSearchDriver
         with:
           executor: chunkidx
+          is_merge: true
           traversal_paths: ['m']

--- a/tests/integration/level_depth/yaml/index-doc.yml
+++ b/tests/integration/level_depth/yaml/index-doc.yml
@@ -15,4 +15,5 @@ requests:
       - !KVSearchDriver
         with:
           executor: docIndexer
+          is_merge: true
           traversal_paths: ['m']


### PR DESCRIPTION
This is to prevent duplicating the embedding and raising the reshaping error in Document (`ValueError: cannot reshape array of size 10 into shape (10,10)`)

A more robust solution should be discussed in the future