### PR TITLE
refactor: clarify controlmessage args

### DIFF
--- a/jina/peapods/pods/__init__.py
+++ b/jina/peapods/pods/__init__.py
@@ -689,7 +689,7 @@ class Pod(BasePod):
                     pea.runtime.ctrl_addr,
                     ControlMessage(
                         command='DUMP',
-                        pod_name=pod_name,
+                        target_pod_name=pod_name,
                         args={
                             'dump_path': dump_path,
                             'shards': shards,

--- a/jina/types/message/common.py
+++ b/jina/types/message/common.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from . import Message
 from ..request import Request
 from ...proto import jina_pb2
@@ -21,7 +23,13 @@ class ControlMessage(Message):
     """
 
     def __init__(
-        self, command: str, pod_name: str = 'ctl', identity: str = '', *args, **kwargs
+        self,
+        command: str,
+        pod_name: str = 'ctl',
+        identity: str = '',
+        target_pod_name: Optional[str] = None,
+        *args,
+        **kwargs,
     ):
         req = Request(jina_pb2.RequestProto())
         if command in _available_commands:
@@ -40,4 +48,4 @@ class ControlMessage(Message):
         if args:
             req.args = args
 
-        req.targets.extend([pod_name])
+        req.targets.extend([target_pod_name])


### PR DESCRIPTION
**Changes introduced**
The way the `ControlMessage` is used seems weird.

The `pod_name` is set to `ctl` to determine that the message is sent from `ctl` and the `target_pod_name` should be another one.