### PR TITLE
fix: black exclude reformat

### DIFF
--- a/scripts/black.sh
+++ b/scripts/black.sh
@@ -1,9 +1,13 @@
 #!/bin/bash
 pip install black==20.8b1
 arrVar=()
-echo we ignore non-*.py files
+echo we ignore non-*.py files and files generated from protobuf
+excluded_files=(
+   jina/proto/jina_pb2.py
+   jina/proto/jina_pb2_grpc.py
+)
 for changed_file in $CHANGED_FILES; do
-  if [[ ${changed_file} == *.py ]]; then
+  if [[ ${changed_file} == *.py ]] && ! [[ " ${excluded_files[@]} " =~ " ${changed_file} " ]]; then
     echo checking ${changed_file}
     arrVar+=(${changed_file})
   fi


### PR DESCRIPTION
in https://github.com/jina-ai/jina/pull/2199 we ignored generated protobuf files for docstring matching.
In this pr, we need to ignore the reformatting as well.