### PR TITLE
fix: track workspace_id

### DIFF
--- a/daemon/stores/__init__.py
+++ b/daemon/stores/__init__.py
@@ -1,9 +1,9 @@
+from .workspace import WorkspaceStore
 from .flow import FlowStore
 from .pea import PeaStore
 from .pod import PodStore
-from .workspace import WorkspaceStore
 
+workspace_store = WorkspaceStore()
 flow_store = FlowStore()
 pea_store = PeaStore()
 pod_store = PodStore()
-workspace_store = WorkspaceStore()

--- a/daemon/stores/flow.py
+++ b/daemon/stores/flow.py
@@ -3,11 +3,11 @@ from typing import Optional, BinaryIO
 
 from jina.flow import Flow
 from jina.helper import colored, random_uuid
-from .base import BaseStore
+from .workunit import WorkunitStore
 from .helper import jina_workspace
 
 
-class FlowStore(BaseStore):
+class FlowStore(WorkunitStore):
     def add(self, config: BinaryIO, workspace_id: Optional[uuid.UUID] = None, **kwargs):
         try:
             if not workspace_id:
@@ -29,6 +29,11 @@ class FlowStore(BaseStore):
                 'object': f,
                 'arguments': vars(f.args),
                 'yaml_source': y_spec,
+                'workdir': _workdir,
+                'workspace_id': workspace_id,
+            }
+            self._workspace_store[workspace_id] = {
+                'arguments': [],
                 'workdir': _workdir,
                 'workspace_id': workspace_id,
             }

--- a/daemon/stores/pea.py
+++ b/daemon/stores/pea.py
@@ -3,11 +3,11 @@ from argparse import Namespace
 
 from jina.helper import random_uuid, colored
 from jina.peapods import Pea
-from .base import BaseStore
+from .workunit import WorkunitStore
 from .helper import jina_workspace
 
 
-class PeaStore(BaseStore):
+class PeaStore(WorkunitStore):
     peapod_cls = Pea
 
     def add(self, args: Namespace, **kwargs):
@@ -15,6 +15,8 @@ class PeaStore(BaseStore):
             workspace_id = args.workspace_id
             if not workspace_id:
                 workspace_id = random_uuid()
+            else:
+                workspace_id = uuid.UUID(workspace_id)
 
             with jina_workspace(workspace_id) as _workdir:
                 p = self.peapod_cls(args).start()
@@ -27,6 +29,11 @@ class PeaStore(BaseStore):
             self[_id] = {
                 'object': p,
                 'arguments': vars(args),
+                'workdir': _workdir,
+                'workspace_id': workspace_id,
+            }
+            self._workspace_store[workspace_id] = {
+                'arguments': [],
                 'workdir': _workdir,
                 'workspace_id': workspace_id,
             }

--- a/daemon/stores/workunit.py
+++ b/daemon/stores/workunit.py
@@ -1,0 +1,43 @@
+import uuid
+from pathlib import Path
+from typing import Union
+
+from jina.helper import colored
+from .base import BaseStore
+
+class WorkunitStore(BaseStore):
+    def __init__(self):
+        super().__init__()
+        from . import workspace_store
+        self._workspace_store = workspace_store
+
+    def add(self, *args, **kwargs) -> 'uuid.UUID':
+        """Add a new element to the store. This method needs to be overridden by the subclass"""
+        raise NotImplementedError
+
+    def delete(
+        self,
+        id: Union[str, uuid.UUID],
+        workspace: bool = False,
+        **kwargs,
+    ):
+        if isinstance(id, str):
+            id = uuid.UUID(id)
+
+        if id in self._items:
+            v = self._items[id]
+            if 'object' in v and hasattr(v['object'], 'close'):
+                v['object'].close()
+            if workspace and v.get('workdir', None):
+                for path in Path(v['workdir']).rglob('[!logging.log]*'):
+                    if path.is_file():
+                        self._logger.debug(f'file to be deleted: {path}')
+                        path.unlink()
+            del self[id]
+            del self._workspace_store[v.get('workspace_id')]
+            self._logger.success(
+                f'{colored(str(id), "cyan")} is released from the store along  with workspace \
+                    {colored(str(v.get("workspace_id")), "cyan")}.'
+            )
+        else:
+            raise KeyError(f'{colored(str(id), "cyan")} not found in store.')

--- a/daemon/stores/workunit.py
+++ b/daemon/stores/workunit.py
@@ -5,6 +5,7 @@ from typing import Union
 from jina.helper import colored
 from .base import BaseStore
 
+
 class WorkunitStore(BaseStore):
     def __init__(self):
         super().__init__()
@@ -21,6 +22,7 @@ class WorkunitStore(BaseStore):
         workspace: bool = False,
         **kwargs,
     ):
+        """Deletes an element from the store. Deletes associated workspace from workspace store as well"""
         if isinstance(id, str):
             id = uuid.UUID(id)
 

--- a/tests/daemon/unit/api/endpoints/test_upload_add.py
+++ b/tests/daemon/unit/api/endpoints/test_upload_add.py
@@ -146,6 +146,14 @@ def test_post_and_delete_workspace(fastapi_client):
 
 @pytest.mark.parametrize('api', ['/peas', '/pods'])
 def test_upload_peapod_and_check_workspace(api, fastapi_client):
+    # Delete all Pea/Pod
+    response = fastapi_client.delete(api)
+    assert response.status_code == 200
+
+    # Delete the Workspaces
+    response = fastapi_client.delete('/workspaces')
+    assert response.status_code == 200
+
     # Create a Pea/Pod
     response = fastapi_client.post(
         api, json={'name': 'my_pod'}
@@ -173,6 +181,14 @@ def test_upload_peapod_and_check_workspace(api, fastapi_client):
 
 
 def test_upload_flow_and_check_workspace(fastapi_client):
+    # Delete the Flows
+    response = fastapi_client.delete('/flows')
+    assert response.status_code == 200
+
+    # Delete the Workspaces
+    response = fastapi_client.delete('/workspaces')
+    assert response.status_code == 200
+
     # Create a Flow
     response = fastapi_client.post(
         '/flows',
@@ -200,3 +216,4 @@ def test_upload_flow_and_check_workspace(fastapi_client):
     response = fastapi_client.get('/workspaces')
     assert response.status_code == 200
     assert response.json()['size'] == 0
+

--- a/tests/daemon/unit/api/endpoints/test_upload_add.py
+++ b/tests/daemon/unit/api/endpoints/test_upload_add.py
@@ -142,3 +142,61 @@ def test_post_and_delete_workspace(fastapi_client):
     response = fastapi_client.delete(f'/workspaces/{workspace_id}')
     assert response.status_code == 200
     assert not os.path.exists(get_workspace_path(workspace_id))
+
+
+@pytest.mark.parametrize('api', ['/peas', '/pods'])
+def test_upload_peapod_and_check_workspace(api, fastapi_client):
+    # Create a Pea/Pod
+    response = fastapi_client.post(
+        api, json={'name': 'my_pod'}
+    )
+    assert response.status_code == 201
+
+    # Fetch all Peas/Pods
+    response = fastapi_client.get(api)
+    assert response.status_code == 200
+    assert response.json()['size'] == 1
+
+    # Fetch the Workspace
+    response = fastapi_client.get('/workspaces')
+    assert response.status_code == 200
+    assert response.json()['size'] == 1
+
+    # Delete the Workspaces
+    response = fastapi_client.delete('/workspaces')
+    assert response.status_code == 200
+
+    # Fetch the Workspace
+    response = fastapi_client.get('/workspaces')
+    assert response.status_code == 200
+    assert response.json()['size'] == 0
+
+
+def test_upload_flow_and_check_workspace(fastapi_client):
+    # Create a Flow
+    response = fastapi_client.post(
+        '/flows',
+        files={'flow':
+                   ('good_flow.yml', open(str(cur_dir / 'good_flow.yml'), 'rb'))
+               }
+    )
+    assert response.status_code == 201
+
+    # Fetch all Flows
+    response = fastapi_client.get('/flows')
+    assert response.status_code == 200
+    assert response.json()['size'] == 1
+
+    # Fetch the Workspace
+    response = fastapi_client.get('/workspaces')
+    assert response.status_code == 200
+    assert response.json()['size'] == 1
+
+    # Delete the Workspaces
+    response = fastapi_client.delete('/workspaces')
+    assert response.status_code == 200
+
+    # Fetch the Workspace
+    response = fastapi_client.get('/workspaces')
+    assert response.status_code == 200
+    assert response.json()['size'] == 0


### PR DESCRIPTION
- Fixes issue: #1868 
- When a Flow/Pod/Pea gets created via POST endpoint or gets terminated via DELETE endpoint, there are updates to different workspaces and their workspace_id get tracked in WorkspaceStore.