### PR TITLE
feat: async control request

### DIFF
--- a/jina/peapods/runtimes/zmq/base.py
+++ b/jina/peapods/runtimes/zmq/base.py
@@ -69,7 +69,6 @@ class ZMQManyRuntime(BaseRuntime, ABC):
 
     def cancel(self):
         """Send cancel control messages to all control address."""
-        # TODO: can use send_message_async to avoid sequential waiting
         for ctrl_addr in self.many_ctrl_addr:
             send_ctrl_message(ctrl_addr, 'TERMINATE', timeout=self.timeout_ctrl)
 
@@ -80,7 +79,6 @@ class ZMQManyRuntime(BaseRuntime, ABC):
 
         :return: received messages
         """
-        # TODO: can use send_ctrl_message to avoid sequential waiting
         result = []
         for ctrl_addr in self.many_ctrl_addr:
             result.append(

--- a/jina/peapods/zmq/__init__.py
+++ b/jina/peapods/zmq/__init__.py
@@ -428,7 +428,7 @@ def send_ctrl_message(address: str, cmd: str, timeout: int) -> 'Message':
         ctx.setsockopt(zmq.LINGER, 0)
         sock, _ = _init_socket(ctx, address, None, SocketType.PAIR_CONNECT)
         msg = ControlMessage(cmd)
-        send_message(sock, msg, timeout)
+        send_message_async(sock, msg, timeout)
         r = None
         try:
             r = recv_message(sock, timeout)


### PR DESCRIPTION
Work in progress...
When making rolling updates on replicas, we can not wait until all the peas are closed. This would lead to waiting time on the search requests.
```
with flow:
    flow.index()
    flow.rolling_update() <-  needs to ran asynchronously but  needs to send the control requests synchronized (TERMINATE, IDLE)
    flow.index()
```
