### PR TITLE
test: added more test logging

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -17,7 +17,7 @@ jobs:
       !startsWith(github.event.head_commit.message, 'chore') &&
       !startsWith(github.event.head_commit.message, 'build: hotfix') &&
       !endsWith(github.event.head_commit.message, 'reformatted by jina-dev-bot')
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         with:
@@ -93,7 +93,7 @@ jobs:
 
   update-docker:
     needs: update-doc
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
@@ -150,7 +150,7 @@ jobs:
 
   prep-testbed:
     needs: update-doc
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         with:
@@ -177,7 +177,7 @@ jobs:
 
   core-test:
     needs: prep-testbed
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
@@ -197,6 +197,7 @@ jobs:
           docker pull docker.pkg.github.com/jina-ai/jina/jina:test-pip
           docker tag docker.pkg.github.com/jina-ai/jina/jina:test-pip jinaai/jina:test-pip
           python -m pip install --upgrade pip
+          python -m pip install wheel
           pip install ".[cicd,test,daemon]" --no-cache-dir
           jina check
           export JINA_LOG_LEVEL="ERROR"
@@ -208,14 +209,14 @@ jobs:
           if [[ "${{ matrix.test-path }}" == "tests/distributed/test_against_external_daemon/" ]]; then
             docker build -f Dockerfiles/debianx.Dockerfile -t jinaai/jina:test-daemon .
             docker run --name jinad -v /var/run/docker.sock:/var/run/docker.sock --network=host -d jinaai/jina:test-daemon
-            pytest --suppress-no-test-exit-code --force-flaky --min-passes 1 --max-runs 5 --cov=jina --cov-report=xml -n 1 --timeout=120 -v --ignore-glob='tests/integration/hub_usage/dummyhub*' ${{ matrix.test-path }}
+            pytest --suppress-no-test-exit-code --force-flaky --min-passes 1 --max-runs 5 --cov=jina --cov-report=xml --timeout=180 -v -s --ignore-glob='tests/integration/hub_usage/dummyhub*' ${{ matrix.test-path }}
             docker rm -f jinad
           else
             SUB='daemon'
             if [[ "${{ matrix.test-path }}" == *"$SUB"* ]]; then
-              pytest --suppress-no-test-exit-code --force-flaky --min-passes 1 --max-runs 5 --cov=daemon --cov-report=xml -n 1 --timeout=120 -v --ignore-glob='tests/integration/hub_usage/dummyhub*' ${{ matrix.test-path }}
+              pytest --suppress-no-test-exit-code --force-flaky --min-passes 1 --max-runs 5 --cov=daemon --cov-report=xml --timeout=180 -v -s --ignore-glob='tests/integration/hub_usage/dummyhub*' ${{ matrix.test-path }}
             else
-              pytest --suppress-no-test-exit-code --force-flaky --min-passes 1 --max-runs 5 --cov=jina --cov-report=xml -n 1 --timeout=120 -v --ignore-glob='tests/integration/hub_usage/dummyhub*' ${{ matrix.test-path }}
+              pytest --suppress-no-test-exit-code --force-flaky --min-passes 1 --max-runs 5 --cov=jina --cov-report=xml --timeout=180 -v -s --ignore-glob='tests/integration/hub_usage/dummyhub*' ${{ matrix.test-path }}
             fi
           fi
           SUB='daemon'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,17 +139,18 @@ jobs:
       - name: Test
         id: test
         run: |
+          pip freeze
           if [[ "${{ matrix.test-path }}" == "tests/distributed/test_against_external_daemon/" ]]; then
             docker build -f Dockerfiles/debianx.Dockerfile -t jinaai/jina:test-daemon .
             docker run --name jinad -v /var/run/docker.sock:/var/run/docker.sock --network=host -d jinaai/jina:test-daemon
-            pytest --suppress-no-test-exit-code --force-flaky --min-passes 1 --max-runs 5 --cov=jina --cov-report=xml -n 1 --timeout=300 -v -s --ignore-glob='tests/integration/hub_usage/dummyhub*' ${{ matrix.test-path }}
+            pytest --suppress-no-test-exit-code --force-flaky --min-passes 1 --max-runs 5 --cov=jina --cov-report=xml --timeout=300 -v -s --ignore-glob='tests/integration/hub_usage/dummyhub*' ${{ matrix.test-path }}
             docker rm -f jinad
           else
             SUB='daemon'
             if [[ "${{ matrix.test-path }}" == *"$SUB"* ]]; then
-              pytest --suppress-no-test-exit-code --force-flaky --min-passes 1 --max-runs 5 --cov=daemon --cov-report=xml -n 1 --timeout=300 -v -s --ignore-glob='tests/integration/hub_usage/dummyhub*' ${{ matrix.test-path }}
+              pytest --suppress-no-test-exit-code --force-flaky --min-passes 1 --max-runs 5 --cov=daemon --cov-report=xml --timeout=300 -v -s --ignore-glob='tests/integration/hub_usage/dummyhub*' ${{ matrix.test-path }}
             else
-              pytest --suppress-no-test-exit-code --force-flaky --min-passes 1 --max-runs 5 --cov=jina --cov-report=xml -n 1 --timeout=300 -v -s --ignore-glob='tests/integration/hub_usage/dummyhub*' ${{ matrix.test-path }}
+              pytest --suppress-no-test-exit-code --force-flaky --min-passes 1 --max-runs 5 --cov=jina --cov-report=xml --timeout=300 -v -s --ignore-glob='tests/integration/hub_usage/dummyhub*' ${{ matrix.test-path }}
             fi
           fi
           SUB='daemon'
@@ -160,7 +161,7 @@ jobs:
             echo "flag it as jina for codeoverage"
             echo "::set-output name=codecov_flag::jina"
           fi
-        timeout-minutes: 30
+        timeout-minutes: 15
         env:
           JINAHUB_USERNAME: ${{ secrets.JINAHUB_USERNAME }}
           JINAHUB_PASSWORD: ${{ secrets.JINAHUB_PASSWORD }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,18 +139,17 @@ jobs:
       - name: Test
         id: test
         run: |
-          pip freeze
           if [[ "${{ matrix.test-path }}" == "tests/distributed/test_against_external_daemon/" ]]; then
             docker build -f Dockerfiles/debianx.Dockerfile -t jinaai/jina:test-daemon .
             docker run --name jinad -v /var/run/docker.sock:/var/run/docker.sock --network=host -d jinaai/jina:test-daemon
-            pytest --suppress-no-test-exit-code --force-flaky --min-passes 1 --max-runs 5 --cov=jina --cov-report=xml --timeout=300 -v -s --ignore-glob='tests/integration/hub_usage/dummyhub*' ${{ matrix.test-path }}
+            pytest --suppress-no-test-exit-code --force-flaky --min-passes 1 --max-runs 5 --cov=jina --cov-report=xml --timeout=180 -v -s --ignore-glob='tests/integration/hub_usage/dummyhub*' ${{ matrix.test-path }}
             docker rm -f jinad
           else
             SUB='daemon'
             if [[ "${{ matrix.test-path }}" == *"$SUB"* ]]; then
-              pytest --suppress-no-test-exit-code --force-flaky --min-passes 1 --max-runs 5 --cov=daemon --cov-report=xml --timeout=300 -v -s --ignore-glob='tests/integration/hub_usage/dummyhub*' ${{ matrix.test-path }}
+              pytest --suppress-no-test-exit-code --force-flaky --min-passes 1 --max-runs 5 --cov=daemon --cov-report=xml --timeout=180 -v -s --ignore-glob='tests/integration/hub_usage/dummyhub*' ${{ matrix.test-path }}
             else
-              pytest --suppress-no-test-exit-code --force-flaky --min-passes 1 --max-runs 5 --cov=jina --cov-report=xml --timeout=300 -v -s --ignore-glob='tests/integration/hub_usage/dummyhub*' ${{ matrix.test-path }}
+              pytest --suppress-no-test-exit-code --force-flaky --min-passes 1 --max-runs 5 --cov=jina --cov-report=xml --timeout=180 -v -s --ignore-glob='tests/integration/hub_usage/dummyhub*' ${{ matrix.test-path }}
             fi
           fi
           SUB='daemon'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,10 @@ jobs:
       - name: Test
         id: test
         run: |
+          nproc
+          hostname -I
+          vmstat -s
+          cat /proc/meminfo
           if [[ "${{ matrix.test-path }}" == "tests/distributed/test_against_external_daemon/" ]]; then
             docker build -f Dockerfiles/debianx.Dockerfile -t jinaai/jina:test-daemon .
             docker run --name jinad -v /var/run/docker.sock:/var/run/docker.sock --network=host -d jinaai/jina:test-daemon

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       fail-fast: false
+      max-parallel: 6
       matrix:
         python-version: [3.7]
         test-path: ${{fromJson(needs.prep-testbed.outputs.matrix)}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   commit-lint:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: find the prev warning if exist
         uses: peter-evans/find-comment@v1
@@ -54,7 +54,7 @@ jobs:
 
   lint-flake-8:
     needs: commit-lint
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python 3.7
@@ -70,7 +70,7 @@ jobs:
           flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics --exclude .git,__pycache__,docs/source/conf.py,old,build,dist,tests/,jina/hub/
 
   check-docstring:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         with:
@@ -87,7 +87,7 @@ jobs:
           CHANGED_FILES: ${{ steps.file_changes.outputs.all }}
 
   prep-testbed:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - id: set-matrix
@@ -99,7 +99,7 @@ jobs:
 
   docker-image-test:
     needs: commit-lint
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - run: |
@@ -112,7 +112,7 @@ jobs:
 
   core-test:
     needs: [prep-testbed, commit-lint, lint-flake-8]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
@@ -184,7 +184,7 @@ jobs:
   success-all-test:
     needs: [core-test, docker-image-test]
     if: always()
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: technote-space/workflow-conclusion-action@v2
       - name: Check Failure

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,14 +145,14 @@ jobs:
           if [[ "${{ matrix.test-path }}" == "tests/distributed/test_against_external_daemon/" ]]; then
             docker build -f Dockerfiles/debianx.Dockerfile -t jinaai/jina:test-daemon .
             docker run --name jinad -v /var/run/docker.sock:/var/run/docker.sock --network=host -d jinaai/jina:test-daemon
-            pytest --suppress-no-test-exit-code --force-flaky --min-passes 1 --max-runs 5 --cov=jina --cov-report=xml --timeout=300 -v -s --ignore-glob='tests/integration/hub_usage/dummyhub*' ${{ matrix.test-path }}
+            pytest --suppress-no-test-exit-code --force-flaky --min-passes 1 --max-runs 5 --cov=jina --cov-report=xml -n 1 --timeout=300 -v -s --ignore-glob='tests/integration/hub_usage/dummyhub*' ${{ matrix.test-path }}
             docker rm -f jinad
           else
             SUB='daemon'
             if [[ "${{ matrix.test-path }}" == *"$SUB"* ]]; then
-              pytest --suppress-no-test-exit-code --force-flaky --min-passes 1 --max-runs 5 --cov=daemon --cov-report=xml --timeout=300 -v -s --ignore-glob='tests/integration/hub_usage/dummyhub*' ${{ matrix.test-path }}
+              pytest --suppress-no-test-exit-code --force-flaky --min-passes 1 --max-runs 5 --cov=daemon --cov-report=xml -n 1 --timeout=300 -v -s --ignore-glob='tests/integration/hub_usage/dummyhub*' ${{ matrix.test-path }}
             else
-              pytest --suppress-no-test-exit-code --force-flaky --min-passes 1 --max-runs 5 --cov=jina --cov-report=xml --timeout=300 -v -s --ignore-glob='tests/integration/hub_usage/dummyhub*' ${{ matrix.test-path }}
+              pytest --suppress-no-test-exit-code --force-flaky --min-passes 1 --max-runs 5 --cov=jina --cov-report=xml -n 1 --timeout=300 -v -s --ignore-glob='tests/integration/hub_usage/dummyhub*' ${{ matrix.test-path }}
             fi
           fi
           SUB='daemon'
@@ -163,7 +163,7 @@ jobs:
             echo "flag it as jina for codeoverage"
             echo "::set-output name=codecov_flag::jina"
           fi
-        timeout-minutes: 15
+        timeout-minutes: 30
         env:
           JINAHUB_USERNAME: ${{ secrets.JINAHUB_USERNAME }}
           JINAHUB_PASSWORD: ${{ secrets.JINAHUB_PASSWORD }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,7 @@ jobs:
         run: |
           docker build -f Dockerfiles/pip.Dockerfile -t jinaai/jina:test-pip .
           python -m pip install --upgrade pip
+          python -m pip install wheel
           pip install ".[cicd,test,daemon]" --no-cache-dir
           jina check
           export JINA_LOG_LEVEL="ERROR"
@@ -138,10 +139,6 @@ jobs:
       - name: Test
         id: test
         run: |
-          nproc
-          hostname -I
-          vmstat -s
-          cat /proc/meminfo
           if [[ "${{ matrix.test-path }}" == "tests/distributed/test_against_external_daemon/" ]]; then
             docker build -f Dockerfiles/debianx.Dockerfile -t jinaai/jina:test-daemon .
             docker run --name jinad -v /var/run/docker.sock:/var/run/docker.sock --network=host -d jinaai/jina:test-daemon

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,6 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       fail-fast: false
-      max-parallel: 6
       matrix:
         python-version: [3.7]
         test-path: ${{fromJson(needs.prep-testbed.outputs.matrix)}}
@@ -164,7 +163,7 @@ jobs:
             echo "flag it as jina for codeoverage"
             echo "::set-output name=codecov_flag::jina"
           fi
-        timeout-minutes: 30
+        timeout-minutes: 15
         env:
           JINAHUB_USERNAME: ${{ secrets.JINAHUB_USERNAME }}
           JINAHUB_PASSWORD: ${{ secrets.JINAHUB_PASSWORD }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,14 +146,14 @@ jobs:
           if [[ "${{ matrix.test-path }}" == "tests/distributed/test_against_external_daemon/" ]]; then
             docker build -f Dockerfiles/debianx.Dockerfile -t jinaai/jina:test-daemon .
             docker run --name jinad -v /var/run/docker.sock:/var/run/docker.sock --network=host -d jinaai/jina:test-daemon
-            pytest --suppress-no-test-exit-code --force-flaky --min-passes 1 --max-runs 5 --cov=jina --cov-report=xml -n 1 --timeout=300 -v -s --ignore-glob='tests/integration/hub_usage/dummyhub*' ${{ matrix.test-path }}
+            pytest --suppress-no-test-exit-code --force-flaky --min-passes 1 --max-runs 5 --cov=jina --cov-report=xml --timeout=300 -v -s --ignore-glob='tests/integration/hub_usage/dummyhub*' ${{ matrix.test-path }}
             docker rm -f jinad
           else
             SUB='daemon'
             if [[ "${{ matrix.test-path }}" == *"$SUB"* ]]; then
-              pytest --suppress-no-test-exit-code --force-flaky --min-passes 1 --max-runs 5 --cov=daemon --cov-report=xml -n 1 --timeout=300 -v -s --ignore-glob='tests/integration/hub_usage/dummyhub*' ${{ matrix.test-path }}
+              pytest --suppress-no-test-exit-code --force-flaky --min-passes 1 --max-runs 5 --cov=daemon --cov-report=xml --timeout=300 -v -s --ignore-glob='tests/integration/hub_usage/dummyhub*' ${{ matrix.test-path }}
             else
-              pytest --suppress-no-test-exit-code --force-flaky --min-passes 1 --max-runs 5 --cov=jina --cov-report=xml -n 1 --timeout=300 -v -s --ignore-glob='tests/integration/hub_usage/dummyhub*' ${{ matrix.test-path }}
+              pytest --suppress-no-test-exit-code --force-flaky --min-passes 1 --max-runs 5 --cov=jina --cov-report=xml --timeout=300 -v -s --ignore-glob='tests/integration/hub_usage/dummyhub*' ${{ matrix.test-path }}
             fi
           fi
           SUB='daemon'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Set up Python 3.7
         uses: actions/setup-python@v1
         with:
-          python-version: 3.7
+          python-version: 3.7.9
       - name: Lint with flake8
         run: |
           pip install flake8
@@ -78,7 +78,7 @@ jobs:
       - name: Set up Python 3.7
         uses: actions/setup-python@v1
         with:
-          python-version: 3.7
+          python-version: 3.7.9
       - id: file_changes
         uses: jitterbit/get-changed-files@v1
       - name: docstring check with darglint and pydocstyle
@@ -116,7 +116,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7]
+        python-version: [3.7.9]
         test-path: ${{fromJson(needs.prep-testbed.outputs.matrix)}}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Set up Python 3.7
         uses: actions/setup-python@v1
         with:
-          python-version: 3.7.9
+          python-version: 3.7
       - name: Lint with flake8
         run: |
           pip install flake8
@@ -78,7 +78,7 @@ jobs:
       - name: Set up Python 3.7
         uses: actions/setup-python@v1
         with:
-          python-version: 3.7.9
+          python-version: 3.7
       - id: file_changes
         uses: jitterbit/get-changed-files@v1
       - name: docstring check with darglint and pydocstyle
@@ -116,7 +116,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7.9]
+        python-version: [3.7]
         test-path: ${{fromJson(needs.prep-testbed.outputs.matrix)}}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,7 @@ jobs:
           if [[ "${{ matrix.test-path }}" == "tests/distributed/test_against_external_daemon/" ]]; then
             docker build -f Dockerfiles/debianx.Dockerfile -t jinaai/jina:test-daemon .
             docker run --name jinad -v /var/run/docker.sock:/var/run/docker.sock --network=host -d jinaai/jina:test-daemon
-            pytest --suppress-no-test-exit-code --force-flaky --min-passes 1 --max-runs 5 --cov=jina --cov-report=xml --timeout=180 -v -s --ignore-glob='tests/integration/hub_usage/dummyhub*' ${{ matrix.test-path }}
+            pytest --suppress-no-test-exit-code --force-flaky --min-passes 1 --max-runs 5 --cov=jina --cov-report=xml --timeout=180 -v -s ${{ matrix.test-path }}
             docker rm -f jinad
           else
             SUB='daemon'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,14 +141,14 @@ jobs:
           if [[ "${{ matrix.test-path }}" == "tests/distributed/test_against_external_daemon/" ]]; then
             docker build -f Dockerfiles/debianx.Dockerfile -t jinaai/jina:test-daemon .
             docker run --name jinad -v /var/run/docker.sock:/var/run/docker.sock --network=host -d jinaai/jina:test-daemon
-            pytest --suppress-no-test-exit-code --force-flaky --min-passes 1 --max-runs 5 --cov=jina --cov-report=xml -n 1 --timeout=600 -v --ignore-glob='tests/integration/hub_usage/dummyhub*' ${{ matrix.test-path }}
+            pytest --suppress-no-test-exit-code --force-flaky --min-passes 1 --max-runs 5 --cov=jina --cov-report=xml -n 1 --timeout=300 -v -s --ignore-glob='tests/integration/hub_usage/dummyhub*' ${{ matrix.test-path }}
             docker rm -f jinad
           else
             SUB='daemon'
             if [[ "${{ matrix.test-path }}" == *"$SUB"* ]]; then
-              pytest --suppress-no-test-exit-code --force-flaky --min-passes 1 --max-runs 5 --cov=daemon --cov-report=xml -n 1 --timeout=600 -v --ignore-glob='tests/integration/hub_usage/dummyhub*' ${{ matrix.test-path }}
+              pytest --suppress-no-test-exit-code --force-flaky --min-passes 1 --max-runs 5 --cov=daemon --cov-report=xml -n 1 --timeout=300 -v -s --ignore-glob='tests/integration/hub_usage/dummyhub*' ${{ matrix.test-path }}
             else
-              pytest --suppress-no-test-exit-code --force-flaky --min-passes 1 --max-runs 5 --cov=jina --cov-report=xml -n 1 --timeout=600 -v --ignore-glob='tests/integration/hub_usage/dummyhub*' ${{ matrix.test-path }}
+              pytest --suppress-no-test-exit-code --force-flaky --min-passes 1 --max-runs 5 --cov=jina --cov-report=xml -n 1 --timeout=300 -v -s --ignore-glob='tests/integration/hub_usage/dummyhub*' ${{ matrix.test-path }}
             fi
           fi
           SUB='daemon'

--- a/jina/clients/base.py
+++ b/jina/clients/base.py
@@ -5,7 +5,7 @@ __license__ = "Apache-2.0"
 import argparse
 import os
 from typing import Callable, Union, Optional, Iterator, List, Dict, AsyncIterator
-from concurrent.futures._base import CancelledError
+import asyncio
 
 import grpc
 import inspect
@@ -172,8 +172,10 @@ class BaseClient:
                                       logger=self.logger)
                         p_bar.update(self.args.request_size)
                         yield resp
-        except (KeyboardInterrupt, CancelledError):
+        except KeyboardInterrupt:
             self.logger.warning('user cancel the process')
+        except asyncio.CancelledError as ex:
+            self.logger.warning(f'process error: {ex!r}, terminate signal send?')
         except grpc.aio._call.AioRpcError as rpc_ex:
             # Since this object is guaranteed to be a grpc.Call, might as well include that in its name.
             my_code = rpc_ex.code()

--- a/jina/clients/base.py
+++ b/jina/clients/base.py
@@ -5,6 +5,7 @@ __license__ = "Apache-2.0"
 import argparse
 import os
 from typing import Callable, Union, Optional, Iterator, List, Dict, AsyncIterator
+from concurrent.futures._base import CancelledError
 
 import grpc
 import inspect
@@ -171,7 +172,7 @@ class BaseClient:
                                       logger=self.logger)
                         p_bar.update(self.args.request_size)
                         yield resp
-        except KeyboardInterrupt:
+        except (KeyboardInterrupt, CancelledError):
             self.logger.warning('user cancel the process')
         except grpc.aio._call.AioRpcError as rpc_ex:
             # Since this object is guaranteed to be a grpc.Call, might as well include that in its name.

--- a/jina/peapods/zmq/__init__.py
+++ b/jina/peapods/zmq/__init__.py
@@ -283,10 +283,13 @@ class AsyncZmqlet(Zmqlet):
         """
         try:
             msg = await recv_message_async(self.in_sock, **self.send_recv_kwargs)
-            self.bytes_recv += msg.size
             self.msg_recv += 1
-            if callback:
-                return callback(msg)
+            if msg is not None:
+                self.bytes_recv += msg.size
+                if callback:
+                    return callback(msg)
+            else:
+                self.logger.error('received an empty message')
         except (asyncio.CancelledError, TypeError) as ex:
             self.logger.error(f'receiving message error: {ex!r}, gateway cancelled?')
 

--- a/jina/peapods/zmq/__init__.py
+++ b/jina/peapods/zmq/__init__.py
@@ -283,10 +283,13 @@ class AsyncZmqlet(Zmqlet):
         """
         try:
             msg = await recv_message_async(self.in_sock, **self.send_recv_kwargs)
-            self.bytes_recv += msg.size
             self.msg_recv += 1
-            if callback:
-                return callback(msg)
+            if msg is not None:
+                self.bytes_recv += msg.size
+                if callback:
+                    return callback(msg)
+            else:
+                self.logger.error('Received message is empty.')
         except (asyncio.CancelledError, TypeError) as ex:
             self.logger.error(f'receiving message error: {ex!r}, gateway cancelled?')
 

--- a/jina/peapods/zmq/__init__.py
+++ b/jina/peapods/zmq/__init__.py
@@ -274,12 +274,12 @@ class AsyncZmqlet(Zmqlet):
         except (asyncio.CancelledError, TypeError) as ex:
             self.logger.error(f'sending message error: {ex!r}, gateway cancelled?')
 
-    async def recv_message(self, callback: Callable[['Message'], Union['Message', 'Request']] = None) -> 'Message':
+    async def recv_message(self, callback: Callable[['Message'], Union['Message', 'Request']] = None) -> Optional['Message']:
         """
         Receive a protobuf message in async manner.
 
         :param callback: Callback function to receive message
-        :return: Received protobuf message.
+        :return: Received protobuf message. Or None in case of any error.
         """
         try:
             msg = await recv_message_async(self.in_sock, **self.send_recv_kwargs)

--- a/jina/peapods/zmq/__init__.py
+++ b/jina/peapods/zmq/__init__.py
@@ -283,13 +283,10 @@ class AsyncZmqlet(Zmqlet):
         """
         try:
             msg = await recv_message_async(self.in_sock, **self.send_recv_kwargs)
+            self.bytes_recv += msg.size
             self.msg_recv += 1
-            if msg is not None:
-                self.bytes_recv += msg.size
-                if callback:
-                    return callback(msg)
-            else:
-                self.logger.error('received an empty message')
+            if callback:
+                return callback(msg)
         except (asyncio.CancelledError, TypeError) as ex:
             self.logger.error(f'receiving message error: {ex!r}, gateway cancelled?')
 

--- a/scripts/get-all-test-paths.sh
+++ b/scripts/get-all-test-paths.sh
@@ -6,7 +6,7 @@ declare -a array1=( "tests/unit/*.py" "tests/integration/*.py" "tests/distribute
 declare -a array2=( $(ls -d tests/{unit,integration,distributed}/*/ | grep -v '__pycache__' ))
 dest1=( "${array1[@]}" "${array2[@]}" )
 
-declare -a array1=( "tests/daemon/unit/*.py" "tests/daemon/integration/*.py" )
+declare -a array1=( "tests/daemon/unit/*.py" )
 declare -a array2=( $(ls -d tests/daemon/{unit,integration}/*/ | grep -v '__pycache__' ))
 dest2=( "${array1[@]}" "${array2[@]}" )
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -50,13 +50,12 @@ def rm_files(file_paths):
 
 
 def validate_callback(mock, validate_func):
-
     for args, kwargs in mock.call_args_list:
         validate_func(*args, **kwargs)
 
     mock.assert_called()
 
-    
+
 np.random.seed(0)
 d_embedding = np.array([1, 1, 1, 1, 1, 1, 1])
 c_embedding = np.array([2, 2, 2, 2, 2, 2, 2])
@@ -143,5 +142,4 @@ def test_docs_generator(chunks, same_content, nr):
     new_docs = list(get_documents(chunks=chunks, same_content=same_content, nr=nr, index_start=index_start))
     new_ids = set([d.id for d in new_docs])
     assert len(new_ids.intersection(ids_used)) == 0
-
     check_docs(chunk_content, chunks, same_content, new_docs, ids_used, index_start)

--- a/tests/distributed/test_against_external_daemon/test_single_instance.py
+++ b/tests/distributed/test_against_external_daemon/test_single_instance.py
@@ -131,7 +131,7 @@ def docker_image():
 
 @pytest.mark.parametrize('silent_log', [True, False])
 @pytest.mark.parametrize('parallels', [1, 2, 3])
-def test_l_r_l_with_upload_docker(silent_log, parallels, docker_image, mocker):
+def test_l_r_l_with_upload_remote(silent_log, parallels, docker_image, mocker):
     response_mock = mocker.Mock()
     f = (Flow()
          .add()

--- a/tests/distributed/test_against_external_daemon/test_single_instance.py
+++ b/tests/distributed/test_against_external_daemon/test_single_instance.py
@@ -131,7 +131,7 @@ def docker_image():
 
 @pytest.mark.parametrize('silent_log', [True, False])
 @pytest.mark.parametrize('parallels', [1, 2, 3])
-def test_l_r_l_with_upload(silent_log, parallels, docker_image, mocker):
+def test_l_r_l_with_upload_docker(silent_log, parallels, docker_image, mocker):
     response_mock = mocker.Mock()
     f = (Flow()
          .add()

--- a/tests/distributed/test_join_local_from_remote/test_integration.py
+++ b/tests/distributed/test_join_local_from_remote/test_integration.py
@@ -5,6 +5,7 @@ import pytest
 from ..helpers import create_flow_2, assert_request
 from jina import Client, Document
 from jina.parsers import set_client_cli_parser
+from tests import validate_callback
 
 cur_dir = os.path.dirname(os.path.abspath(__file__))
 compose_yml = os.path.join(cur_dir, 'docker-compose.yml')
@@ -30,16 +31,15 @@ def client():
 @pytest.mark.timeout(360)
 @pytest.mark.parametrize('docker_compose', [compose_yml], indirect=['docker_compose'])
 def test_flow(docker_compose, doc_to_index, client, mocker):
-    m = mocker.Mock()
 
     def validate_resp(resp):
-        m()
         assert len(resp.search.docs) == 1
         assert resp.search.docs[0].text == 'test'
 
+    m = mocker.Mock()
     flow_id = create_flow_2(flow_yaml=flow_yaml)
 
-    client.search(input_fn=[doc_to_index], on_done=validate_resp)
+    client.search(input_fn=[doc_to_index], on_done=m)
 
     assert_request(method='get',
                    url=f'http://localhost:8000/flows/{flow_id}')
@@ -47,4 +47,6 @@ def test_flow(docker_compose, doc_to_index, client, mocker):
     assert_request(method='delete',
                    url=f'http://localhost:8000/flows/{flow_id}',
                    payload={'workspace': False})
+
     m.assert_called_once()
+    validate_callback(m, validate_resp)

--- a/tests/distributed/test_join_local_from_remote/test_integration.py
+++ b/tests/distributed/test_join_local_from_remote/test_integration.py
@@ -36,10 +36,10 @@ def test_flow(docker_compose, doc_to_index, client, mocker):
         assert len(resp.search.docs) == 1
         assert resp.search.docs[0].text == 'test'
 
-    m = mocker.Mock()
+    mock = mocker.Mock()
     flow_id = create_flow_2(flow_yaml=flow_yaml)
 
-    client.search(input_fn=[doc_to_index], on_done=m)
+    client.search(input_fn=[doc_to_index], on_done=mock)
 
     assert_request(method='get',
                    url=f'http://localhost:8000/flows/{flow_id}')
@@ -48,5 +48,5 @@ def test_flow(docker_compose, doc_to_index, client, mocker):
                    url=f'http://localhost:8000/flows/{flow_id}',
                    payload={'workspace': False})
 
-    m.assert_called_once()
-    validate_callback(m, validate_resp)
+    mock.assert_called_once()
+    validate_callback(mock, validate_resp)

--- a/tests/distributed/test_local_flow_local_remote_local/test_integration.py
+++ b/tests/distributed/test_local_flow_local_remote_local/test_integration.py
@@ -4,6 +4,7 @@ import pytest
 
 from jina import Document
 from jina.flow import Flow
+from tests import validate_callback
 
 cur_dir = os.path.dirname(os.path.abspath(__file__))
 compose_yml = os.path.join(cur_dir, 'docker-compose.yml')
@@ -15,10 +16,8 @@ flow_yml = os.path.join(cur_dir, 'flow.yml')
                          [('crafter', 'encoder', 'add'), ('gateway', '[encoder, crafter]', 'needs')])
 def test_flow(docker_compose, tmpdir, mocker, encoder_needs, indexer_needs, indexer_method):
     text = 'cats rules'
-    m = mocker.Mock()
 
     def validate_output(resp):
-        m()
         assert len(resp.index.docs) == 1
         assert resp.index.docs[0].text == text
 
@@ -31,7 +30,9 @@ def test_flow(docker_compose, tmpdir, mocker, encoder_needs, indexer_needs, inde
     with Document() as doc:
         doc.content = text
 
+    m = mocker.Mock()
     with Flow.load_config(flow_yml) as f:
-        f.index([doc], on_done=validate_output)
+        f.index([doc], on_done=m)
 
     m.assert_called_once()
+    validate_callback(m, validate_output)

--- a/tests/distributed/test_local_flow_local_remote_local/test_integration.py
+++ b/tests/distributed/test_local_flow_local_remote_local/test_integration.py
@@ -30,9 +30,9 @@ def test_flow(docker_compose, tmpdir, mocker, encoder_needs, indexer_needs, inde
     with Document() as doc:
         doc.content = text
 
-    m = mocker.Mock()
+    mock = mocker.Mock()
     with Flow.load_config(flow_yml) as f:
-        f.index([doc], on_done=m)
+        f.index([doc], on_done=mock)
 
-    m.assert_called_once()
-    validate_callback(m, validate_output)
+    mock.assert_called_once()
+    validate_callback(mock, validate_output)

--- a/tests/distributed/test_local_flow_remote_local_remote/test_integration.py
+++ b/tests/distributed/test_local_flow_remote_local_remote/test_integration.py
@@ -4,6 +4,7 @@ import pytest
 
 from jina import Document
 from jina.flow import Flow
+from tests import validate_callback
 
 cur_dir = os.path.dirname(os.path.abspath(__file__))
 compose_yml = os.path.join(cur_dir, 'docker-compose.yml')
@@ -14,10 +15,8 @@ flow_yml = os.path.join(cur_dir, 'flow.yml')
 @pytest.mark.parametrize('encoder_needs, indexer_needs', [('crafter', 'encoder'), ('gateway', '[encoder, crafter]')])
 def test_flow(docker_compose, mocker, encoder_needs, indexer_needs):
     text = 'cats rules'
-    m = mocker.Mock()
 
     def validate_output(resp):
-        m()
         assert len(resp.index.docs) == 1
         assert resp.index.docs[0].text == text
 
@@ -29,7 +28,9 @@ def test_flow(docker_compose, mocker, encoder_needs, indexer_needs):
     with Document() as doc:
         doc.content = text
 
+    m = mocker.Mock()
     with Flow.load_config(flow_yml) as f:
-        f.index([doc], on_done=validate_output)
+        f.index([doc], on_done=m)
 
     m.assert_called_once()
+    validate_callback(m, validate_output)

--- a/tests/distributed/test_local_flow_remote_local_remote/test_integration.py
+++ b/tests/distributed/test_local_flow_remote_local_remote/test_integration.py
@@ -28,9 +28,9 @@ def test_flow(docker_compose, mocker, encoder_needs, indexer_needs):
     with Document() as doc:
         doc.content = text
 
-    m = mocker.Mock()
+    mock = mocker.Mock()
     with Flow.load_config(flow_yml) as f:
-        f.index([doc], on_done=m)
+        f.index([doc], on_done=mock)
 
-    m.assert_called_once()
-    validate_callback(m, validate_output)
+    mock.assert_called_once()
+    validate_callback(mock, validate_output)

--- a/tests/distributed/test_simple_local_remote/test_integration.py
+++ b/tests/distributed/test_simple_local_remote/test_integration.py
@@ -26,9 +26,9 @@ def test_flow(docker_compose, mocker):
     with Document() as doc:
         doc.content = text
 
-    m = mocker.Mock()
+    mock = mocker.Mock()
     with Flow.load_config(flow_yml) as f:
-        f.index([doc], on_done=m)
+        f.index([doc], on_done=mock)
 
-    m.assert_called_once()
-    validate_callback(m, validate_output)
+    mock.assert_called_once()
+    validate_callback(mock, validate_output)

--- a/tests/integration/crud/advanced/test_crud_advanced_example.py
+++ b/tests/integration/crud/advanced/test_crud_advanced_example.py
@@ -156,7 +156,6 @@ def test_crud_advanced_example(tmpdir, config, mocker, monkeypatch):
         search_flow.search(
             input_fn=search_data,
             on_done=mock,
-
         )
 
     mock.assert_called_once()

--- a/tests/integration/crud/advanced/test_crud_advanced_example.py
+++ b/tests/integration/crud/advanced/test_crud_advanced_example.py
@@ -1,9 +1,11 @@
 import os
+import pytest
 
 from jina import Document
 from jina.executors.indexers import BaseIndexer
 from jina.flow import Flow
-import pytest
+
+from tests import validate_callback
 
 
 @pytest.fixture
@@ -117,10 +119,8 @@ def test_crud_advanced_example(tmpdir, config, mocker, monkeypatch):
             ('vecidx.bin', 10)
         ]
     )
-    mock = mocker.Mock()
 
     def validate_granularity_1(resp):
-        mock()
         assert len(resp.docs) == 3
         for doc in resp.docs:
             assert doc.granularity == 0
@@ -151,11 +151,13 @@ def test_crud_advanced_example(tmpdir, config, mocker, monkeypatch):
         'm',
     ]
 
+    mock = mocker.Mock()
     with Flow.load_config('flow-query.yml') as search_flow:
         search_flow.search(
             input_fn=search_data,
-            on_done=validate_granularity_1,
+            on_done=mock,
 
         )
 
     mock.assert_called_once()
+    validate_callback(mock, validate_granularity_1)

--- a/tests/integration/crud/simple/chunks/test_chunks.py
+++ b/tests/integration/crud/simple/chunks/test_chunks.py
@@ -9,6 +9,8 @@ from jina import Document
 from jina.executors.indexers import BaseIndexer
 from jina.flow import Flow
 
+from tests import validate_callback
+
 TOP_K = 10
 
 
@@ -63,7 +65,6 @@ def test_delete_vector(config, mocker, flow_file):
 
     def validate_result_factory(num_matches):
         def validate_results(resp):
-            mock()
             assert len(resp.docs) == num_searches
             for doc in resp.docs:
                 assert len(doc.matches) == num_matches
@@ -79,8 +80,9 @@ def test_delete_vector(config, mocker, flow_file):
     with Flow.load_config(flow_file) as search_flow:
         search_flow.search(
             input_fn=document_generator(start=0, num_docs=num_docs, num_chunks=num_chunks),
-            on_done=validate_result_factory(TOP_K))
+            on_done=mock)
     mock.assert_called_once()
+    validate_callback(mock, validate_result_factory(TOP_K))
 
     delete_ids = []
     for d in document_generator(start=0, num_docs=num_docs, num_chunks=num_chunks):
@@ -96,8 +98,9 @@ def test_delete_vector(config, mocker, flow_file):
     with Flow.load_config(flow_file) as search_flow:
         search_flow.search(
             input_fn=document_generator(start=0, num_docs=num_docs, num_chunks=num_chunks),
-            on_done=validate_result_factory(0))
+            on_done=mock)
     mock.assert_called_once()
+    validate_callback(mock, validate_result_factory(0))
 
 
 @pytest.mark.parametrize('flow_file', ['flow_vector.yml'])
@@ -113,7 +116,6 @@ def test_update_vector(config, mocker, flow_file):
 
     def validate_result_factory(has_changed, num_matches):
         def validate_results(resp):
-            mock()
             assert len(resp.docs) == num_searches
             for d in docs_before:
                 ids_before.append(d.id)
@@ -138,8 +140,9 @@ def test_update_vector(config, mocker, flow_file):
     with Flow.load_config(flow_file) as search_flow:
         search_flow.search(
             input_fn=document_generator(start=0, num_docs=num_docs, num_chunks=num_chunks),
-            on_done=validate_result_factory(has_changed=False, num_matches=TOP_K))
+            on_done=mock)
     mock.assert_called_once()
+    validate_callback(mock, validate_result_factory(has_changed=False, num_matches=TOP_K))
 
     with Flow.load_config(flow_file) as index_flow:
         index_flow.update(input_fn=docs_updated)
@@ -149,5 +152,6 @@ def test_update_vector(config, mocker, flow_file):
     with Flow.load_config(flow_file) as search_flow:
         search_flow.search(
             input_fn=document_generator(start=10, num_docs=20, num_chunks=num_chunks),
-            on_done=validate_result_factory(has_changed=True, num_matches=num_docs))
+            on_done=mock)
     mock.assert_called_once()
+    validate_callback(mock, validate_result_factory(has_changed=True, num_matches=num_docs))

--- a/tests/integration/crud/simple/test_crud.py
+++ b/tests/integration/crud/simple/test_crud.py
@@ -11,6 +11,8 @@ from jina.executors.indexers import BaseIndexer
 from jina import Document
 from jina.flow import Flow
 
+from tests import validate_callback
+
 random.seed(0)
 np.random.seed(0)
 
@@ -69,7 +71,6 @@ def test_delete_vector(config, mocker, flow_file, has_content, compound):
 
     def validate_result_factory(num_matches):
         def validate_results(resp):
-            mock()
             assert len(resp.docs) == NUMBER_OF_SEARCHES
             for doc in resp.docs:
                 assert len(doc.matches) == num_matches
@@ -83,8 +84,9 @@ def test_delete_vector(config, mocker, flow_file, has_content, compound):
     mock = mocker.Mock()
     with Flow.load_config(flow_file) as search_flow:
         search_flow.search(input_fn=random_docs(0, NUMBER_OF_SEARCHES),
-                           on_done=validate_result_factory(TOPK))
+                           on_done=mock)
     mock.assert_called_once()
+    validate_callback(mock, validate_result_factory(TOPK))
 
     delete_ids = []
     for d in random_docs(0, 10, has_content=has_content):
@@ -99,8 +101,9 @@ def test_delete_vector(config, mocker, flow_file, has_content, compound):
     mock = mocker.Mock()
     with Flow.load_config(flow_file) as search_flow:
         search_flow.search(input_fn=random_docs(0, NUMBER_OF_SEARCHES),
-                           on_done=validate_result_factory(0))
+                           on_done=mock)
     mock.assert_called_once()
+    validate_callback(mock, validate_result_factory(0))
 
 
 @pytest.mark.parametrize('as_string', [True, False])
@@ -109,7 +112,6 @@ def test_delete_kv(config, mocker, as_string):
 
     def validate_result_factory(num_matches):
         def validate_results(resp):
-            mock()
             assert len(resp.docs) == num_matches
 
         return validate_results
@@ -120,8 +122,9 @@ def test_delete_kv(config, mocker, as_string):
     mock = mocker.Mock()
     with Flow.load_config(flow_file) as search_flow:
         search_flow.search(input_fn=chain(random_docs(2, 5), random_docs(100, 120)),
-                           on_done=validate_result_factory(3))
+                           on_done=mock)
     mock.assert_called_once()
+    validate_callback(mock, validate_result_factory(3))
 
     with Flow.load_config(flow_file) as index_flow:
         index_flow.delete(ids=get_ids_to_delete(0, 3, as_string))
@@ -130,8 +133,9 @@ def test_delete_kv(config, mocker, as_string):
     mock = mocker.Mock()
     with Flow.load_config(flow_file) as search_flow:
         search_flow.search(input_fn=random_docs(2, 4),
-                           on_done=validate_result_factory(1))
+                           on_done=mock)
     mock.assert_called_once()
+    validate_callback(mock, validate_result_factory(1))
 
 
 @pytest.mark.parametrize('flow_file, compound', [
@@ -145,7 +149,6 @@ def test_update_vector(config, mocker, flow_file, compound):
 
     def validate_result_factory(has_changed):
         def validate_results(resp):
-            mock()
             assert len(resp.docs) == NUMBER_OF_SEARCHES
             hash_set_before = [hash(d.embedding.tobytes()) for d in docs_before]
             hash_set_updated = [hash(d.embedding.tobytes()) for d in docs_updated]
@@ -172,8 +175,9 @@ def test_update_vector(config, mocker, flow_file, compound):
     with Flow.load_config(flow_file) as search_flow:
         search_docs = list(random_docs(0, NUMBER_OF_SEARCHES))
         search_flow.search(input_fn=search_docs,
-                           on_done=validate_result_factory(has_changed=False))
+                           on_done=mock)
     mock.assert_called_once()
+    validate_callback(mock, validate_result_factory(has_changed=False))
 
     with Flow.load_config(flow_file) as index_flow:
         index_flow.update(input_fn=docs_updated)
@@ -182,8 +186,9 @@ def test_update_vector(config, mocker, flow_file, compound):
     mock = mocker.Mock()
     with Flow.load_config(flow_file) as search_flow:
         search_flow.search(input_fn=random_docs(0, NUMBER_OF_SEARCHES),
-                           on_done=validate_result_factory(has_changed=True))
+                           on_done=mock)
     mock.assert_called_once()
+    validate_callback(mock, validate_result_factory(has_changed=True))
 
 
 def test_update_kv(config, mocker):
@@ -193,7 +198,6 @@ def test_update_kv(config, mocker):
     docs_updated = list(random_docs(0, 10))
 
     def validate_results(resp):
-        mock()
         assert len(resp.docs) == NUMBER_OF_SEARCHES
 
     with Flow.load_config(flow_file) as index_flow:
@@ -206,8 +210,9 @@ def test_update_kv(config, mocker):
     with Flow.load_config(flow_file) as search_flow:
         search_docs = list(random_docs(0, NUMBER_OF_SEARCHES))
         search_flow.search(input_fn=search_docs,
-                           on_done=validate_results)
+                           on_done=mock)
     mock.assert_called_once()
+    validate_callback(mock, validate_results)
 
     with Flow.load_config(flow_file) as index_flow:
         index_flow.update(input_fn=docs_updated)
@@ -216,5 +221,6 @@ def test_update_kv(config, mocker):
     mock = mocker.Mock()
     with Flow.load_config(flow_file) as search_flow:
         search_flow.search(input_fn=random_docs(0, NUMBER_OF_SEARCHES),
-                           on_done=validate_results)
+                           on_done=mock)
     mock.assert_called_once()
+    validate_callback(mock, validate_results)

--- a/tests/integration/crud/simple/test_crud_readme.py
+++ b/tests/integration/crud/simple/test_crud_readme.py
@@ -12,37 +12,37 @@ def test_crud_in_readme(mocker):
             Document(id='🐯', embedding=np.array([1, 1]), tags={'guardian': 'White Tiger', 'position': 'West'})]
 
     # create
-    m = mocker.Mock()
+    mock = mocker.Mock()
     with Flow().add(uses='_index') as f:
-        f.index(docs, on_done=m)
+        f.index(docs, on_done=mock)
 
-    m.assert_called_once()
+    mock.assert_called_once()
 
     # read
     def validate(req):
         assert len(req.docs[0].matches) == 3
-        for m in req.docs[0].matches:
-            assert m.id != '🐯'
-            assert 'position' in m.tags
-            assert 'guardian' in m.tags
-            assert m.score.ref_id == req.docs[0].id
+        for match in req.docs[0].matches:
+            assert match.id != '🐯'
+            assert 'position' in match.tags
+            assert 'guardian' in match.tags
+            assert match.score.ref_id == req.docs[0].id
 
-    m = mocker.Mock()
+    mock = mocker.Mock()
 
     with f:
         f.search(docs[0],
                  top_k=3,
-                 on_done=m)
-    validate_callback(m, validate)
+                 on_done=mock)
+    validate_callback(mock, validate)
 
     # update
-    m = mocker.Mock()
+    mock = mocker.Mock()
 
     d = docs[0]
     d.embedding = np.array([1, 1])
     with f:
-        f.update(d, on_done=m)
-    m.assert_called_once()
+        f.update(d, on_done=mock)
+    mock.assert_called_once()
 
     # search again
 
@@ -52,30 +52,30 @@ def test_crud_in_readme(mocker):
         # embeddings are removed in the CompoundIndexer via ExcludeQL
         np.testing.assert_array_equal(req.docs[0].matches[0].embedding, np.array(None))
 
-    m = mocker.Mock()
+    mock = mocker.Mock()
 
     with f:
         f.search(docs[0],
                  top_k=1,
-                 on_done=m)
-    validate_callback(m, validate)
+                 on_done=mock)
+    validate_callback(mock, validate)
 
     # delete
-    m = mocker.Mock()
+    mock = mocker.Mock()
 
     with f:
-        f.delete(['🐦', '🐲'], on_done=m)
-    m.assert_called_once()
+        f.delete(['🐦', '🐲'], on_done=mock)
+    mock.assert_called_once()
 
     # search again
 
     def validate(req):
         assert len(req.docs[0].matches) == 2
 
-    m = mocker.Mock()
+    mock = mocker.Mock()
 
     with f:
         f.search(docs[0],
                  top_k=4,
-                 on_done=m)
-    validate_callback(m, validate)
+                 on_done=mock)
+    validate_callback(mock, validate)

--- a/tests/integration/crud_corrupted_docs/test_crud_corrupted_docs.py
+++ b/tests/integration/crud_corrupted_docs/test_crud_corrupted_docs.py
@@ -8,6 +8,8 @@ from jina import Document
 from jina.executors.indexers import BaseIndexer
 from jina.flow import Flow
 
+from tests import validate_callback
+
 
 def random_docs_only_tags(nr_docs, start=0):
     for j in range(start, nr_docs + start):
@@ -50,7 +52,6 @@ def test_only_tags(tmp_path, mocker):
 
     def validate_result_factory(num_matches):
         def validate_results(resp):
-            mock()
             assert len(resp.docs) == NUMBER_OF_SEARCHES
             for doc in resp.docs:
                 assert len(doc.matches) == num_matches
@@ -64,8 +65,9 @@ def test_only_tags(tmp_path, mocker):
     mock = mocker.Mock()
     with f:
         f.search(input_fn=docs_search,
-                 on_done=validate_result_factory(EXPECTED_ONLY_TAGS_RESULTS))
+                 on_done=mock)
     mock.assert_called_once()
+    validate_callback(mock, validate_result_factory(EXPECTED_ONLY_TAGS_RESULTS))
 
     # this won't increase the index size as the ids are new
     with f:
@@ -75,14 +77,16 @@ def test_only_tags(tmp_path, mocker):
     mock = mocker.Mock()
     with f:
         f.search(input_fn=docs_search,
-                 on_done=validate_result_factory(EXPECTED_ONLY_TAGS_RESULTS))
+                 on_done=mock)
     mock.assert_called_once()
+    validate_callback(mock, validate_result_factory(EXPECTED_ONLY_TAGS_RESULTS))
 
     mock = mocker.Mock()
     with f:
         f.search(input_fn=docs_search,
-                 on_done=validate_result_factory(0))
+                 on_done=mock)
     mock.assert_called_once()
+    validate_callback(mock, validate_result_factory(0))
 
 
 np.random.seed(0)
@@ -130,7 +134,6 @@ def test_only_embedding_and_mime_type(tmp_path, mocker, field):
 
     def validate_result_factory(num_matches):
         def validate_results(resp):
-            mock()
             assert len(resp.docs) == NUMBER_OF_SEARCHES
             for doc in resp.docs:
                 assert len(doc.matches) == num_matches
@@ -155,8 +158,9 @@ def test_only_embedding_and_mime_type(tmp_path, mocker, field):
     mock = mocker.Mock()
     with f:
         f.search(input_fn=docs_search,
-                 on_done=validate_result_factory(TOPK))
+                 on_done=mock)
     mock.assert_called_once()
+    validate_callback(mock, validate_result_factory(TOPK))
 
     # this won't increase the index size as the ids are new
     with f:
@@ -166,8 +170,9 @@ def test_only_embedding_and_mime_type(tmp_path, mocker, field):
     mock = mocker.Mock()
     with f:
         f.search(input_fn=docs_search,
-                 on_done=validate_result_factory(TOPK))
+                 on_done=mock)
     mock.assert_called_once()
+    validate_callback(mock, validate_result_factory(TOPK))
 
     with f:
         f.delete(ids=[d.id for d in all_docs_indexed])
@@ -176,8 +181,9 @@ def test_only_embedding_and_mime_type(tmp_path, mocker, field):
     mock = mocker.Mock()
     with f:
         f.search(input_fn=docs_search,
-                 on_done=validate_result_factory(0))
+                 on_done=mock)
     mock.assert_called_once()
+    validate_callback(mock, validate_result_factory(0))
 
 
 def random_docs_image_mime_text_content(nr_docs, start=0):
@@ -206,7 +212,6 @@ def test_wrong_mime_type(tmp_path, mocker):
 
     def validate_result_factory(num_matches):
         def validate_results(resp):
-            mock()
             assert len(resp.docs) == NUMBER_OF_SEARCHES
             for doc in resp.docs:
                 assert len(doc.matches) == num_matches
@@ -222,8 +227,9 @@ def test_wrong_mime_type(tmp_path, mocker):
     mock = mocker.Mock()
     with f_query:
         f_query.search(input_fn=docs_search,
-                       on_done=validate_result_factory(TOPK))
+                       on_done=mock)
     mock.assert_called_once()
+    validate_callback(mock, validate_result_factory(TOPK))
 
     # this won't increase the index size as the ids are new
     with f_index:
@@ -233,8 +239,9 @@ def test_wrong_mime_type(tmp_path, mocker):
     mock = mocker.Mock()
     with f_query:
         f_query.search(input_fn=docs_search,
-                       on_done=validate_result_factory(TOPK))
+                       on_done=mock)
     mock.assert_called_once()
+    validate_callback(mock, validate_result_factory(TOPK))
 
     with f_index:
         f_index.delete(ids=[d.id for d in all_docs_indexed])
@@ -243,8 +250,9 @@ def test_wrong_mime_type(tmp_path, mocker):
     mock = mocker.Mock()
     with f_query:
         f_query.search(input_fn=docs_search,
-                       on_done=validate_result_factory(0))
+                       on_done=mock)
     mock.assert_called_once()
+    validate_callback(mock, validate_result_factory(0))
 
 
 START_SHAPE = (7)
@@ -280,7 +288,6 @@ def test_dimensionality_search_wrong(tmp_path, mocker):
 
     def validate_result_factory(num_matches):
         def validate_results(resp):
-            mock()
             assert len(resp.docs) == NUMBER_OF_SEARCHES
             for doc in resp.docs:
                 assert len(doc.matches) == num_matches
@@ -295,8 +302,9 @@ def test_dimensionality_search_wrong(tmp_path, mocker):
     with f_query:
         f_query.search(input_fn=docs_search,
                        # 0 because search docs have wrong shape
-                       on_done=validate_result_factory(0))
+                       on_done=mock)
     mock.assert_called_once()
+    validate_callback(mock, validate_result_factory(0))
 
     # this won't increase the index size as the ids are new
     with f_index:
@@ -307,8 +315,9 @@ def test_dimensionality_search_wrong(tmp_path, mocker):
     with f_query:
         f_query.search(input_fn=docs_search,
                        # 0 because search docs have wrong shape
-                       on_done=validate_result_factory(0))
+                       on_done=mock)
     mock.assert_called_once()
+    validate_callback(mock, validate_result_factory(0))
 
     with f_index:
         f_index.delete(ids=[d.id for d in all_docs_indexed])
@@ -317,5 +326,6 @@ def test_dimensionality_search_wrong(tmp_path, mocker):
     mock = mocker.Mock()
     with f_query:
         f_query.search(input_fn=docs_search,
-                       on_done=validate_result_factory(0))
+                       on_done=mock)
     mock.assert_called_once()
+    validate_callback(mock, validate_result_factory(0))

--- a/tests/integration/doccache/test_crud_cache.py
+++ b/tests/integration/doccache/test_crud_cache.py
@@ -8,7 +8,7 @@ from jina.executors.indexers import BaseIndexer
 from jina.executors.indexers.cache import DocCache
 from jina.executors.indexers.keyvalue import BinaryPbIndexer
 from jina.executors.indexers.vector import NumpyIndexer
-from tests import get_documents
+from tests import get_documents, validate_callback
 
 cur_dir = os.path.dirname(os.path.abspath(__file__))
 
@@ -137,7 +137,6 @@ def test_cache_crud(
 
     def validate_result_factory(num_matches):
         def validate_results(resp):
-            mock()
             assert len(resp.docs) == DOCS_TO_SEARCH
             for d in resp.docs:
                 matches = list(d.matches)
@@ -179,9 +178,10 @@ def test_cache_crud(
     with flow_query as f:
         f.search(
             search_docs,
-            on_done=validate_result_factory(TOP_K)
+            on_done=mock
         )
     mock.assert_called_once()
+    validate_callback(mock, validate_result_factory(TOP_K))
 
     # UPDATE
     docs.extend(new_docs)
@@ -209,9 +209,10 @@ def test_cache_crud(
     with flow_query as f:
         f.search(
             search_docs,
-            on_done=validate_result_factory(TOP_K)
+            on_done=mock
         )
     mock.assert_called_once()
+    validate_callback(mock, validate_result_factory(TOP_K))
 
     # DELETE
     delete_ids = []
@@ -229,6 +230,7 @@ def test_cache_crud(
     with flow_query as f:
         f.search(
             search_docs,
-            on_done=validate_result_factory(0)
+            on_done=mock
         )
     mock.assert_called_once()
+    validate_callback(mock, validate_result_factory(0))

--- a/tests/integration/encode_driver_batching/test_encode_driver_batching.py
+++ b/tests/integration/encode_driver_batching/test_encode_driver_batching.py
@@ -9,6 +9,8 @@ from jina.drivers.encode import LegacyEncodeDriver
 from jina.flow import Flow
 from jina import Document, NdArray
 
+from tests import validate_callback
+
 
 class MockEncoder(BaseEncoder):
     def __init__(self,
@@ -84,7 +86,7 @@ def document_generator(num_docs, num_chunks, num_chunks_chunks):
 
 @pytest.mark.parametrize('request_size', [8, 16, 32])
 @pytest.mark.parametrize('driver_batch_size', [3, 4, 13])
-def test_encode_driver_batching(request_size, driver_batch_size, tmpdir):
+def test_encode_driver_batching(request_size, driver_batch_size, tmpdir, mocker):
     num_docs = 137
     num_chunks = 0
     num_chunks_chunks = 0
@@ -99,9 +101,6 @@ def test_encode_driver_batching(request_size, driver_batch_size, tmpdir):
         for doc in resp.search.docs:
             assert NdArray(doc.embedding).value is not None
 
-    def fail_if_error(resp):
-        assert False
-
     encoder = MockEncoder(driver_batch_size=driver_batch_size,
                           num_docs_in_same_request=request_size,
                           total_num_docs=num_docs)
@@ -115,11 +114,17 @@ def test_encode_driver_batching(request_size, driver_batch_size, tmpdir):
     executor_yml_file = os.path.join(tmpdir, 'executor.yml')
     encoder.save_config(executor_yml_file)
 
+    on_done_mock = mocker.Mock()
+    on_error_mock = mocker.Mock()
+
     with Flow().add(uses=executor_yml_file) as f:
         f.search(input_fn=document_generator(num_docs, num_chunks, num_chunks_chunks),
                  request_size=request_size,
-                 on_done=validate_response,
-                 on_error=fail_if_error)
+                 on_done=on_done_mock,
+                 on_error=on_error_mock)
+
+    validate_callback(on_done_mock, validate_response)
+    on_error_mock.assert_not_called()
 
 
 @pytest.mark.parametrize('request_size', [8, 16, 32])
@@ -127,7 +132,7 @@ def test_encode_driver_batching(request_size, driver_batch_size, tmpdir):
 @pytest.mark.parametrize('num_chunks', [2, 8])
 @pytest.mark.parametrize('num_chunks_chunks', [2, 8])
 def test_encode_driver_batching_with_chunks(request_size, driver_batch_size, num_chunks, num_chunks_chunks,
-                                            tmpdir):
+                                            tmpdir, mocker):
     num_docs = 137
     num_requests = int(num_docs / request_size)
     num_docs_last_req_batch = num_docs % (num_requests * request_size)
@@ -143,9 +148,6 @@ def test_encode_driver_batching_with_chunks(request_size, driver_batch_size, num
                 for chunk_chunk in chunk.chunks:
                     assert NdArray(chunk_chunk.embedding).value is not None
 
-    def fail_if_error(resp):
-        assert False
-
     encoder = MockEncoder(driver_batch_size=driver_batch_size,
                           num_docs_in_same_request=request_size + request_size * num_chunks + request_size * num_chunks * num_chunks_chunks,
                           total_num_docs=num_docs + num_docs * num_chunks + num_docs * num_chunks * num_chunks_chunks)
@@ -159,8 +161,14 @@ def test_encode_driver_batching_with_chunks(request_size, driver_batch_size, num
     executor_yml_file = os.path.join(tmpdir, 'executor.yml')
     encoder.save_config(executor_yml_file)
 
+    on_done_mock = mocker.Mock()
+    on_error_mock = mocker.Mock()
+
     with Flow().add(uses=executor_yml_file) as f:
         f.search(input_fn=document_generator(num_docs, num_chunks, num_chunks_chunks),
                  request_size=request_size,
-                 on_done=validate_response,
-                 on_error=fail_if_error)
+                 on_done=on_done_mock,
+                 on_error=on_error_mock)
+
+    validate_callback(on_done_mock, validate_response)
+    on_error_mock.assert_not_called()

--- a/tests/integration/evaluation/test_evaluation_from_file.py
+++ b/tests/integration/evaluation/test_evaluation_from_file.py
@@ -87,12 +87,12 @@ def test_evaluation_from_file(random_workspace, index_groundtruth, evaluate_docs
         for gt in resp.groundtruths:
             assert gt.tags['groundtruth']
 
-    m = mocker.Mock()
+    mock = mocker.Mock()
     with Flow.load_config(search_yaml) as evaluate_flow:
         evaluate_flow.search(
             input_fn=evaluate_docs,
-            on_done=m
+            on_done=mock
         )
 
-    m.assert_called_once()
-    validate_callback(m, validate_evaluation_response)
+    mock.assert_called_once()
+    validate_callback(mock, validate_evaluation_response)

--- a/tests/integration/high_order_matches/test_adjacency.py
+++ b/tests/integration/high_order_matches/test_adjacency.py
@@ -9,25 +9,30 @@ from tests import random_docs, validate_callback
 cur_dir = os.path.dirname(os.path.abspath(__file__))
 
 
-# def test_high_order_matches():
-#     f = Flow().add(uses=os.path.join(cur_dir, 'test-adjacency.yml'))
-#
-#     with f:
-#         f.index(random_docs(100, chunks_per_doc=0, embed_dim=2))
-#
-#     with f:
-#         f.search(random_docs(1, chunks_per_doc=0, embed_dim=2), on_done=validate)
+def validate(req):
+    assert len(req.docs) == 1
+    assert len(req.docs[0].matches) == 5
+    assert len(req.docs[0].matches) == 5
+    assert len(req.docs[0].matches[0].matches) == 5
+    assert len(req.docs[0].matches[-1].matches) == 5
+    assert len(req.docs[0].matches[0].matches[0].matches) == 0
+
+
+def test_high_order_matches(mocker):
+    response_mock = mocker.Mock()
+
+    f = Flow().add(uses=os.path.join(cur_dir, 'test-adjacency.yml'))
+
+    with f:
+        f.index(random_docs(100, chunks_per_doc=0, embed_dim=2))
+
+    with f:
+        f.search(random_docs(1, chunks_per_doc=0, embed_dim=2), on_done=response_mock)
+    validate_callback(response_mock, validate)
 
 
 @pytest.mark.parametrize('restful', [False, True])
 def test_high_order_matches_integrated(mocker, restful):
-    def validate(req):
-        assert len(req.docs) == 1
-        assert len(req.docs[0].matches) == 5
-        assert len(req.docs[0].matches) == 5
-        assert len(req.docs[0].matches[0].matches) == 5
-        assert len(req.docs[0].matches[-1].matches) == 5
-        assert len(req.docs[0].matches[0].matches[0].matches) == 0
 
     response_mock = mocker.Mock()
     # this is equivalent to the last test but with simplified YAML spec.

--- a/tests/integration/issues/github_1072/test_queryset.py
+++ b/tests/integration/issues/github_1072/test_queryset.py
@@ -8,6 +8,8 @@ from jina.flow import Flow
 from jina.proto import jina_pb2
 from jina.types.ndarray.generic import NdArray
 
+from tests import validate_callback
+
 cur_dir = os.path.dirname(os.path.abspath(__file__))
 
 
@@ -32,21 +34,21 @@ def test_queryset_with_struct(random_workspace, mocker):
          .add(uses='- !FilterQL | {lookups: {tags__label__in: [label1, label2]}, traversal_paths: [r]}'))
 
     def validate_all_docs(resp):
-        mock1()
         assert len(resp.docs) == total_docs
 
     def validate_label2_docs(resp):
-        mock2()
         assert len(resp.docs) == total_docs / 2
 
     mock1 = mocker.Mock()
     mock2 = mocker.Mock()
     with f:
         # keep all the docs
-        f.index(docs, on_done=validate_all_docs)
+        f.index(docs, on_done=mock1)
         # keep only the docs with label2
         qs = QueryLang({'name': 'FilterQL', 'priority': 1, 'parameters': {'lookups': {'tags__label': 'label2'}, 'traversal_paths': ['r']}})
-        f.index(docs, queryset=qs, on_done=validate_label2_docs)
+        f.index(docs, queryset=qs, on_done=mock2)
 
     mock1.assert_called_once()
+    validate_callback(mock1, validate_all_docs)
     mock2.assert_called_once()
+    validate_callback(mock2, validate_label2_docs)

--- a/tests/integration/issues/github_1229/test_sharding_empty_index.py
+++ b/tests/integration/issues/github_1229/test_sharding_empty_index.py
@@ -4,6 +4,8 @@ import pytest
 
 from jina import Flow, Document
 
+from tests import validate_callback
+
 callback_was_called = False
 
 
@@ -60,13 +62,13 @@ def test_sharding_empty_index(tmpdir, execution_number, mocker):
             query.append(doc)
 
     def callback(result):
-        mock()
         assert len(result.docs) == num_query
         for d in result.docs:
             assert len(list(d.matches)) == num_docs
 
     mock = mocker.Mock()
     with f:
-        f.search(query, on_done=callback)
+        f.search(query, on_done=mock)
 
     mock.assert_called_once()
+    validate_callback(mock, callback)

--- a/tests/integration/issues/github_1684/test_empty_shard.py
+++ b/tests/integration/issues/github_1684/test_empty_shard.py
@@ -6,6 +6,8 @@ import numpy as np
 from jina.flow import Flow
 from jina import Document
 
+from tests import validate_callback
+
 cur_dir = os.path.dirname(os.path.abspath(__file__))
 
 
@@ -20,20 +22,17 @@ def test_empty_shard(mocker, workdir):
     doc = Document()
     doc.text = 'text'
     doc.embedding = np.array([1, 1, 1])
-    mock = mocker.Mock()
 
     def validate_response(resp):
-        mock()
         assert len(resp.docs) == 1
         assert len(resp.docs[0].matches) == 0
 
+    mock = mocker.Mock()
     error_mock = mocker.Mock()
 
-    def on_error_call():
-        error_mock()
-
     with Flow.load_config(os.path.join(cur_dir, 'flow.yml')) as f:
-        f.search([doc], on_done=validate_response, on_error=on_error_call)
+        f.search([doc], on_done=mock, on_error=error_mock)
 
-    mock.assert_called_once()
+    validate_callback(mock, validate_response)
+
     error_mock.assert_not_called()

--- a/tests/integration/issues/github_1684/test_empty_shard.py
+++ b/tests/integration/issues/github_1684/test_empty_shard.py
@@ -33,6 +33,7 @@ def test_empty_shard(mocker, workdir):
     with Flow.load_config(os.path.join(cur_dir, 'flow.yml')) as f:
         f.search([doc], on_done=mock, on_error=error_mock)
 
+    mock.assert_called_once()
     validate_callback(mock, validate_response)
 
     error_mock.assert_not_called()

--- a/tests/integration/issues/github_929/test_shelfindexer.py
+++ b/tests/integration/issues/github_929/test_shelfindexer.py
@@ -6,7 +6,7 @@ import pytest
 from jina.flow import Flow
 from jina.logging.profile import used_memory
 from jina.proto import jina_pb2
-from tests import random_docs
+from tests import random_docs, validate_callback
 
 cur_dir = os.path.dirname(os.path.abspath(__file__))
 
@@ -27,7 +27,6 @@ def test_shelf_in_flow(uses, mocker):
     d = jina_pb2.DocumentProto()
 
     def validate(req):
-        mock()
         m4 = used_memory()
         print(f'before: {m1}, after index: {m2}, after loading: {m3} after searching {m4}')
 
@@ -35,7 +34,8 @@ def test_shelf_in_flow(uses, mocker):
 
     with f:
         m3 = used_memory()
-        f.search([d], on_done=validate)
+        f.search([d], on_done=mock)
 
     shutil.rmtree('test-workspace', ignore_errors=False, onerror=None)
     mock.assert_called_once()
+    validate_callback(mock, validate)

--- a/tests/integration/issues/github_969/test_messages_different_types.py
+++ b/tests/integration/issues/github_969/test_messages_different_types.py
@@ -31,7 +31,6 @@ def input_doc_with_chunks():
 
 def test_message_docs_different_chunk_types(input_doc_with_chunks, mocker):
     def validate_chunks_fn(resp):
-        mock()
         assert len(resp.search.docs) == 1
         doc = resp.search.docs[0]
         assert int(doc.tags['id']) == 1
@@ -53,9 +52,10 @@ def test_message_docs_different_chunk_types(input_doc_with_chunks, mocker):
     mock = mocker.Mock()
 
     with Flow().add() as f:
-        f.search(input_fn=[input_doc_with_chunks], on_done=validate_chunks_fn)
+        f.search(input_fn=[input_doc_with_chunks], on_done=mock)
 
     mock.assert_called_once()
+    validate_callback(mock, validate_chunks_fn)
 
 
 @pytest.fixture
@@ -77,7 +77,6 @@ def input_doc_with_matches():
 
 def test_message_docs_different_matches_types(input_doc_with_matches, mocker):
     def validate_matches_fn(resp):
-        mock()
         assert len(resp.search.docs) == 1
         doc = resp.search.docs[0]
         assert int(doc.tags['id']) == 1
@@ -98,8 +97,9 @@ def test_message_docs_different_matches_types(input_doc_with_matches, mocker):
 
     mock = mocker.Mock()
     with Flow().add() as f:
-        f.search(input_fn=[input_doc_with_matches], on_done=validate_matches_fn)
+        f.search(input_fn=[input_doc_with_matches], on_done=mock)
     mock.assert_called_once()
+    validate_callback(mock, validate_matches_fn)
 
 
 @pytest.fixture
@@ -164,10 +164,10 @@ def test_message_docs_different_chunks_and_matches_types(input_doc_chunks_and_ma
         assert int(match2.tags['id']) == 30
         assert match2.buffer == buffer
 
-    response_mock = mocker.Mock()
+    mock = mocker.Mock()
 
     with Flow().add() as f:
-        f.search(input_fn=[input_doc_chunks_and_matches], on_done=response_mock)
+        f.search(input_fn=[input_doc_chunks_and_matches], on_done=mock)
 
-    validate_callback(response_mock, validate_chunks_and_matches_fn)
+    validate_callback(mock, validate_chunks_and_matches_fn)
 

--- a/tests/integration/issues/github_976/test_topk.py
+++ b/tests/integration/issues/github_976/test_topk.py
@@ -8,7 +8,7 @@ from jina.flow import Flow
 from jina.proto import jina_pb2
 from jina.types.ndarray.generic import NdArray
 
-from pytest import validate_callback
+from tests import validate_callback
 
 
 @pytest.fixture

--- a/tests/integration/issues/github_976/test_topk.py
+++ b/tests/integration/issues/github_976/test_topk.py
@@ -8,6 +8,8 @@ from jina.flow import Flow
 from jina.proto import jina_pb2
 from jina.types.ndarray.generic import NdArray
 
+from pytest import validate_callback
+
 
 @pytest.fixture
 def config(tmpdir):
@@ -32,7 +34,6 @@ def test_topk(config, mocker):
     TOPK = int(os.getenv('JINA_TOPK'))
 
     def validate(resp):
-        mock()
         assert len(resp.search.docs) == NDOCS
         for doc in resp.search.docs:
             assert len(doc.matches) == TOPK
@@ -43,9 +44,10 @@ def test_topk(config, mocker):
     mock = mocker.Mock()
     with Flow.load_config('flow.yml') as search_flow:
         search_flow.search(input_fn=random_docs(NDOCS),
-                           on_done=validate)
+                           on_done=mock)
 
     mock.assert_called_once()
+    validate_callback(mock, validate)
 
 
 def test_topk_override(config, mocker):
@@ -53,7 +55,6 @@ def test_topk_override(config, mocker):
     TOPK_OVERRIDE = 11
 
     def validate(resp):
-        mock()
         assert len(resp.search.docs) == NDOCS
         for doc in resp.search.docs:
             assert len(doc.matches) == TOPK_OVERRIDE
@@ -67,5 +68,6 @@ def test_topk_override(config, mocker):
     mock = mocker.Mock()
     with Flow.load_config('flow.yml') as search_flow:
         search_flow.search(input_fn=random_docs(NDOCS),
-                           on_done=validate, queryset=[top_k_queryset])
+                           on_done=mock, queryset=[top_k_queryset])
     mock.assert_called_once()
+    validate_callback(mock, validate)

--- a/tests/integration/mime/test_segmenter.py
+++ b/tests/integration/mime/test_segmenter.py
@@ -4,7 +4,7 @@ import pytest
 
 from jina.executors.segmenters import BaseSegmenter
 from jina.flow import Flow
-from tests import random_docs
+from tests import random_docs, validate_callback
 
 cur_dir = os.path.dirname(os.path.abspath(__file__))
 
@@ -14,14 +14,10 @@ class DummySegment(BaseSegmenter):
         return [dict(buffer=b'aa'), dict(buffer=b'bb')]
 
 
-def validate_factory(mock):
-    def validate(req):
-        mock()
-        chunk_ids = [c.id for d in req.index.docs for c in d.chunks]
-        assert len(chunk_ids) == len(set(chunk_ids))
-        assert len(chunk_ids) == 20
-
-    return validate
+def validate(req):
+    chunk_ids = [c.id for d in req.index.docs for c in d.chunks]
+    assert len(chunk_ids) == len(set(chunk_ids))
+    assert len(chunk_ids) == 20
 
 
 @pytest.mark.parametrize('restful', [False, True])
@@ -29,8 +25,9 @@ def test_dummy_seg(mocker, restful):
     mock = mocker.Mock()
     f = Flow(restful=restful).add(uses='DummySegment')
     with f:
-        f.index(input_fn=random_docs(10, chunks_per_doc=0), on_done=validate_factory(mock))
+        f.index(input_fn=random_docs(10, chunks_per_doc=0), on_done=mock)
     mock.assert_called_once()
+    validate_callback(mock, validate)
 
 
 @pytest.mark.parametrize('restful', [False, True])
@@ -38,8 +35,9 @@ def test_dummy_seg_random(mocker, restful):
     mock = mocker.Mock()
     f = Flow(restful=restful).add(uses=os.path.join(cur_dir, 'dummy-seg-random.yml'))
     with f:
-        f.index(input_fn=random_docs(10, chunks_per_doc=0), on_done=validate_factory(mock))
+        f.index(input_fn=random_docs(10, chunks_per_doc=0), on_done=mock)
     mock.assert_called_once()
+    validate_callback(mock, validate)
 
 
 @pytest.mark.parametrize('restful', [False, True])
@@ -47,5 +45,6 @@ def test_dummy_seg_not_random(mocker, restful):
     mock = mocker.Mock()
     f = Flow(restful=restful).add(uses=os.path.join(cur_dir, 'dummy-seg-not-random.yml'))
     with f:
-        f.index(input_fn=random_docs(10, chunks_per_doc=0), on_done=validate_factory(mock))
+        f.index(input_fn=random_docs(10, chunks_per_doc=0), on_done=mock)
     mock.assert_called_once()
+    validate_callback(mock, validate)

--- a/tests/integration/multimodal/test_multimodal_parallel.py
+++ b/tests/integration/multimodal/test_multimodal_parallel.py
@@ -7,6 +7,8 @@ from jina.flow import Flow
 from jina.proto import jina_pb2
 from jina.types.ndarray.generic import NdArray
 
+from tests import validate_callback
+
 NUM_DOCS = 100
 cur_dir = os.path.dirname(os.path.abspath(__file__))
 
@@ -43,7 +45,6 @@ def test_multimodal_embedding_parallel(multimodal_documents, mocker, monkeypatch
     monkeypatch.setenv("RESTFUL", restful)
 
     def validate_response(resp):
-        mock()
         assert len(resp.index.docs) == NUM_DOCS
         for idx, doc in enumerate(resp.index.docs):
             np.testing.assert_almost_equal(NdArray(doc.embedding).value, np.array([idx, idx, idx, idx, idx]))
@@ -51,8 +52,9 @@ def test_multimodal_embedding_parallel(multimodal_documents, mocker, monkeypatch
     mock = mocker.Mock()
     with Flow.load_config(os.path.join(cur_dir, 'flow-embedding-multimodal-parallel.yml')) as index_gt_flow:
         index_gt_flow.index(input_fn=multimodal_documents,
-                            on_done=validate_response)
+                            on_done=mock)
     mock.assert_called_once()
+    validate_callback(mock, validate_response)
 
 
 @pytest.fixture
@@ -93,7 +95,6 @@ def test_multimodal_all_types_parallel(multimodal_all_types_documents, mocker, m
     monkeypatch.setenv("RESTFUL", restful)
 
     def validate_response(resp):
-        mock()
         assert len(resp.index.docs) == NUM_DOCS
         for idx, doc in enumerate(resp.index.docs):
             np.testing.assert_almost_equal(NdArray(doc.embedding).value,
@@ -102,5 +103,6 @@ def test_multimodal_all_types_parallel(multimodal_all_types_documents, mocker, m
     mock = mocker.Mock()
     with Flow.load_config(os.path.join(cur_dir, 'flow-multimodal-all-types-parallel.yml')) as index_gt_flow:
         index_gt_flow.index(input_fn=multimodal_all_types_documents,
-                            on_done=validate_response)
+                            on_done=mock)
     mock.assert_called_once()
+    validate_callback(mock, validate_response)

--- a/tests/integration/ref_indexer/test_numpy_indexer_with_ref_indexer.py
+++ b/tests/integration/ref_indexer/test_numpy_indexer_with_ref_indexer.py
@@ -7,6 +7,8 @@ import pytest
 from jina.flow import Flow
 from jina import Document
 
+from tests import validate_callback
+
 cur_dir = os.path.dirname(os.path.abspath(__file__))
 
 
@@ -59,16 +61,16 @@ def test_indexer_with_ref_indexer(random_workspace, parallel, index_docs, mocker
     mock = mocker.Mock()
 
     def validate_response(resp):
-        mock()
         assert len(resp.search.docs) == 1
         assert len(resp.search.docs[0].matches) == top_k
 
     query_document = Document()
     query_document.embedding = np.array([1, 1])
     with Flow.load_config(os.path.join('query.yml')) as query_flow:
-        query_flow.search(input_fn=[query_document], on_done=validate_response, top_k=top_k)
+        query_flow.search(input_fn=[query_document], on_done=mock, top_k=top_k)
 
     mock.assert_called_once()
+    validate_callback(mock, validate_response)
 
 
 @pytest.mark.parametrize('parallel', [1, 2], indirect=True)
@@ -80,16 +82,16 @@ def test_indexer_with_ref_indexer_compound(random_workspace, parallel, index_doc
     mock = mocker.Mock()
 
     def validate_response(resp):
-        mock()
         assert len(resp.search.docs) == 1
         assert len(resp.search.docs[0].matches) == top_k
 
     query_document = Document()
     query_document.embedding = np.array([1, 1])
     with Flow.load_config(os.path.join(cur_dir, 'compound-query.yml')) as query_flow:
-        query_flow.search(input_fn=[query_document], on_done=validate_response, top_k=top_k)
+        query_flow.search(input_fn=[query_document], on_done=mock, top_k=top_k)
 
     mock.assert_called_once()
+    validate_callback(mock, validate_response)
 
 
 @pytest.fixture
@@ -115,16 +117,16 @@ def test_indexer_with_ref_indexer_move(random_workspace_move, parallel, index_do
     shutil.rmtree(os.environ['JINA_TEST_INDEXER_WITH_REF_INDEXER'])
 
     def validate_response(resp):
-        mock()
         assert len(resp.search.docs) == 1
         assert len(resp.search.docs[0].matches) == top_k
 
     query_document = Document()
     query_document.embedding = np.array([1, 1])
     with Flow.load_config(os.path.join(cur_dir, 'query.yml')) as query_flow:
-        query_flow.search(input_fn=[query_document], on_done=validate_response, top_k=top_k)
+        query_flow.search(input_fn=[query_document], on_done=mock, top_k=top_k)
 
     mock.assert_called_once()
+    validate_callback(mock, validate_response)
 
 
 @pytest.mark.parametrize('parallel', [1, 2], indirect=True)
@@ -141,16 +143,16 @@ def test_indexer_with_ref_indexer_compound_move(random_workspace_move, parallel,
     shutil.rmtree(os.environ['JINA_TEST_INDEXER_WITH_REF_INDEXER'])
 
     def validate_response(resp):
-        mock()
         assert len(resp.search.docs) == 1
         assert len(resp.search.docs[0].matches) == top_k
 
     query_document = Document()
     query_document.embedding = np.array([1, 1])
     with Flow.load_config(os.path.join(cur_dir, 'compound-query.yml')) as query_flow:
-        query_flow.search(input_fn=[query_document], on_done=validate_response, top_k=top_k)
+        query_flow.search(input_fn=[query_document], on_done=mock, top_k=top_k)
 
     mock.assert_called_once()
+    validate_callback(mock, validate_response)
 
 
 @pytest.fixture
@@ -194,16 +196,16 @@ def test_indexer_with_ref_indexer_in_docker(random_workspace_in_docker, parallel
     mock = mocker.Mock()
 
     def validate_response(resp):
-        mock()
         assert len(resp.search.docs) == 1
         assert len(resp.search.docs[0].matches) == top_k
 
     query_document = Document()
     query_document.embedding = np.array([1, 1])
     with Flow.load_config(os.path.join('query.yml')) as query_flow:
-        query_flow.search(input_fn=[query_document], on_done=validate_response, top_k=top_k)
+        query_flow.search(input_fn=[query_document], on_done=mock, top_k=top_k)
 
     mock.assert_called_once()
+    validate_callback(mock, validate_response)
 
 
 @pytest.mark.parametrize('parallel', [1, 2], indirect=True)
@@ -215,13 +217,13 @@ def test_indexer_with_ref_indexer_compound_in_docker(random_workspace_in_docker,
     mock = mocker.Mock()
 
     def validate_response(resp):
-        mock()
         assert len(resp.search.docs) == 1
         assert len(resp.search.docs[0].matches) == top_k
 
     query_document = Document()
     query_document.embedding = np.array([1, 1])
     with Flow.load_config(os.path.join(cur_dir, 'compound-query.yml')) as query_flow:
-        query_flow.search(input_fn=[query_document], on_done=validate_response, top_k=top_k)
+        query_flow.search(input_fn=[query_document], on_done=mock, top_k=top_k)
 
     mock.assert_called_once()
+    validate_callback(mock, validate_response)

--- a/tests/integration/sharding/test_search_non_existent.py
+++ b/tests/integration/sharding/test_search_non_existent.py
@@ -7,6 +7,8 @@ import pytest
 
 from jina import Document, Flow
 
+from tests import validate_callback
+
 random.seed(0)
 np.random.seed(0)
 
@@ -34,7 +36,6 @@ def test_search_non_existent(config, mocker):
     yaml_file = 'index_kv_simple.yml'
 
     def validate_results(resp):
-        mock()
         assert len(resp.docs) == 3
 
     with Flow().add(
@@ -50,8 +51,11 @@ def test_search_non_existent(config, mocker):
             uses_after='_merge_root',
             polling='all'
     ) as search_flow:
-        search_flow.search(input_fn=random_docs(0, 5),
-                           on_done=validate_results,
-                           request_size=5
-                           )
+        search_flow.search(
+            input_fn=random_docs(0, 5),
+            on_done=mock,
+            request_size=5
+        )
+
     mock.assert_called_once()
+    validate_callback(mock, validate_results)

--- a/tests/integration/sharding/test_sharding.py
+++ b/tests/integration/sharding/test_sharding.py
@@ -10,6 +10,8 @@ from jina import Document
 from jina.executors.indexers import BaseIndexer
 from jina.flow import Flow
 
+from tests import validate_callback
+
 random.seed(0)
 np.random.seed(0)
 
@@ -102,7 +104,6 @@ def validate_index_size(expected_count, index_name):
 def test_delete_vector(config, mocker, index_conf, index_names, num_shards):
     def _validate_result_factory(num_matches):
         def _validate_results(resp):
-            mock()
             assert len(resp.docs) == 7
             for doc in resp.docs:
                 assert len(doc.matches) == num_matches
@@ -137,10 +138,11 @@ def test_delete_vector(config, mocker, index_conf, index_names, num_shards):
     with get_search_flow(index_conf, num_shards) as search_flow:
         search_flow.search(
             input_fn=random_docs(28, 35),
-            on_done=_validate_result_factory(10),
+            on_done=mock,
             request_size=100
         )
     mock.assert_called_once()
+    validate_callback(mock, _validate_result_factory(10))
 
 
 @pytest.mark.parametrize(
@@ -152,7 +154,6 @@ def test_delete_kv(config, mocker, num_shards):
 
     def _validate_result_factory(num_matches):
         def _validate_results(resp):
-            mock()
             assert len(resp.docs) == num_matches
 
         return _validate_results
@@ -180,9 +181,10 @@ def test_delete_kv(config, mocker, num_shards):
     with get_search_flow(index_conf, num_shards, '_merge_root') as search_flow:
         search_flow.search(
             input_fn=random_docs(28, 35),
-            on_done=_validate_result_factory(5),
+            on_done=mock,
             request_size=100)
     mock.assert_called_once()
+    validate_callback(mock, _validate_result_factory(5))
 
 
 @pytest.mark.parametrize(
@@ -200,7 +202,6 @@ def test_update_vector(config, mocker, index_conf, index_names, num_shards):
 
     def _validate_result_factory():
         def _validate_results(resp):
-            mock()
             assert len(resp.docs) == 1
             for doc in resp.docs:
                 assert len(doc.matches) == 10
@@ -232,9 +233,10 @@ def test_update_vector(config, mocker, index_conf, index_names, num_shards):
     with get_search_flow(index_conf, num_shards) as search_flow:
         search_flow.search(
             input_fn=random_docs(0, 1),
-            on_done=_validate_result_factory(),
+            on_done=mock,
             request_size=100)
-    assert mock.call_count == 1
+    mock.assert_called_once()
+    validate_callback(mock, _validate_result_factory())
 
 
 @pytest.mark.parametrize(
@@ -250,7 +252,6 @@ def test_update_kv(config, mocker, num_shards):
     hash_set_updated = [hash(d.embedding.tobytes()) for d in docs_updated]
 
     def _validate_results_1(resp):
-        mock()
         assert len(resp.docs) == 100
         for i, doc in enumerate(resp.docs):
             h = hash(doc.embedding.tobytes())
@@ -259,7 +260,6 @@ def test_update_kv(config, mocker, num_shards):
             assert h not in hash_set_updated
 
     def _validate_results_2(resp):
-        mock()
         assert len(resp.docs) == 100
         for i, doc in enumerate(resp.docs):
             h = hash(doc.embedding.tobytes())
@@ -271,7 +271,6 @@ def test_update_kv(config, mocker, num_shards):
                 assert h in hash_set_updated
 
     def _validate_results_3(resp):
-        mock()
         assert len(resp.docs) == 1
         h = hash(resp.docs[0].embedding.tobytes())
         assert h not in hash_set_before
@@ -291,15 +290,16 @@ def test_update_kv(config, mocker, num_shards):
 
     validate_index_size(201, index_name)
 
-    mock = mocker.Mock()
     for start, end, validate_results in (
             (0, 100, _validate_results_1),
             (100, 200, _validate_results_2),
             (200, 201, _validate_results_3)
     ):
+        mock = mocker.Mock()
         with get_search_flow(index_conf, num_shards, '_merge_root') as search_flow:
             search_flow.search(
                 input_fn=random_docs(start, end),
-                on_done=validate_results,
+                on_done=mock,
                 request_size=100)
-    assert mock.call_count == 3
+        validate_callback(mock, validate_results)
+        mock.assert_called_once()

--- a/tests/unit/clients/python/test_client.py
+++ b/tests/unit/clients/python/test_client.py
@@ -95,9 +95,9 @@ def test_mime_type(restful):
 def test_client_ndjson(restful, mocker, func_name):
     with Flow(restful=restful).add() as f, \
             open(os.path.join(cur_dir, 'docs.jsonlines')) as fp:
-        m = mocker.Mock()
-        getattr(f, f'{func_name}_ndjson')(fp, on_done=m)
-        m.assert_called_once()
+        mock = mocker.Mock()
+        getattr(f, f'{func_name}_ndjson')(fp, on_done=mock)
+        mock.assert_called_once()
 
 
 @pytest.mark.parametrize('func_name', ['index', 'search'])
@@ -105,6 +105,6 @@ def test_client_ndjson(restful, mocker, func_name):
 def test_client_csv(restful, mocker, func_name):
     with Flow(restful=restful).add() as f, \
             open(os.path.join(cur_dir, 'docs.csv')) as fp:
-        m = mocker.Mock()
-        getattr(f, f'{func_name}_csv')(fp, on_done=m)
-        m.assert_called_once()
+        mock = mocker.Mock()
+        getattr(f, f'{func_name}_csv')(fp, on_done=mock)
+        mock.assert_called_once()

--- a/tests/unit/docker/hubapi/test_remote.py
+++ b/tests/unit/docker/hubapi/test_remote.py
@@ -35,10 +35,10 @@ def test_register_to_mongodb(dummy_access_token, tmpdir, monkeypatch, mocker, su
         def status_code(self):
             return response_code
 
-    m = mocker.Mock()
+    mock = mocker.Mock()
 
     def _mock_post(url, headers, data):
-        m(url=url, headers=headers, data=data)
+        mock(url=url, headers=headers, data=data)
         resp = {'text': f'return status code {response_code}'}
         return MockResponse(resp)
 
@@ -49,7 +49,7 @@ def test_register_to_mongodb(dummy_access_token, tmpdir, monkeypatch, mocker, su
     monkeypatch.setattr(Path, 'home', _mock_home)
     _register_to_mongodb(JinaLogger('test_mongodb_register'), summary)
 
-    request_args = m.call_args_list[0][1]
+    request_args = mock.call_args_list[0][1]
     assert request_args['url'] == 'https://hubapi.jina.ai/push'
     assert request_args['headers'] == {'Accept': 'application/json', 'authorizationToken': f'{DUMMY_ACCESS_TOKEN}'}
     assert request_args['data'] == json.dumps(summary)

--- a/tests/unit/docker/test_hub_build_level.py
+++ b/tests/unit/docker/test_hub_build_level.py
@@ -48,7 +48,7 @@ def test_hub_build_level_pass(monkeypatch, test_workspace, docker_image):
 
 def test_hub_build_level_fail(monkeypatch, test_workspace, docker_image):
     args = set_hub_build_parser().parse_args(['path/hub-mwu', '--push', '--host-info', '--test-level', 'FLOW'])
-    expected_failed_levels = [BuildTestLevel.POD_NONDOCKER, BuildTestLevel.POD_DOCKER, BuildTestLevel.FLOW]
+    expected_failed_levels = [BuildTestLevel.POD_DOCKER, BuildTestLevel.FLOW]
 
     _, failed_levels = HubIO(args)._test_build(docker_image, BuildTestLevel.FLOW,
                                                os.path.join(cur_dir, 'yaml/test-joint.yml'), 60000, True,

--- a/tests/unit/docker/test_hub_build_level.py
+++ b/tests/unit/docker/test_hub_build_level.py
@@ -40,7 +40,7 @@ def test_hub_build_level_pass(monkeypatch, test_workspace, docker_image):
     expected_failed_levels = []
 
     _, failed_levels = HubIO(args)._test_build(docker_image, BuildTestLevel.EXECUTOR,
-                                               os.path.join(cur_dir, 'yaml/test-joint.yml'), 60, True,
+                                               os.path.join(cur_dir, 'yaml/test-joint.yml'), 60000, True,
                                                JinaLogger('unittest'))
 
     assert expected_failed_levels == failed_levels
@@ -51,7 +51,7 @@ def test_hub_build_level_fail(monkeypatch, test_workspace, docker_image):
     expected_failed_levels = [BuildTestLevel.POD_NONDOCKER, BuildTestLevel.POD_DOCKER, BuildTestLevel.FLOW]
 
     _, failed_levels = HubIO(args)._test_build(docker_image, BuildTestLevel.FLOW,
-                                               os.path.join(cur_dir, 'yaml/test-joint.yml'), 60, True,
+                                               os.path.join(cur_dir, 'yaml/test-joint.yml'), 60000, True,
                                                JinaLogger('unittest'))
 
     assert expected_failed_levels == failed_levels

--- a/tests/unit/docker/test_hubio.py
+++ b/tests/unit/docker/test_hubio.py
@@ -32,10 +32,10 @@ def test_login(tmpdir, monkeypatch, mocker):
         def status_code(self):
             return requests.codes.ok
 
-    m = mocker.Mock()
+    mock = mocker.Mock()
 
     def _mock_post(url, headers, data):
-        m(url=url, headers=headers, data=data)
+        mock(url=url, headers=headers, data=data)
         resp = {'device_code': 'device',
                 'user_code': 'user',
                 'verification_uri': 'verification',
@@ -51,13 +51,13 @@ def test_login(tmpdir, monkeypatch, mocker):
     monkeypatch.setattr(webbrowser, 'open', None)
     monkeypatch.setattr(Path, 'home', _mock_home)
     HubIO(args).login()
-    device_request_kwargs = m.call_args_list[0][1]
+    device_request_kwargs = mock.call_args_list[0][1]
     assert device_request_kwargs['url'] == 'https://github.com/login/device/code'
     assert device_request_kwargs['headers'] == {'Accept': 'application/json'}
     assert 'client_id' in device_request_kwargs['data']
     assert 'scope' in device_request_kwargs['data']
 
-    access_request_kwargs = m.call_args_list[1][1]
+    access_request_kwargs = mock.call_args_list[1][1]
     assert access_request_kwargs['url'] == 'https://github.com/login/oauth/access_token'
     assert access_request_kwargs['headers'] == {'Accept': 'application/json'}
     assert 'client_id' in access_request_kwargs['data']

--- a/tests/unit/drivers/test_concat_driver.py
+++ b/tests/unit/drivers/test_concat_driver.py
@@ -6,6 +6,8 @@ from jina import Document
 from jina.flow import Flow
 from jina.types.ndarray.generic import NdArray
 
+from tests import validate_callback
+
 e1 = np.random.random([7])
 e2 = np.random.random([5])
 e3 = np.random.random([3])
@@ -46,7 +48,6 @@ def test_concat_embed_driver(mocker):
         del os.environ['JINA_ARRAY_QUANT']
 
     def validate(req):
-        mock()
         assert len(req.docs) == 2
         assert NdArray(req.docs[0].embedding).value.shape == (e1.shape[0] * 2,)
         assert NdArray(req.docs[1].embedding).value.shape == (e3.shape[0] * 2,)
@@ -60,6 +61,7 @@ def test_concat_embed_driver(mocker):
             .join(needs=['a', 'b'], uses='- !ConcatEmbedDriver | {}'))
 
     with flow:
-        flow.index(input_fn=input_fn, on_done=validate)
+        flow.index(input_fn=input_fn, on_done=mock)
 
     mock.assert_called_once()
+    validate_callback(mock, validate)

--- a/tests/unit/drivers/test_eval_collect_driver.py
+++ b/tests/unit/drivers/test_eval_collect_driver.py
@@ -1,6 +1,8 @@
 from jina.flow import Flow
 from jina.proto.jina_pb2 import DocumentProto
 
+from tests import validate_callback
+
 
 def input_fn():
     doc1 = DocumentProto()
@@ -17,7 +19,6 @@ def input_fn():
 
 def test_collect_evals_driver(mocker):
     def validate(req):
-        mock()
         assert len(req.docs) == 2
         # each doc should now have two evaluations
         for d in req.docs:
@@ -29,6 +30,7 @@ def test_collect_evals_driver(mocker):
             .add(name='b', needs='gateway')
             .join(needs=['a', 'b'], uses='- !CollectEvaluationDriver {}'))
     with flow:
-        flow.index(input_fn=input_fn, on_done=validate)
+        flow.index(input_fn=input_fn, on_done=mock)
 
     mock.assert_called_once()
+    validate_callback(mock, validate)

--- a/tests/unit/drivers/test_rankingevaluation_driver.py
+++ b/tests/unit/drivers/test_rankingevaluation_driver.py
@@ -85,16 +85,18 @@ def test_ranking_evaluate_extract_multiple_fields(simple_rank_evaluate_driver,
                                                   ground_truth_pairs,
                                                   mocker):
 
-    def _eval_fn(actual, desired):
+    m = mocker.Mock()
+    m.return_value = 1.0
+
+    def eval_function(actual, desired):
         assert isinstance(actual[0], Tuple)
         assert isinstance(desired[0], Tuple)
         return 1.0
 
-    m = mocker.Mock()
     simple_rank_evaluate_driver._exec_fn = m
     simple_rank_evaluate_driver._apply_all(ground_truth_pairs)
 
-    validate_callback(m, _eval_fn)
+    validate_callback(m, eval_function)
 
 
 @pytest.mark.parametrize('fields', [('tags__id',), ('score__value',)])

--- a/tests/unit/drivers/test_rankingevaluation_driver.py
+++ b/tests/unit/drivers/test_rankingevaluation_driver.py
@@ -85,18 +85,17 @@ def test_ranking_evaluate_extract_multiple_fields(simple_rank_evaluate_driver,
                                                   ground_truth_pairs,
                                                   mocker):
 
-    m = mocker.Mock()
-    m.return_value = 1.0
+    mock = mocker.Mock()
+    mock.return_value = 1.0
 
     def eval_function(actual, desired):
         assert isinstance(actual[0], Tuple)
         assert isinstance(desired[0], Tuple)
-        return 1.0
 
-    simple_rank_evaluate_driver._exec_fn = m
+    simple_rank_evaluate_driver._exec_fn = mock
     simple_rank_evaluate_driver._apply_all(ground_truth_pairs)
 
-    validate_callback(m, eval_function)
+    validate_callback(mock, eval_function)
 
 
 @pytest.mark.parametrize('fields', [('tags__id',), ('score__value',)])

--- a/tests/unit/drivers/test_rankingevaluation_driver.py
+++ b/tests/unit/drivers/test_rankingevaluation_driver.py
@@ -7,6 +7,8 @@ from jina.executors.evaluators.rank.precision import PrecisionEvaluator
 from jina.proto import jina_pb2
 from jina.types.document.helper import DocGroundtruthPair
 
+from tests import validate_callback
+
 
 class SimpleRankEvaluateDriver(RankEvaluateDriver):
 
@@ -82,17 +84,17 @@ def test_ranking_evaluate_simple_driver(simple_rank_evaluate_driver,
 def test_ranking_evaluate_extract_multiple_fields(simple_rank_evaluate_driver,
                                                   ground_truth_pairs,
                                                   mocker):
-    m = mocker.Mock()
 
     def _eval_fn(actual, desired):
-        m()
         assert isinstance(actual[0], Tuple)
         assert isinstance(desired[0], Tuple)
         return 1.0
 
-    simple_rank_evaluate_driver._exec_fn = _eval_fn
+    m = mocker.Mock()
+    simple_rank_evaluate_driver._exec_fn = m
     simple_rank_evaluate_driver._apply_all(ground_truth_pairs)
-    m.assert_called()
+
+    validate_callback(m, _eval_fn)
 
 
 @pytest.mark.parametrize('fields', [('tags__id',), ('score__value',)])

--- a/tests/unit/executors/indexers/test_binary_indexer.py
+++ b/tests/unit/executors/indexers/test_binary_indexer.py
@@ -7,8 +7,7 @@ import pytest
 from jina.executors.indexers import BaseIndexer
 from jina.executors.indexers.keyvalue import BinaryPbIndexer
 from jina.flow import Flow
-from jina.types.ndarray.generic import NdArray
-from tests import random_docs
+from tests import random_docs, validate_callback
 
 
 @pytest.mark.parametrize('random_workspace_name', ['JINA_TEST_WORKSPACE_BINARY_PB'])
@@ -16,7 +15,6 @@ def test_binarypb_in_flow(test_metas, mocker):
     docs = list(random_docs(10))
 
     def validate(req):
-        mock()
         assert len(docs) == len(req.docs)
         for d, d0 in zip(req.docs, docs):
             np.testing.assert_almost_equal(d.embedding,
@@ -33,9 +31,10 @@ def test_binarypb_in_flow(test_metas, mocker):
 
     mock = mocker.Mock()
     with f:
-        f.search(docs_no_embedding, on_done=validate)
+        f.search(docs_no_embedding, on_done=mock)
 
     mock.assert_called_once()
+    validate_callback(mock, validate)
 
 
 def test_binarypb_update1(test_metas):

--- a/tests/unit/flow/test_flow.py
+++ b/tests/unit/flow/test_flow.py
@@ -2,6 +2,7 @@ import os
 
 import numpy as np
 import pytest
+import time
 
 from jina import Flow, Document
 from jina.enums import SocketType, FlowBuildLevel
@@ -66,6 +67,8 @@ def test_flow_with_jump(tmpdir):
         _validate(f)
 
     f.save_config(os.path.join(str(tmpdir), 'tmp.yml'))
+    with open(os.path.join(str(tmpdir), 'tmp.yml')) as file_:
+        print(file_.readlines())
     Flow.load_config(os.path.join(str(tmpdir), 'tmp.yml'))
 
     with Flow.load_config(os.path.join(str(tmpdir), 'tmp.yml')) as f:

--- a/tests/unit/flow/test_flow.py
+++ b/tests/unit/flow/test_flow.py
@@ -2,7 +2,6 @@ import os
 
 import numpy as np
 import pytest
-import time
 
 from jina import Flow, Document
 from jina.enums import SocketType, FlowBuildLevel
@@ -12,7 +11,7 @@ from jina.helper import random_identity
 from jina.proto.jina_pb2 import DocumentProto
 from jina.types.request import Response
 from jina.peapods.pods import BasePod
-from tests import random_docs, rm_files, validate_callback
+from tests import random_docs, validate_callback
 
 cur_dir = os.path.dirname(os.path.abspath(__file__))
 
@@ -67,8 +66,6 @@ def test_flow_with_jump(tmpdir):
         _validate(f)
 
     f.save_config(os.path.join(str(tmpdir), 'tmp.yml'))
-    with open(os.path.join(str(tmpdir), 'tmp.yml')) as file_:
-        print(file_.readlines())
     Flow.load_config(os.path.join(str(tmpdir), 'tmp.yml'))
 
     with Flow.load_config(os.path.join(str(tmpdir), 'tmp.yml')) as f:

--- a/tests/unit/flow/test_flow_index.py
+++ b/tests/unit/flow/test_flow_index.py
@@ -5,7 +5,7 @@ import pytest
 
 from jina import Document
 from jina.flow import Flow
-from tests import random_docs
+from tests import random_docs, validate_callback
 
 cur_dir = os.path.dirname(os.path.abspath(__file__))
 
@@ -19,7 +19,6 @@ def random_queries(num_docs, chunks_per_doc=5):
             dd.id = num_docs + j * chunks_per_doc + k
             d.chunks.add(dd)
         yield d
-
 
 
 @pytest.fixture
@@ -42,7 +41,6 @@ def test_shards_insufficient_data(mocker, restful, docpb_workspace):
     mock = mocker.Mock()
 
     def validate(req):
-        mock()
         assert len(req.docs) == 1
         assert len(req.docs[0].matches) == index_docs
 
@@ -70,6 +68,7 @@ def test_shards_insufficient_data(mocker, restful, docpb_workspace):
     with f:
         f.search(input_fn=random_queries(1, index_docs),
 
-                 on_done=validate)
+                 on_done=mock)
     time.sleep(2)
     mock.assert_called_once()
+    validate_callback(mock, validate)

--- a/tests/unit/optimizers/test_flow_runner.py
+++ b/tests/unit/optimizers/test_flow_runner.py
@@ -1,14 +1,12 @@
 import os
 
 from jina.optimizers.flow_runner import SingleFlowRunner
-from tests import random_docs
+from tests import random_docs, validate_callback
 
 
 def test_flow_runner(tmpdir, mocker):
-    m = mocker.Mock()
 
     def callback(resp):
-        m()
         if len(resp.search.docs):
             assert True
         else:
@@ -35,7 +33,8 @@ def test_flow_runner(tmpdir, mocker):
         execution_method='search',
     )
 
-    flow_runner.run(workspace=workspace, trial_parameters={'JINA_TEST_FLOW_RUNNER_WORKSPACE': workspace}, callback=callback)
+    m = mocker.Mock()
+    flow_runner.run(workspace=workspace, trial_parameters={'JINA_TEST_FLOW_RUNNER_WORKSPACE': workspace}, callback=m)
 
-    m.assert_called()
+    validate_callback(m, callback)
     assert os.path.exists(os.path.join(workspace, 'tmp2'))

--- a/tests/unit/optimizers/test_flow_runner.py
+++ b/tests/unit/optimizers/test_flow_runner.py
@@ -33,8 +33,8 @@ def test_flow_runner(tmpdir, mocker):
         execution_method='search',
     )
 
-    m = mocker.Mock()
-    flow_runner.run(workspace=workspace, trial_parameters={'JINA_TEST_FLOW_RUNNER_WORKSPACE': workspace}, callback=m)
+    mock = mocker.Mock()
+    flow_runner.run(workspace=workspace, trial_parameters={'JINA_TEST_FLOW_RUNNER_WORKSPACE': workspace}, callback=mock)
 
-    validate_callback(m, callback)
+    validate_callback(mock, callback)
     assert os.path.exists(os.path.join(workspace, 'tmp2'))

--- a/tests/unit/test_cust_driver.py
+++ b/tests/unit/test_cust_driver.py
@@ -4,6 +4,8 @@ from jina.executors import BaseExecutor
 from jina.parsers import set_pea_parser
 from jina.peapods.peas import BasePea
 
+from tests import validate_callback
+
 cur_dir = os.path.dirname(os.path.abspath(__file__))
 
 
@@ -23,11 +25,10 @@ def test_load_flow_with_custom_driver(mocker):
     mock = mocker.Mock()
 
     def validate(req):
-        mock()
         assert len(req.docs) == 1
         assert req.docs[0].text == 'hello from DummyEncodeDriver'
 
     with Flow().add(uses=os.path.join(cur_dir, 'yaml/test-executor-with-custom-driver.yml')) as f:
-        f.index([Document()], on_done=validate)
+        f.index([Document()], on_done=mock)
 
-    mock.assert_called()
+    validate_callback(mock, validate)


### PR DESCRIPTION
So many things.
1. python3.7.10 and ubuntu18.04 do not work well together for us. We get errors just from using this combination.
2. refactored all mocks in the way, that the validate provides way better readability in the logs, if a test fails.
3. removed `-n 1` parameter from `pytest` calls. Reasoning: if `-n` is set, `-s -v` will be ignored and we get less verbose logs.
4. fixed some further tests here and there
5. timeout and try again does not work well together in the current setup (and even at all). We should wait for [this](https://github.community/t/ability-to-rerun-just-a-single-job-in-a-workflow/17234/117) feature and move the retry to the github-action itself. I don't see pytest supporting this properly ever. The best workaround I have seen so far is (https://github.community/t/re-run-jobs/16145/11) which is still bad.