### PR TITLE
fix(document): fix wav type sniff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,6 @@ jobs:
     needs: [prep-testbed, commit-lint, lint-flake-8]
     runs-on: ubuntu-18.04
     strategy:
-      max-parallel: 5
       fail-fast: false
       matrix:
         python-version: [3.7]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,7 @@ jobs:
     needs: [prep-testbed, commit-lint, lint-flake-8]
     runs-on: ubuntu-18.04
     strategy:
+      max-parallel: 5
       fail-fast: false
       matrix:
         python-version: [3.7]

--- a/jina/types/document/__init__.py
+++ b/jina/types/document/__init__.py
@@ -573,6 +573,9 @@ class Document(ProtoTypeMixin):
         """
         if value in mimetypes.types_map.values():
             self._pb_body.mime_type = value
+        if value == 'audio/wav':
+            self._pb_body.mime_type = 'audio/x-wav'
+            return
         elif value:
             # given but not recognizable, do best guess
             r = mimetypes.guess_type(f'*.{value}')[0]

--- a/jina/types/document/__init__.py
+++ b/jina/types/document/__init__.py
@@ -571,8 +571,7 @@ class Document(ProtoTypeMixin):
         :param value: the acceptable MIME type, raise ``ValueError`` when MIME type is not
                 recognizable.
         """
-        if value == 'audio/wav':
-            value = 'audio/x-wav'
+        mimetypes.add_type('audio/wav', '.wav')
         if value in mimetypes.types_map.values():
             self._pb_body.mime_type = value
         elif value:

--- a/jina/types/document/__init__.py
+++ b/jina/types/document/__init__.py
@@ -571,11 +571,10 @@ class Document(ProtoTypeMixin):
         :param value: the acceptable MIME type, raise ``ValueError`` when MIME type is not
                 recognizable.
         """
+        if value == 'audio/wav':
+            value = 'audio/x-wav'
         if value in mimetypes.types_map.values():
             self._pb_body.mime_type = value
-        if value == 'audio/wav':
-            self._pb_body.mime_type = 'audio/x-wav'
-            return
         elif value:
             # given but not recognizable, do best guess
             r = mimetypes.guess_type(f'*.{value}')[0]


### PR DESCRIPTION
This kind of hardcode check is not the best solution.
Wonder if we can change the audio/wav -> audio/x-wav when we construct the `Documents`?