### PR TITLE
feat: allow empty data req

### DIFF
--- a/cli/autocomplete.py
+++ b/cli/autocomplete.py
@@ -304,8 +304,6 @@ ac_table = {
         'client': [
             '--help',
             '--request-size',
-            '--mode',
-            '--top-k',
             '--mime-type',
             '--continue-on-error',
             '--return-results',

--- a/jina/clients/base.py
+++ b/jina/clients/base.py
@@ -52,6 +52,11 @@ class BaseClient:
         :param inputs: the inputs
         :param kwargs: keyword arguments
         """
+
+        if inputs is None:
+            # empty inputs is considered as valid
+            return
+
         if hasattr(inputs, '__call__'):
             # it is a function
             inputs = inputs()
@@ -108,10 +113,7 @@ class BaseClient:
 
         :return: inputs
         """
-        if self._inputs is not None:
-            return self._inputs
-        else:
-            raise BadClient('inputs are not defined')
+        return self._inputs
 
     @inputs.setter
     def inputs(self, bytes_gen: InputType) -> None:

--- a/jina/clients/mixin.py
+++ b/jina/clients/mixin.py
@@ -12,7 +12,7 @@ class PostMixin:
     def post(
         self,
         on: str,
-        inputs: InputType,
+        inputs: Optional[InputType] = None,
         on_done: CallbackFnType = None,
         on_error: CallbackFnType = None,
         on_always: CallbackFnType = None,
@@ -68,7 +68,7 @@ class AsyncPostMixin:
     async def post(
         self,
         on: str,
-        inputs: InputType,
+        inputs: Optional[InputType] = None,
         on_done: CallbackFnType = None,
         on_error: CallbackFnType = None,
         on_always: CallbackFnType = None,

--- a/jina/clients/request/__init__.py
+++ b/jina/clients/request/__init__.py
@@ -2,7 +2,7 @@
 
 from typing import Iterator, Union, Tuple, AsyncIterable, Iterable, Optional, Dict
 
-from .helper import _new_data_request_from_batch
+from .helper import _new_data_request_from_batch, _new_data_request
 from ... import Request
 from ...enums import DataInputType
 from ...helper import batch_iterator
@@ -49,17 +49,23 @@ def request_generator(
     _kwargs = dict(mime_type=mime_type, weight=1.0, extra_kwargs=kwargs)
 
     try:
-        if not isinstance(data, Iterable):
-            data = [data]
-        for batch in batch_iterator(data, request_size):
-            yield _new_data_request_from_batch(
-                _kwargs=kwargs,
-                batch=batch,
-                data_type=data_type,
-                endpoint=exec_endpoint,
-                target=target_peapod,
-                parameters=parameters,
+        if data is None:
+            # this allows empty inputs, i.e. a data request with only parameters
+            yield _new_data_request(
+                endpoint=exec_endpoint, target=target_peapod, parameters=parameters
             )
+        else:
+            if not isinstance(data, Iterable):
+                data = [data]
+            for batch in batch_iterator(data, request_size):
+                yield _new_data_request_from_batch(
+                    _kwargs=kwargs,
+                    batch=batch,
+                    data_type=data_type,
+                    endpoint=exec_endpoint,
+                    target=target_peapod,
+                    parameters=parameters,
+                )
 
     except Exception as ex:
         # must be handled here, as grpc channel wont handle Python exception

--- a/jina/clients/request/helper.py
+++ b/jina/clients/request/helper.py
@@ -9,18 +9,7 @@ from ...excepts import BadDocType, BadRequestType
 def _new_data_request_from_batch(
     _kwargs, batch, data_type, endpoint, target, parameters
 ):
-    req = Request()
-    req.request_type = 'data'
-
-    # set up header
-    if endpoint:
-        req.header.exec_endpoint = endpoint
-    if target:
-        req.header.target_peapod = target
-
-    # add parameters field
-    if parameters:
-        req.parameters.update(parameters)
+    req = _new_data_request(endpoint, target, parameters)
 
     # add docs, groundtruths fields
     try:
@@ -30,6 +19,21 @@ def _new_data_request_from_batch(
             f'error when building {req.request_type} from {batch}'
         ) from ex
 
+    return req
+
+
+def _new_data_request(endpoint, target, parameters):
+    req = Request()
+    req.request_type = 'data'
+
+    # set up header
+    if endpoint:
+        req.header.exec_endpoint = endpoint
+    if target:
+        req.header.target_peapod = target
+    # add parameters field
+    if parameters:
+        req.parameters.update(parameters)
     return req
 
 

--- a/jina/helloworld/fashion/flow.yml
+++ b/jina/helloworld/fashion/flow.yml
@@ -1,7 +1,6 @@
 jtype: Flow
-version: '1.0'
+version: '1'
 with:
-  compress_hwm: 1024
   workspace: $HW_WORKDIR
 pods:
   - name: encode

--- a/jina/parsers/client.py
+++ b/jina/parsers/client.py
@@ -17,27 +17,6 @@ def mixin_client_cli_parser(parser):
         help='The number of Documents in each Request.',
     )
 
-    gp.add_argument(
-        '--mode',
-        choices=list(RequestType),
-        type=RequestType.from_string,
-        # required=True,
-        help='''
-The Request mode. This applies to all Requests sent from this client.
-
-- INDEX: store new Documents into the system
-- SEARCH: query Documents from an indexed system
-- UPDATE: update existing Documents in an indexed system
-- DELETE: delete existing Documents from an indexed system
-- CONTROL: (advance) control Pea/Pod such as shutdown, status
-- TRAIN: (experimental) train the system
-                    ''',
-    )
-    gp.add_argument(
-        '--top-k',
-        type=int,
-        help='At maximum k results are returned.',
-    )
     gp.add_argument('--mime-type', type=str, help='MIME type of the input Documents.')
     gp.add_argument(
         '--continue-on-error',

--- a/jina/peapods/runtimes/zmq/zed.py
+++ b/jina/peapods/runtimes/zmq/zed.py
@@ -170,7 +170,6 @@ class ZEDRuntime(ZMQRuntime):
             msg.envelope.status.code != jina_pb2.StatusProto.ERROR
             or self.args.on_error_strategy < OnErrorStrategy.SKIP_HANDLE
         ):
-
             if not re.match(self.request.header.target_peapod, self.name):
                 return self
 

--- a/tests/unit/flow/test_flow.py
+++ b/tests/unit/flow/test_flow.py
@@ -715,3 +715,21 @@ def test_flow_allinone_yaml():
     f = Flow.load_config(os.path.join(cur_dir, 'yaml/flow-allinone-oldstyle.yml'))
     with f:
         pass
+
+
+def test_flow_empty_data_request(mocker):
+    from jina import Executor, requests
+
+    class MyExec(Executor):
+        @requests
+        def foo(self, parameters, **kwargs):
+            assert parameters['hello'] == 'world'
+
+    f = Flow().add(uses=MyExec)
+
+    mock = mocker.Mock()
+
+    with f:
+        f.post('/hello', parameters={'hello': 'world'}, on_done=mock)
+
+    mock.assert_called()

--- a/tests/unit/peapods/runtimes/remote/jinad/yamls/flow-index.yaml
+++ b/tests/unit/peapods/runtimes/remote/jinad/yamls/flow-index.yaml
@@ -1,7 +1,5 @@
 !Flow
 version: '1'
-with:
-  compress_hwm: 1024
 pods:
   - name: encode
     uses: yamls/encoder.yml


### PR DESCRIPTION
allowing no `inptus` data request, `f.post('/hello', parameters={'foo': 'bar'})`. This is useful for sending pure commands to executors