### PR TITLE
feat: separate instantiate and start

### DIFF
--- a/jina/peapods/peas/__init__.py
+++ b/jina/peapods/peas/__init__.py
@@ -8,6 +8,8 @@ from ...enums import PeaRoleType, RuntimeBackendType
 from ...excepts import RuntimeFailToStart, RuntimeTerminated
 from ...helper import typename
 from ...logging.logger import JinaLogger
+import multiprocessing
+import threading
 
 __all__ = ['BasePea']
 
@@ -108,13 +110,14 @@ class BasePea(metaclass=PeaType):
             self.is_ready.clear()
             self._unset_envs()
 
-    def start(self):
+    def start(self) -> 'BasePea':
         """Start the Pea.
 
         This method overrides :meth:`start` in :class:`threading.Thread` or :class:`multiprocesssing.Process`.
-        """
 
-        super().start()  #: required here to call process/thread method
+        .. # noqa: DAR201
+        """
+        super().start()
         if not self.args.noblock_on_start:
             self.wait_start_success()
 
@@ -230,5 +233,8 @@ class BasePea(metaclass=PeaType):
 
     @property
     def role(self) -> 'PeaRoleType':
-        """Get the role of this pea in a pod"""
+        """Get the role of this pea in a pod
+
+        .. # noqa: DAR201
+        """
         return self.args.pea_role

--- a/jina/peapods/pods/__init__.py
+++ b/jina/peapods/pods/__init__.py
@@ -284,9 +284,6 @@ class Pod(BasePod):
             _args.noblock_on_start = getattr(self.args, 'noblock_on_start', False)
             self.peas.append(BasePea(_args))
 
-        for pea in self.peas:
-            print(f' hey Pea {pea}')
-
     @property
     def is_singleton(self) -> bool:
         """Return if the Pod contains only a single Pea

--- a/tests/unit/peapods/pods/test_compound_pods.py
+++ b/tests/unit/peapods/pods/test_compound_pods.py
@@ -257,18 +257,19 @@ def test_sockets(polling, parallel, pea_scheduling, pea_socket_in, pea_socket_ou
         ]
     )
     compound_pod = CompoundPod(args)
-    replica_args = compound_pod.replicas_args
-    head = replica_args['head']
+    head_pea = compound_pod.head_pea
+    tail_pea = compound_pod.tail_pea
+
+    head = head_pea.args
     assert head.socket_in == SocketType.PULL_BIND
     assert head.socket_out == SocketType.ROUTER_BIND
     assert head.scheduling == SchedulerType.LOAD_BALANCE
-    tail = replica_args['tail']
+    tail = tail_pea.args
     assert tail.socket_in == SocketType.PULL_BIND
     assert tail.socket_out == SocketType.PUSH_BIND
     assert tail.scheduling == SchedulerType.LOAD_BALANCE
-    replicas = replica_args['replicas']
-    for pod_args in replicas:
-        pod = Pod(pod_args)
+    for pod in compound_pod.replicas:
+        pod_args = pod.args
         if parallel > 1:
             assert pod_args.polling == polling_type
             for pea in pod.peas_args['peas']:


### PR DESCRIPTION
Help PR #2347 

It applies the view of separating `Instantation` of Pods and Peas from the `context` entering. So that unittesting capacity is better