### PR TITLE
ci(rest): added redoc docs for rest gateway

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -51,17 +51,25 @@ jobs:
           cd schema
           jina export-api --yaml-path "$JINA_VERSION.yml" master.yml --json-path "$JINA_VERSION.json" master.json master
           python -c "from daemon import _write_openapi_schema; _write_openapi_schema()"
+          python ../scripts/get-gateway-openapi.py
           cd -
       - name: redoc-cli-jinad
         uses: seeebiii/redoc-cli-github-action@v10
         with:
           args: 'bundle schema/daemon.json -o jinad.html'
+      - name: redoc-cli-gateway
+        uses: seeebiii/redoc-cli-github-action@v10
+        with:
+          args: 'bundle schema/gateway.json -o rest.html'
       - name: push-to-api-repo
         run: |
           mkdir -p schema/daemon/
           cp jinad.html schema/daemon/master.html
           rm schema/daemon.json
           rm -rf schema/jinad
+          mkdir -p schema/rest/
+          cp rest.html schema/rest/master.html
+          rm schema/gateway.json
           cd schema
           git config --local user.email "dev-bot@jina.ai"
           git config --local user.name "Jina Dev Bot"

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -32,11 +32,16 @@ jobs:
           cd schema
           jina export-api --yaml-path "$JINA_VERSION.yml" latest.yml --json-path "$JINA_VERSION.json" latest.json latest
           python -c "from daemon import _write_openapi_schema; _write_openapi_schema()"
+          python ../scripts/get-gateway-openapi.py
           cd -
       - name: redoc-cli-jinad
         uses: seeebiii/redoc-cli-github-action@v10
         with:
           args: 'bundle schema/daemon.json -o jinad.html'
+      - name: redoc-cli-gateway
+        uses: seeebiii/redoc-cli-github-action@v10
+        with:
+          args: 'bundle schema/gateway.json -o rest.html'
       - name: push-to-api-repo
         run: |
           mkdir -p schema/daemon/
@@ -44,6 +49,10 @@ jobs:
           cp jinad.html schema/daemon/${{env.JINA_VERSION}}.html
           rm schema/daemon.json
           rm -rf schema/jinad
+          mkdir -p schema/rest/
+          cp rest.html schema/rest/index.html
+          cp rest.html schema/rest/${{env.JINA_VERSION}}.html
+          rm schema/gateway.json
           cd schema
           git config --local user.email "dev-bot@jina.ai"
           git config --local user.name "Jina Dev Bot"


### PR DESCRIPTION
Tested with a workflow in cloud-ops repo: https://github.com/jina-ai/cloud-ops/blob/master/.github/workflows/test-checkout.yml

Run: https://github.com/jina-ai/cloud-ops/runs/1830403348?check_suite_focus=true

Docs with test run: https://api.jina.ai/rest/master.html