### PR TITLE
fix: exclusivity doccontent

### DIFF
--- a/.github/2.0/cookbooks/Document.md
+++ b/.github/2.0/cookbooks/Document.md
@@ -186,8 +186,7 @@ You can assign multiple attributes in the constructor via:
 ```python
 from jina import Document
 
-d = Document(content='hello',
-             uri='https://jina.ai',
+d = Document(uri='https://jina.ai',
              mime_type='text/plain',
              granularity=1,
              adjacency=3,
@@ -195,7 +194,7 @@ d = Document(content='hello',
 ```
 
 ```text
-<jina.types.document.Document id=e01a53bc-aedb-11eb-88e6-1e008a366d48 uri=https://jina.ai mimeType=text/plain tags={'foo': 'bar'} text=hello granularity=1 adjacency=3 at 6317309200>
+<jina.types.document.Document id=e01a53bc-aedb-11eb-88e6-1e008a366d48 uri=https://jina.ai mimeType=text/plain tags={'foo': 'bar'} granularity=1 adjacency=3 at 6317309200>
 ```
 
 #### Construct from Dict or JSON String

--- a/tests/unit/types/document/test_document.py
+++ b/tests/unit/types/document/test_document.py
@@ -1,5 +1,6 @@
 import json
 import os
+from contextlib import contextmanager
 
 import numpy as np
 import pytest
@@ -791,3 +792,25 @@ def test_evaluations():
     score.value = 10.0
     assert document.evaluations[0].value == 10.0
     assert document.evaluations[0].op_name == 'operation'
+
+
+@contextmanager
+def does_not_raise():
+    yield
+
+
+@pytest.mark.parametrize(
+    'doccontent, expectation',
+    [
+        ({'content': 'hello', 'uri': 'https://jina.ai'}, pytest.raises(Exception)),
+        ({'content': 'hello', 'text': 'world'}, pytest.raises(Exception)),
+        ({'content': 'hello', 'blob': np.array([1, 2, 3])}, pytest.raises(Exception)),
+        ({'content': 'hello', 'buffer': b'hello'}, pytest.raises(Exception)),
+        ({'buffer': b'hello', 'text': 'world'}, pytest.raises(Exception)),
+        ({'content': 'hello', 'id': 1}, does_not_raise()),
+    ],
+)
+def test_conflicting_doccontent(doccontent, expectation):
+    with expectation:
+        document = Document(**doccontent)
+        assert document.content is not None

--- a/tests/unit/types/document/test_document.py
+++ b/tests/unit/types/document/test_document.py
@@ -802,11 +802,11 @@ def does_not_raise():
 @pytest.mark.parametrize(
     'doccontent, expectation',
     [
-        ({'content': 'hello', 'uri': 'https://jina.ai'}, pytest.raises(Exception)),
-        ({'content': 'hello', 'text': 'world'}, pytest.raises(Exception)),
-        ({'content': 'hello', 'blob': np.array([1, 2, 3])}, pytest.raises(Exception)),
-        ({'content': 'hello', 'buffer': b'hello'}, pytest.raises(Exception)),
-        ({'buffer': b'hello', 'text': 'world'}, pytest.raises(Exception)),
+        ({'content': 'hello', 'uri': 'https://jina.ai'}, pytest.raises(ValueError)),
+        ({'content': 'hello', 'text': 'world'}, pytest.raises(ValueError)),
+        ({'content': 'hello', 'blob': np.array([1, 2, 3])}, pytest.raises(ValueError)),
+        ({'content': 'hello', 'buffer': b'hello'}, pytest.raises(ValueError)),
+        ({'buffer': b'hello', 'text': 'world'}, pytest.raises(ValueError)),
         ({'content': 'hello', 'id': 1}, does_not_raise()),
     ],
 )


### PR DESCRIPTION
**Problem:**
There is an inconsistency in the document _cookbook_ and potentially in the implementation of the `Document` constructor.

The cookbook explains that the document content fields are mutually exclusive (buffer/text/blob/uri) and that they are all `content`.
So a `Document` can only have one content, not a `uri` AND a `text` etc.
In the current example of the _cookbook_ this is actually the case: It creates a `Document` which has a content and a different uri. That does not happen with the actual implementation, it will always take the last content parameter.

This behavior of the code is also debatable. It is not really incorrect, but it is a bit confusing that the implementation just takes the last value in the `kwargs` list. I think it might be better to raise a `ValueError` in this case, because it is unclear what to do in case these **mutually exclusive** fields are provided by the caller.

**This PR changes the following:**

1. Change the cookbook by remove the additional content parameter from the Document constructor and change the debug output accordingly
2. Raise a ValueError if a Document is constructed with conflicting doc content fields
3. A test for the Error cases


