### PR TITLE
fix: key exception can be thrown by other lookups

### DIFF
--- a/daemon/api/endpoints/flow.py
+++ b/daemon/api/endpoints/flow.py
@@ -97,8 +97,8 @@ async def _update(
 ):
     try:
         store.update(id, kind, dump_path, pod_name, shards)
-    except KeyError:
-        raise HTTPException(status_code=404, detail=f'{id} not found in {store!r}')
+    except KeyError as e:
+        raise HTTPException(status_code=404, detail=f'{e!r}')
     except Exception as e:
         raise HTTPException(status_code=500, detail=f'{e!r}')
     return Response(status_code=HTTP_200_OK)


### PR DESCRIPTION
JinaD assumes any KeyException is about not finding the Flow, but it can be triggered by others