### PR TITLE
fix: vector indexer only uses str as keys

### DIFF
--- a/jina/clients/__init__.py
+++ b/jina/clients/__init__.py
@@ -99,7 +99,7 @@ class Client(BaseClient):
         return run_async(self._get_results, input_fn, on_done, on_error, on_always, **kwargs)
 
     @deprecated_alias(buffer=('input_fn', 1), callback=('on_done', 1), output_fn=('on_done', 1))
-    def delete(self, input_fn: Iterable[int],
+    def delete(self, input_fn: Iterable[str],
                on_done: CallbackFnType = None,
                on_error: CallbackFnType = None,
                on_always: CallbackFnType = None,

--- a/jina/clients/asyncio.py
+++ b/jina/clients/asyncio.py
@@ -106,7 +106,7 @@ class AsyncClient(BaseClient):
             yield r
 
     @deprecated_alias(buffer=('input_fn', 1), callback=('on_done', 1), output_fn=('on_done', 1))
-    async def delete(self, input_fn: Iterable[int],
+    async def delete(self, input_fn: Iterable[str],
                     on_done: CallbackFnType = None,
                     on_error: CallbackFnType = None,
                     on_always: CallbackFnType = None,

--- a/jina/drivers/delete.py
+++ b/jina/drivers/delete.py
@@ -1,8 +1,6 @@
 __copyright__ = "Copyright (c) 2020 Jina AI Limited. All rights reserved."
 __license__ = "Apache-2.0"
 
-import numpy as np
-
 from . import BaseExecutableDriver
 
 
@@ -13,10 +11,4 @@ class DeleteDriver(BaseExecutableDriver):
         super().__init__(executor, method, *args, **kwargs)
 
     def __call__(self, *args, **kwargs):
-        from ..executors.indexers.vector import BaseNumpyIndexer
-        if isinstance(self.exec, BaseNumpyIndexer):
-            keys = np.array(self.req.ids, dtype=(np.str_, self._exec.key_length))
-        else:
-            keys = self.req.ids
-
-        self.exec_fn(keys)
+        self.exec_fn(self.req.ids)

--- a/jina/drivers/index.py
+++ b/jina/drivers/index.py
@@ -25,9 +25,7 @@ class VectorIndexDriver(BaseIndexDriver):
         if bad_docs:
             self.runtime.logger.warning(f'these bad docs can not be added: {bad_docs}')
         if docs_pts:
-            self.exec_fn(np.array([doc.id for doc in docs_pts],
-                                  dtype=(np.str_, self._exec.key_length)),
-                         np.stack(embed_vecs))
+            self.exec_fn([doc.id for doc in docs_pts], np.stack(embed_vecs))
 
 
 class KVIndexDriver(BaseIndexDriver):

--- a/jina/drivers/search.py
+++ b/jina/drivers/search.py
@@ -80,7 +80,7 @@ class VectorFillDriver(QuerySetReader, BaseSearchDriver):
     """ Fill in the embedding by their doc id
     """
 
-    def __init__(self, executor: str = None, method: str = 'query_by_id', *args, **kwargs):
+    def __init__(self, executor: str = None, method: str = 'query_by_key', *args, **kwargs):
         super().__init__(executor, method, *args, **kwargs)
 
     def _apply_all(self, docs: 'DocumentSet', *args, **kwargs) -> None:
@@ -99,7 +99,7 @@ class VectorSearchDriver(QuerySetReader, BaseSearchDriver):
 
         :param top_k: top-k doc id to retrieve
         :param fill_embedding: fill in the embedding of the corresponding doc,
-                this requires the executor to implement :meth:`query_by_id`
+                this requires the executor to implement :meth:`query_by_key`
         :param args:
         :param kwargs:
         """
@@ -113,9 +113,9 @@ class VectorSearchDriver(QuerySetReader, BaseSearchDriver):
         if not doc_pts:
             return
 
-        fill_fn = getattr(self.exec, 'query_by_id', None)
+        fill_fn = getattr(self.exec, 'query_by_key', None)
         if self._fill_embedding and not fill_fn:
-            self.logger.warning(f'"fill_embedding=True" but {self.exec} does not have "query_by_id" method')
+            self.logger.warning(f'"fill_embedding=True" but {self.exec} does not have "query_by_key" method')
 
         if bad_docs:
             self.logger.warning(f'these bad docs can not be added: {bad_docs}')

--- a/jina/executors/__init__.py
+++ b/jina/executors/__init__.py
@@ -112,7 +112,7 @@ class BaseExecutor(JAMLCompatible, metaclass=ExecutorType):
 
     """
     store_args_kwargs = False  #: set this to ``True`` to save ``args`` (in a list) and ``kwargs`` (in a map) in YAML config
-    exec_methods = ['encode', 'add', 'query', 'craft', 'segment', 'score', 'evaluate', 'predict', 'query_by_id',
+    exec_methods = ['encode', 'add', 'query', 'craft', 'segment', 'score', 'evaluate', 'predict', 'query_by_key',
                     'delete', 'update']
 
     def __init__(self, *args, **kwargs):

--- a/jina/executors/indexers/__init__.py
+++ b/jina/executors/indexers/__init__.py
@@ -216,10 +216,10 @@ class BaseVectorIndexer(BaseIndexer):
         """
         raise NotImplementedError
 
-    def query(self, keys: 'np.ndarray', top_k: int, *args, **kwargs) -> Tuple['np.ndarray', 'np.ndarray']:
+    def query(self, query_vectors: 'np.ndarray', top_k: int, *args, **kwargs) -> Tuple['np.ndarray', 'np.ndarray']:
         """Find k-NN using query vectors, return chunk ids and chunk scores
 
-        :param keys: query vectors in ndarray, shape B x D
+        :param query_vectors: query vectors in ndarray, shape B x D
         :param top_k: int, the number of nearest neighbour to return
         :return: a tuple of two ndarray.
             The first is ids in shape B x K (`dtype=int`), the second is scores in shape B x K (`dtype=float`)

--- a/jina/executors/indexers/__init__.py
+++ b/jina/executors/indexers/__init__.py
@@ -2,7 +2,7 @@ __copyright__ = "Copyright (c) 2020 Jina AI Limited. All rights reserved."
 __license__ = "Apache-2.0"
 
 import os
-from typing import Tuple, Union, List, Iterator, Optional, Any
+from typing import Tuple, List, Iterator, Optional, Any
 
 import numpy as np
 
@@ -198,7 +198,7 @@ class BaseVectorIndexer(BaseIndexer):
     It can be used to tell whether an indexer is vector indexer, via ``isinstance(a, BaseVectorIndexer)``
     """
 
-    def query_by_id(self, ids: Union[List[int], 'np.ndarray'], *args, **kwargs) -> 'np.ndarray':
+    def query_by_id(self, ids: Iterator[str], *args, **kwargs) -> 'np.ndarray':
         """ Get the vectors by id, return a subset of indexed vectors
 
         :param ids: a list of ``id``, i.e. ``doc.id`` in protobuf
@@ -208,7 +208,7 @@ class BaseVectorIndexer(BaseIndexer):
         """
         raise NotImplementedError
 
-    def add(self, keys: 'np.ndarray', vectors: 'np.ndarray', *args, **kwargs):
+    def add(self, keys: Iterator[str], vectors: 'np.ndarray', *args, **kwargs):
         """Add new chunks and their vector representations
 
         :param keys: ``chunk_id`` in 1D-ndarray, shape B x 1

--- a/jina/executors/indexers/__init__.py
+++ b/jina/executors/indexers/__init__.py
@@ -198,10 +198,10 @@ class BaseVectorIndexer(BaseIndexer):
     It can be used to tell whether an indexer is vector indexer, via ``isinstance(a, BaseVectorIndexer)``
     """
 
-    def query_by_id(self, ids: Iterator[str], *args, **kwargs) -> 'np.ndarray':
+    def query_by_key(self, keys: Iterator[str], *args, **kwargs) -> 'np.ndarray':
         """ Get the vectors by id, return a subset of indexed vectors
 
-        :param ids: a list of ``id``, i.e. ``doc.id`` in protobuf
+        :param keys: a list of ``id``, i.e. ``doc.id`` in protobuf
         :param args:
         :param kwargs:
         :return:

--- a/jina/executors/indexers/vector.py
+++ b/jina/executors/indexers/vector.py
@@ -199,15 +199,15 @@ class BaseNumpyIndexer(BaseVectorIndexer):
             return np.memmap(self.index_abspath, dtype=self.dtype, mode='r',
                              shape=(self.size + deleted_keys, self.num_dim))
 
-    def query_by_id(self, ids: Sequence[str], *args, **kwargs) -> Optional['np.ndarray']:
+    def query_by_key(self, keys: Sequence[str], *args, **kwargs) -> Optional['np.ndarray']:
         """
         Search the index by the external key (passed during `.add(`)
 
-        :param ids: The list of keys to be queried
+        :param keys: The list of keys to be queried
         """
-        ids = self._filter_nonexistent_keys(ids, self._ext2int_id.keys(), self.save_abspath)
-        if ids:
-            indices = [self._ext2int_id[key] for key in ids]
+        keys = self._filter_nonexistent_keys(keys, self._ext2int_id.keys(), self.save_abspath)
+        if keys:
+            indices = [self._ext2int_id[key] for key in keys]
             return self._raw_ndarray[indices]
         else:
             return None

--- a/jina/executors/indexers/vector.py
+++ b/jina/executors/indexers/vector.py
@@ -5,7 +5,7 @@ import gzip
 import os
 from functools import lru_cache
 from os import path
-from typing import Optional, List, Union, Tuple, Dict, Sequence
+from typing import Optional, Iterator, Tuple, Dict, Sequence
 
 import numpy as np
 
@@ -49,7 +49,7 @@ class BaseNumpyIndexer(BaseVectorIndexer):
         self.dtype = None
         self.compress_level = compress_level
         self.key_bytes = b''
-        self.key_length = key_length
+        self.key_dtype = (np.str_, key_length)
         self.valid_indices = np.array([], dtype=bool)
         self.ref_indexer_workspace_name = None
 
@@ -59,7 +59,7 @@ class BaseNumpyIndexer(BaseVectorIndexer):
             self.dtype = ref_indexer.dtype
             self.compress_level = ref_indexer.compress_level
             self.key_bytes = ref_indexer.key_bytes
-            self.key_length = ref_indexer.key_length
+            self.key_dtype = ref_indexer.key_dtype
             self._size = ref_indexer._size
             # point to the ref_indexer.index_filename
             # so that later in `post_init()` it will load from the referred index_filename
@@ -122,39 +122,37 @@ class BaseNumpyIndexer(BaseVectorIndexer):
         elif keys.shape[0] != vectors.shape[0]:
             raise ValueError(f'number of key {keys.shape[0]} not equal to number of vectors {vectors.shape[0]}')
 
-    def add(self, keys: 'np.ndarray', vectors: 'np.ndarray', *args, **kwargs) -> None:
+    def add(self, keys: Iterator[str], vectors: 'np.ndarray', *args, **kwargs) -> None:
+        np_keys = np.array(keys, dtype=self.key_dtype)
+        self._add(np_keys, vectors)
+
+    def _add(self, keys: 'np.ndarry', vectors: 'np.ndarray'):
         self._validate_key_vector_shapes(keys, vectors)
         self.write_handler.write(vectors.tobytes())
         self.valid_indices = np.concatenate((self.valid_indices, np.full(len(keys), True)))
         self.key_bytes += keys.tobytes()
         self._size += keys.shape[0]
 
-    def update(self, keys: Sequence[int], values: Sequence[bytes], *args, **kwargs) -> None:
+    def update(self, keys: Iterator[str], values: Sequence[bytes], *args, **kwargs) -> None:
         # noinspection PyTypeChecker
-        keys, values = self._filter_nonexistent_keys_values(keys, values, self.ext2int_id.keys(), self.save_abspath)
-        # could be empty
-        # please do not use "if keys:", it wont work on both sequence and ndarray
-        if getattr(keys, 'size', len(keys)):
-            # expects np array for computing shapes
-            keys = np.array(list(keys))
-            self._delete(keys, keys_precomputed=True)
-            self.add(np.array(keys, dtype=(np.str_, self.key_length)), np.array(values))
+        keys, values = self._filter_nonexistent_keys_values(keys, values, self._ext2int_id.keys(), self.save_abspath)
+        np_keys = np.array(keys, dtype=self.key_dtype)
 
-    def _delete(self, keys, keys_precomputed):
-        # could be empty
-        if keys_precomputed is not True:
-            keys = self._filter_nonexistent_keys(keys, self.ext2int_id.keys(), self.save_abspath)
-        # please do not use "if keys:", it wont work on both sequence and ndarray
-        if getattr(keys, 'size', len(keys)):
-            # expects np array for computing shapes
-            keys = np.array(list(keys))
+        if np_keys.size:
+            self._delete(np_keys)
+            self._add(np_keys, np.array(values))
+
+    def _delete(self, keys):
+        if keys.size:
             for key in keys:
                 # mark as `False` in mask
-                self.valid_indices[self.ext2int_id[key]] = False
+                self.valid_indices[self._ext2int_id[key]] = False
                 self._size -= 1
 
-    def delete(self, keys: Sequence[int], *args, **kwargs) -> None:
-        self._delete(keys, keys_precomputed=False)
+    def delete(self, keys: Iterator[str], *args, **kwargs) -> None:
+        keys = self._filter_nonexistent_keys(keys, self._ext2int_id.keys(), self.save_abspath)
+        np_keys = np.array(keys, dtype=self.key_dtype)
+        self._delete(np_keys)
 
     def get_query_handler(self) -> Optional['np.ndarray']:
         """Open a gzip file and load it as a numpy ndarray
@@ -162,9 +160,9 @@ class BaseNumpyIndexer(BaseVectorIndexer):
         :return: a numpy ndarray of vectors
         """
         if np.all(self.valid_indices):
-            vecs = self.raw_ndarray
+            vecs = self._raw_ndarray
         else:
-            vecs = self.raw_ndarray[self.valid_indices]
+            vecs = self._raw_ndarray[self.valid_indices]
 
         if vecs is not None:
             return self.build_advanced_index(vecs)
@@ -188,7 +186,7 @@ class BaseNumpyIndexer(BaseVectorIndexer):
                 f'{abspath} is broken/incomplete, perhaps forgot to ".close()" in the last usage?')
 
     @cached_property
-    def raw_ndarray(self) -> Optional['np.ndarray']:
+    def _raw_ndarray(self) -> Optional['np.ndarray']:
         if not (path.exists(self.index_abspath) or self.num_dim or self.dtype):
             return
 
@@ -201,39 +199,39 @@ class BaseNumpyIndexer(BaseVectorIndexer):
             return np.memmap(self.index_abspath, dtype=self.dtype, mode='r',
                              shape=(self.size + deleted_keys, self.num_dim))
 
-    def query_by_id(self, ids: Union[List[int], 'np.ndarray'], *args, **kwargs) -> Optional['np.ndarray']:
+    def query_by_id(self, ids: Sequence[str], *args, **kwargs) -> Optional['np.ndarray']:
         """
         Search the index by the external key (passed during `.add(`)
 
         :param ids: The list of keys to be queried
         """
-        ids = self._filter_nonexistent_keys(ids, self.ext2int_id.keys(), self.save_abspath)
+        ids = self._filter_nonexistent_keys(ids, self._ext2int_id.keys(), self.save_abspath)
         if ids:
-            indices = [self.ext2int_id[key] for key in ids]
-            return self.raw_ndarray[indices]
+            indices = [self._ext2int_id[key] for key in ids]
+            return self._raw_ndarray[indices]
         else:
             return None
 
     @cached_property
-    def int2ext_id(self) -> Optional['np.ndarray']:
+    def _int2ext_id(self) -> Optional['np.ndarray']:
         """Convert internal ids (0,1,2,3,4,...) to external ids (random index) """
         if self.key_bytes:
-            r = np.frombuffer(self.key_bytes, dtype=(np.str_, self.key_length))
+            r = np.frombuffer(self.key_bytes, dtype=self.key_dtype)
             # `==` is required. `is False` does not work in np
             deleted_keys = len(self.valid_indices[self.valid_indices == False])  # noqa
-            if r.shape[0] == (self.size + deleted_keys) == self.raw_ndarray.shape[0]:
+            if r.shape[0] == (self.size + deleted_keys) == self._raw_ndarray.shape[0]:
                 return r
             else:
                 self.logger.error(
                     f'the size of the keys and vectors are inconsistent '
-                    f'({r.shape[0]}, {self._size}, {self.raw_ndarray.shape[0]}), '
+                    f'({r.shape[0]}, {self._size}, {self._raw_ndarray.shape[0]}), '
                     f'did you write to this index twice? or did you forget to save indexer?')
 
     @cached_property
-    def ext2int_id(self) -> Optional[Dict]:
+    def _ext2int_id(self) -> Optional[Dict]:
         """Convert external ids (random index) to internal ids (0,1,2,3,4,...) """
-        if self.int2ext_id is not None:
-            return {k: idx for idx, k in enumerate(self.int2ext_id)}
+        if self._int2ext_id is not None:
+            return {k: idx for idx, k in enumerate(self._int2ext_id)}
 
 
 @lru_cache(maxsize=3)
@@ -343,7 +341,7 @@ class NumpyIndexer(BaseNumpyIndexer):
             raise NotImplementedError(f'{self.metric} is not implemented')
 
         idx, dist = self._get_sorted_top_k(dist, top_k)
-        indices = self.int2ext_id[self.valid_indices][idx]
+        indices = self._int2ext_id[self.valid_indices][idx]
         return indices, dist
 
     def build_advanced_index(self, vecs: 'np.ndarray'):

--- a/jina/executors/indexers/vector.py
+++ b/jina/executors/indexers/vector.py
@@ -314,7 +314,7 @@ class NumpyIndexer(BaseNumpyIndexer):
 
         return idx, dist
 
-    def query(self, keys: 'np.ndarray', top_k: int, *args, **kwargs) -> Tuple[
+    def query(self, query_vectors: 'np.ndarray', top_k: int, *args, **kwargs) -> Tuple[
         Optional['np.ndarray'], Optional['np.ndarray']]:
         """ Find the top-k vectors with smallest ``metric`` and return their ids in ascending order.
 
@@ -330,13 +330,13 @@ class NumpyIndexer(BaseNumpyIndexer):
         if self.size == 0:
             return None, None
         if self.metric not in {'cosine', 'euclidean'} or self.backend == 'scipy':
-            dist = self._cdist(keys, self.query_handler)
+            dist = self._cdist(query_vectors, self.query_handler)
         elif self.metric == 'euclidean':
-            _keys = _ext_A(keys)
-            dist = self._euclidean(_keys, self.query_handler)
+            _query_vectors = _ext_A(query_vectors)
+            dist = self._euclidean(_query_vectors, self.query_handler)
         elif self.metric == 'cosine':
-            _keys = _ext_A(_norm(keys))
-            dist = self._cosine(_keys, self.query_handler)
+            _query_vectors = _ext_A(_norm(query_vectors))
+            dist = self._cosine(_query_vectors, self.query_handler)
         else:
             raise NotImplementedError(f'{self.metric} is not implemented')
 

--- a/jina/flow/__init__.py
+++ b/jina/flow/__init__.py
@@ -240,7 +240,7 @@ class Flow(BaseFlow):
         """
         self._get_client(**kwargs).update(input_fn, on_done, on_error, on_always, **kwargs)
 
-    def delete(self, input_fn: Iterable[int],
+    def delete(self, input_fn: Iterable[str],
                on_done: CallbackFnType = None,
                on_error: CallbackFnType = None,
                on_always: CallbackFnType = None,

--- a/jina/flow/asyncio.py
+++ b/jina/flow/asyncio.py
@@ -367,7 +367,7 @@ class AsyncFlow(BaseFlow):
             yield r
 
     @deprecated_alias(buffer=('input_fn', 1), callback=('on_done', 1), output_fn=('on_done', 1))
-    async def delete(self, input_fn: Iterable[int],
+    async def delete(self, input_fn: Iterable[str],
                      on_done: CallbackFnType = None,
                      on_error: CallbackFnType = None,
                      on_always: CallbackFnType = None,

--- a/jina/types/document/__init__.py
+++ b/jina/types/document/__init__.py
@@ -1,15 +1,18 @@
 import base64
+import mimetypes
 import os
 import urllib.parse
 import urllib.request
+import warnings
+import numpy as np
 from hashlib import blake2b
 from typing import Union, Dict, Optional, TypeVar, Any, Callable, Sequence, Tuple
 
 from google.protobuf import json_format
 from google.protobuf.field_mask_pb2 import FieldMask
 
-from .converters import *
-from .uid import *
+from .converters import png_to_buffer, to_datauri, guess_mime
+from .uid import DIGEST_SIZE, UniqueId
 from ..ndarray.generic import NdArray
 from ..score import NamedScore
 from ..sets.chunk import ChunkSet
@@ -211,7 +214,7 @@ class Document:
         elif exclude_fields is not None:
             FieldMask(paths=exclude_fields).MergeMessage(empty_doc, masked_d, replace_repeated_field=True)
 
-        self._document.content_hash = blake2b(masked_d.SerializeToString(), digest_size=uid._digest_size).hexdigest()
+        self._document.content_hash = blake2b(masked_d.SerializeToString(), digest_size=DIGEST_SIZE).hexdigest()
 
     @property
     def id(self) -> 'UniqueId':

--- a/jina/types/document/converters.py
+++ b/jina/types/document/converters.py
@@ -22,9 +22,9 @@ def png_to_buffer_1d(arr: 'np.ndarray', width: int, height: int) -> bytes:
 
     def png_pack(png_tag, data):
         chunk_head = png_tag + data
-        return (struct.pack('!I', len(data)) +
-                chunk_head +
-                struct.pack('!I', 0xFFFFFFFF & zlib.crc32(chunk_head)))
+        return (struct.pack('!I', len(data))
+                + chunk_head
+                + struct.pack('!I', 0xFFFFFFFF & zlib.crc32(chunk_head)))
 
     png_bytes = b''.join([
         b'\x89PNG\r\n\x1a\n',

--- a/jina/types/document/uid.py
+++ b/jina/types/document/uid.py
@@ -15,7 +15,6 @@ __license__ = "Apache-2.0"
 
 import re
 import sys
-import warnings
 from binascii import unhexlify
 
 import numpy as np
@@ -23,12 +22,12 @@ import numpy as np
 from ...excepts import BadDocID
 from ...helper import typename
 
-_digest_size = 8
+DIGEST_SIZE = 8
 _id_regex = re.compile(r'([0-9a-fA-F][0-9a-fA-F])+')
 
 
 def int2bytes(value: int) -> bytes:
-    return int(value).to_bytes(_digest_size, sys.byteorder, signed=True)
+    return int(value).to_bytes(DIGEST_SIZE, sys.byteorder, signed=True)
 
 
 def bytes2int(value: bytes) -> int:

--- a/tests/integration/memmap/test_mmap.py
+++ b/tests/integration/memmap/test_mmap.py
@@ -33,7 +33,7 @@ def test_standard_query(tmpdir, test_standard):
     with NumpyIndexer.load(os.path.join(tmpdir, 'a.bin')) as ni:
         ni.batch_size = 256
         print(used_memory_readable())
-        print(ni.raw_ndarray.shape)
+        print(ni._raw_ndarray.shape)
         print(used_memory_readable())
         with TimeContext('query topk') as ti:
             result = ni.query(queries, top_k=10)

--- a/tests/unit/drivers/test_vector_fill_driver.py
+++ b/tests/unit/drivers/test_vector_fill_driver.py
@@ -23,9 +23,9 @@ def docs_to_encode(num_docs):
 
 
 class MockIndexer(BaseIndexer):
-    def query_by_id(self, data: Any, *args, **kwargs) -> Any:
-        # encodes 10 * data into the encoder, so return data
-        return np.random.random([len(data), 5])
+    def query_by_key(self, keys: Any, *args, **kwargs) -> Any:
+        # encodes 10 * keys into the encoder, so return keys
+        return np.random.random([len(keys), 5])
 
 
 class SimpleFillDriver(VectorFillDriver):

--- a/tests/unit/drivers/test_vector_index_driver.py
+++ b/tests/unit/drivers/test_vector_index_driver.py
@@ -16,7 +16,6 @@ class MockGroundTruthVectorIndexer(BaseVectorIndexer):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.docs = {}
-        self.key_length = 16
 
     def add(self, keys: 'np.ndarray', vectors: 'np.ndarray', *args, **kwargs):
         for key, value in zip(keys, vectors):

--- a/tests/unit/drivers/test_vector_search_driver.py
+++ b/tests/unit/drivers/test_vector_search_driver.py
@@ -62,14 +62,14 @@ def mock_query(vectors: 'np.ndarray', top_k: int) -> Tuple['np.ndarray', 'np.nda
     return idx, dist
 
 
-def mock_query_by_id(ids: 'np.ndarray'):
-    return np.random.random([len(ids), 7])
+def mock_query_by_key(keys: 'np.ndarray'):
+    return np.random.random([len(keys), 7])
 
 
 def test_vectorsearch_driver_mock_indexer(monkeypatch, create_document_to_search):
     driver = MockVectorSearchDriver(top_k=2)
     index = BaseVectorIndexer()
-    monkeypatch.setattr(index, 'query_by_id', None)
+    monkeypatch.setattr(index, 'query_by_key', None)
     monkeypatch.setattr(driver, '_exec', index)
     monkeypatch.setattr(driver, 'runtime', None)
     monkeypatch.setattr(driver, '_exec_fn', mock_query)
@@ -89,7 +89,7 @@ def test_vectorsearch_driver_mock_indexer(monkeypatch, create_document_to_search
 def test_vectorsearch_driver_mock_indexer_with_fill(monkeypatch, create_document_to_search):
     driver = MockVectorSearchDriver(top_k=2, fill_embedding=True)
     index = BaseVectorIndexer()
-    monkeypatch.setattr(index, 'query_by_id', mock_query_by_id)
+    monkeypatch.setattr(index, 'query_by_key', mock_query_by_key)
     monkeypatch.setattr(driver, '_exec', index)
     monkeypatch.setattr(driver, 'runtime', None)
     monkeypatch.setattr(driver, '_exec_fn', mock_query)

--- a/tests/unit/executors/indexers/test_numpyindexer.py
+++ b/tests/unit/executors/indexers/test_numpyindexer.py
@@ -83,7 +83,7 @@ def test_numpy_indexer_known(batch_size, compress_level, test_metas):
         np.testing.assert_equal(idx, np.array([['4', '5'], ['5', '4'], ['6', '5'], ['7', '6']]))
         assert idx.shape == dist.shape
         assert idx.shape == (4, 2)
-        np.testing.assert_equal(indexer.query_by_id(np.array(['7', '4'])), vectors[[3, 0]])
+        np.testing.assert_equal(indexer.query_by_key(['7', '4']), vectors[[3, 0]])
 
 
 @pytest.mark.parametrize('batch_size, compress_level', [(None, 0), (None, 1), (16, 0), (16, 1)])
@@ -138,7 +138,7 @@ def test_numpy_indexer_known_big(batch_size, compress_level, test_metas):
             [['10000'], ['11000'], ['12000'], ['13000'], ['14000'], ['15000'], ['16000'], ['17000'], ['18000'], ['19000']]))
         assert idx.shape == dist.shape
         assert idx.shape == (10, 1)
-        np.testing.assert_equal(indexer.query_by_id(np.array(['10000', '15000'])), vectors[[0, 5000]])
+        np.testing.assert_equal(indexer.query_by_key(['10000', '15000']), vectors[[0, 5000]])
 
 
 @pytest.mark.parametrize('compress_level', [0, 1, 2, 3, 4, 5])
@@ -174,7 +174,7 @@ def test_scipy_indexer_known_big(compress_level, test_metas):
             [['10000'], ['11000'], ['12000'], ['13000'], ['14000'], ['15000'], ['16000'], ['17000'], ['18000'], ['19000']]))
         assert idx.shape == dist.shape
         assert idx.shape == (10, 1)
-        np.testing.assert_equal(indexer.query_by_id(['10000', '15000']), vectors[[0, 5000]])
+        np.testing.assert_equal(indexer.query_by_key(['10000', '15000']), vectors[[0, 5000]])
 
 
 @pytest.mark.parametrize('batch_size, num_docs, top_k',
@@ -277,7 +277,7 @@ def test_numpy_update_delete(compress_level, test_metas):
 
     with BaseIndexer.load(save_abspath) as indexer:
         assert isinstance(indexer, NumpyIndexer)
-        query_results = indexer.query_by_id(vec_idx)
+        query_results = indexer.query_by_key(vec_idx)
         assert np.array_equal(vec, query_results)
 
     # update
@@ -296,7 +296,7 @@ def test_numpy_update_delete(compress_level, test_metas):
 
     with BaseIndexer.load(save_abspath) as indexer:
         assert isinstance(indexer, NumpyIndexer)
-        query_results = indexer.query_by_id([key_to_update])
+        query_results = indexer.query_by_key([key_to_update])
         assert np.array_equal(data_to_update, query_results)
 
     # delete
@@ -315,8 +315,8 @@ def test_numpy_update_delete(compress_level, test_metas):
         assert isinstance(indexer, NumpyIndexer)
         assert indexer.size == len(vec_idx) - keys_to_delete
         # random non-existent key
-        assert indexer.query_by_id(['123861942']) is None
-        query_results = indexer.query_by_id(vec_idx[keys_to_delete:])
+        assert indexer.query_by_key(['123861942']) is None
+        query_results = indexer.query_by_key(vec_idx[keys_to_delete:])
         expected = vec[keys_to_delete:]
         np.testing.assert_allclose(query_results, expected, equal_nan=True)
 
@@ -344,7 +344,7 @@ def test_numpy_indexer_known_and_delete(batch_size, compress_level, test_metas):
         np.testing.assert_equal(idx, np.array([['4', '5', '6'], ['5', '4', '6']]))
         assert idx.shape == dist.shape
         assert idx.shape == (len(queries), top_k)
-        np.testing.assert_equal(indexer.query_by_id(['5', '4', '6']), vectors[[1, 0, 2]])
+        np.testing.assert_equal(indexer.query_by_key(['5', '4', '6']), vectors[[1, 0, 2]])
 
     # update and query again
     key_to_update = np.array(['4'])
@@ -377,12 +377,12 @@ def test_numpy_indexer_known_and_delete(batch_size, compress_level, test_metas):
         np.testing.assert_equal(idx, np.array([['6', '5'], ['5', '6']]))
         assert idx.shape == dist.shape
         assert idx.shape == (len(queries), top_k)
-        np.testing.assert_equal(indexer.query_by_id(['6', '5']), vectors[[2, 1]])
+        np.testing.assert_equal(indexer.query_by_key(['6', '5']), vectors[[2, 1]])
 
     # test query by nonexistent key
     with BaseIndexer.load(save_abspath) as indexer:
         assert isinstance(indexer, NumpyIndexer)
-        assert indexer.query_by_id(['91237124']) is None
+        assert indexer.query_by_key(['91237124']) is None
 
 
 @pytest.mark.parametrize('compress_level', [0, 1, 2, 3])
@@ -413,4 +413,4 @@ def test_numpy_indexer_with_ref_indexer(compress_level, test_metas):
         np.testing.assert_equal(idx, np.array([['4', '5'], ['5', '4'], ['6', '5'], ['7', '6']]))
         assert idx.shape == dist.shape
         assert idx.shape == (4, 2)
-        np.testing.assert_equal(new_indexer.query_by_id(np.array(['7', '4'])), vectors[[3, 0]])
+        np.testing.assert_equal(new_indexer.query_by_key(['7', '4']), vectors[[3, 0]])

--- a/tests/unit/executors/indexers/test_numpyindexer_batching.py
+++ b/tests/unit/executors/indexers/test_numpyindexer_batching.py
@@ -51,4 +51,4 @@ def test_numpy_indexer_known_big_batch(batch_size, test_metas):
             [['10000'], ['11000'], ['12000'], ['13000'], ['14000'], ['15000'], ['16000'], ['17000'], ['18000'], ['19000']]))
         assert idx.shape == dist.shape
         assert idx.shape == (10, 1)
-        np.testing.assert_equal(indexer.query_by_id(['10000', '15000']), vectors[[0, 5000]])
+        np.testing.assert_equal(indexer.query_by_key(['10000', '15000']), vectors[[0, 5000]])

--- a/tests/unit/executors/indexers/test_numpyindexer_batching.py
+++ b/tests/unit/executors/indexers/test_numpyindexer_batching.py
@@ -45,7 +45,7 @@ def test_numpy_indexer_known_big_batch(batch_size, test_metas):
     with BaseIndexer.load(save_abspath) as indexer:
         indexer.batch_size = batch_size
         assert isinstance(indexer, MockNumpyIndexer)
-        assert isinstance(indexer.raw_ndarray, np.memmap)
+        assert isinstance(indexer._raw_ndarray, np.memmap)
         idx, dist = indexer.query(queries, top_k=1)
         np.testing.assert_equal(idx, np.array(
             [['10000'], ['11000'], ['12000'], ['13000'], ['14000'], ['15000'], ['16000'], ['17000'], ['18000'], ['19000']]))

--- a/tests/unit/types/document/test_document.py
+++ b/tests/unit/types/document/test_document.py
@@ -4,7 +4,8 @@ from google.protobuf.json_format import MessageToDict
 
 from jina import NdArray, Request
 from jina.proto.jina_pb2 import DocumentProto
-from jina.types.document import Document, BadDocID
+from jina.types.document import Document
+from jina.excepts import BadDocID
 from tests import random_docs
 
 DOCUMENTS_PER_LEVEL = 1


### PR DESCRIPTION
`keys` inside the `NumpyIndexer` are not always of type `str`. I am not sure, whether it should be `Iterator[str]`, `Iterable[str]`, `Sequence[str]` or simply `List[str]` though. Input would be highly appreciated.

`query_by_id` => `query_by_key` to keep consistency.

`def query(keys:...`=> `def query(query_vectors, ...`

Furthermore, I changed the interface of the `delete` function to also use `str` instead of `int`. Not sure about this change as well.

Quite a few hub changes must be done after this PR is merged in order to keep all hub indexer in sync with this PR.