### PR TITLE
ci: rebase and not merge for better coverage comments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,12 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+      - run: |
+          git fetch origin master
+          git rebase origin/master
       - run: |
           echo "PIP_TAG='[devel]'" >> $GITHUB_ENV
       - run: |
@@ -122,6 +128,11 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Rebase on master
+        run: |
+          git fetch origin master
+          git rebase origin/master
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v1
         with:


### PR DESCRIPTION
According to comments in #2028 the source of missleading information on codecov reports could be due to the usage of merge instead of rebase which makes codecov choose the wrong base commit for comparison