### PR TITLE
fix: workspace from dump may not match the one from yaml

### DIFF
--- a/jina/jaml/parsers/executor/legacy.py
+++ b/jina/jaml/parsers/executor/legacy.py
@@ -18,7 +18,7 @@ class LegacyParser(VersionedYAMLParser):
             if work_dir:
                 # then try to see if it can be loaded from its regular expected workspace (ref_indexer)
                 dump_path = BaseExecutor.get_shard_workspace(work_dir, name, pea_id)
-                bin_dump_path = os.path.join(dump_path, f'{name}.{"bin"}')
+                bin_dump_path = os.path.join(dump_path, f'{name}.bin')
                 if os.path.exists(bin_dump_path):
                     return bin_dump_path
 
@@ -52,6 +52,12 @@ class LegacyParser(VersionedYAMLParser):
         if dump_path:
             obj = cls.load(dump_path)
             obj.logger.success(f'restore {cls.__name__} from {dump_path}')
+            # consider the case where `dump_path` is not based on `obj.workspace`. This is needed
+            # for
+            workspace_loaded_from = data.get('metas', {})['workspace']
+            workspace_in_dump = getattr(obj, 'workspace', None)
+            if workspace_in_dump != workspace_loaded_from:
+                obj.workspace = workspace_loaded_from
             load_from_dump = True
         else:
             cls._init_from_yaml = True

--- a/tests/unit/yaml/test-kvindexer-workspace.yml
+++ b/tests/unit/yaml/test-kvindexer-workspace.yml
@@ -1,0 +1,6 @@
+!BinaryPbIndexer
+with:
+  index_filename: 'inner_indexer.gz'
+metas:
+  name: kv_indexer
+  workspace: $JINA_TEST_WORKSPACE


### PR DESCRIPTION
**Changes introduced**
After refactoring in #1722, it seems that there was a bug when indexers are moved to docker.

The problem is that when the executor is loaded from the `mapped volume` in docker, the workspace is still in the `.bin` and although is capable of recreating itself, it tries to fetch the data from the old workspace.

**Solution**
I propose to have the workspace switched to the `workspace` folder from where is it loaded as it indicates that it has been "moved" or "mapped into the `docker` system".

In the long term, I would suggest to get rid of `.bin` and have a single source of configuration from YAML and have every executor know what to expect