### PR TITLE
test: assert there are no embeddings by default

### DIFF
--- a/tests/integration/crud/simple/test_crud.py
+++ b/tests/integration/crud/simple/test_crud.py
@@ -37,6 +37,7 @@ def random_docs(start, end, embed_dim=10, jitter=1, has_content=True):
             d.text = ''.join(
                 random.choice(string.ascii_lowercase) for _ in range(10)
             ).encode('utf8')
+            assert d.embedding is None
             d.embedding = np.random.random([embed_dim + np.random.randint(0, jitter)])
         yield d
 


### PR DESCRIPTION
(The previous [branch](https://github.com/jina-ai/jina/pull/2219) had a mess while rebasing master. This is the same but the updated master will prevents the other tests in CI to fail)

As discussed [here](https://github.com/jina-ai/jina/pull/2213) right now there is no way to access the embedding. They are being excluded by default during query time. 
It refers to this [issue](https://github.com/jina-ai/jina/issues/2069) 