### PR TITLE
feat: add pythonic dict view for pb struct

### DIFF
--- a/cli/autocomplete.py
+++ b/cli/autocomplete.py
@@ -9,8 +9,9 @@ def _update_autocomplete():
                 _compl.extend(v.option_strings)
             elif v.choices:
                 _compl.extend(v.choices)
-                for kk, vv in v.choices.items():
-                    _result.update(_gaa(' '.join([key, kk]).strip(), vv))
+                if isinstance(v.choices, dict):
+                    for kk, vv in v.choices.items():
+                        _result.update(_gaa(' '.join([key, kk]).strip(), vv))
         # filer out single dash, as they serve as abbrev
         _compl = [k for k in _compl if (not k.startswith('-') or k.startswith('--'))]
         _result.update({key: _compl})
@@ -74,7 +75,8 @@ ac_table = {
             '--port-expose',
             '--unblock-query-flow',
         ],
-        'hello': ['--help', 'fashion', 'chatbot', 'multimodal'],
+        'hello fork': ['--help', 'fashion', 'chatbot', 'multimodal'],
+        'hello': ['--help', 'fashion', 'chatbot', 'multimodal', 'fork'],
         'executor': [
             '--help',
             '--name',

--- a/jina/clients/request/helper.py
+++ b/jina/clients/request/helper.py
@@ -34,7 +34,7 @@ def _new_data_request(endpoint, target, parameters):
         req.header.target_peapod = target
     # add parameters field
     if parameters:
-        req.parameters.update(parameters)
+        req.parameters = parameters
     return req
 
 

--- a/jina/helloworld/chatbot/app.py
+++ b/jina/helloworld/chatbot/app.py
@@ -47,7 +47,7 @@ def hello_world(args):
 
     f = (
         Flow()
-        .add(uses=MyTransformer, parallel=args.parallel, timeout_ready=600000)
+        .add(uses=MyTransformer, parallel=args.parallel)
         .add(uses=MyIndexer, workspace=args.workdir)
     )
 

--- a/jina/parsers/hub/build.py
+++ b/jina/parsers/hub/build.py
@@ -71,7 +71,7 @@ The content source to be shipped into a Docker image. It can one of the followin
     gp.add_argument(
         '--timeout-ready',
         type=int,
-        default=60000,
+        default=600000,
         help='The timeout in millisecond to give for the Pod to start before considering a test failed',
     )
     gp.add_argument(

--- a/jina/parsers/peapods/pea.py
+++ b/jina/parsers/peapods/pea.py
@@ -39,7 +39,7 @@ def mixin_pea_parser(parser):
     gp.add_argument(
         '--timeout-ready',
         type=int,
-        default=60000,
+        default=600000,
         help='The timeout in milliseconds of a Pea waits for the runtime to be ready, -1 for waiting '
         'forever',
     )

--- a/jina/peapods/runtimes/zmq/zed.py
+++ b/jina/peapods/runtimes/zmq/zed.py
@@ -4,7 +4,6 @@ from collections import defaultdict
 from typing import Dict, List
 
 import zmq
-from google.protobuf.json_format import MessageToDict
 
 from .base import ZMQRuntime
 from ...zmq import ZmqStreamlet
@@ -204,7 +203,7 @@ class ZEDRuntime(ZMQRuntime):
         r_docs = self._executor(
             req_endpoint=self.envelope.header.exec_endpoint,
             docs=self.docs,
-            parameters=MessageToDict(self.request.parameters),
+            parameters=self.request.parameters,
             docs_matrix=self.docs_matrix,
             groundtruths=self.groundtruths,
             groundtruths_matrix=self.groundtruths_matrix,

--- a/jina/types/document/__init__.py
+++ b/jina/types/document/__init__.py
@@ -1,10 +1,8 @@
 import base64
 import io
-import itertools as it
 import json
 import mimetypes
 import os
-import random
 import urllib.parse
 import urllib.request
 import warnings
@@ -24,6 +22,7 @@ from typing import (
 import numpy as np
 from google.protobuf import json_format
 from google.protobuf.field_mask_pb2 import FieldMask
+from jina.types.struct import StructView
 
 from .converters import png_to_buffer, to_datauri, guess_mime, to_image_blob
 from ..arrays.chunk import ChunkArray
@@ -337,6 +336,23 @@ class Document(ProtoTypeMixin):
         :return: the content_hash from the proto
         """
         return self._pb_body.content_hash
+
+    @property
+    def tags(self) -> Dict:
+        """Return the `tags` field of this Document as a Python dict
+
+        :return: a Python dict view of the tags.
+        """
+        return StructView(self._pb_body.tags)
+
+    @tags.setter
+    def tags(self, value: Dict):
+        """Set the `tags` field of this Document to a Python dict
+
+        :param value: a Python dict
+        """
+        self._pb_body.tags.Clear()
+        self._pb_body.tags.update(value)
 
     @staticmethod
     def _update(
@@ -1169,10 +1185,10 @@ class Document(ProtoTypeMixin):
 
         mermaid_str = (
             """
-                    %%{init: {'theme': 'base', 'themeVariables': { 'primaryColor': '#FFC666'}}}%%
-                    classDiagram
-                
-                            """
+                        %%{init: {'theme': 'base', 'themeVariables': { 'primaryColor': '#FFC666'}}}%%
+                        classDiagram
+                    
+                                """
             + self.__mermaid_str__()
         )
 

--- a/jina/types/request/__init__.py
+++ b/jina/types/request/__init__.py
@@ -1,6 +1,7 @@
 from typing import Union, Optional, TypeVar, Dict
 
 from google.protobuf import json_format
+from jina.types.struct import StructView
 
 from ..mixin import ProtoTypeMixin
 from ...enums import CompressAlgo, RequestType
@@ -233,6 +234,23 @@ class Request(ProtoTypeMixin):
         base_cls = self.__class__
         base_cls_name = self.__class__.__name__
         self.__class__ = type(base_cls_name, (base_cls, Response), {})
+
+    @property
+    def parameters(self) -> Dict:
+        """Return the `tags` field of this Document as a Python dict
+
+        :return: a Python dict view of the tags.
+        """
+        return StructView(self._pb_body.parameters)
+
+    @parameters.setter
+    def parameters(self, value: Dict):
+        """Set the `tags` field of this Document to a Python dict
+
+        :param value: a Python dict
+        """
+        self._pb_body.parameters.Clear()
+        self._pb_body.parameters.update(value)
 
 
 class Response:

--- a/jina/types/struct.py
+++ b/jina/types/struct.py
@@ -1,0 +1,40 @@
+from google.protobuf.internal.well_known_types import Struct
+from google.protobuf.json_format import MessageToDict
+
+
+class StructView(dict):
+    """Create a Python dict view of Protobuf Struct.
+
+    This can be used in all Jina types where a protobuf.Struct is returned, e.g. Document.tags
+
+    """
+
+    def __init__(self, struct: Struct):
+        """Create a Python dict view of Protobuf Struct.
+
+        :param struct: the protobuf Struct object
+        """
+        super().__init__(MessageToDict(struct))
+        self._pb_body = struct
+
+    def __setitem__(self, key, value):
+        self._pb_body[key] = value
+
+    def __delitem__(self, key):
+        del self._pb_body[key]
+
+    def update(self, dictionary):  # pylint: disable=invalid-name
+        """
+        # noqa: DAR101
+        # noqa: DAR102
+        # noqa: DAR103
+        """
+        self._pb_body.update(dictionary)
+
+    def clear(self) -> None:
+        """
+        # noqa: DAR101
+        # noqa: DAR102
+        # noqa: DAR103
+        """
+        self._pb_body.Clear()

--- a/tests/system/multimodal/test_multimodal.py
+++ b/tests/system/multimodal/test_multimodal.py
@@ -12,7 +12,13 @@ from tests import validate_callback
 @pytest.fixture
 def helloworld_args(tmpdir):
     return set_hw_multimodal_parser().parse_args(
-        ['--workdir', str(tmpdir), '--unblock-query-flow']
+        [
+            '--workdir',
+            str(tmpdir),
+            '--unblock-query-flow',
+            '--index-data-url',
+            'https://static.jina.ai/multimodal/people-img-cicd.zip',
+        ]
     )
 
 

--- a/tests/unit/peapods/runtimes/asyncio/rest/test_models.py
+++ b/tests/unit/peapods/runtimes/asyncio/rest/test_models.py
@@ -1,13 +1,11 @@
-from tests import random_docs
-from jina.types.document import Document
+import pydantic
+import pytest
 from jina.peapods.runtimes.asyncio.rest.models import (
     PROTO_TO_PYDANTIC_MODELS,
     JinaRequestModel,
 )
-
-import pytest
-import pydantic
-from google.protobuf.json_format import MessageToDict
+from jina.types.document import Document
+from tests import random_docs
 
 
 def test_schema_invocation():
@@ -128,11 +126,11 @@ def test_oneof_validation_error():
 def test_tags_document():
     doc = PROTO_TO_PYDANTIC_MODELS.DocumentProto(hello='world')
     assert doc.tags == {'hello': 'world'}
-    assert MessageToDict(Document(doc.dict()).tags) == {'hello': 'world'}
+    assert Document(doc.dict()).tags == {'hello': 'world'}
 
     doc = PROTO_TO_PYDANTIC_MODELS.DocumentProto(hello='world', tags={'key': 'value'})
     assert doc.tags == {'hello': 'world', 'key': 'value'}
-    assert MessageToDict(Document(doc.dict()).tags) == {
+    assert Document(doc.dict()).tags == {
         'hello': 'world',
         'key': 'value',
     }

--- a/tests/unit/proto/test_pb_struct_tags.py
+++ b/tests/unit/proto/test_pb_struct_tags.py
@@ -85,6 +85,18 @@ def test_tags_property():
     assert d.tags['123'] == 456
     assert d.proto.tags['123'] == 456
 
+    # init from another doc.tags
+    d2 = Document(tags=d.tags)
+    assert d2.tags['123'] == 456
+    assert d2.proto.tags['123'] == 456
+
+    # copy is a deep copy
+    d.tags.clear()
+    assert not d.tags
+    assert not d.proto.tags
+    assert d2.tags['123'] == 456
+    assert d2.proto.tags['123'] == 456
+
 
 def test_tags_assign():
     d = DocumentProto()

--- a/tests/unit/proto/test_pb_struct_tags.py
+++ b/tests/unit/proto/test_pb_struct_tags.py
@@ -1,5 +1,6 @@
 import pytest
 from google.protobuf.json_format import MessageToJson, Parse
+from jina import Document
 
 from jina.proto.jina_pb2 import DocumentProto
 
@@ -26,6 +27,63 @@ def test_tags(document):
     # can be used as a dict
     for _, _ in d2.tags['nested'].items():
         continue
+
+
+def test_tags_property():
+    d = Document()
+    assert not d.tags
+    assert not d.proto.tags
+
+    # set item
+    d.tags['hello'] = 'world'
+    assert isinstance(d.tags, dict)
+    assert d.tags == {'hello': 'world'}
+    assert d.proto.tags['hello'] == 'world'
+
+    # set composite item
+    d.tags = {'world': ['hello', 'world']}
+    assert isinstance(d.tags, dict)
+    assert d.tags == {'world': ['hello', 'world']}
+    assert d.proto.tags['world'][0] == 'hello'
+    assert d.proto.tags['world'][1] == 'world'
+
+    # set scalar item
+    d.tags['world'] = 123
+    assert isinstance(d.tags, dict)
+    assert d.tags['world'] == 123
+    assert d.proto.tags['world'] == 123
+
+    # clear
+    d.clear()
+    assert not d.tags
+    assert not d.proto.tags
+
+    # update
+    d.tags.update({'hello': 'world'})
+    assert d.tags['hello'] == 'world'
+    assert d.proto.tags['hello'] == 'world'
+
+    # delete
+    del d.tags['hello']
+    assert not d.tags
+    assert not d.proto.tags
+
+    # init from the Doc
+    d = Document(tags={'123': 456})
+    assert d.tags['123'] == 456
+    assert d.proto.tags['123'] == 456
+
+    # copy from other doc
+    d1 = Document(d, copy=True)
+    assert d1.tags['123'] == 456
+    assert d1.proto.tags['123'] == 456
+
+    # copy is a deep copy
+    d1.tags.clear()
+    assert not d1.tags
+    assert not d1.proto.tags
+    assert d.tags['123'] == 456
+    assert d.proto.tags['123'] == 456
 
 
 def test_tags_assign():

--- a/tests/unit/types/document/test_document.py
+++ b/tests/unit/types/document/test_document.py
@@ -86,7 +86,7 @@ def test_doc_update_fields():
     np.testing.assert_equal(a.embedding, b)
     assert list(a.location) == d
     assert a.modality == e
-    assert MessageToDict(a.tags) == c
+    assert a.tags == c
     assert a.weight == w
 
 


### PR DESCRIPTION
this PR enables a Python organic dict view of `Protobuf.Struct`, useful in `doc.tags`, `request.parameters`