### PR TITLE
fix(helper): fetching external ip is extremely slow

### DIFF
--- a/jina/helper.py
+++ b/jina/helper.py
@@ -1054,7 +1054,6 @@ def get_public_ip():
 
     def _get_ip(url):
         try:
-            print(url)
             with urllib.request.urlopen(url, timeout=0.5) as fp:
                 return fp.read().decode('utf8')
         except:


### PR DESCRIPTION
- fetching external ip is slow in china because of the network issue. 
- the original implementation fetch IP sequentially, called twice
- **with timeout at 1, in China mainland it takes (1+1+1)*2 = 6s to start at Flow!**
- change it to async and smaller timeout