### PR TITLE
fix(websocket-client): fix blocking on empty requests

### DIFF
--- a/jina/clients/websocket.py
+++ b/jina/clients/websocket.py
@@ -76,7 +76,7 @@ class WebSocketClientMixin(BaseClient, ABC):
                         await websocket.send(bytes(True))
                     else:
                         # There is nothing to send, disconnect gracefully
-                        await websocket.close(reason="No data to send")
+                        await websocket.close(reason='No data to send')
 
                 with ProgressBar(task_name=tname) as p_bar, TimeContext(tname):
                     # Unlike gRPC, any arbitrary function (generator) cannot be passed via websockets.

--- a/jina/clients/websocket.py
+++ b/jina/clients/websocket.py
@@ -64,13 +64,19 @@ class WebSocketClientMixin(BaseClient, ABC):
                 self.num_responses = 0
 
                 async def _send_requests(request_iterator):
+                    next_request = None
                     for next_request in request_iterator:
                         await websocket.send(next_request.SerializeToString())
                         self.num_requests += 1
-                    # Server has no way of knowing when to stop the await on sending response back to the client
-                    # We send one last message to say `request_iterator` is completed.
-                    # On the client side, this :meth:`send` doesn't need to be awaited with a :meth:`recv`
-                    await websocket.send(bytes(True))
+                    # Check if there was any request generated
+                    if next_request is not None:
+                        # Server has no way of knowing when to stop the await on sending response back to the client
+                        # We send one last message to say `request_iterator` is completed.
+                        # On the client side, this :meth:`send` doesn't need to be awaited with a :meth:`recv`
+                        await websocket.send(bytes(True))
+                    else:
+                        # There is nothing to send, disconnect gracefully
+                        await websocket.close(reason="No data to send")
 
                 with ProgressBar(task_name=tname) as p_bar, TimeContext(tname):
                     # Unlike gRPC, any arbitrary function (generator) cannot be passed via websockets.


### PR DESCRIPTION
This fixes https://github.com/jina-ai/jina/issues/2367

I am basically just checking if we enter the for loop which is generating the actual requests to Jina. If this is not the case I will gracefully disconnect (close the websocket) again. This stops the waiting for a server response and the client unblocks.

There are no tests for our clients unfortunately, but I checked the new code manually with a local stress test and it behaves as expected: If a caller passes in an exhausted input generator, the client will just disconnect without any error and the caller can continue its business. Before this change we blocked the caller indefinetely.