### PR TITLE
feat(driver): add param to use content to predict tags

### DIFF
--- a/jina/drivers/predict.py
+++ b/jina/drivers/predict.py
@@ -10,9 +10,15 @@ if False:
 
 
 class BasePredictDriver(FastRecursiveMixin, BaseExecutableDriver):
-    """Drivers inherited from this Driver will bind :meth:`predict` by default """
+    """Drivers inherited from this Driver will bind :meth:`predict` by default
 
-    def __init__(self, executor: str = None, method: str = 'predict', *args, **kwargs):
+    :param use_embeddings: use ``doc.embeddings``, else use ``doc.content``, default True
+    :param *args: *args for super
+    :param **kwargs: **kwargs for super
+    """
+    
+    def __init__(self, executor: str = None, method: str = 'predict', use_embeddings: bool = True, *args, **kwargs):
+        self.use_embeddings = use_embeddings
         super().__init__(executor, method, *args, **kwargs)
 
 
@@ -34,7 +40,10 @@ class BaseLabelPredictDriver(BasePredictDriver):
             *args,
             **kwargs,
     ) -> None:
-        embed_vecs, docs_pts = docs.all_embeddings
+        if self.use_embeddings:
+            embed_vecs, docs_pts = docs.all_embeddings
+        else:
+            embed_vecs, docs_pts = docs.all_contents
 
         if docs_pts:
             prediction = self.exec_fn(embed_vecs)
@@ -160,7 +169,10 @@ class Prediction2DocBlobDriver(BasePredictDriver):
             *args,
             **kwargs,
     ) -> None:
-        embed_vecs, docs_pts = docs.all_embeddings
+        if self.use_embeddings:
+            embed_vecs, docs_pts = docs.all_embeddings
+        else:
+            embed_vecs, docs_pts = docs.all_contents
 
         if docs_pts:
             prediction = self.exec_fn(embed_vecs)

--- a/jina/drivers/predict.py
+++ b/jina/drivers/predict.py
@@ -17,7 +17,7 @@ class BasePredictDriver(FastRecursiveMixin, BaseExecutableDriver):
     :param **kwargs: **kwargs for super
     """
     
-    def __init__(self, executor: str = None, method: str = 'predict', fields: Union[Tuple, str] = 'embeddings', *args, **kwargs):
+    def __init__(self, executor: str = None, method: str = 'predict', fields: Union[Tuple, str] = 'embedding', *args, **kwargs):
         self.fields = fields
         super().__init__(executor, method, *args, **kwargs)
 
@@ -40,9 +40,9 @@ class BaseLabelPredictDriver(BasePredictDriver):
             *args,
             **kwargs,
     ) -> None:
-        if self.fields == 'embeddings':
+        if self.fields == 'embedding':
             predict_input, docs_pts = docs.all_embeddings
-        elif self.fields == 'contents':
+        elif self.fields == 'content':
             predict_input, docs_pts = docs.all_contents
         else:
             raise ValueError(f'{self.fields} is not a valid field name for {self!r}, must be one of embeddings, contents')
@@ -171,9 +171,9 @@ class Prediction2DocBlobDriver(BasePredictDriver):
             *args,
             **kwargs,
     ) -> None:
-        if self.fields == 'embeddings':
+        if self.fields == 'embedding':
             predict_input, docs_pts = docs.all_embeddings
-        elif self.fields == 'contents':
+        elif self.fields == 'content':
             predict_input, docs_pts = docs.all_contents
         else:
             raise ValueError(f'{self.fields} is not a valid field name for {self!r}, must be one of embeddings, contents')

--- a/tests/unit/drivers/test_predict_mock_driver.py
+++ b/tests/unit/drivers/test_predict_mock_driver.py
@@ -1,16 +1,33 @@
 import numpy as np
+import pytest
 from google.protobuf.struct_pb2 import ListValue
-
-from jina.drivers.predict import BinaryPredictDriver, MultiLabelPredictDriver, OneHotPredictDriver, \
-    Prediction2DocBlobDriver
+from jina import Document
+from jina.drivers.predict import (BinaryPredictDriver, MultiLabelPredictDriver,
+                                  OneHotPredictDriver,
+                                  Prediction2DocBlobDriver)
+from jina.executors.classifiers import BaseClassifier
 from jina.types.ndarray.generic import NdArray
 from jina.types.sets import DocumentSet
 from tests import random_docs
 
 
+@pytest.fixture(scope='function')
+def num_docs():
+    return 10
+
+
+@pytest.fixture(scope='function')
+def docs_to_encode(num_docs):
+    docs = []
+    for idx in range(num_docs):
+        doc = Document(content=np.array([idx]))
+        docs.append(doc)
+    return DocumentSet(docs)
+
+
 class MockBinaryPredictDriver(BinaryPredictDriver):
     def exec_fn(self, embed):
-        random_label = np.random.randint(0, 1, [embed.shape[0]])
+        random_label = np.random.randint(0, 2, [embed.shape[0]])
         return random_label.astype(np.int64)
 
 
@@ -33,6 +50,21 @@ class MockPrediction2DocBlobDriver(Prediction2DocBlobDriver):
     def exec_fn(self, embed):
         return np.eye(3)[np.random.choice(3, embed.shape[0])]
 
+class MockClassifierDriver(BinaryPredictDriver):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    @property
+    def exec_fn(self):
+        return self._exec_fn
+
+class MockClassifier(BaseClassifier):
+    def __init__(self,*args, **kwargs):
+        super().__init__(*args, **kwargs)
+        
+    def predict(self, data: 'np.ndarray', *args, **kwargs) -> 'np.ndarray':
+        # predict 0 or 1 based on divisiblity by 2
+        return (data%2==0).astype(int)
 
 def test_binary_predict_driver():
     docs = DocumentSet(random_docs(2))
@@ -82,3 +114,16 @@ def test_as_blob_driver():
 
     for d in docs:
         assert NdArray(d.blob).value.shape == (3,)
+
+
+def test_predict_driver_without_embeddings(docs_to_encode, num_docs):
+    executor = MockClassifier(total_num_docs=num_docs)
+    driver = MockClassifierDriver(use_embeddings=False) #uses doc.content to predict tags
+    driver.attach(executor=executor, runtime=None)
+    assert len(docs_to_encode) == num_docs
+    for doc in docs_to_encode:
+        assert doc.embedding is None
+    driver._apply_all(docs_to_encode)
+    assert len(docs_to_encode) == num_docs
+    for doc in docs_to_encode:
+        assert doc.tags['prediction'] in ['yes','no']

--- a/tests/unit/drivers/test_predict_mock_driver.py
+++ b/tests/unit/drivers/test_predict_mock_driver.py
@@ -118,7 +118,7 @@ def test_as_blob_driver():
 
 def test_predict_driver_without_embeddings(docs_to_encode, num_docs):
     executor = MockClassifier(total_num_docs=num_docs)
-    driver = MockClassifierDriver(fields='contents') #uses doc.contents to predict tags
+    driver = MockClassifierDriver(fields='content') #use doc.content to predict tags
     driver.attach(executor=executor, runtime=None)
     assert len(docs_to_encode) == num_docs
     for doc in docs_to_encode:

--- a/tests/unit/drivers/test_predict_mock_driver.py
+++ b/tests/unit/drivers/test_predict_mock_driver.py
@@ -118,7 +118,7 @@ def test_as_blob_driver():
 
 def test_predict_driver_without_embeddings(docs_to_encode, num_docs):
     executor = MockClassifier(total_num_docs=num_docs)
-    driver = MockClassifierDriver(use_embeddings=False) #uses doc.content to predict tags
+    driver = MockClassifierDriver(fields='contents') #uses doc.contents to predict tags
     driver.attach(executor=executor, runtime=None)
     assert len(docs_to_encode) == num_docs
     for doc in docs_to_encode:


### PR DESCRIPTION
https://github.com/jina-ai/jina-hub/issues/3068#issuecomment-778720794

Current implementation of `BasePredictDriver` does not allow to use content of `Document` to predict tags. Methods like Zero shot classification might require a feature extraction pipeline totally independent from the embeddings from encoder and hence can have their own model for predicting tags based on the content. 