### PR TITLE
fix(driver): compoundindexer should turn on is_merge

### DIFF
--- a/jina/resources/executors.requests.CompoundIndexer.yml
+++ b/jina/resources/executors.requests.CompoundIndexer.yml
@@ -10,6 +10,7 @@ on:
     - !KVSearchDriver
       with:
         executor: BaseKVIndexer
+        is_merge: True
         traversal_paths: ['m']
   [IndexRequest, UpdateRequest]:
     - !VectorIndexDriver


### PR DESCRIPTION
without `is_merge=True`, all scored info is lost due to copy override