### PR TITLE
test: ignore resources folder for pytest and codecov

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,3 +3,5 @@
 # regrexes for lines to exclude from consideration
 exclude_lines =
   NotImplementedError
+omit =
+  jina/resources/*

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -3,6 +3,7 @@ codecov:
   allow_coverage_offsets: true
 ignore:
   - "jina/hub"
+  - "jina/resources"
 coverage:
   status:
     project:


### PR DESCRIPTION
resources folder has some python scripts, while most of them are `yml`, should not be included in pytest and codecov.