### PR TITLE
fix: hub_build_level  test

### DIFF
--- a/tests/unit/docker/test_hub_build_level.py
+++ b/tests/unit/docker/test_hub_build_level.py
@@ -27,48 +27,45 @@ def docker_image():
         else:
             return False
 
+    img_name = 'jinahub/pod.dummy_mwu_encoder:0.0.6'
     client = docker.from_env()
+    client.images.pull(img_name)
     images = client.images.list()
-    try:
-        image_name = list(filter(lambda image: _filter_repo_tag(image), images))[0]
-    except IndexError:
-        return None
+    image_name = list(filter(lambda image: _filter_repo_tag(image), images))[0]
     return image_name
 
 
 def test_hub_build_level_pass(monkeypatch, test_workspace, docker_image):
-    if docker_image:
-        args = set_hub_build_parser().parse_args(
-            ['path/hub-mwu', '--push', '--host-info', '--test-level', 'EXECUTOR']
-        )
-        expected_failed_levels = []
+    args = set_hub_build_parser().parse_args(
+        ['path/hub-mwu', '--push', '--host-info', '--test-level', 'EXECUTOR']
+    )
+    expected_failed_levels = []
 
-        _, failed_levels = HubIO(args)._test_build(
-            docker_image,
-            BuildTestLevel.EXECUTOR,
-            os.path.join(cur_dir, 'yaml/test-joint.yml'),
-            60000,
-            True,
-            JinaLogger('unittest'),
-        )
+    _, failed_levels = HubIO(args)._test_build(
+        docker_image,
+        BuildTestLevel.EXECUTOR,
+        os.path.join(cur_dir, 'yaml/test-joint.yml'),
+        60000,
+        True,
+        JinaLogger('unittest'),
+    )
 
-        assert expected_failed_levels == failed_levels
+    assert expected_failed_levels == failed_levels
 
 
 def test_hub_build_level_fail(monkeypatch, test_workspace, docker_image):
-    if docker_image:
-        args = set_hub_build_parser().parse_args(
-            ['path/hub-mwu', '--push', '--host-info', '--test-level', 'FLOW']
-        )
-        expected_failed_levels = [BuildTestLevel.POD_DOCKER, BuildTestLevel.FLOW]
+    args = set_hub_build_parser().parse_args(
+        ['path/hub-mwu', '--push', '--host-info', '--test-level', 'FLOW']
+    )
+    expected_failed_levels = [BuildTestLevel.POD_DOCKER, BuildTestLevel.FLOW]
 
-        _, failed_levels = HubIO(args)._test_build(
-            docker_image,
-            BuildTestLevel.FLOW,
-            os.path.join(cur_dir, 'yaml/test-joint.yml'),
-            60000,
-            True,
-            JinaLogger('unittest'),
-        )
+    _, failed_levels = HubIO(args)._test_build(
+        docker_image,
+        BuildTestLevel.FLOW,
+        os.path.join(cur_dir, 'yaml/test-joint.yml'),
+        60000,
+        True,
+        JinaLogger('unittest'),
+    )
 
-        assert expected_failed_levels == failed_levels
+    assert expected_failed_levels == failed_levels

--- a/tests/unit/docker/test_hub_build_level.py
+++ b/tests/unit/docker/test_hub_build_level.py
@@ -7,7 +7,6 @@ from jina.enums import BuildTestLevel
 from jina.logging import JinaLogger
 from jina.parsers.hub import set_hub_build_parser
 
-cli = docker.APIClient(base_url='unix://var/run/docker.sock')
 cur_dir = os.path.dirname(os.path.abspath(__file__))
 
 

--- a/tests/unit/docker/test_hub_build_level.py
+++ b/tests/unit/docker/test_hub_build_level.py
@@ -29,42 +29,46 @@ def docker_image():
 
     client = docker.from_env()
     images = client.images.list()
-    image_name = list(filter(lambda image: _filter_repo_tag(image), images))[0]
-
+    try:
+        image_name = list(filter(lambda image: _filter_repo_tag(image), images))[0]
+    except IndexError:
+        return None
     return image_name
 
 
 def test_hub_build_level_pass(monkeypatch, test_workspace, docker_image):
-    args = set_hub_build_parser().parse_args(
-        ['path/hub-mwu', '--push', '--host-info', '--test-level', 'EXECUTOR']
-    )
-    expected_failed_levels = []
+    if docker_image:
+        args = set_hub_build_parser().parse_args(
+            ['path/hub-mwu', '--push', '--host-info', '--test-level', 'EXECUTOR']
+        )
+        expected_failed_levels = []
 
-    _, failed_levels = HubIO(args)._test_build(
-        docker_image,
-        BuildTestLevel.EXECUTOR,
-        os.path.join(cur_dir, 'yaml/test-joint.yml'),
-        60000,
-        True,
-        JinaLogger('unittest'),
-    )
+        _, failed_levels = HubIO(args)._test_build(
+            docker_image,
+            BuildTestLevel.EXECUTOR,
+            os.path.join(cur_dir, 'yaml/test-joint.yml'),
+            60000,
+            True,
+            JinaLogger('unittest'),
+        )
 
-    assert expected_failed_levels == failed_levels
+        assert expected_failed_levels == failed_levels
 
 
 def test_hub_build_level_fail(monkeypatch, test_workspace, docker_image):
-    args = set_hub_build_parser().parse_args(
-        ['path/hub-mwu', '--push', '--host-info', '--test-level', 'FLOW']
-    )
-    expected_failed_levels = [BuildTestLevel.POD_DOCKER, BuildTestLevel.FLOW]
+    if docker_image:
+        args = set_hub_build_parser().parse_args(
+            ['path/hub-mwu', '--push', '--host-info', '--test-level', 'FLOW']
+        )
+        expected_failed_levels = [BuildTestLevel.POD_DOCKER, BuildTestLevel.FLOW]
 
-    _, failed_levels = HubIO(args)._test_build(
-        docker_image,
-        BuildTestLevel.FLOW,
-        os.path.join(cur_dir, 'yaml/test-joint.yml'),
-        60000,
-        True,
-        JinaLogger('unittest'),
-    )
+        _, failed_levels = HubIO(args)._test_build(
+            docker_image,
+            BuildTestLevel.FLOW,
+            os.path.join(cur_dir, 'yaml/test-joint.yml'),
+            60000,
+            True,
+            JinaLogger('unittest'),
+        )
 
-    assert expected_failed_levels == failed_levels
+        assert expected_failed_levels == failed_levels


### PR DESCRIPTION
This is a test PR from the forked repo.
For PRs from fork repo, tests/unit/docker/test_hub_build_level.py will fail. The direct reason is that the list is empty. 
`image_name = list(filter(lambda image: _filter_repo_tag(image), images))[0]`

- [ ] One solution is that we could catch this exception and skip the two tests.
- [x] Another is to pull an image before using it.
- [ ] Refactor the hubIO tests?

This issue needs to dig deeper. This means that for PR from fork repo, before this test there are no images in the testing environment, but for our PRs, there are images in env. 
Then there must be some other tests not working as expected, take this for example: 
https://github.com/jina-ai/jina/blob/4578fd65c4b5477f1fd2ddf723aaa7a7e9cbc22d/tests/unit/docker/test_hub_build.py#L12

This test is not asserted so we won't know even it fails. If it **fails to pull the images**, the test of this PR will fail for sure.

