### PR TITLE
fix: show exc info by default

### DIFF
--- a/jina/parsers/peapods/base.py
+++ b/jina/parsers/peapods/base.py
@@ -34,6 +34,6 @@ When not given, then the default naming strategy will apply.
                     help='A UUID string to represent the identity of this object'
                     if _SHOW_ALL_ARGS else argparse.SUPPRESS)
 
-    gp.add_argument('--show-exc-info', action='store_true', default=False,
+    gp.add_argument('--hide-exc-info', action='store_true', default=True,
                     help='If set, then exception stack information to be added to the logging message, '
                          'useful in debugging')

--- a/jina/parsers/peapods/base.py
+++ b/jina/parsers/peapods/base.py
@@ -34,6 +34,6 @@ When not given, then the default naming strategy will apply.
                     help='A UUID string to represent the identity of this object'
                     if _SHOW_ALL_ARGS else argparse.SUPPRESS)
 
-    gp.add_argument('--hide-exc-info', action='store_true', default=True,
+    gp.add_argument('--hide-exc-info', action='store_true', default=False,
                     help='If set, then exception stack information to be added to the logging message, '
                          'useful in debugging')

--- a/jina/peapods/peas/__init__.py
+++ b/jina/peapods/peas/__init__.py
@@ -78,7 +78,7 @@ class BasePea(metaclass=PeaType):
             except KeyboardInterrupt:
                 self.logger.info(f'{self.runtime!r} is interrupted by user')
             except (Exception, SystemError) as ex:
-                self.logger.error(f'{ex!r} during {self.runtime_cls.__init__!r}' +
+                self.logger.error(f'{ex!r} during {self.runtime.run_forever!r}' +
                                   f'add "--hide-exc-info" if you do not want to see the exception stack in details'
                                   if not self.args.hide_exc_info else '',
                                   exc_info=not self.args.hide_exc_info)
@@ -137,7 +137,7 @@ class BasePea(metaclass=PeaType):
                 self.runtime.cancel()
                 self.is_shutdown.wait()
             except Exception as ex:
-                self.logger.error(f'{ex!r} during {self.runtime_cls.__init__!r}' +
+                self.logger.error(f'{ex!r} during {self.runtime.cancel!r}' +
                                   f'add "--hide-exc-info" if you do not want to see the exception stack in details'
                                   if not self.args.hide_exc_info else '',
                                   exc_info=not self.args.hide_exc_info)

--- a/jina/peapods/peas/__init__.py
+++ b/jina/peapods/peas/__init__.py
@@ -65,7 +65,7 @@ class BasePea(metaclass=PeaType):
         try:
             self.runtime.setup()
         except Exception as ex:
-            self.logger.error(f'{ex!r} during {self.runtime_cls.__init__!r}' +
+            self.logger.error(f'{ex!r} during {self.runtime.setup!r}' +
                               f'add "--hide-exc-info" if you do not want to see the exception stack in details'
                               if not self.args.hide_exc_info else '',
                               exc_info=not self.args.hide_exc_info)

--- a/jina/peapods/peas/__init__.py
+++ b/jina/peapods/peas/__init__.py
@@ -86,7 +86,7 @@ class BasePea(metaclass=PeaType):
             try:
                 self.runtime.teardown()
             except Exception as ex:
-                self.logger.error(f'{ex!r} during {self.runtime_cls.__init__!r}' +
+                self.logger.error(f'{ex!r} during {self.runtime.teardown!r}' +
                                   f'add "--hide-exc-info" if you do not want to see the exception stack in details'
                                   if not self.args.hide_exc_info else '',
                                   exc_info=not self.args.hide_exc_info)

--- a/jina/peapods/peas/__init__.py
+++ b/jina/peapods/peas/__init__.py
@@ -113,7 +113,7 @@ class BasePea(metaclass=PeaType):
                 # return too early and the shutdown is set, means something fails!!
                 if self.args.hide_exc_info:
                     self.logger.critical(f'fail to start {self!r} because {self.runtime!r} throws some exception, '
-                                         f'remote "--hide-exc-info" to see the exception stack in details')
+                                         f'remove "--hide-exc-info" to see the exception stack in details')
                 raise RuntimeFailToStart
             else:
                 self.logger.success(__ready_msg__)

--- a/jina/peapods/peas/__init__.py
+++ b/jina/peapods/peas/__init__.py
@@ -45,9 +45,9 @@ class BasePea(metaclass=PeaType):
             self.runtime = self._get_runtime_cls()(self.args)  # type: 'BaseRuntime'
         except Exception as ex:
             self.logger.error(f'{ex!r} during {self.runtime_cls.__init__!r}' +
-                              f'add "--show-exc-info" to see the exception stack in details'
-                              if not self.args.show_exc_info else '',
-                              exc_info=self.args.show_exc_info)
+                              f'add "--hide-exc-info" if you do not want to see the exception stack in details'
+                              if not self.args.hide_exc_info else '',
+                              exc_info=not self.args.hide_exc_info)
             raise RuntimeFailToStart from ex
 
     def run(self):
@@ -65,10 +65,10 @@ class BasePea(metaclass=PeaType):
         try:
             self.runtime.setup()
         except Exception as ex:
-            self.logger.error(f'{ex!r} during {self.runtime.setup!r}' +
-                              f'add "--show-exc-info" to see the exception stack in details'
-                              if not self.args.show_exc_info else '',
-                              exc_info=self.args.show_exc_info)
+            self.logger.error(f'{ex!r} during {self.runtime_cls.__init__!r}' +
+                              f'add "--hide-exc-info" if you do not want to see the exception stack in details'
+                              if not self.args.hide_exc_info else '',
+                              exc_info=not self.args.hide_exc_info)
         else:
             self.is_ready.set()
             try:
@@ -78,18 +78,18 @@ class BasePea(metaclass=PeaType):
             except KeyboardInterrupt:
                 self.logger.info(f'{self.runtime!r} is interrupted by user')
             except (Exception, SystemError) as ex:
-                self.logger.error(f'{ex!r} during {self.runtime.run_forever!r}' +
-                                  f'add "--show-exc-info" to see the exception stack in details'
-                                  if not self.args.show_exc_info else '',
-                                  exc_info=self.args.show_exc_info)
+                self.logger.error(f'{ex!r} during {self.runtime_cls.__init__!r}' +
+                                  f'add "--hide-exc-info" if you do not want to see the exception stack in details'
+                                  if not self.args.hide_exc_info else '',
+                                  exc_info=not self.args.hide_exc_info)
 
             try:
                 self.runtime.teardown()
             except Exception as ex:
-                self.logger.error(f'{ex!r} during {self.runtime.teardown!r}' +
-                                  f'add "--show-exc-info" to see the exception stack in details'
-                                  if not self.args.show_exc_info else '',
-                                  exc_info=self.args.show_exc_info)
+                self.logger.error(f'{ex!r} during {self.runtime_cls.__init__!r}' +
+                                  f'add "--hide-exc-info" if you do not want to see the exception stack in details'
+                                  if not self.args.hide_exc_info else '',
+                                  exc_info=not self.args.hide_exc_info)
         finally:
             self.is_shutdown.set()
             self.is_ready.clear()
@@ -111,8 +111,9 @@ class BasePea(metaclass=PeaType):
         if self.ready_or_shutdown.wait(_timeout):
             if self.is_shutdown.is_set():
                 # return too early and the shutdown is set, means something fails!!
-                self.logger.critical(f'fail to start {self!r} because {self.runtime!r} throws some exception, '
-                                     f'add "--show-exc-info" to see the exception stack in details')
+                if self.args.hide_exc_info:
+                    self.logger.critical(f'fail to start {self!r} because {self.runtime!r} throws some exception, '
+                                         f'remote "--hide-exc-info" to see the exception stack in details')
                 raise RuntimeFailToStart
             else:
                 self.logger.success(__ready_msg__)
@@ -136,10 +137,10 @@ class BasePea(metaclass=PeaType):
                 self.runtime.cancel()
                 self.is_shutdown.wait()
             except Exception as ex:
-                self.logger.error(f'{ex!r} during {self.runtime.cancel!r}' +
-                                  f'add "--show-exc-info" to see the exception stack in details'
-                                  if not self.args.show_exc_info else '',
-                                  exc_info=self.args.show_exc_info)
+                self.logger.error(f'{ex!r} during {self.runtime_cls.__init__!r}' +
+                                  f'add "--hide-exc-info" if you do not want to see the exception stack in details'
+                                  if not self.args.hide_exc_info else '',
+                                  exc_info=not self.args.hide_exc_info)
 
             # if it is not daemon, block until the process/thread finish work
             if not self.args.daemon:

--- a/jina/peapods/runtimes/zmq/zed.py
+++ b/jina/peapods/runtimes/zmq/zed.py
@@ -181,16 +181,16 @@ class ZEDRuntime(ZMQRuntime):
                 raise
             if isinstance(ex, ChainedPodException):
                 msg.add_exception()
-                self.logger.warning(f'{ex!r}' +
-                                    f'add "--show-exc-info" to see the exception stack in details'
-                                    if not self.args.show_exc_info else '',
-                                    exc_info=self.args.show_exc_info)
+                self.logger.error(f'{ex!r}' +
+                                  f'add "--hide-exc-info" if you do not want to see the exception stack in details'
+                                  if not self.args.hide_exc_info else '',
+                                  exc_info=not self.args.hide_exc_info)
             else:
                 msg.add_exception(ex, executor=getattr(self, '_executor'))
                 self.logger.error(f'{ex!r}' +
-                                  f'add "--show-exc-info" to see the exception stack in details'
-                                  if not self.args.show_exc_info else '',
-                                  exc_info=self.args.show_exc_info)
+                                  f'add "--hide-exc-info" if you do not want to see the exception stack in details'
+                                  if not self.args.hide_exc_info else '',
+                                  exc_info=not self.args.hide_exc_info)
 
             self._zmqlet.send_message(msg)
 


### PR DESCRIPTION
**Changes introduced**
Productivity boost to capture faster exceptions and problems when defining problems. Also easier for the community to see the problems and to have better reporting.

@cristianmtr 