### PR TITLE
feat: remove excludeQL from CompoundIndexer in SearchRequest

### DIFF
--- a/jina/resources/executors.requests.CompoundIndexer.yml
+++ b/jina/resources/executors.requests.CompoundIndexer.yml
@@ -3,10 +3,6 @@ on:
     - !VectorSearchDriver
       with:
         executor: BaseVectorIndexer
-    - !ExcludeQL
-      with:
-        fields:
-          - embedding
     - !KVSearchDriver
       with:
         executor: BaseKVIndexer


### PR DESCRIPTION
Could we remove the ExcludeQL directive? Maybe it's needed to return the embedding at some point 