### PR TITLE
fix: default value of workspace dir

### DIFF
--- a/jina/optimizers/__init__.py
+++ b/jina/optimizers/__init__.py
@@ -115,7 +115,7 @@ class FlowOptimizer(JAMLCompatible):
             parameter_yaml: str,
             evaluation_callback: 'OptimizerCallback',
             n_trials: int,
-            workspace_base_dir: str = '',
+            workspace_base_dir: str = '.',
             sampler: str = 'TPESampler',
             direction: str = 'maximize',
             seed: int = 42,


### PR DESCRIPTION
Better to take current local as default instead of `/` implicitly