### PR TITLE
feat(jaml): add keyword jtype to represent YAML tag

### DIFF
--- a/jina/jaml/__init__.py
+++ b/jina/jaml/__init__.py
@@ -123,6 +123,10 @@ class JAML:
 
     @staticmethod
     def registered_tags() -> List[str]:
+        """
+        Return a list of :class:`JAMLCompatible` classes that have been registered.
+
+        """
         return list(v[1:] for v in set(JinaLoader.yaml_constructors.keys()) if v and v.startswith('!'))
 
     @staticmethod

--- a/jina/jaml/__init__.py
+++ b/jina/jaml/__init__.py
@@ -92,25 +92,33 @@ class JAML:
         return r
 
     @staticmethod
-    def escape(value: str) -> str:
+    def escape(value: str, include_unknown_tags: bool = True) -> str:
         """
         Escape the YAML content by replacing all customized tags ``!`` to ``jtype: ``.
 
         :param value: the original YAML content
+        :param include_unknown_tags: if to include unknown tags during escaping
         """
-        r = '|'.join(JAML.registered_tags())
-        r = rf'!({r}|\w+)\b'
+        if include_unknown_tags:
+            r = r'!(\w+)\b'
+        else:
+            r = '|'.join(JAML.registered_tags())
+            r = rf'!({r})\b'
         return re.sub(r, r'jtype: \1', value)
 
     @staticmethod
-    def unescape(value: str) -> str:
+    def unescape(value: str, include_unknown_tags: bool = True) -> str:
         """
         Unescape the YAML content by replacing all ``jtype: `` to tags.
 
         :param value: the escaped YAML content
+        :param include_unknown_tags: if to include unknown tags during unescaping
         """
-        r = '|'.join(JAML.registered_tags())
-        r = rf'jtype: ({r}|\w+)\b'
+        if include_unknown_tags:
+            r = r'jtype: (\w+)\b'
+        else:
+            r = '|'.join(JAML.registered_tags())
+            r = rf'jtype: ({r})\b'
         return re.sub(r, r'!\1', value)
 
     @staticmethod

--- a/tests/unit/flow/test_flow_yaml_parser.py
+++ b/tests/unit/flow/test_flow_yaml_parser.py
@@ -104,7 +104,7 @@ def test_flow_uses_from_dict():
     class DummyEncoder(BaseEncoder):
         pass
 
-    d1 = {'__cls': 'DummyEncoder',
+    d1 = {'jtype': 'DummyEncoder',
           'metas': {'name': 'dummy1'}}
     with Flow().add(uses=d1):
         pass

--- a/tests/unit/jaml/test_type_parse.py
+++ b/tests/unit/jaml/test_type_parse.py
@@ -1,0 +1,161 @@
+import pytest
+from jina.executors import BaseExecutor
+from jina.jaml import JAML
+
+class MyExecutor(BaseExecutor):
+    pass
+
+def test_non_empty_reg_tags():
+    assert JAML.registered_tags()
+    assert '!BaseExecutor' in JAML.registered_tags()
+
+
+@pytest.mark.parametrize('original, escaped',
+                         [(
+                                 '''
+!BaseExecutor {}
+!Blah {}
+!MyExecutor {}
+                                 ''',
+                                 '''
+jtype: BaseExecutor {}
+!Blah {}
+jtype: MyExecutor {}
+                                 '''
+                         ), (
+                                 '''
+!BaseExecutor
+with:
+    a: 123
+    b: BaseExecutor
+    jtype: unknown-blah
+                                 ''',
+                                 '''
+jtype: BaseExecutor
+with:
+    a: 123
+    b: BaseExecutor
+    jtype: unknown-blah    
+                                 '''
+                         ), (
+                                 '''
+!CompoundIndexer
+components:
+  - !NumpyIndexer
+    with:
+      index_filename: vec.gz
+      metric: euclidean
+    metas:
+      name: vecidx
+  - !BinaryPbIndexer
+    with:
+      index_filename: doc.gz
+    metas:
+      name: docidx
+metas:
+  name: indexer
+  workspace: $JINA_WORKSPACE
+
+                                 ''',
+                                 '''
+jtype: CompoundIndexer
+components:
+  - jtype: NumpyIndexer
+    with:
+      index_filename: vec.gz
+      metric: euclidean
+    metas:
+      name: vecidx
+  - jtype: BinaryPbIndexer
+    with:
+      index_filename: doc.gz
+    metas:
+      name: docidx
+metas:
+  name: indexer
+  workspace: $JINA_WORKSPACE
+                                 '''
+                         ),(
+                                 '''
+!CompoundIndexer
+metas:
+  workspace: $TMP_WORKSPACE
+components:
+  - !NumpyIndexer
+    with:
+      metric: euclidean
+      index_filename: vec.gz
+    metas:
+      name: vecidx  # a customized name
+  - !BinaryPbIndexer
+    with:
+      index_filename: chunk.gz
+    metas:
+      name: kvidx  # a customized name
+requests:
+  on:
+    IndexRequest:
+      - !VectorIndexDriver
+        with:
+          executor: NumpyIndexer
+          filter_by: $FILTER_BY
+      - !KVIndexDriver
+        with:
+          executor: BinaryPbIndexer
+          filter_by: $FILTER_BY
+    SearchRequest:
+      - !VectorSearchDriver
+        with:
+          executor: NumpyIndexer
+          filter_by: $FILTER_BY
+      - !KVSearchDriver
+        with:
+          executor: BinaryPbIndexer
+          filter_by: $FILTER_BY
+
+                                 ''',
+                                 '''
+jtype: CompoundIndexer
+metas:
+  workspace: $TMP_WORKSPACE
+components:
+  - jtype: NumpyIndexer
+    with:
+      metric: euclidean
+      index_filename: vec.gz
+    metas:
+      name: vecidx  # a customized name
+  - jtype: BinaryPbIndexer
+    with:
+      index_filename: chunk.gz
+    metas:
+      name: kvidx  # a customized name
+requests:
+  on:
+    IndexRequest:
+      - jtype: VectorIndexDriver
+        with:
+          executor: NumpyIndexer
+          filter_by: $FILTER_BY
+      - jtype: KVIndexDriver
+        with:
+          executor: BinaryPbIndexer
+          filter_by: $FILTER_BY
+    SearchRequest:
+      - jtype: VectorSearchDriver
+        with:
+          executor: NumpyIndexer
+          filter_by: $FILTER_BY
+      - jtype: KVSearchDriver
+        with:
+          executor: BinaryPbIndexer
+          filter_by: $FILTER_BY
+
+                                 '''
+                         ),
+                         ])
+def test_escape(original, escaped):
+    print(JAML.escape(original.strip()))
+    print(escaped.strip())
+    assert JAML.escape(original.strip()) == escaped.strip()
+    assert JAML.unescape(JAML.escape(original.strip())) == original.strip()

--- a/tests/unit/test_yamlparser.py
+++ b/tests/unit/test_yamlparser.py
@@ -189,7 +189,7 @@ def test_load_from_dict():
     #   workspace: ${{this.name}}-${{this.batch_size}}
 
     d1 = {
-        '__cls': 'BaseEncoder',
+        'jtype': 'BaseEncoder',
         'metas': {'name': '${{BE_TEST_NAME}}',
                   'batch_size': '${{BATCH_SIZE}}',
                   'pea_id': '${{pea_id}}',
@@ -212,16 +212,16 @@ def test_load_from_dict():
     #   name: compound1
 
     d2 = {
-        '__cls': 'CompoundExecutor',
+        'jtype': 'CompoundExecutor',
         'components':
             [
                 {
-                    '__cls': 'BinaryPbIndexer',
+                    'jtype': 'BinaryPbIndexer',
                     'with': {'index_filename': 'tmp1'},
                     'metas': {'name': 'test1'}
                 },
                 {
-                    '__cls': 'BinaryPbIndexer',
+                    'jtype': 'BinaryPbIndexer',
                     'with': {'index_filename': 'tmp2'},
                     'metas': {'name': 'test2'}
                 },


### PR DESCRIPTION
# Content
- we will be slowly migrating from `!YAMLTag` to `jtype: YAMLTag`, this PR is a starting point
- the rationale behind this is we want to enable [JSONSchema](https://www.schemastore.org/json/) (FYI, YAML is a superset of JSON) for IDE-level of validation and autocompletion, as we heavily rely on YAML configs.
- the current problem is that those customized tags are not compatible to JSONschema, but also creates problem during internal/external-integration. (@BastinJafari on dashboard)
- in general, we want the maximum compatibility of our YAML file, to get broader support from the Schema ecosystem.

# Breaking Changes
- the old way of `{"__cls": "SomeExecutor" }` to construct executor from JSON is now replaced by `{"jtype": "SomeExecutor"}`


# Alternatives
Other alternatives to realize this but dropped: https://github.com/jina-ai/jina/blob/refactor-jaml-tag-2/