### PR TITLE
fix: channel axis in normaliser

### DIFF
--- a/jina/helloworld/multimodal/executors.py
+++ b/jina/helloworld/multimodal/executors.py
@@ -120,7 +120,7 @@ class ImageCrafter(Executor):
         img_std: Tuple[float] = (1, 1, 1),
         resize_dim: int = 256,
         channel_axis: int = -1,
-        target_channel_axis: int = -1,
+        target_channel_axis: int = 0,
         *args,
         **kwargs,
     ):
@@ -142,9 +142,10 @@ class ImageCrafter(Executor):
         for doc in chunks:
             getattr(doc, fn)()
             raw_img = _load_image(doc.blob, self.channel_axis)
-            _img = self._normalize(raw_img)
+            img = self._normalize(raw_img)
             # move the channel_axis to target_channel_axis to better fit different models
-            img = _move_channel_axis(_img, -1, self.target_channel_axis)
+            if self.channel_axis != self.target_channel_axis:
+                img = np.moveaxis(img, self.channel_axis, self.target_channel_axis)
             doc.blob = img
         return chunks
 
@@ -187,7 +188,6 @@ class ImageEncoder(Executor):
         self.model.to(torch.device('cpu'))
 
     def _get_features(self, content):
-        content = content.permute(0, 3, 1, 2)
         return self.model(content)
 
     def _get_pooling(self, feature_map: 'np.ndarray') -> 'np.ndarray':


### PR DESCRIPTION
Align channel axis in `Crafter`, remove channel permute in `Encoder`.