### PR TITLE
fix: add delete() for cached property

### DIFF
--- a/jina/executors/indexers/keyvalue.py
+++ b/jina/executors/indexers/keyvalue.py
@@ -210,13 +210,13 @@ class BinaryPbIndexer(BaseKVIndexer):
         keys, values = self._filter_nonexistent_keys_values(
             keys, values, self.query_handler.header.keys()
         )
+        del self.query_handler
+        self.handler_mutex = False
         if keys:
             self._delete(keys)
             self.add(keys, values)
 
     def _delete(self, keys: Iterable[str]) -> None:
-        self.query_handler.close()
-        self.handler_mutex = False
         for key in keys:
             self.write_handler.header.write(
                 np.array(
@@ -229,9 +229,6 @@ class BinaryPbIndexer(BaseKVIndexer):
                     ],
                 ).tobytes()
             )
-
-            if self.query_handler:
-                del self.query_handler.header[key]
             self._size -= 1
 
     def delete(self, keys: Iterable[str], *args, **kwargs) -> None:
@@ -242,6 +239,8 @@ class BinaryPbIndexer(BaseKVIndexer):
         :param kwargs: keyword arguments
         """
         keys = self._filter_nonexistent_keys(keys, self.query_handler.header.keys())
+        del self.query_handler
+        self.handler_mutex = False
         if keys:
             self._delete(keys)
 

--- a/jina/executors/indexers/vector.py
+++ b/jina/executors/indexers/vector.py
@@ -93,8 +93,8 @@ class BaseNumpyIndexer(BaseVectorIndexer):
         self.key_bytes = valid_key_bytes
         self._size = len(valid)
         self.valid_indices = valid
-        del self.__dict__['CACHED__int2ext_id']
-        del self.__dict__['CACHED__ext2int_id']
+        del self._int2ext_id
+        del self._ext2int_id
 
     def _clean_memmap(self):
         # clean up the underlying matrix of entries marked for deletion
@@ -105,7 +105,7 @@ class BaseNumpyIndexer(BaseVectorIndexer):
             self.handler_mutex = False
         # force the raw_ndarray (underlying matrix) to re-read from disk
         # (needed when there were writing ops to be flushed)
-        del self.__dict__['CACHED__raw_ndarray']
+        del self._raw_ndarray
         filtered = self._raw_ndarray[self.valid_indices]
         # we need an intermediary file
         tmp_path = self.index_abspath + 'tmp'
@@ -123,7 +123,7 @@ class BaseNumpyIndexer(BaseVectorIndexer):
         os.remove(self.index_abspath)
         os.rename(tmp_path, self.index_abspath)
         # force it to re-read again from the new file
-        del self.__dict__['CACHED__raw_ndarray']
+        del self._raw_ndarray
 
     def __getstate__(self):
         # called on pickle save

--- a/jina/helper.py
+++ b/jina/helper.py
@@ -972,6 +972,13 @@ class cached_property:
         value = obj.__dict__[f'CACHED_{self.func.__name__}'] = self.func(obj)
         return value
 
+    def __delete__(self, obj):
+        cached_value = obj.__dict__.get(f'CACHED_{self.func.__name__}', None)
+        if cached_value is not None:
+            if hasattr(cached_value, 'close'):
+                cached_value.close()
+            del obj.__dict__[f'CACHED_{self.func.__name__}']
+
 
 def get_now_timestamp():
     """

--- a/tests/unit/executors/indexers/test_binary_indexer.py
+++ b/tests/unit/executors/indexers/test_binary_indexer.py
@@ -163,7 +163,7 @@ def test_binarypb_update_twice(test_metas, delete_on_dump):
 
 # benchmark only
 @pytest.mark.skipif(
-    'GITHUB_WORKFLOW' in os.environ, reason='skip the network test on github workflow'
+    'GITHUB_WORKFLOW' in os.environ, reason='skip the benchmark test on github workflow'
 )
 @pytest.mark.parametrize('delete_on_dump', [True, False])
 def test_binarypb_benchmark(test_metas, delete_on_dump):


### PR DESCRIPTION
- [x] provide overridden method for `del` for `@cached_property`
- [x] correct closing of query handler in BinaryPb

NOTE

@florian-hoenicke @JoanFM @maximilianwerk 

Closing the query_handler is now coherent, but makes the update and delete ops slower. This is a trade-off we need to discuss perhaps.

Before, we were only closing the qhandler's body but still relying on its header to get the keys. That was a bit of smell due to the design of the Write/ReadHandlers in BinaryPb. Once we call close we shouldn't be able to access it, but we are. 

Do we want to keep the old way (less readable, but more efficient), or this way (more readable, less efficient)?