### PR TITLE
fix(client): remove sibling setting in client

### DIFF
--- a/jina/clients/request/__init__.py
+++ b/jina/clients/request/__init__.py
@@ -49,9 +49,7 @@ def request_generator(
     :yield: request
     """
 
-    _kwargs = dict(
-        mime_type=mime_type, siblings=request_size, weight=1.0, extra_kwargs=kwargs
-    )
+    _kwargs = dict(mime_type=mime_type, weight=1.0, extra_kwargs=kwargs)
 
     try:
         if not isinstance(data, Iterable):

--- a/jina/clients/request/asyncio.py
+++ b/jina/clients/request/asyncio.py
@@ -36,7 +36,7 @@ async def request_generator(
     :param kwargs: additional key word arguments
     :yield: request
     """
-    _kwargs = dict(mime_type=mime_type, siblings=request_size, weight=1.0)
+    _kwargs = dict(mime_type=mime_type, weight=1.0)
 
     try:
         with ImportExtensions(required=True):


### PR DESCRIPTION
`Flow.index(Document())` gives this single Document `doc.siblings=100` (as 100 is the default `request_size`), this logic is wrong.

One may argue not setting it (i.e. implicit 0) is also wrong, but given not-set and 100 are both wrong, I would choose not-set.