### PR TITLE
ci: only trigger ci when update py yml and requirements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,6 +136,17 @@ jobs:
         python-version: [3.7]
         test-path: ${{fromJson(needs.prep-testbed.outputs.matrix)}}
     steps:
+      - name: Check for python file changes
+          uses: getsentry/paths-filter@v2
+          with:
+            token: ${{ secrets.GITHUB_TOKEN }}
+            filters: |
+              python:
+                - '**/*.py'
+              requirements:
+                - '*requirements*.txt'
+              yml:
+                - '**/*.yml'
       - uses: actions/checkout@v2
 #        with:
 #          submodules: true


### PR DESCRIPTION
if we only update markdown/readme or files not important, we should not wait too long for CI. This change will create a filter to only trigger CI if we change:
1. python files
2. yml (CI/CD) files
3. requirements