### PR TITLE
ci: add fixed ref for workflow dispatch event

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -71,6 +71,7 @@ jobs:
           workflow: Sync version with Jina core
           repo: jina-ai/dashboard
           token: ${{ secrets.JINA_DEV_BOT }}
+          ref: refs/heads/master
           inputs: '{ "version": "${{ env.JINA_VERSION }}" }'
 
   update-doc:


### PR DESCRIPTION
There's an issue with workflow_dispatch in GH - ([link1](https://github.community/t/error-in-docs-or-misunderstanding-for-workflow-dispatch-event/125066/2), [link2](https://github.community/t/workflow-dispatch-cant-set-ref-to-commit-sha/138132)), which means `ref` cannot point to a commit sha. And for some reason, it is not able to pick the latest tag that triggered the event too, Hence hardcoding to `refs/heads/master` 

[Here's](https://github.com/jina-ai/cloud-ops/runs/1849186307?check_suite_focus=true) an example that got triggered by a `tag push` in `cloud-ops` repo. 