### PR TITLE
test: add regression for chatbot

### DIFF
--- a/extra-requirements.txt
+++ b/extra-requirements.txt
@@ -59,7 +59,7 @@ pytest-mock:                test
 pytest-cov:                 test
 pytest-repeat:              test
 pytest-asyncio:             test
-pytest-xprocess             test
+pytest-xprocess:            test
 flaky:                      test
 mock:                       test
 requests:                   http, devel, cicd, daemon

--- a/extra-requirements.txt
+++ b/extra-requirements.txt
@@ -59,6 +59,7 @@ pytest-mock:                test
 pytest-cov:                 test
 pytest-repeat:              test
 pytest-asyncio:             test
+pytest-xprocess             test
 flaky:                      test
 mock:                       test
 requests:                   http, devel, cicd, daemon

--- a/tests/system/chatbot/test_chatbot.py
+++ b/tests/system/chatbot/test_chatbot.py
@@ -1,5 +1,3 @@
-from multiprocessing import Process
-
 import pytest
 import requests
 from xprocess import ProcessStarter

--- a/tests/system/chatbot/test_chatbot.py
+++ b/tests/system/chatbot/test_chatbot.py
@@ -1,0 +1,35 @@
+import pytest
+import requests
+
+from jina.helloworld.chatbot import hello_world
+from jina.parsers.helloworld import set_hw_chatbot_parser
+
+
+@pytest.fixture
+def chatbot_args(tmpdir):
+    return set_hw_chatbot_parser().parse_args(
+        ['--workdir', str(tmpdir), '--unblock-query-flow', '--port-expose', '8080']
+    )
+
+
+@pytest.fixture
+def payload():
+    return {'top_k': 1, 'data': ['text:Is my dog safe from virus']}
+
+
+@pytest.fixture
+def post_uri():
+    return 'http://localhost:8080/api/search'
+
+
+@pytest.fixture
+def expected_result():
+    return '''There’s no evidence from the outbreak that eating garlic, sipping water every 15 minutes or taking vitamin C will protect people from the new coronavirus.'''
+
+
+def test_chatbot(chatbot_args, payload, post_uri, expected_result):
+    """Regression test for multimodal example."""
+    hello_world(chatbot_args)
+    resp = requests.post(post_uri, json=payload)
+    assert resp.status_code == 200
+    assert expected_result in resp.text

--- a/tests/system/chatbot/test_chatbot.py
+++ b/tests/system/chatbot/test_chatbot.py
@@ -1,3 +1,5 @@
+from multiprocessing import Process
+
 import pytest
 import requests
 
@@ -8,7 +10,7 @@ from jina.parsers.helloworld import set_hw_chatbot_parser
 @pytest.fixture
 def chatbot_args(tmpdir):
     return set_hw_chatbot_parser().parse_args(
-        ['--workdir', str(tmpdir), '--unblock-query-flow', '--port-expose', '8080']
+        ['--workdir', str(tmpdir), '--port-expose', '8080']
     )
 
 
@@ -27,9 +29,16 @@ def expected_result():
     return '''There’s no evidence from the outbreak that eating garlic, sipping water every 15 minutes or taking vitamin C will protect people from the new coronavirus.'''
 
 
-def test_chatbot(chatbot_args, payload, post_uri, expected_result):
-    """Regression test for multimodal example."""
-    hello_world(chatbot_args)
+@pytest.fixture
+def server(chatbot_args):
+    proc = Process(target=hello_world(chatbot_args), daemon=True)
+    proc.start()
+    yield
+    proc.kill()
+
+
+def test_chatbot(server, payload, post_uri, expected_result):
+    """Regression test for chatbot example."""
     resp = requests.post(post_uri, json=payload)
     assert resp.status_code == 200
     assert expected_result in resp.text

--- a/tests/system/chatbot/test_chatbot.py
+++ b/tests/system/chatbot/test_chatbot.py
@@ -32,7 +32,6 @@ def expected_result():
 
 @pytest.fixture(autouse=True)
 def start_server(xprocess, chatbot_args):
-
     class Starter(ProcessStarter):
         pattern = "You should see a demo page opened in your browser"
         args = ["jina", "hello", "chatbot"]

--- a/tests/system/chatbot/test_chatbot.py
+++ b/tests/system/chatbot/test_chatbot.py
@@ -35,18 +35,11 @@ def start_server(xprocess, chatbot_args):
 
     class Starter(ProcessStarter):
         pattern = "You should see a demo page opened in your browser"
-
-        # command to start process
         args = ["jina", "hello", "chatbot"]
-
         max_read_lines = 10000
 
-    # ensure process is running and return its logfile
     xprocess.ensure("server", Starter)
-
     yield
-
-    # clean up whole process tree afterwards
     xprocess.getinfo("server").terminate()
 
 


### PR DESCRIPTION
Given a system under test, `test_chatbot` depends on the `index` flow to be fired. While `f.block` blocked the process. I did some search and find the official plugin: [pytest-xprocess](https://github.com/pytest-dev/pytest-xprocess)

> pytest plugin for managing processes across test runs.

This plugin:

1. Bootstrap `hello_world` example in another process.
2. Monitor system logs to check if it is ready to test using `pattern matching`.
3. Run the test.
4. Kill the process.

This PR completes regression tests for three examples.