### PR TITLE
fix(contributing, readme): all 101 links go to 101.jina.ai

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ In this guide, we're going to go through the steps for each kind of contribution
 <a name="-before-you-start"></a>
 ## 🏁 Before you Start
 
-Make sure you've read through our [README](https://github.com/jina-ai/jina), [Jina 101](https://github.com/jina-ai/docs/tree/master/chapters/101), and [example tutorials](https://learn.jina.ai) so you have a good understanding of what Jina is and how it works.
+Make sure you've read through our [README](https://github.com/jina-ai/jina), [Jina 101](https://101.jina.ai), and [example tutorials](https://learn.jina.ai) so you have a good understanding of what Jina is and how it works.
 
 ### Not a coder but still want to contribute?
 
@@ -279,7 +279,7 @@ Good docs make developers happy, and we love happy developers! We've got a few d
 
 #### General Documentation
 
-This covers files like [Jina 101](https://github.com/jina-ai/docs/tree/master/chapters/101), [Input and Output Functions](https://docs.jina.ai/chapters/io/index.html), etc.
+This covers files like [Jina 101](https://101.jina.ai), [Input and Output Functions](https://docs.jina.ai/chapters/io/index.html), etc.
 
 These are typically written in Markdown, though some may be in RestructuredText.
 

--- a/README.md
+++ b/README.md
@@ -455,7 +455,7 @@ with Flow().add() as f, open('output.txt', 'w') as fp:
 #### Add Logic
 <a href="https://mybinder.org/v2/gh/jina-ai/jupyter-notebooks/main?filepath=basic-add-logic.ipynb"><img align="right" src="https://github.com/jina-ai/jina/blob/master/.github/badges/run-badge.svg?raw=true"/></a>
 
-To add logic to the Flow, use the `uses` parameter to attach a Pod with an [Executor](https://101.jina.ai/#executors). `uses` accepts multiple value types including class name, Docker image, (inline) YAML or built-in shortcut.
+To add logic to the Flow, use the `uses` parameter to attach a Pod with an [Executor](https://101.jina.ai/#executor). `uses` accepts multiple value types including class name, Docker image, (inline) YAML or built-in shortcut.
 
 
 ```python
@@ -624,7 +624,7 @@ class MyEncoder(BaseImageEncoder):
         return (data.reshape([-1, 784]) / 255) @ self.oth_mat
 ```
 
-Jina provides [a family of `Executor` classes](https://github.com/jina-ai/jina/tree/master/docs/chapters/101#the-executor-family), which summarize frequently-used algorithmic components in neural search. This family consists of encoders, indexers, crafters, evaluators, and classifiers, each with a well-designed interface. You can find the list of [all 107 built-in executors here](https://docs.jina.ai/chapters/all_exec.html). If they don't meet your needs, inheriting from one of them is the easiest way to bootstrap your own Executor. Simply use our Jina Hub CLI:
+Jina provides [a family of `Executor` classes](https://101.jina.ai/#executor), which summarize frequently-used algorithmic components in neural search. This family consists of encoders, indexers, crafters, evaluators, and classifiers, each with a well-designed interface. You can find the list of [all 107 built-in executors here](https://docs.jina.ai/chapters/all_exec.html). If they don't meet your needs, inheriting from one of them is the easiest way to bootstrap your own Executor. Simply use our Jina Hub CLI:
 
 
 ```bash
@@ -793,14 +793,6 @@ This creates a Python entrypoint, YAML configs and a Dockerfile. You can start f
     </td>
     <td width="75%">
 &nbsp;&nbsp;<h3><a href="https://101.jina.ai">Jina 101: First Things to Learn About Jina</a></h3>
-&nbsp;&nbsp;<a href="https://github.com/jina-ai/docs/tree/master/chapters/101">English</a> •
-  <a href="https://github.com/jina-ai/docs/tree/master/chapters/101/README.ja.md">日本語</a> •
-  <a href="https://github.com/jina-ai/docs/tree/master/chapters/101/README.fr.md">Français</a> •
-  <a href="https://github.com/jina-ai/docs/tree/master/chapters/101/README.pt.md">Português</a> •
-  <a href="https://github.com/jina-ai/docs/tree/master/chapters/101/README.de.md">Deutsch</a> •
-  <a href="https://github.com/jina-ai/docs/tree/master/chapters/101/README.ru.md">Русский язык</a> •
-  <a href="https://github.com/jina-ai/docs/tree/master/chapters/101/README.zh.md">中文</a> •
-  <a href="https://github.com/jina-ai/docs/tree/master/chapters/101/README.ar.md">عربية</a>
     </td>
 
   </tr>


### PR DESCRIPTION
Also removed multilingual 101 links since that's [deprecated](https://jinaai.slack.com/archives/C018QCARHNG/p1612451976206900?thread_ts=1612449397.203800&cid=C018QCARHNG) (and files are gone)
