### PR TITLE
refactor: returns to return

### DIFF
--- a/jina/logging/formatter.py
+++ b/jina/logging/formatter.py
@@ -27,7 +27,7 @@ class ColorFormatter(Formatter):
         Format the LogRecord with corresponding colour.
 
         :param record: A LogRecord object
-        :returns: Formatted LogRecord with level-colour MAPPING to add corresponding colour.
+        :return:: Formatted LogRecord with level-colour MAPPING to add corresponding colour.
         """
         cr = copy(record)
         if cr.levelname != 'INFO':
@@ -44,7 +44,7 @@ class PlainFormatter(Formatter):
         Format the LogRecord by removing all control chars and plain text, and restrict the max-length of msg to 512.
 
         :param record: A LogRecord object.
-        :returns: Formatted plain LogRecord.
+        :return:: Formatted plain LogRecord.
         """
         cr = copy(record)
         if isinstance(cr.msg, str):
@@ -77,7 +77,7 @@ class JsonFormatter(Formatter):
         Format the log message as a JSON object.
 
         :param record: A LogRecord object.
-        :returns: LogRecord with JSON format.
+        :return:: LogRecord with JSON format.
         """
         cr = copy(record)
         cr.msg = re.sub(r'\u001b\[.*?[@-~]', '', str(cr.msg))
@@ -94,7 +94,7 @@ class ProfileFormatter(Formatter):
         Format the log message as JSON object and add the current used memory.
 
         :param record: A LogRecord object.
-        :returns: Return JSON formatted log if msg of LogRecord is dict type else return empty.
+        :return:: Return JSON formatted log if msg of LogRecord is dict type else return empty.
         """
         cr = copy(record)
         if isinstance(cr.msg, dict):

--- a/jina/logging/logger.py
+++ b/jina/logging/logger.py
@@ -44,7 +44,7 @@ class JinaLogger:
     :param identity: The id of the group the messages from this logger will belong, used by fluentd default
     configuration to group logs by pod.
     :param workspace_path: The workspace path where the log will be stored at (only apply to fluentd)
-    :returns: an executor object.
+    :return:: an executor object.
     """
 
     supported = {'FileHandler', 'StreamHandler', 'SysLogHandler', 'FluentHandler'}
@@ -122,7 +122,7 @@ class JinaLogger:
         """
         Get the handlers of the logger.
 
-        :returns: Handlers of logger.
+        :return:: Handlers of logger.
         """
         return self.logger.handlers
 

--- a/jina/optimizers/__init__.py
+++ b/jina/optimizers/__init__.py
@@ -83,7 +83,7 @@ class MeanEvaluationCallback(OptimizerCallback):
         """
         Calculates and returns mean evaluation value on the metric defined in the :method:`__init__`.
 
-        :returns: The aggregation of all evaluation collected via :method:`__call__`
+        :return:: The aggregation of all evaluation collected via :method:`__call__`
         """
         if self._eval_name is not None:
             evaluation_name = self._eval_name
@@ -125,14 +125,14 @@ class ResultProcessor(JAMLCompatible):
     @property
     def study(self):
         """
-        :returns: Raw optuna study as calculated by the :py:class:`FlowOptimizer`.
+        :return:: Raw optuna study as calculated by the :py:class:`FlowOptimizer`.
         """
         return self._study
 
     @property
     def best_parameters(self):
         """
-        :returns: The parameter set, which got the best evaluation result during the optimization.
+        :return:: The parameter set, which got the best evaluation result during the optimization.
         """
         return self._best_parameters
 
@@ -255,7 +255,7 @@ class FlowOptimizer(JAMLCompatible):
         Will run the actual optimization.
 
         :param kwargs: extra parameters for optuna sampler
-        :returns: The aggregated result of the optimization run as a :class:`ResultProcessor`.
+        :return:: The aggregated result of the optimization run as a :class:`ResultProcessor`.
         """
         with ImportExtensions(required=True):
             import optuna

--- a/jina/optimizers/parameters.py
+++ b/jina/optimizers/parameters.py
@@ -106,7 +106,7 @@ def load_optimization_parameters(filepath: str):
     """
     Loads optimization parameters from a `.yml` file and parses it with the JAML parser.
     :param filepath: Path to a file that contains optimization parameters.
-    :returns: The loaded :class:`OptimizationParameter` objects.
+    :return:: The loaded :class:`OptimizationParameter` objects.
     """
 
     with open(filepath, encoding='utf8') as fp:

--- a/jina/types/querylang/queryset/dunderkey.py
+++ b/jina/types/querylang/queryset/dunderkey.py
@@ -46,7 +46,7 @@ def dunderkey(*args: str) -> str:
        >>> 'a__b__c'
 
     :param *args: the multiple strings
-    :returns: the joined key
+    :return:: the joined key
     """
     return '__'.join(args)
 
@@ -153,11 +153,22 @@ def undunder_keys(_dict: Dict) -> Dict:
     """
 
     def f(keys, value):
-        """Recursively undunder the keys."""
+        """
+        Recursively undunder the keys.
+
+        :param keys: keys to undunder
+        :param value: related value
+        :return: undundered keys
+        """
         return {keys[0]: f(keys[1:], value)} if keys else value
 
     def merge(dict1, dict2):
-        """Merge two dictionaries."""
+        """
+        Merge second dictionary into the first one.
+
+        :param dict1: dictionary which gets modified
+        :param dict2: dictionary to read from
+        """
         key, val = list(dict2.items())[0]
 
         if key in dict1:

--- a/jina/types/score/__init__.py
+++ b/jina/types/score/__init__.py
@@ -74,7 +74,7 @@ class NamedScore(ProtoTypeMixin):
     def ref_id(self) -> str:
         """
         Return the ``ref_id`` of this NamedScore, the `id` of which this NamedScore is a score.
-        :returns: the ref_id
+        :return:: the ref_id
         """
         return self._pb_body.ref_id
 
@@ -90,7 +90,7 @@ class NamedScore(ProtoTypeMixin):
     def operands(self) -> List['NamedScore']:
         """
         Returns list of nested NamedScore operands.
-        :returns: list of nested NamedScore operands.
+        :return:: list of nested NamedScore operands.
         """
         return [NamedScore(operand) for operand in self._pb_body.operands]
 

--- a/tests/unit/types/sets/test_querylangset.py
+++ b/tests/unit/types/sets/test_querylangset.py
@@ -7,7 +7,7 @@ from jina.types.sets.querylang import QueryLangSet
 
 @pytest.fixture(scope='function')
 def querylang_protos():
-    """:returns: A :class:`RepeatedCompositeContainer` consist list of :class:`QueryLangProto`."""
+    """:return:: A :class:`RepeatedCompositeContainer` consist list of :class:`QueryLangProto`."""
     req = RequestProto()
     for _ in range(3):
         req.queryset.extend([QueryLangProto()])
@@ -16,13 +16,13 @@ def querylang_protos():
 
 @pytest.fixture(scope='function')
 def querylang_set(querylang_protos):
-    """:returns: A :class:`RepeatedCompositeContainer` consist list of :class:`QueryLangProto`."""
+    """:return:: A :class:`RepeatedCompositeContainer` consist list of :class:`QueryLangProto`."""
     return QueryLangSet(querylang_protos=querylang_protos)
 
 
 @pytest.fixture(scope='function')
 def querylang_instance():
-    """:returns: An instance of :class:`QueryLang`."""
+    """:return:: An instance of :class:`QueryLang`."""
     query_lang = QueryLang()
     query_lang.name = 'test'
     query_lang.priority = 5


### PR DESCRIPTION
A small correction for the docstrings.
We had cases where we were using `:returns:` in the docstring, but it has to be `:return:`

Resolves https://github.com/jina-ai/jina/issues/2149