### PR TITLE
refactor: optional disable uses_b/a if parallel is 1

### DIFF
--- a/jina/parsers/peapods/pods/base.py
+++ b/jina/parsers/peapods/pods/base.py
@@ -9,12 +9,15 @@ def mixin_base_pod_parser(parser):
     gp = add_arg_group(parser, title='Pod')
 
     gp.add_argument('--uses-before', type=str,
-                    help='the executor used before sending to all parallels, '
-                         'accepted type follows "--uses"')
+                    help='the executor attached after the Peas described by --uses, typically before sending to all '
+                         'parallels, accepted type follows "--uses"')
     gp.add_argument('--uses-after', type=str,
-                    help='the executor used after receiving from all parallels, '
-                         'accepted type follows "--uses"')
-
+                    help='the executor attached after the Peas described by --uses, typically used for receiving from '
+                         'all parallels, accepted type follows "--uses"')
+    gp.add_argument('--remove-uses-ba', action='store_true', default=False,
+                    help='a flag to disable `uses-before` or `uses-after` if parallel is equal to 1. Useful'
+                         'to parametrize parallelization and sharding without having `uses_after` or `uses_before` '
+                         'taking extra processes and network hops')
     gp.add_argument('--parallel', '--shards', type=int, default=1,
                     help='number of parallel peas in the pod running at the same time, '
                          '`port_in` and `port_out` will be set to random, '

--- a/jina/peapods/pods/__init__.py
+++ b/jina/peapods/pods/__init__.py
@@ -23,6 +23,7 @@ class BasePod(ExitStack):
         """
         super().__init__()
         self.args = args
+        BasePod._set_conditional_args(self.args)
         self.needs = needs if needs else set()  #: used in the :class:`jina.flow.Flow` to build the graph
 
         self.peas = []  # type: List['BasePea']
@@ -38,7 +39,7 @@ class BasePod(ExitStack):
             self.peas_args = self._parse_args(args)
 
         for a in self.all_args:
-            self._set_conditional_args(a)
+            BasePod._set_conditional_args(a)
 
     @property
     def role(self) -> 'PodRoleType':
@@ -223,13 +224,16 @@ class BasePod(ExitStack):
 
     @staticmethod
     def _set_conditional_args(args):
-        if args.pod_role == PodRoleType.GATEWAY:
+        if 'pod_role' in args and args.pod_role == PodRoleType.GATEWAY:
             if args.restful:
                 args.runtime_cls = 'RESTRuntime'
             else:
                 args.runtime_cls = 'GRPCRuntime'
         if 'parallel' in args and args.parallel == 1:
             args.separated_workspace = False
+            if args.remove_uses_ba:
+                args.uses_after = None
+                args.uses_before = None
 
     def connect_to_tail_of(self, pod: 'BasePod'):
         """Eliminate the head node by connecting prev_args node directly to peas """

--- a/tests/unit/peapods/pods/test_pods.py
+++ b/tests/unit/peapods/pods/test_pods.py
@@ -66,3 +66,20 @@ def test_pod_remote_context(runtime):
         assert remote_pod.num_peas == 4  # head + tail + 2 peas
 
     Pod(remote_pod_args).start().close()
+
+
+@pytest.mark.parametrize('remove_uses_ba', [False, True])
+def test_pod_args_remove_uses_ba(remove_uses_ba):
+    if remove_uses_ba:
+        args = set_pod_parser().parse_args(['--remove-uses-ba', '--uses-before', '_pass', '--uses-after', '_pass'])
+    else:
+        args = set_pod_parser().parse_args(['--uses-before', '_pass', '--uses-after', '_pass'])
+
+    pod = Pod(args)
+
+    if remove_uses_ba:
+        assert pod.args.uses_before is None
+        assert pod.args.uses_after is None
+    else:
+        assert pod.args.uses_before == '_pass'
+        assert pod.args.uses_after == '_pass'


### PR DESCRIPTION
**Changes introduced**
Right now if we use `uses_before` or `uses_after` it is added even when parallel is 1. Although it can be desired to have a `uses_after` or `uses_before` it is more common to only want it when there are multiple Peas inside a Pod.

Add an option to disable them if parallel is 1. Like this one can keep the same `Flow` structure for `sharding` and no `sharding` and just parametrize the number of parallels or other options while not wasting CPU and network hops by these extra Peas