### PR TITLE
feat: support url read in converters

### DIFF
--- a/jina/types/document/converters.py
+++ b/jina/types/document/converters.py
@@ -84,15 +84,19 @@ def png_to_buffer(arr: 'np.ndarray', width: int, height: int, resize_method: str
 
 def to_image_blob(source, color_axis: int = -1) -> 'np.ndarray':
     """
-    Convert an image buffer to blob
+    Convert an image uri to blob
 
-    :param source: image bytes buffer
+    :param source: image uri.
     :param color_axis: the axis id of the color channel, ``-1`` indicates the color channel info at the last axis
     :return: image blob
     """
     from PIL import Image
 
-    raw_img = Image.open(source).convert('RGB')
+    uri_segments = urllib.parse.urlparse(source)
+    if all([uri_segments.scheme, uri_segments.netloc, uri_segments.path]):
+        raw_img = Image.open(urllib.request.urlopen(source)).convert('RGB')
+    else:
+        raw_img = Image.open(source).convert('RGB')
     img = np.array(raw_img).astype('float32')
     if color_axis != -1:
         img = np.moveaxis(img, -1, color_axis)

--- a/tests/unit/types/document/test_converters.py
+++ b/tests/unit/types/document/test_converters.py
@@ -13,6 +13,12 @@ def test_uri_to_blob():
     doc.convert_image_uri_to_blob()
     assert isinstance(doc.blob, np.ndarray)
     assert doc.blob.shape == (85, 152, 3)  # h,w,c
+    doc = Document(
+        uri='https://raw.githubusercontent.com/jina-ai/jina/master/tests/unit/types/document/test.png'
+    )
+    doc.convert_image_uri_to_blob()
+    assert isinstance(doc.blob, np.ndarray)
+    assert doc.blob.shape == (85, 152, 3)  # h,w,c
 
 
 def test_datauri_to_blob():


### PR DESCRIPTION
since url is `oneof` uri.  This changes allows us to do:

```python
document = Document(uri='https://jina.ai/assets/images/search_logo.svg')
doc.convert_image_uri_to_blob() # with a real image url
```