### PR TITLE
fix: linter ignore generated files

### DIFF
--- a/scripts/docstrings_lint.sh
+++ b/scripts/docstrings_lint.sh
@@ -10,9 +10,10 @@ arrVar=()
 # we ignore tests files
 for changed_file in $CHANGED_FILES; do
   case ${changed_file} in
-    !(tests/* | \
+    tests/* | \
     jina/proto/jina_pb2.py | \
-    jina/proto/jina_pb2_grpc.py))
+    jina/proto/jina_pb2_grpc.py)
+    ;;*)
       echo keeping ${changed_file}
       arrVar+=(${changed_file})
     ;;

--- a/scripts/docstrings_lint.sh
+++ b/scripts/docstrings_lint.sh
@@ -9,10 +9,14 @@ echo 'removing files under /tests...'
 arrVar=()
 # we ignore tests files
 for changed_file in $CHANGED_FILES; do
-  if [[ ${changed_file} != tests/* ]]; then
-    echo keeping ${changed_file}
-    arrVar+=(${changed_file})
-  fi
+  case ${changed_file} in
+    !(tests/* | \
+    jina/proto/jina_pb2.py | \
+    jina/proto/jina_pb2_grpc.py))
+      echo keeping ${changed_file}
+      arrVar+=(${changed_file})
+    ;;
+  esac
 done
 
 # if array is empty


### PR DESCRIPTION
generated files from the protobuf definition should not be checked in the linter
The problem got revealed when updating the proto definition in https://github.com/jina-ai/jina/pull/2198
resolves https://github.com/jina-ai/jina/issues/2200