### PR TITLE
fix: metavar for docker args

### DIFF
--- a/jina/parsers/peapods/runtimes/container.py
+++ b/jina/parsers/peapods/runtimes/container.py
@@ -28,7 +28,7 @@ the Docker container.
     gp.add_argument(
         '--docker-kwargs',
         action=KVAppendAction,
-        metavar='KEY=VALUE',
+        metavar='KEY: VALUE',
         nargs='*',
         help='''
 Dictionary of kwargs arguments that will be passed to Docker SDK when starting the docker '


### PR DESCRIPTION
minor fix on type, it has been used in `KEY: VALUE` format.