### PR TITLE
fix: benchmark dump test

### DIFF
--- a/jina/types/message/__init__.py
+++ b/jina/types/message/__init__.py
@@ -126,7 +126,9 @@ class Message:
 
         :return: boolean which states if data is requested
         """
-        return self.envelope.request_type != 'ControlRequest' or self.request.propagate
+        return (
+            self.envelope.request_type != 'ControlRequest' or self.request.propagate
+        ) and self.envelope.request_type != 'DumpRequest'
 
     def _add_envelope(
         self,

--- a/tests/integration/dump/test_dump_dbms.py
+++ b/tests/integration/dump/test_dump_dbms.py
@@ -74,13 +74,17 @@ def assert_dump_data(dump_path, docs, shards, pea_id):
     )
 
     # assert with Indexers
-    # noinspection PyTypeChecker
     # TODO currently metas are only passed to the parent Compound, not to the inner components
-    cp: CompoundQueryExecutor = BaseQueryIndexer.load_config(
-        'indexer_query.yml',
-        pea_id=pea_id,
-        metas={'workspace': os.path.join(dump_path, 'new_ws'), 'dump_path': dump_path},
-    )
+    with TimeContext(f'### reloading {len(docs_expected)}'):
+        # noinspection PyTypeChecker
+        cp: CompoundQueryExecutor = BaseQueryIndexer.load_config(
+            'indexer_query.yml',
+            pea_id=pea_id,
+            metas={
+                'workspace': os.path.join(dump_path, 'new_ws'),
+                'dump_path': dump_path,
+            },
+        )
     for c in cp.components:
         assert c.size == len(docs_expected)
 
@@ -107,7 +111,7 @@ def path_size(dump_path):
 @pytest.mark.parametrize('shards', [6, 3, 1])
 @pytest.mark.parametrize('nr_docs', [7])
 @pytest.mark.parametrize('emb_size', [10])
-def test_dump_keyvalue(tmpdir, shards, nr_docs, emb_size, benchmark=False):
+def test_dump_keyvalue(tmpdir, shards, nr_docs, emb_size, run_basic=False):
     docs = list(get_documents(nr=nr_docs, index_start=0, emb_size=emb_size))
     assert len(docs) == nr_docs
     nr_search = 1
@@ -132,7 +136,7 @@ def test_dump_keyvalue(tmpdir, shards, nr_docs, emb_size, benchmark=False):
     def error_callback(resp):
         raise Exception('error callback called')
 
-    if benchmark:
+    if run_basic:
         basic_benchmark(
             tmpdir, docs, _validate_results_nonempty, error_callback, nr_search
         )
@@ -144,8 +148,7 @@ def test_dump_keyvalue(tmpdir, shards, nr_docs, emb_size, benchmark=False):
             flow_dbms.index(docs)
 
         with TimeContext(f'### dumping {len(docs)} docs'):
-            # TODO move to control request approach
-            flow_dbms.dump('indexer_dbms', dump_path, shards=shards, timeout=120)
+            flow_dbms.dump('indexer_dbms', dump_path, shards=shards, timeout=-1)
 
         dir_size = path_size(dump_path)
         print(f'### dump path size: {dir_size} MBs')
@@ -160,8 +163,7 @@ def test_dump_keyvalue(tmpdir, shards, nr_docs, emb_size, benchmark=False):
     'GITHUB_WORKFLOW' in os.environ, reason='skip the benchmark test on github workflow'
 )
 def test_benchmark(tmpdir):
-    # TODO 10000 seems to break the test
-    nr_docs = 8000
+    nr_docs = 100000
     return test_dump_keyvalue(
-        tmpdir, shards=1, nr_docs=nr_docs, emb_size=128, benchmark=True
+        tmpdir, shards=1, nr_docs=nr_docs, emb_size=128, run_basic=True
     )


### PR DESCRIPTION
Fix dumprequest not being propagated to the send ctrl message

Baseline:
```
### baseline - query time with 1 on 100000 docs ...	         Client@86294[S]:connected to the gateway at 0.0.0.0:55803!
### baseline - query time with 1 on 100000 docs takes 1 second (1.57s)
### baseline - indexing: 100000 docs ...	         Client@86294[S]:connected to the gateway at 0.0.0.0:37613!
### baseline - indexing: 100000 docs takes 9 seconds (9.75s)
```

Dump / Reload

```
### indexing 100000 docs takes 17 seconds (17.56s)
### dumping 100000 docs takes 3 seconds (3.27s)
### dump path size: 112.75556 MBs
### reloading 100000 takes 2 seconds (2.50s)
```

The reason indexing is slower for the DBMSBinaryPb vs Baseline BinaryPb is because we need to pickle both the vector and the metadata before storing them in the underlying KV data structure the BinaryPb uses:

```
    def add(
        self, ids: List[str], vecs: List[np.array], metas: List[bytes], *args, **kwargs
    ):
        """Add to the DBMS Indexer, both vectors and metadata

        :param ids: the ids of the documents
        :param vecs: the vectors
        :param metas: the metadata, in binary format
        :param args: not used
        :param kwargs: not used
        """
        if not any(ids):
            return

        vecs_metas = [pickle.dumps((vec, meta)) for vec, meta in zip(vecs, metas)]
        self._add(ids, vecs_metas)
```