### PR TITLE
docs: add repo dispatch event when release

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -48,12 +48,6 @@ jobs:
           git config --local user.email "dev-bot@jina.ai"
           git config --local user.name "Jina Dev Bot"
           git add . && git commit -m "update ${{env.JINA_VERSION}} due to ${{github.event_name}} on ${{github.repository}}" && git push
-      - name: send-repository-dispatch-event-to-docs
-        uses: peter-evans/repository-dispatch@v1
-        with:
-          token: ${{ secrets.JINA_DEV_BOT }}
-          repository: jina-ai/jina-docs
-          event-type: jina-release-event
 
 
   update-doc:
@@ -89,6 +83,12 @@ jobs:
           directory: docs/_build/html
           tags: true
           branch: master
+      - name: send-repository-dispatch-event-to-docs
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.JINA_DEV_BOT }}
+          repository: jina-ai/jina-docs
+          event-type: jina-release-event
 
   update-docker:
     needs: update-doc

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -83,11 +83,12 @@ jobs:
           directory: docs/_build/html
           tags: true
           branch: master
+      # Tell docs repo jina is going to release
       - name: send-repository-dispatch-event-to-docs
         uses: peter-evans/repository-dispatch@v1
         with:
           token: ${{ secrets.JINA_DEV_BOT }}
-          repository: jina-ai/jina-docs
+          repository: jina-ai/docs
           event-type: jina-release-event
 
   update-docker:

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -48,6 +48,12 @@ jobs:
           git config --local user.email "dev-bot@jina.ai"
           git config --local user.name "Jina Dev Bot"
           git add . && git commit -m "update ${{env.JINA_VERSION}} due to ${{github.event_name}} on ${{github.repository}}" && git push
+      - name: send-repository-dispatch-event-to-docs
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.JINA_DEV_BOT }}
+          repository: jina-ai/jina-docs
+          event-type: jina-release-event
 
 
   update-doc:


### PR DESCRIPTION
Problem definition: Jina runs `make-docs.sh` when release in `tag.yml` -> `on push tags`. We want to let `docs` repo "know" Jina is releasing. To achieve this, while jina is releasing:

1. Jina Docs [tag workflow](https://github.com/jina-ai/docs/blob/docs-migration/.github/workflows/tag.yml) monitors release event.
2. When release, Jina Core [tag workflow](https://github.com/jina-ai/jina/blob/master/.github/workflows/tag.yml#L53) send a customized `jina-release-event`.
3. Jina Docs tag workflow receive `jina-release-event` and performs all the steps defined in [tags.yml](https://github.com/jina-ai/docs/blob/docs-migration/.github/workflows/tag.yml), on `docs-migration` branch.
4. Jina Docs workflow push the updated docs to `gh-pages` branch.