### PR TITLE
refactor(driver): set default len 36, move check to driver

### DIFF
--- a/jina/drivers/index.py
+++ b/jina/drivers/index.py
@@ -1,6 +1,8 @@
 __copyright__ = "Copyright (c) 2020 Jina AI Limited. All rights reserved."
 __license__ = "Apache-2.0"
 
+from typing import Iterable
+
 import numpy as np
 
 from . import BaseExecutableDriver
@@ -15,6 +17,12 @@ class BaseIndexDriver(BaseExecutableDriver):
     def __init__(self, executor: str = None, method: str = 'add', *args, **kwargs):
         super().__init__(executor, method, *args, **kwargs)
 
+    def check_key_length(self, val: Iterable[str]):
+        m_val = max(len(v) for v in val)
+        if m_val > self.exec.key_length:
+            raise ValueError(f'{self.exec} allows only keys of length {self.exec.key_length}, '
+                             f'but yours is {m_val}.')
+
 
 class VectorIndexDriver(BaseIndexDriver):
     """Extracts embeddings and ids from the documents and forwards them to the executor.
@@ -27,7 +35,10 @@ class VectorIndexDriver(BaseIndexDriver):
         if bad_docs:
             self.runtime.logger.warning(f'these bad docs can not be added: {bad_docs}')
         if docs_pts:
-            self.exec_fn([doc.id for doc in docs_pts], np.stack(embed_vecs))
+            keys = [doc.id for doc in docs_pts]
+            if keys:
+                self.check_key_length(keys)
+                self.exec_fn(keys, np.stack(embed_vecs))
 
 
 class KVIndexDriver(BaseIndexDriver):
@@ -36,5 +47,7 @@ class KVIndexDriver(BaseIndexDriver):
 
     def _apply_all(self, docs: 'DocumentSet', *args, **kwargs) -> None:
         keys = [doc.id for doc in docs]
-        values = [doc.SerializeToString() for doc in docs]
-        self.exec_fn(keys, values)
+        if keys:
+            self.check_key_length(keys)
+            values = [doc.SerializeToString() for doc in docs]
+            self.exec_fn(keys, values)

--- a/jina/executors/indexers/__init__.py
+++ b/jina/executors/indexers/__init__.py
@@ -41,7 +41,7 @@ class BaseIndexer(BaseExecutor):
 
     def __init__(self,
                  index_filename: str = None,
-                 key_length: int = None,
+                 key_length: int = 36,
                  *args, **kwargs):
         """
 
@@ -51,24 +51,8 @@ class BaseIndexer(BaseExecutor):
         """
         super().__init__(*args, **kwargs)
         self.index_filename = index_filename  #: the file name of the stored index, no path is required
+        self.key_length = key_length  #: the default minimum length of the key, will be expanded one time on the first batch
         self._size = 0
-        self._key_length = key_length  #: the default minimum length of the key, will be expanded one time on the first batch
-
-    @property
-    def key_length(self) -> int:
-        return self._key_length
-
-    def _assert_key_length(self, keys):
-        max_key_len = max([len(k) for k in keys])
-
-        if self.key_length is None:
-            self.key_length = max(16, max_key_len)
-        elif max_key_len > self.key_length:
-            raise ValueError(f'This indexer allows only keys of length {self._key_length}, but yours is {max_key_len}.')
-
-    @key_length.setter
-    def key_length(self, val: int):
-        self._key_length = val
 
     def add(self, *args, **kwargs):
         """Add documents to the index.

--- a/jina/executors/indexers/keyvalue.py
+++ b/jina/executors/indexers/keyvalue.py
@@ -49,7 +49,7 @@ class BinaryPbIndexer(BaseKVIndexer):
         return self.WriteHandler(self.index_abspath, 'wb')
 
     def get_query_handler(self):
-        return self.ReadHandler(self.index_abspath, self._key_length)
+        return self.ReadHandler(self.index_abspath, self.key_length)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -65,7 +65,6 @@ class BinaryPbIndexer(BaseKVIndexer):
         """
         if not keys:
             return
-        self._assert_key_length(keys)
 
         for key, value in zip(keys, values):
             l = len(value)  #: the length
@@ -74,7 +73,7 @@ class BinaryPbIndexer(BaseKVIndexer):
             self.write_handler.header.write(
                 np.array(
                     (key, p, r, r + l),
-                    dtype=[('', (np.str_, self._key_length)), ('', np.int64), ('', np.int64), ('', np.int64)]
+                    dtype=[('', (np.str_, self.key_length)), ('', np.int64), ('', np.int64), ('', np.int64)]
                 ).tobytes()
             )
             self._start += l
@@ -111,7 +110,7 @@ class BinaryPbIndexer(BaseKVIndexer):
             self.write_handler.header.write(
                 np.array(
                     tuple(np.concatenate([[key], HEADER_NONE_ENTRY])),
-                    dtype=[('', (np.str_, self._key_length)), ('', np.int64), ('', np.int64), ('', np.int64)]
+                    dtype=[('', (np.str_, self.key_length)), ('', np.int64), ('', np.int64), ('', np.int64)]
                 ).tobytes()
             )
 

--- a/jina/executors/indexers/vector.py
+++ b/jina/executors/indexers/vector.py
@@ -124,8 +124,6 @@ class BaseNumpyIndexer(BaseVectorIndexer):
         :param keys: a list of ``id``, i.e. ``doc.id`` in protobuf
         :param vectors: embeddings
         """
-        self._assert_key_length(keys)
-
         np_keys = np.array(keys, (np.str_, self.key_length))
 
         self._add(np_keys, vectors)

--- a/jina/executors/indexers/vector.py
+++ b/jina/executors/indexers/vector.py
@@ -55,7 +55,7 @@ class BaseNumpyIndexer(BaseVectorIndexer):
             self.dtype = ref_indexer.dtype
             self.compress_level = ref_indexer.compress_level
             self.key_bytes = ref_indexer.key_bytes
-            self._key_length = ref_indexer._key_length
+            self.key_length = ref_indexer.key_length
             self._size = ref_indexer._size
             # point to the ref_indexer.index_filename
             # so that later in `post_init()` it will load from the referred index_filename


### PR DESCRIPTION
- uuid1 (default doc_id) is 36, therefore default_length needs to be 36
- no need do property for simple get/set
- move check to driver