### PR TITLE
docs: added docstring for paramters

### DIFF
--- a/jina/optimizers/__init__.py
+++ b/jina/optimizers/__init__.py
@@ -4,8 +4,7 @@ from typing import Optional
 
 import yaml
 
-from .parameters import IntegerParameter, FloatParameter, UniformParameter, LogUniformParameter, CategoricalParameter, \
-    DiscreteUniformParameter
+from .parameters import IntegerParameter, UniformParameter, LogUniformParameter, CategoricalParameter, DiscreteUniformParameter
 from .parameters import load_optimization_parameters
 from ..helper import colored
 from ..importer import ImportExtensions
@@ -106,6 +105,8 @@ class ResultProcessor(JAMLCompatible):
 class FlowOptimizer(JAMLCompatible):
     """Optimizer runs the given flows on multiple parameter configurations in order
        to find the best performing parameters. Uses `optuna` behind the scenes.
+       For a detailed information how the parameters are sampled by optuna see
+       https://optuna.readthedocs.io/en/stable/reference/generated/optuna.trial.Trial.html
     """
 
     def __init__(
@@ -161,14 +162,6 @@ class FlowOptimizer(JAMLCompatible):
                 high=param.high,
                 step=param.step_size,
                 log=param.log
-            )
-        elif isinstance(param, FloatParameter):
-            return trial.suggest_float(
-                name=param.jaml_variable,
-                low=param.low,
-                high=param.high,
-                step=param.step_size,
-                log=param.log,
             )
         elif isinstance(param, UniformParameter):
             return trial.suggest_uniform(

--- a/jina/optimizers/parameters.py
+++ b/jina/optimizers/parameters.py
@@ -4,6 +4,8 @@ from ..jaml import JAML, JAMLCompatible
 
 
 class OptimizationParameter(JAMLCompatible):
+    """Base class for all optimization parameters."""
+
     def __init__(
         self,
         parameter_name: str = "",
@@ -19,6 +21,11 @@ class OptimizationParameter(JAMLCompatible):
 
 
 class IntegerParameter(OptimizationParameter):
+    """Used for optimizing integer parameters with the Jina Optimizer.
+       For a detailed information about sampling and usage see
+       https://optuna.readthedocs.io/en/stable/reference/generated/optuna.trial.Trial.html#optuna.trial.Trial.suggest_int
+    """
+
     def __init__(
         self,
         low: int,
@@ -37,24 +44,12 @@ class IntegerParameter(OptimizationParameter):
         self.log = log
 
 
-class FloatParameter(OptimizationParameter):
-    def __init__(
-        self,
-        low: float,
-        high: float,
-        step_size: Optional[float] = None,
-        log: bool = False,
-        *args,
-        **kwargs,
-    ):
-        super().__init__(*args, **kwargs)
-        self.low = low
-        self.high = high
-        self.step_size = step_size
-        self.log = log
-
-
 class UniformParameter(OptimizationParameter):
+    """Used for optimizing float parameters with the Jina Optimizer with uniform sampling.
+       For a detailed information about sampling and usage see
+       https://optuna.readthedocs.io/en/stable/reference/generated/optuna.trial.Trial.html#optuna.trial.Trial.suggest_discrete_uniform
+    """
+
     def __init__(self, low: float, high: float, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.low = low
@@ -62,6 +57,11 @@ class UniformParameter(OptimizationParameter):
 
 
 class LogUniformParameter(OptimizationParameter):
+    """Used for optimizing float parameters with the Jina Optimizer with loguniform sampling.
+       For a detailed information about sampling and usage see
+       https://optuna.readthedocs.io/en/stable/reference/generated/optuna.trial.Trial.html#optuna.trial.Trial.suggest_loguniform
+    """
+
     def __init__(self, low: float, high: float, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.low = low
@@ -69,6 +69,11 @@ class LogUniformParameter(OptimizationParameter):
 
 
 class CategoricalParameter(OptimizationParameter):
+    """Used for optimizing categorical parameters with the Jina Optimizer.
+       For a detailed information about sampling and usage see
+       https://optuna.readthedocs.io/en/stable/reference/generated/optuna.trial.Trial.html#optuna.trial.Trial.suggest_categorical
+    """
+
     def __init__(
         self, choices: Sequence[Union[None, bool, int, float, str]], *args, **kwargs
     ):
@@ -77,6 +82,11 @@ class CategoricalParameter(OptimizationParameter):
 
 
 class DiscreteUniformParameter(OptimizationParameter):
+    """Used for optimizing discrete parameters with the Jina Optimizer with uniform sampling.
+       For a detailed information about sampling and usage it is used by Jina with optuna see
+       https://optuna.readthedocs.io/en/stable/reference/generated/optuna.trial.Trial.html#optuna.trial.Trial.suggest_discrete_uniform
+    """
+
     def __init__(self, low: float, high: float, q: float, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.low = low

--- a/jina/optimizers/parameters.py
+++ b/jina/optimizers/parameters.py
@@ -21,8 +21,8 @@ class OptimizationParameter(JAMLCompatible):
 
 
 class IntegerParameter(OptimizationParameter):
-    """Used for optimizing integer parameters with the Jina Optimizer.
-       For a detailed information about sampling and usage see
+    """Used for optimizing integer parameters with the FlowOptimizer.
+       For detailed information about sampling and usage see
        https://optuna.readthedocs.io/en/stable/reference/generated/optuna.trial.Trial.html#optuna.trial.Trial.suggest_int
     """
 
@@ -45,8 +45,8 @@ class IntegerParameter(OptimizationParameter):
 
 
 class UniformParameter(OptimizationParameter):
-    """Used for optimizing float parameters with the Jina Optimizer with uniform sampling.
-       For a detailed information about sampling and usage see
+    """Used for optimizing float parameters with the FlowOptimizer with uniform sampling.
+       For detailed information about sampling and usage see
        https://optuna.readthedocs.io/en/stable/reference/generated/optuna.trial.Trial.html#optuna.trial.Trial.suggest_discrete_uniform
     """
 
@@ -57,8 +57,8 @@ class UniformParameter(OptimizationParameter):
 
 
 class LogUniformParameter(OptimizationParameter):
-    """Used for optimizing float parameters with the Jina Optimizer with loguniform sampling.
-       For a detailed information about sampling and usage see
+    """Used for optimizing float parameters with the FlowOptimizer with loguniform sampling.
+       For detailed information about sampling and usage see
        https://optuna.readthedocs.io/en/stable/reference/generated/optuna.trial.Trial.html#optuna.trial.Trial.suggest_loguniform
     """
 
@@ -69,8 +69,8 @@ class LogUniformParameter(OptimizationParameter):
 
 
 class CategoricalParameter(OptimizationParameter):
-    """Used for optimizing categorical parameters with the Jina Optimizer.
-       For a detailed information about sampling and usage see
+    """Used for optimizing categorical parameters with the FlowOptimizer.
+       For detailed information about sampling and usage see
        https://optuna.readthedocs.io/en/stable/reference/generated/optuna.trial.Trial.html#optuna.trial.Trial.suggest_categorical
     """
 
@@ -82,8 +82,8 @@ class CategoricalParameter(OptimizationParameter):
 
 
 class DiscreteUniformParameter(OptimizationParameter):
-    """Used for optimizing discrete parameters with the Jina Optimizer with uniform sampling.
-       For a detailed information about sampling and usage it is used by Jina with optuna see
+    """Used for optimizing discrete parameters with the FlowOptimizer with uniform sampling.
+       For detailed information about sampling and usage it is used by Jina with optuna see
        https://optuna.readthedocs.io/en/stable/reference/generated/optuna.trial.Trial.html#optuna.trial.Trial.suggest_discrete_uniform
     """
 

--- a/tests/unit/optimizers/parameters.yml
+++ b/tests/unit/optimizers/parameters.yml
@@ -4,12 +4,6 @@
   low: 0
   step_size: 1
   parameter_name: param1
-- !FloatParameter
-  jaml_variable: JINA_EXECUTOR_PARAM2
-  high: 1
-  low: 1
-  step_size: 1
-  parameter_name: param2
 - !UniformParameter
   jaml_variable: JINA_EXECUTOR_PARAM3
   high: 2

--- a/tests/unit/optimizers/test_optimizers.py
+++ b/tests/unit/optimizers/test_optimizers.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock
 import yaml
 
 from jina.optimizers import MeanEvaluationCallback, ResultProcessor, FlowOptimizer
-from jina.optimizers.parameters import IntegerParameter, FloatParameter, UniformParameter, LogUniformParameter, CategoricalParameter, DiscreteUniformParameter
+from jina.optimizers.parameters import IntegerParameter, UniformParameter, LogUniformParameter, CategoricalParameter, DiscreteUniformParameter
 
 
 @pytest.fixture
@@ -71,9 +71,6 @@ def test_suggest(tmpdir):
     def _objective(trial):
 
         value = FlowOptimizer._suggest(IntegerParameter(0, 3, 1, jaml_variable='IntegerParameter'), trial)
-        assert 0 <= value
-        assert value <= 3
-        value = FlowOptimizer._suggest(FloatParameter(0, 3, 1, jaml_variable='FloatParameter'), trial)
         assert 0 <= value
         assert value <= 3
         value = FlowOptimizer._suggest(UniformParameter(0, 3, jaml_variable='UniformParameter'), trial)

--- a/tests/unit/optimizers/test_parameters.py
+++ b/tests/unit/optimizers/test_parameters.py
@@ -2,7 +2,6 @@ import os
 
 from jina.optimizers.parameters import (
     IntegerParameter,
-    FloatParameter,
     LogUniformParameter,
     UniformParameter,
     CategoricalParameter,
@@ -17,7 +16,6 @@ def test_parameter_file_loading():
     )
     expected = [
         IntegerParameter,
-        FloatParameter,
         UniformParameter,
         UniformParameter,
         LogUniformParameter,


### PR DESCRIPTION
Removed `FloatParameter` since `suggest_float` in `optuna` is anyhow just a wrapper around the three float sampling algorithms and I'd rather not forward this "hack".

Furthermore, added docstrings.