### PR TITLE
feat: add test for store serialization

### DIFF
--- a/daemon/models/base.py
+++ b/daemon/models/base.py
@@ -15,9 +15,12 @@ class StoreStatus(BaseModel):
     time_updated: datetime = Field(default_factory=datetime.now)
     num_add: int = 0
     num_del: int = 0
-    items: Dict[DaemonID, StoreItem] = {}
+    items: Dict[DaemonID, StoreItem] = Field(default_factory=dict)
 
     @root_validator(pre=False)
     def set_size(cls, values):
-        values['size'] = len(values['items'])
+        if 'items' in values:
+            values['size'] = len(values['items'])
+        elif 'size' not in values:
+            values['size'] = 0
         return values

--- a/daemon/models/base.py
+++ b/daemon/models/base.py
@@ -19,8 +19,5 @@ class StoreStatus(BaseModel):
 
     @root_validator(pre=False)
     def set_size(cls, values):
-        if 'items' in values:
-            values['size'] = len(values['items'])
-        elif 'size' not in values:
-            values['size'] = 0
+        values['size'] = len(values['items']) if 'items' in values else 0
         return values

--- a/tests/daemon/unit/stores/test_basestore.py
+++ b/tests/daemon/unit/stores/test_basestore.py
@@ -9,40 +9,12 @@ from daemon.stores.base import BaseStore
 from jina.helper import random_identity, random_uuid
 from daemon import __root_workspace__
 
-keys = [DaemonID(f'jflow-{uuid.UUID(random_identity())}') for _ in range(3)]
 
-
-store_items = {keys[0]: StoreItem(), keys[1]: StoreItem(), keys[2]: StoreItem()}
-
-
-def test_base_store_clear():
-    print(keys)
-    s = BaseStore()
-    old_update = s._time_updated
-    assert s._time_updated
-    s._items.update(store_items)
-    assert len(s) == 3
-    s.clear()
-    assert len(s) == 0
-    assert old_update < s._time_updated
-
-
-def test_base_store_del():
-    s = BaseStore()
-    old_update = s._time_updated
-    assert s._time_updated
-    s._items.update(store_items)
-    assert len(s) == 3
-    del s[keys[0]]
-    assert len(s) == 2
-    s.pop(keys[1])
-    assert len(s) == 1
-    assert old_update < s._time_updated
-
-    old_update = s._time_updated
-    with pytest.raises(KeyError):
-        del s[random_uuid()]
-    assert old_update == s._time_updated
+store_items = {
+    DaemonID(f'jflow-{uuid.UUID(random_identity())}'): StoreItem(),
+    DaemonID(f'jflow-{uuid.UUID(random_identity())}'): StoreItem(),
+    DaemonID(f'jflow-{uuid.UUID(random_identity())}'): StoreItem(),
+}
 
 
 class DummyStore(BaseStore):

--- a/tests/daemon/unit/stores/test_basestore.py
+++ b/tests/daemon/unit/stores/test_basestore.py
@@ -1,14 +1,18 @@
+import pathlib
 import uuid
 
 import pytest
 
+from daemon.models import DaemonID
+from daemon.models.base import StoreItem
 from daemon.stores.base import BaseStore
 from jina.helper import random_identity, random_uuid
+from daemon import __root_workspace__
 
-keys = [uuid.UUID(random_identity()) for _ in range(3)]
+keys = [DaemonID(f'jflow-{uuid.UUID(random_identity())}') for _ in range(3)]
 
 
-store_items = {keys[0]: {'object': 'abc'}, keys[1]: {'object': 'hij'}, keys[2]: {}}
+store_items = {keys[0]: StoreItem(), keys[1]: StoreItem(), keys[2]: StoreItem()}
 
 
 def test_base_store_clear():
@@ -39,3 +43,27 @@ def test_base_store_del():
     with pytest.raises(KeyError):
         del s[random_uuid()]
     assert old_update == s._time_updated
+
+
+class DummyStore(BaseStore):
+    def __init__(self, mock):
+        super().__init__()
+        self.some_field = 'hello world'
+        self.mock = mock
+
+    @BaseStore.dump
+    def some_function(self):
+        self.mock()
+
+
+def test_base_store_serialization(mocker):
+    mock = mocker.Mock()
+    pathlib.Path(__root_workspace__).mkdir(parents=True, exist_ok=True)
+
+    dummy_store = DummyStore(mock)
+    dummy_store.status.items.update(store_items)
+    dummy_store.some_function()
+    loaded_store = DummyStore.load()
+
+    assert loaded_store == dummy_store
+    mock.assert_called()


### PR DESCRIPTION
This adds a simple test for serialization of the `BaseStore`. The test just stores and loads some dummy store (inheriting from `BaseStore`) and checks if the stores before and after are equal.

The PR also makes two code changes:

1. For the empty dict one should specify the factory I believe and not use the mutable `{}`
2. In `set_size()` I am checking for the existence of 'items'. Without this check my test fails as the function gets called once without items in the dict. Not sure why this happens.