### PR TITLE
chore: update add() use case in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ To add logic to the Flow, use the `uses` parameter to attach a Pod with an [Exec
 
 ```python
 f = (Flow().add(uses='MyBertEncoder')  # class name of a Jina Executor
-           .add(uses='docker://jinahub/pretrained-cnn:latest')  # the image name
+           .add(uses='docker://jinahub/pod.encoder.dummy_mwu_encoder:0.0.6-0.9.3')  # the image name
            .add(uses='myencoder.yml')  # YAML serialization of a Jina Executor
            .add(uses='!WaveletTransformer | {freq: 20}')  # inline YAML config
            .add(uses='_pass')  # built-in shortcut executor


### PR DESCRIPTION
The old example of `.add(uses='docker://jinahub/pretrained-cnn:latest') ` is outdated since pretrained-cnn:latest doesn't exist in jinahub and will cause error. 
Change it with the most downloaded image `.add(uses='docker://jinahub/pod.encoder.dummy_mwu_encoder:0.0.6-0.9.3')`.