### PR TITLE
fix: import warnings verbose off by default

### DIFF
--- a/jina/__init__.py
+++ b/jina/__init__.py
@@ -128,8 +128,13 @@ from jina.types.document.multimodal import MultimodalDocument
 from jina.types.sets import DocumentSet, QueryLangSet
 
 # ADD GLOBAL NAMESPACE VARIABLES
-
 JINA_GLOBAL = _types.SimpleNamespace()
+JINA_GLOBAL.scipy_installed = None
+JINA_GLOBAL.tensorflow_installed = None
+JINA_GLOBAL.torch_installed = None
+
+
+# JINA_GLOBAL = _types.SimpleNamespace()
 
 import jina.importer as _ji
 

--- a/jina/__init__.py
+++ b/jina/__init__.py
@@ -133,9 +133,6 @@ JINA_GLOBAL.scipy_installed = None
 JINA_GLOBAL.tensorflow_installed = None
 JINA_GLOBAL.torch_installed = None
 
-
-# JINA_GLOBAL = _types.SimpleNamespace()
-
 import jina.importer as _ji
 
 # driver first, as executor may contain driver

--- a/jina/types/document/__init__.py
+++ b/jina/types/document/__init__.py
@@ -433,7 +433,7 @@ class Document(ProtoTypeMixin, Traversable):
         self._pb_body.parent_id = str(value)
 
     @property
-    def blob(self) -> 'Union[np.ndarray, scipy.coo_matrix]':
+    def blob(self) -> 'np.ndarray':
         """Return ``blob``, one of the content form of a Document.
 
         .. note::

--- a/jina/types/document/__init__.py
+++ b/jina/types/document/__init__.py
@@ -51,7 +51,7 @@ with ImportExtensions(
     required=False,
     pkg_name='scipy',
     help_text=f'can not import scipy: pip install scipy ',
-    verbose=False
+    verbose=False,
 ):
     import scipy
 
@@ -61,7 +61,7 @@ with ImportExtensions(
     required=False,
     pkg_name='tensorflow',
     help_text=f'can not import tensorflow: pip install tensorflow ',
-    verbose=False
+    verbose=False,
 ):
     import tensorflow
 
@@ -71,7 +71,7 @@ with ImportExtensions(
     required=False,
     pkg_name='torch',
     help_text=f'can not import torch: pip install torch ',
-    verbose=False
+    verbose=False,
 ):
     import torch
 
@@ -501,12 +501,12 @@ class Document(ProtoTypeMixin, Traversable):
         """
         self._update_ndarray('embedding', value)
 
-    def _update_sparse_ndarray(self, k, v , sparse_cls):
+    def _update_sparse_ndarray(self, k, v, sparse_cls):
         protbuf_updater = NdArray(
-                is_sparse=True,
-                sparse_cls=sparse_cls,
-                proto=getattr(self._pb_body, k),
-            )
+            is_sparse=True,
+            sparse_cls=sparse_cls,
+            proto=getattr(self._pb_body, k),
+        )
         protbuf_updater.value = v
 
     def _update_ndarray(self, k, v):
@@ -519,13 +519,16 @@ class Document(ProtoTypeMixin, Traversable):
             NdArray(getattr(self._pb_body, k)).value = v.value
         elif scipy_installed and scipy.sparse.issparse(v):
             from ..ndarray.sparse.scipy import SparseNdArray
-            self._update_sparse_ndarray(k=k, v=v, sparse_cls = SparseNdArray)
+
+            self._update_sparse_ndarray(k=k, v=v, sparse_cls=SparseNdArray)
         elif tensorflow_installed and isinstance(v, tensorflow.SparseTensor):
             from ..ndarray.sparse.tensorflow import SparseNdArray
-            self._update_sparse_ndarray(k=k, v=v, sparse_cls = SparseNdArray)
+
+            self._update_sparse_ndarray(k=k, v=v, sparse_cls=SparseNdArray)
         elif pytorch_installed and isinstance(v, torch.Tensor) and v.is_sparse:
             from ..ndarray.sparse.pytorch import SparseNdArray
-            self._update_sparse_ndarray(k=k, v=v, sparse_cls = SparseNdArray)
+
+            self._update_sparse_ndarray(k=k, v=v, sparse_cls=SparseNdArray)
         else:
             raise TypeError(f'{k} is in unsupported type {typename(v)}')
 

--- a/jina/types/document/__init__.py
+++ b/jina/types/document/__init__.py
@@ -452,7 +452,7 @@ class Document(ProtoTypeMixin, Traversable):
         self._update_ndarray('blob', value)
 
     @property
-    def embedding(self) -> 'Union[np.ndarray, scipy.coo_matrix]':
+    def embedding(self) -> 'np.ndarray':
         """Return ``embedding`` of the content of a Document.
 
         :return: the embedding from the proto

--- a/jina/types/document/__init__.py
+++ b/jina/types/document/__init__.py
@@ -502,12 +502,11 @@ class Document(ProtoTypeMixin, Traversable):
         self._update_ndarray('embedding', value)
 
     def _update_sparse_ndarray(self, k, v, sparse_cls):
-        protbuf_updater = NdArray(
+        NdArray(
             is_sparse=True,
             sparse_cls=sparse_cls,
             proto=getattr(self._pb_body, k),
-        )
-        protbuf_updater.value = v
+        ).value = v
 
     def _update_ndarray(self, k, v):
         if isinstance(v, jina_pb2.NdArrayProto):


### PR DESCRIPTION
This PR:

- Avoids warning users of external packages with specific arrays that are allowed in documents
- Refactors `update_ndarray` code making it more compact
- fixes `protbuff_updater` mispelled variable names to `protbuf_updater`