### PR TITLE
test(logging): test pipelogger

### DIFF
--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -28,6 +28,11 @@ def test_all_cli(cli):
     subprocess.check_call(['jina', cli, '--help'])
 
 
+@pytest.mark.parametrize('cli', ['log'])
+def test_log_cli(cli):
+    subprocess.check_call(['jina', cli])
+
+    
 def test_parse_env_map():
     a = set_pod_parser().parse_args(['--env', 'key1=value1',
                                      '--env', 'key2=value2'])

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -28,11 +28,10 @@ def test_all_cli(cli):
     subprocess.check_call(['jina', cli, '--help'])
 
 
-@pytest.mark.parametrize('cli', ['log'])
-def test_log_cli(cli):
-    subprocess.check_call(['jina', cli])
+def test_log_cli():
+    subprocess.run(["jina", "log"])
 
-    
+
 def test_parse_env_map():
     a = set_pod_parser().parse_args(['--env', 'key1=value1',
                                      '--env', 'key2=value2'])


### PR DESCRIPTION
PipeLogger is used in cli -> jina log. I wanted to run 'jina log' to cover the test of PipeLogger but seems doesn't work.