### PR TITLE
ci: add system path to get all test paths

### DIFF
--- a/scripts/get-all-test-paths.sh
+++ b/scripts/get-all-test-paths.sh
@@ -3,7 +3,7 @@
 set -ex
 
 declare -a array1=( "tests/unit/*.py" "tests/integration/*.py" "tests/distributed/*.py" "tests/system/*.py")
-declare -a array2=( $(ls -d tests/{unit,integration,distributed}/*/ | grep -v '__pycache__' ))
+declare -a array2=( $(ls -d tests/{unit,integration,distributed,system}/*/ | grep -v '__pycache__' ))
 dest1=( "${array1[@]}" "${array2[@]}" )
 
 declare -a array1=( "tests/daemon/unit/*.py" )

--- a/scripts/get-all-test-paths.sh
+++ b/scripts/get-all-test-paths.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-declare -a array1=( "tests/unit/*.py" "tests/integration/*.py" "tests/distributed/*.py" "tests/system/*.py")
+declare -a array1=( "tests/unit/*.py" "tests/integration/*.py" "tests/distributed/*.py" "tests/system/*.py" )
 declare -a array2=( $(ls -d tests/{unit,integration,distributed,system}/*/ | grep -v '__pycache__' ))
 dest1=( "${array1[@]}" "${array2[@]}" )
 

--- a/scripts/get-all-test-paths.sh
+++ b/scripts/get-all-test-paths.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-declare -a array1=( "tests/unit/*.py" "tests/integration/*.py" "tests/distributed/*.py" "tests/system/*.py" )
+declare -a array1=( "tests/unit/*.py" "tests/integration/*.py" "tests/distributed/*.py" "tests/system/*.py")
 declare -a array2=( $(ls -d tests/{unit,integration,distributed,system}/*/ | grep -v '__pycache__' ))
 dest1=( "${array1[@]}" "${array2[@]}" )
 


### PR DESCRIPTION
add `system` into codecov, to fix the error:

![image](https://user-images.githubusercontent.com/9794489/117662129-84bfa280-b19f-11eb-94ec-bb5d67820e78.png)
