### PR TITLE
docs: add darglint config

### DIFF
--- a/.darglint
+++ b/.darglint
@@ -1,0 +1,2 @@
+[darglint]
+ignore=DAR401


### PR DESCRIPTION
This will ignore docstrings that don't cover exception info. We agreed we would ignore these