### PR TITLE
docs(cookbooks): remove `with` property in minimum yml example

### DIFF
--- a/.github/2.0/cookbooks/Executor.md
+++ b/.github/2.0/cookbooks/Executor.md
@@ -68,14 +68,12 @@ with f:
 
 ### With YAML
 
-`MyExecutor` described as above.
+`MyExecutor` described as above. Save it as `foo.py`.
 
 `my.yml`:
 
 ```yaml
 jtype: MyExecutor
-with:
-  bar: 123
 metas:
   py_modules:
     - foo.py


### PR DESCRIPTION
In the `MyExector` example above, there is no additional parameters of
`__init__` method, which is why we should remove `with` property.
Otherwise, people will get an error here.