### PR TITLE
feat(async): AsyncClient & AsyncFlow's return is async generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,9 +318,9 @@ with Flow().add().add(host='cloud.jina.ai:8000') as f:
 #### Asynchronous Flow
 <a href="https://mybinder.org/v2/gh/jina-ai/jupyter-notebooks/main?filepath=basic-inter-intra-parallelism.ipynb"><img align="right" src="https://github.com/jina-ai/jina/blob/master/.github/badges/run-badge.svg?raw=true"/></a>
 
-Synchronous from outside, Jina runs asynchronously underneath: it manages the eventloop(s) for scheduling the jobs. If user wants more control over the eventloop, then `AsyncFlow` comes to use.
+Synchronous from outside, Jina runs asynchronously underneath: it manages the eventloop(s) for scheduling the jobs. If user wants more control over the eventloop, then `AsyncFlow` comes to use. 
 
-`AsyncFlow`'s CRUD operations support async generator as the input function. This is particular useful when your data sources involves other asynchronous libraries (e.g. motor for Mongodb):
+Unlike `Flow`, the CRUD of `AsyncFlow` accepts input & output functions as [async generator](https://www.python.org/dev/peps/pep-0525/). This is useful when your data sources involves other asynchronous libraries (e.g. motor for MongoDB):
 
 ```python
 from jina import AsyncFlow
@@ -332,7 +332,7 @@ async def input_fn():
 
 with AsyncFlow().add() as f:
     async for resp in f.index(input_fn):
-        yield resp
+        print(resp)
 ```
 
 `AsyncFlow` is particular useful when Jina is using as part of the integration, where another heavy-lifting job is running concurrently:
@@ -340,8 +340,8 @@ with AsyncFlow().add() as f:
 ```python
 async def run_async_flow_5s():  # WaitDriver pause 5s makes total roundtrip ~5s
     with AsyncFlow().add(uses='- !WaitDriver {}') as f:
-        async for resp in f.index_ndarray(numpy.random.random([5, 4]), on_done=validate):
-            yield resp
+        async for resp in f.index_ndarray(numpy.random.random([5, 4])):
+            print(resp)
 
 async def heavylifting():  # total roundtrip takes ~5s
     print('heavylifting other io-bound jobs, e.g. download, upload, file io')

--- a/cli/api.py
+++ b/cli/api.py
@@ -91,6 +91,7 @@ def flow(args: 'Namespace'):
         from jina.logging import default_logger
         default_logger.critical('start a flow from CLI requires a valid "--uses"')
 
+
 def optimizer(args: 'Namespace'):
     """Start an optimization from a YAML file"""
     from jina.optimizers import run_optimizer_cli

--- a/daemon/api/endpoints/__init__.py
+++ b/daemon/api/endpoints/__init__.py
@@ -13,8 +13,8 @@ async def startup():
     from ... import daemon_logger, jinad_args
     daemon_logger.info(f'''
 Welcome to Jina daemon - the manager of distributed Jina
-💬 Swagger UI:\thttp://localhost:8000/docs
-📚 Docs address:\thttp://localhost:8000/redoc
+💬 Swagger UI:\thttp://localhost:{jinad_args.port_expose}/docs
+📚 Docs address:\thttp://localhost:{jinad_args.port_expose}/redoc
 🔒 Private address:\thttp://{get_internal_ip()}:{jinad_args.port_expose}
 🌐 Public address:\thttp://{get_public_ip()}:{jinad_args.port_expose}
     ''')

--- a/daemon/api/endpoints/__init__.py
+++ b/daemon/api/endpoints/__init__.py
@@ -13,10 +13,10 @@ async def startup():
     from ... import daemon_logger, jinad_args
     daemon_logger.info(f'''
 Welcome to Jina daemon - the manager of distributed Jina
-💬 Swagger UI:\thttp://localhost:{jinad_args.port_expose}/docs
-📚 Docs address:\thttp://localhost:{jinad_args.port_expose}/redoc
+💬 Swagger UI     :\thttp://localhost:{jinad_args.port_expose}/docs
+📚 Redoc          :\thttp://localhost:{jinad_args.port_expose}/redoc
 🔒 Private address:\thttp://{get_internal_ip()}:{jinad_args.port_expose}
-🌐 Public address:\thttp://{get_public_ip()}:{jinad_args.port_expose}
+🌐 Public address :\thttp://{get_public_ip()}:{jinad_args.port_expose}
     ''')
     from jina import __ready_msg__
     daemon_logger.success(__ready_msg__)

--- a/jina/clients/__init__.py
+++ b/jina/clients/__init__.py
@@ -14,6 +14,14 @@ class Client(BaseClient):
     """A simple Python client for connecting to the gRPC gateway.
     It manages the asyncio eventloop internally, so all interfaces are synchronous from the outside.
     """
+    async def _get_results(self, *args):
+        result = []
+        async for resp in super()._get_results(*args):
+            if self.args.return_results:
+                result.append(resp)
+
+        if self.args.return_results:
+            return result
 
     @deprecated_alias(buffer=('input_fn', 1), callback=('on_done', 1), output_fn=('on_done', 1))
     def train(self, input_fn: InputFnType = None,

--- a/jina/clients/__init__.py
+++ b/jina/clients/__init__.py
@@ -14,9 +14,9 @@ class Client(BaseClient):
     """A simple Python client for connecting to the gRPC gateway.
     It manages the asyncio eventloop internally, so all interfaces are synchronous from the outside.
     """
-    async def _get_results(self, *args):
+    async def _get_results(self, *args, **kwargs):
         result = []
-        async for resp in super()._get_results(*args):
+        async for resp in super()._get_results(*args, **kwargs):
             if self.args.return_results:
                 result.append(resp)
 

--- a/jina/clients/asyncio.py
+++ b/jina/clients/asyncio.py
@@ -61,7 +61,8 @@ class AsyncClient(BaseClient):
         :return:
         """
         self.mode = RequestType.TRAIN
-        return await self._get_results(input_fn, on_done, on_error, on_always, **kwargs)
+        async for r in self._get_results(input_fn, on_done, on_error, on_always, **kwargs):
+            yield r
 
     @deprecated_alias(buffer=('input_fn', 1), callback=('on_done', 1), output_fn=('on_done', 1))
     async def search(self, input_fn: InputFnType = None,
@@ -80,7 +81,8 @@ class AsyncClient(BaseClient):
         """
         self.mode = RequestType.SEARCH
         self.add_default_kwargs(kwargs)
-        return await self._get_results(input_fn, on_done, on_error, on_always, **kwargs)
+        async for r in self._get_results(input_fn, on_done, on_error, on_always, **kwargs):
+            yield r
 
     @deprecated_alias(buffer=('input_fn', 1), callback=('on_done', 1), output_fn=('on_done', 1))
     async def index(self, input_fn: InputFnType = None,
@@ -98,7 +100,8 @@ class AsyncClient(BaseClient):
         :return:
         """
         self.mode = RequestType.INDEX
-        return await self._get_results(input_fn, on_done, on_error, on_always, **kwargs)
+        async for r in self._get_results(input_fn, on_done, on_error, on_always, **kwargs):
+            yield r
 
     @deprecated_alias(buffer=('input_fn', 1), callback=('on_done', 1), output_fn=('on_done', 1))
     async def delete(self, input_fn: InputFnType = None,
@@ -116,7 +119,8 @@ class AsyncClient(BaseClient):
         :return:
         """
         self.mode = RequestType.DELETE
-        return await self._get_results(input_fn, on_done, on_error, on_always, **kwargs)
+        async for r in self._get_results(input_fn, on_done, on_error, on_always, **kwargs):
+            yield r
 
 
     @deprecated_alias(buffer=('input_fn', 1), callback=('on_done', 1), output_fn=('on_done', 1))
@@ -135,7 +139,8 @@ class AsyncClient(BaseClient):
         :return:
         """
         self.mode = RequestType.UPDATE
-        return await self._get_results(input_fn, on_done, on_error, on_always, **kwargs)
+        async for r in self._get_results(input_fn, on_done, on_error, on_always, **kwargs):
+            yield r
 
 
 class AsyncWebSocketClient(AsyncClient, WebSocketClientMixin):

--- a/jina/clients/websocket.py
+++ b/jina/clients/websocket.py
@@ -76,6 +76,7 @@ class WebSocketClientMixin(BaseClient, ABC):
                                       continue_on_error=self.args.continue_on_error,
                                       logger=self.logger)
                         p_bar.update(self.args.request_size)
+                        yield response
                         self.num_responses += 1
                         if self.num_requests == self.num_responses:
                             break

--- a/jina/clients/websocket.py
+++ b/jina/clients/websocket.py
@@ -1,12 +1,12 @@
 import asyncio
 from abc import ABC
-from typing import Callable, List
+from typing import Callable
 
 from .base import BaseClient
 from .helper import callback_exec
 from ..importer import ImportExtensions
 from ..logging.profile import TimeContext, ProgressBar
-from ..types.request import Request, Response
+from ..types.request import Request
 
 
 class WebSocketClientMixin(BaseClient, ABC):
@@ -32,7 +32,6 @@ class WebSocketClientMixin(BaseClient, ABC):
         with ImportExtensions(required=True):
             import websockets
 
-        result = []  # type: List['Response']
         self.input_fn = input_fn
 
         tname = self._get_task_name(kwargs)
@@ -77,8 +76,6 @@ class WebSocketClientMixin(BaseClient, ABC):
                                       continue_on_error=self.args.continue_on_error,
                                       logger=self.logger)
                         p_bar.update(self.args.request_size)
-                        if self.args.return_results:
-                            result.append(response)
                         self.num_responses += 1
                         if self.num_requests == self.num_responses:
                             break
@@ -87,6 +84,3 @@ class WebSocketClientMixin(BaseClient, ABC):
             self.logger.warning(f'Client got disconnected from the websocket server')
         except websockets.exceptions.WebSocketException as e:
             self.logger.error(f'Got following error while streaming requests via websocket: {e!r}')
-        finally:
-            if self.args.return_results:
-                return result

--- a/jina/flow/asyncio.py
+++ b/jina/flow/asyncio.py
@@ -117,7 +117,8 @@ class AsyncFlow(BaseFlow):
         :param on_always: the function to be called when the :class:`Request` object is  is either resolved or rejected.
         :param kwargs: accepts all keyword arguments of `jina client` CLI
         """
-        return await self._get_client(**kwargs).train(input_fn, on_done, on_error, on_always, **kwargs)
+        async for r in self._get_client(**kwargs).train(input_fn, on_done, on_error, on_always, **kwargs):
+            yield r
 
     @deprecated_alias(buffer=('input_fn', 1), callback=('on_done', 1), output_fn=('on_done', 1))
     async def index_ndarray(self, array: 'np.ndarray', axis: int = 0, size: int = None, shuffle: bool = False,
@@ -137,9 +138,10 @@ class AsyncFlow(BaseFlow):
         :param kwargs: accepts all keyword arguments of `jina client` CLI
         """
         from ..clients.sugary_io import _input_ndarray
-        return await self._get_client(**kwargs).index(_input_ndarray(array, axis, size, shuffle),
-                                                      on_done, on_error, on_always, data_type=DataInputType.CONTENT,
-                                                      **kwargs)
+        async for r in self._get_client(**kwargs).index(_input_ndarray(array, axis, size, shuffle),
+                                                        on_done, on_error, on_always, data_type=DataInputType.CONTENT,
+                                                        **kwargs):
+            yield r
 
     @deprecated_alias(buffer=('input_fn', 1), callback=('on_done', 1), output_fn=('on_done', 1))
     async def search_ndarray(self, array: 'np.ndarray', axis: int = 0, size: int = None, shuffle: bool = False,
@@ -159,9 +161,10 @@ class AsyncFlow(BaseFlow):
         :param kwargs: accepts all keyword arguments of `jina client` CLI
         """
         from ..clients.sugary_io import _input_ndarray
-        return await self._get_client(**kwargs).search(_input_ndarray(array, axis, size, shuffle),
-                                                       on_done, on_error, on_always, data_type=DataInputType.CONTENT,
-                                                       **kwargs)
+        async for r in self._get_client(**kwargs).search(_input_ndarray(array, axis, size, shuffle),
+                                                         on_done, on_error, on_always, data_type=DataInputType.CONTENT,
+                                                         **kwargs):
+            yield r
 
     @deprecated_alias(buffer=('input_fn', 1), callback=('on_done', 1), output_fn=('on_done', 1))
     async def index_lines(self, lines: Iterator[str] = None, filepath: str = None, size: int = None,
@@ -184,9 +187,10 @@ class AsyncFlow(BaseFlow):
         :param kwargs: accepts all keyword arguments of `jina client` CLI
         """
         from ..clients.sugary_io import _input_lines
-        return await self._get_client(**kwargs).index(_input_lines(lines, filepath, size, sampling_rate, read_mode),
-                                                      on_done, on_error, on_always, data_type=DataInputType.CONTENT,
-                                                      **kwargs)
+        async for r in self._get_client(**kwargs).index(_input_lines(lines, filepath, size, sampling_rate, read_mode),
+                                                        on_done, on_error, on_always, data_type=DataInputType.CONTENT,
+                                                        **kwargs):
+            yield r
 
     @deprecated_alias(buffer=('input_fn', 1), callback=('on_done', 1), output_fn=('on_done', 1))
     async def index_files(self, patterns: Union[str, List[str]], recursive: bool = True,
@@ -210,9 +214,11 @@ class AsyncFlow(BaseFlow):
         :param kwargs: accepts all keyword arguments of `jina client` CLI
         """
         from ..clients.sugary_io import _input_files
-        return await self._get_client(**kwargs).index(_input_files(patterns, recursive, size, sampling_rate, read_mode),
-                                                      on_done, on_error, on_always, data_type=DataInputType.CONTENT,
-                                                      **kwargs)
+        async for r in self._get_client(**kwargs).index(
+                _input_files(patterns, recursive, size, sampling_rate, read_mode),
+                on_done, on_error, on_always, data_type=DataInputType.CONTENT,
+                **kwargs):
+            yield r
 
     @deprecated_alias(buffer=('input_fn', 1), callback=('on_done', 1), output_fn=('on_done', 1))
     async def search_files(self, patterns: Union[str, List[str]], recursive: bool = True,
@@ -236,9 +242,10 @@ class AsyncFlow(BaseFlow):
         :param kwargs: accepts all keyword arguments of `jina client` CLI
         """
         from ..clients.sugary_io import _input_files
-        return await self._get_client(**kwargs).search(
+        async for r in self._get_client(**kwargs).search(
             _input_files(patterns, recursive, size, sampling_rate, read_mode),
-            on_done, on_error, on_always, data_type=DataInputType.CONTENT, **kwargs)
+            on_done, on_error, on_always, data_type=DataInputType.CONTENT, **kwargs):
+            yield r
 
     @deprecated_alias(buffer=('input_fn', 1), callback=('on_done', 1), output_fn=('on_done', 1))
     async def search_lines(self, lines: Iterator[str] = None, filepath: str = None, size: int = None,
@@ -261,9 +268,10 @@ class AsyncFlow(BaseFlow):
         :param kwargs: accepts all keyword arguments of `jina client` CLI
         """
         from ..clients.sugary_io import _input_lines
-        return await self._get_client(**kwargs).search(_input_lines(lines, filepath, size, sampling_rate, read_mode),
-                                                       on_done, on_error, on_always, data_type=DataInputType.CONTENT,
-                                                       **kwargs)
+        async for r in self._get_client(**kwargs).search(_input_lines(lines, filepath, size, sampling_rate, read_mode),
+                                                         on_done, on_error, on_always, data_type=DataInputType.CONTENT,
+                                                         **kwargs):
+            yield r
 
     @deprecated_alias(buffer=('input_fn', 1), callback=('on_done', 1), output_fn=('on_done', 1))
     async def index(self, input_fn: InputFnType = None,
@@ -307,14 +315,15 @@ class AsyncFlow(BaseFlow):
         :param on_always: the function to be called when the :class:`Request` object is  is either resolved or rejected.
         :param kwargs: accepts all keyword arguments of `jina client` CLI
         """
-        return await self._get_client(**kwargs).index(input_fn, on_done, on_error, on_always, **kwargs)
+        async for r in self._get_client(**kwargs).index(input_fn, on_done, on_error, on_always, **kwargs):
+            yield r
 
     @deprecated_alias(buffer=('input_fn', 1), callback=('on_done', 1), output_fn=('on_done', 1))
     async def update(self, input_fn: InputFnType = None,
-                    on_done: CallbackFnType = None,
-                    on_error: CallbackFnType = None,
-                    on_always: CallbackFnType = None,
-                    **kwargs):
+                     on_done: CallbackFnType = None,
+                     on_error: CallbackFnType = None,
+                     on_always: CallbackFnType = None,
+                     **kwargs):
         """Do updates on the current flow
 
         Example,
@@ -354,15 +363,15 @@ class AsyncFlow(BaseFlow):
         :param on_always: the function to be called when the :class:`Request` object is  is either resolved or rejected.
         :param kwargs: accepts all keyword arguments of `jina client` CLI
         """
-        return await self._get_client(**kwargs).update(input_fn, on_done, on_error, on_always, **kwargs)
-
+        async for r in self._get_client(**kwargs).update(input_fn, on_done, on_error, on_always, **kwargs):
+            yield r
 
     @deprecated_alias(buffer=('input_fn', 1), callback=('on_done', 1), output_fn=('on_done', 1))
     async def delete(self, input_fn: InputFnType = None,
-                    on_done: CallbackFnType = None,
-                    on_error: CallbackFnType = None,
-                    on_always: CallbackFnType = None,
-                    **kwargs):
+                     on_done: CallbackFnType = None,
+                     on_error: CallbackFnType = None,
+                     on_always: CallbackFnType = None,
+                     **kwargs):
         """Do deletion on the current flow
 
         Example,
@@ -402,7 +411,8 @@ class AsyncFlow(BaseFlow):
         :param on_always: the function to be called when the :class:`Request` object is  is either resolved or rejected.
         :param kwargs: accepts all keyword arguments of `jina client` CLI
         """
-        return await self._get_client(**kwargs).delete(input_fn, on_done, on_error, on_always, **kwargs)
+        async for r in self._get_client(**kwargs).delete(input_fn, on_done, on_error, on_always, **kwargs):
+            yield r
 
     @deprecated_alias(buffer=('input_fn', 1), callback=('on_done', 1), output_fn=('on_done', 1))
     async def search(self, input_fn: InputFnType = None,
@@ -447,4 +457,5 @@ class AsyncFlow(BaseFlow):
         :param on_always: the function to be called when the :class:`Request` object is  is either resolved or rejected.
         :param kwargs: accepts all keyword arguments of `jina client` CLI
         """
-        return await self._get_client(**kwargs).search(input_fn, on_done, on_error, on_always, **kwargs)
+        async for r in self._get_client(**kwargs).search(input_fn, on_done, on_error, on_always, **kwargs):
+            yield r

--- a/jina/peapods/runtimes/asyncio/rest/models.py
+++ b/jina/peapods/runtimes/asyncio/rest/models.py
@@ -1,0 +1,9 @@
+from typing import Dict
+
+from pydantic.main import BaseModel
+
+
+class JinaStatus(BaseModel):
+    jina: Dict
+    envs: Dict
+    used_memory: str

--- a/jina/peapods/runtimes/asyncio/rest/models.py
+++ b/jina/peapods/runtimes/asyncio/rest/models.py
@@ -1,9 +1,44 @@
-from typing import Dict
+from typing import Dict, Any, Optional, List
 
 from pydantic.main import BaseModel
 
+from jina.enums import RequestType, DataInputType
 
-class JinaStatus(BaseModel):
+
+class JinaStatusModel(BaseModel):
     jina: Dict
     envs: Dict
     used_memory: str
+
+
+class JinaRequestModel(BaseModel):
+    data: List[Dict[str, Any]]
+    request_size: Optional[int] = 0
+    mode: RequestType
+    mime_type: Optional[str] = None
+    queryset: List[Dict[str, Any]]
+    data_type: DataInputType = DataInputType.AUTO
+
+
+class JinaIndexRequestModel(JinaRequestModel):
+    mode: RequestType = RequestType.INDEX
+
+
+class JinaSearchRequestModel(JinaRequestModel):
+    mode: RequestType = RequestType.SEARCH
+
+
+class JinaUpdateRequestModel(JinaRequestModel):
+    mode: RequestType = RequestType.UPDATE
+
+
+class JinaDeleteRequestModel(JinaRequestModel):
+    mode: RequestType = RequestType.DELETE
+
+
+class JinaControlRequestModel(JinaRequestModel):
+    mode: RequestType = RequestType.CONTROL
+
+
+class JinaTrainRequestModel(JinaRequestModel):
+    mode: RequestType = RequestType.TRAIN

--- a/tests/unit/clients/python/test_client.py
+++ b/tests/unit/clients/python/test_client.py
@@ -47,7 +47,7 @@ def test_check_input_fail(input_fn):
 @pytest.mark.parametrize(
     'port_expose, route, status_code',
     [
-        (random_port(), '/ready', 200),
+        (random_port(), '/status', 200),
         (random_port(), '/api/ass', 405)
     ]
 )


### PR DESCRIPTION
This is a breaking change to AsyncFlow API #1606 

- as a continuation of #1543 , this PR introduces return of an AsyncFlow as async generator (PEP525);
- now AsyncFlow are "fully async" in the sense that both `input_fn` and return are now async, (the flow itself is intrinsically async as well)
- note, this reverts the #1540, as `return` can not be used inside an `async generator`. Also keeping all results in a list is pretty trivial and users can do it themselves by looping over the async generator.