### PR TITLE
fix: delete invalid entries before dumping NpIndexer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,6 @@ shell/jina-wizard.sh
 # IntelliJ IDEA
 *.iml
 .idea
+
+# test with config in resources
+tests/integration/crud/simple/simple_indexer/

--- a/jina/executors/indexers/vector.py
+++ b/jina/executors/indexers/vector.py
@@ -47,7 +47,6 @@ class BaseNumpyIndexer(BaseVectorIndexer):
         self.dtype = None
         self.compress_level = compress_level
         self.key_bytes = b''
-        self.valid_indices = np.array([], dtype=bool)
         self.ref_indexer_workspace_name = None
 
         if ref_indexer:
@@ -60,7 +59,6 @@ class BaseNumpyIndexer(BaseVectorIndexer):
             self._size = ref_indexer._size
             # point to the ref_indexer.index_filename
             # so that later in `post_init()` it will load from the referred index_filename
-            self.valid_indices = ref_indexer.valid_indices
             self.index_filename = ref_indexer.index_filename
             self.logger.warning(f'\n'
                                 f'num_dim extracted from `ref_indexer` to {ref_indexer.num_dim} \n'
@@ -69,6 +67,19 @@ class BaseNumpyIndexer(BaseVectorIndexer):
                                 f'compress_level overriden from `ref_indexer` to {ref_indexer.compress_level} \n'
                                 f'index_filename overriden from `ref_indexer` to {ref_indexer.index_filename}')
             self.ref_indexer_workspace_name = ref_indexer.workspace_name
+
+    def post_init(self):
+        super().post_init()
+        self.valid_indices = np.array([], dtype=bool)
+
+    def _delete_invalid_indices(self):
+        """Here rebuild the index with only valid entries"""
+        pass
+
+    def __getstate__(self):
+        self._delete_invalid_indices()
+        d = super().__getstate__()
+        return d
 
     @property
     def workspace_name(self):

--- a/jina/resources/executors._index.yml
+++ b/jina/resources/executors._index.yml
@@ -4,6 +4,7 @@ components:
     with:
       index_filename: vec.gz
       metric: euclidean
+      delete_on_dump: true
     metas:
       name: vecidx  # a customized name
   - !BinaryPbIndexer

--- a/tests/integration/crud/advanced/yaml/index-chunk.yml
+++ b/tests/integration/crud/advanced/yaml/index-chunk.yml
@@ -4,6 +4,7 @@ components:
     with:
       index_filename: vec.gz
       metric: cosine
+      delete_on_dump: true
     metas:
       name: vecidx
       workspace: $JINA_CRUD_ADVANCED_WORKSPACE

--- a/tests/integration/crud/simple/chunks/yaml/index_vector.yml
+++ b/tests/integration/crud/simple/chunks/yaml/index_vector.yml
@@ -2,6 +2,7 @@
 with:
   index_filename: vec.gz
   metric: cosine
+  delete_on_dump: true
 metas:
   name: vecidx
   workspace: $JINA_CRUD_CHUNKS

--- a/tests/integration/crud/simple/yaml/index_vector.yml
+++ b/tests/integration/crud/simple/yaml/index_vector.yml
@@ -2,6 +2,7 @@
 with:
   index_filename: vec.gz
   metric: cosine
+  delete_on_dump: true
 metas:
   name: vecidx
   workspace: $JINA_TOPK_DIR

--- a/tests/integration/doccache/vector.yml
+++ b/tests/integration/doccache/vector.yml
@@ -4,6 +4,7 @@ components:
     with:
       index_filename: vec.gz
       metric: euclidean
+      delete_on_dump: true
     metas:
       name: $JINA_VEC_IDX_NAME
 metas:

--- a/tests/unit/drivers/test_cache_driver.py
+++ b/tests/unit/drivers/test_cache_driver.py
@@ -187,7 +187,6 @@ def test_cache_driver_update(tmpdir, test_metas, field_type, mocker):
     driver = MockBaseCacheDriver(method='update', traversal_paths=['r'])
 
     docs = [Document(text=f'doc_{i}') for i in range(5)]
-    # TODO
     [d.update_content_hash() for d in docs]
 
     def validate_delete(self, keys, *args, **kwargs):


### PR DESCRIPTION
Delete invalid entries when saving

- [x] test np indexer
- [x] benchmark on large datasets
- [x] make it a parameter (default = `False`)
- [x] test hub indexers

---

Benchmark code (no point in adding it to CI):

```python

@pytest.mark.parametrize('save', [False, True])
def test_scipy_indexer_known_big_benchmark_save(save, test_metas):
    """Let's try to have some real test. We will have an index with 10k vectors of random values between 5 and 10.
     We will change tweak some specific vectors that we expect to be retrieved at query time. We will tweak vector
     at index [0, 1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000, 9000], this will also be the query vectors.
     Then the keys will be assigned shifted to test the proper usage of `int2ext_id` and `ext2int_id`
    """
    vectors = np.random.uniform(low=5.0, high=10.0, size=(100000, 1024))
    keys = np.arange(0, len(vectors)).astype(np.str_)
    print(f'benchmarking delete_on_save with {len(keys)} docs')

    with NumpyIndexer(metric='euclidean', index_filename='np.test.gz', delete_on_save=save,
                      metas=test_metas) as indexer:
        indexer.add(keys, vectors)
        indexer.save()
        assert os.path.exists(indexer.index_abspath)
        save_abspath = indexer.save_abspath

    import time
    with BaseIndexer.load(save_abspath) as indexer:
        assert isinstance(indexer, NumpyIndexer)
        assert isinstance(indexer.query_handler, np.memmap)
        indexer.delete(keys[:len(keys)//2])
        time_start = time.time()
        indexer.save()
    time_end = time.time()
    print(f'took = {time_end - time_start}')
```

False: `took = 0.026610612869262695`
True: `took = 0.539351224899292`