### PR TITLE
revert: "fix: KVSearchDriver `is_merge` should be `False` by default"

### DIFF
--- a/jina/drivers/search.py
+++ b/jina/drivers/search.py
@@ -47,7 +47,7 @@ class KVSearchDriver(BaseSearchDriver):
             - K is the top-k
     """
 
-    def __init__(self, is_merge: bool = False, *args, **kwargs):
+    def __init__(self, is_merge: bool = True, *args, **kwargs):
         """
 
         :param is_merge: when set to true the retrieved docs are merged into current message using :meth:`MergeFrom`,

--- a/tests/integration/level_depth/yaml/index-chunk.yml
+++ b/tests/integration/level_depth/yaml/index-chunk.yml
@@ -35,5 +35,4 @@ requests:
       - !KVSearchDriver
         with:
           executor: chunkidx
-          is_merge: true
           traversal_paths: ['m']

--- a/tests/integration/level_depth/yaml/index-doc.yml
+++ b/tests/integration/level_depth/yaml/index-doc.yml
@@ -15,5 +15,4 @@ requests:
       - !KVSearchDriver
         with:
           executor: docIndexer
-          is_merge: true
           traversal_paths: ['m']


### PR DESCRIPTION
Reverts jina-ai/jina#1701 due to #1705 