### PR TITLE
fix: CI should never skip last step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,12 @@ jobs:
   # just for blocking the merge until all parallel core-test are successful
   success-all-test:
     needs: [core-test, docker-image-test]
+    if: always()
     runs-on: ubuntu-18.04
     steps:
-      - run: echo "All Done"
+      - name: Success
+        if: ${{ success() }}
+        run: echo "All Done"
+      - name: Fail
+        if: ${{ failure() }}
+        run: exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,9 +152,11 @@ jobs:
     if: always()
     runs-on: ubuntu-18.04
     steps:
+      - uses: technote-space/workflow-conclusion-action@v2
+      - name: Check Failure
+        if: env.WORKFLOW_CONCLUSION == 'failure'
+        run: exit 1
       - name: Success
         if: ${{ success() }}
         run: echo "All Done"
-      - name: Fail
-        if: ${{ failure() }}
-        run: exit 1
+


### PR DESCRIPTION
The CI was successfull and I was allowed to merge even with failing tests.

According to this issue in github runner https://github.com/actions/runner/issues/777 and documentation on github runners I believe this is the way to go
