### PR TITLE
feat(types): traverse is a method of document set

### DIFF
--- a/jina/drivers/__init__.py
+++ b/jina/drivers/__init__.py
@@ -235,15 +235,6 @@ class BaseDriver(JAMLCompatible, metaclass=DriverType):
     def __call__(self, *args, **kwargs) -> None:
         raise NotImplementedError
 
-    @staticmethod
-    def _dump_instance_to_yaml(data) -> Dict[str, Dict]:
-        # note: we only save non-default property for the sake of clarity
-        a = {k: v for k, v in data._init_kwargs_dict.items()}
-        r = {}
-        if a:
-            r['with'] = a
-        return r
-
     def __eq__(self, other):
         return self.__class__ == other.__class__
 

--- a/jina/types/sets/document.py
+++ b/jina/types/sets/document.py
@@ -126,14 +126,32 @@ class DocumentSet(MutableSequence):
             self._docs_proto.reverse()
 
     def build(self):
-       """Build a doc_id to doc mapping so one can later index a Document using doc_id as string key."""
-       self._docs_map = {d.id: d for d in self._docs_proto}
+        """Build a doc_id to doc mapping so one can later index a Document using doc_id as string key."""
+        self._docs_map = {d.id: d for d in self._docs_proto}
 
     def sort(self, *args, **kwargs):
         """Sort the list of :class:`DocumentSet`."""
         self._docs_proto.sort(*args, **kwargs)
 
     def traverse(self, traversal_paths: Iterable[str]) -> Iterable['Document']:
+        """
+        Return an iterator of :class:`Document` that traverses this :class:`DocumentSet` object according to the
+        ``traversal_paths``.
+
+        :param traversal_paths: a list of string that represents the traversal path
+
+
+        Example on ``traversal_paths``:
+
+            - [`r`]: docs in this DocumentSet
+            - [`m`]: all match-documents at adjacency 1
+            - [`c`]: all child-documents at granularity 1
+            - [`cc`]: all child-documents at granularity 2
+            - [`mm`]: all match-documents at adjacency 2
+            - [`cm`]: all match-document at adjacency 1 and granularity 1
+            - [`r`, `c`]: docs in this DocumentSet and all child-documents at granularity 1
+
+        """
         def _traverse(docs: 'DocumentSet', path: str) -> Iterable['Document']:
             if path:
                 loc = path[0]

--- a/tests/unit/types/document/test_document_traverse.py
+++ b/tests/unit/types/document/test_document_traverse.py
@@ -2,7 +2,7 @@ from collections import Iterator
 
 import pytest
 
-from jina import Document
+from jina import Document, DocumentSet
 from jina.clients.request import request_generator
 from jina.executors.decorators import batching
 from tests import random_docs
@@ -79,3 +79,23 @@ def test_batching_traverse(doc_req):
     # under this contruction, num_doc is the common denominator
 
     foo(ds)
+
+
+def test_docuset_traverse_over_iterator_HACKY():
+    # HACKY USAGE DO NOT RECOMMEND: can also traverse over "runtime"-documentset
+    ds = DocumentSet(random_docs(num_docs, num_chunks_per_doc)).traverse(['r'])
+    assert len(list(ds)) == num_docs
+
+    ds = DocumentSet(random_docs(num_docs, num_chunks_per_doc)).traverse(['c'])
+    assert len(list(ds)) == num_docs * num_chunks_per_doc
+
+
+def test_docuset_traverse_over_iterator_CAVEAT():
+    # HACKY USAGE's CAVEAT: but it can not iterate over an iterator twice
+    ds = DocumentSet(random_docs(num_docs, num_chunks_per_doc)).traverse(['r', 'c'])
+    # note that random_docs is a generator and can be only used once,
+    # therefore whoever comes first wil get iterated, and then it becomes empty
+    assert len(list(ds)) == num_docs
+
+    ds = DocumentSet(random_docs(num_docs, num_chunks_per_doc)).traverse(['c', 'r'])
+    assert len(list(ds)) == num_docs * num_chunks_per_doc

--- a/tests/unit/types/document/test_document_traverse.py
+++ b/tests/unit/types/document/test_document_traverse.py
@@ -4,6 +4,7 @@ import pytest
 
 from jina import Document
 from jina.clients.request import request_generator
+from jina.executors.decorators import batching
 from tests import random_docs
 
 # some random prime number for sanity check
@@ -66,3 +67,15 @@ def test_traverse_root_match_chunk(doc_req):
     ds = list(doc_req.docs.traverse(['r', 'c', 'm', 'cm']))
     assert (len(ds) == num_docs + num_chunks_per_doc * num_docs +
             num_matches_per_doc * num_docs + num_docs * num_chunks_per_doc * num_matches_per_chunk)
+
+
+def test_batching_traverse(doc_req):
+    @batching(batch_size=num_docs, slice_on=0)
+    def foo(docs):
+        print(f'batch_size:{len(docs)}')
+        assert len(docs) == num_docs
+
+    ds = list(doc_req.docs.traverse(['r', 'c', 'm', 'cm']))
+    # under this contruction, num_doc is the common denominator
+
+    foo(ds)

--- a/tests/unit/types/document/test_document_traverse.py
+++ b/tests/unit/types/document/test_document_traverse.py
@@ -1,0 +1,68 @@
+from collections import Iterator
+
+import pytest
+
+from jina import Document
+from jina.clients.request import request_generator
+from tests import random_docs
+
+# some random prime number for sanity check
+num_docs = 7
+num_chunks_per_doc = 11
+num_matches_per_doc = 3
+num_matches_per_chunk = 5
+
+
+@pytest.fixture
+def doc_req():
+    """Build a dummy request that has docs """
+    ds = list(random_docs(num_docs, num_chunks_per_doc))
+    # add some random matches
+    for d in ds:
+        for _ in range(num_matches_per_doc):
+            d.matches.add(Document(content='hello'))
+        for c in d.chunks:
+            for _ in range(num_matches_per_chunk):
+                c.matches.add(Document(content='world'))
+    req = list(request_generator(ds))[0]
+    yield req
+
+
+def test_traverse_type(doc_req):
+    assert isinstance(doc_req.docs.traverse(['r']), Iterator)
+
+
+def test_traverse_empty_type(doc_req):
+    assert isinstance(doc_req.docs.traverse([]), Iterator)
+    assert len(list(doc_req.docs.traverse([]))) == 0
+
+
+def test_traverse_root(doc_req):
+    ds = list(doc_req.docs.traverse(['r']))
+    assert len(ds) == num_docs
+
+
+def test_traverse_chunk(doc_req):
+    ds = list(doc_req.docs.traverse(['c']))
+    assert len(ds) == num_docs * num_chunks_per_doc
+
+
+def test_traverse_root_plus_chunk(doc_req):
+    ds = list(doc_req.docs.traverse(['c', 'r']))
+    assert len(ds) == num_docs + num_docs * num_chunks_per_doc
+
+
+def test_traverse_match(doc_req):
+    ds = list(doc_req.docs.traverse(['m']))
+    assert len(ds) == num_docs * num_matches_per_doc
+
+
+def test_traverse_match_chunk(doc_req):
+    ds = list(doc_req.docs.traverse(['cm']))
+    assert len(ds) == num_docs * num_chunks_per_doc * num_matches_per_chunk
+
+
+def test_traverse_root_match_chunk(doc_req):
+    ds = list(doc_req.docs.traverse(['r', 'c', 'm', 'cm']))
+    assert (len(ds) == num_docs + num_chunks_per_doc * num_docs +
+            num_matches_per_doc * num_docs + num_docs * num_chunks_per_doc * num_matches_per_chunk)


### PR DESCRIPTION
Note that this PR is the first step of #1932, no driver is refactored yet. The recursive driver needs to be refactored to use this feature.

The scope of this PR is to implement my comment here https://github.com/jina-ai/jina/issues/1932#issuecomment-778371142

- `DocumentSet.traverse` gives a high performant generator, allowing iterating over it in one-shot
- it supports current traverse grammar, such as `r`, `c`, `cm`, `mc`, and the combination of them
- one can do batching over it, see `test_batching_traverse`