### PR TITLE
fix: fix the bug in the default value

### DIFF
--- a/jina/drivers/search.py
+++ b/jina/drivers/search.py
@@ -60,7 +60,7 @@ class KVSearchDriver(ContextAwareRecursiveMixin, BaseSearchDriver):
     def __init__(
         self,
         is_update: bool = True,
-        traversal_paths: Tuple[str] = ('m'),
+        traversal_paths: Tuple[str] = ('m',),
         *args,
         **kwargs,
     ):


### PR DESCRIPTION
the default value should be a `tuple` instead of a `str`
```
Python 3.7.5 (default, Feb 15 2020, 23:39:06)
Type 'copyright', 'credits' or 'license' for more information
IPython 7.12.0 -- An enhanced Interactive Python. Type '?' for help.
In [1]: a = ('m')
In [2]: type(a)
Out[2]: str
```