### PR TITLE
fix(daemon): handle empty requirements

### DIFF
--- a/daemon/models/base.py
+++ b/daemon/models/base.py
@@ -1,6 +1,7 @@
-from typing import Dict
 from datetime import datetime
-from pydantic import BaseModel, root_validator, Field
+from typing import Dict
+
+from pydantic import BaseModel, Field
 
 from .id import DaemonID
 
@@ -10,14 +11,11 @@ class StoreItem(BaseModel):
 
 
 class StoreStatus(BaseModel):
-    size: int = 0
     time_created: datetime = Field(default_factory=datetime.now)
     time_updated: datetime = Field(default_factory=datetime.now)
     num_add: int = 0
     num_del: int = 0
     items: Dict[DaemonID, StoreItem] = Field(default_factory=dict)
 
-    @root_validator(pre=False)
-    def set_size(cls, values):
-        values['size'] = len(values['items']) if 'items' in values else 0
-        return values
+    def __len__(self):
+        return len(self.items)

--- a/daemon/models/workspaces.py
+++ b/daemon/models/workspaces.py
@@ -8,7 +8,7 @@ from .base import StoreItem, StoreStatus
 class WorkspaceArguments(BaseModel):
     files: List[str]
     jinad: Dict[str, str]
-    requirements: List
+    requirements: str
 
 
 class WorkspaceMetadata(BaseModel):

--- a/daemon/stores/base.py
+++ b/daemon/stores/base.py
@@ -83,7 +83,6 @@ class BaseStore(MutableMapping):
         """
         self.status.items[key] = value
         self.status.num_add += 1
-        self.status.size += 1
         self.status.time_updated = datetime.now()
 
     def __delitem__(self, key: DaemonID) -> None:
@@ -95,7 +94,6 @@ class BaseStore(MutableMapping):
         .. #noqa: DAR201"""
         self.status.items.pop(key)
         self.status.num_del += 1
-        self.status.size -= 1
         self.status.time_updated = datetime.now()
 
     def __setstate__(self, state: Dict):
@@ -144,3 +142,6 @@ class BaseStore(MutableMapping):
         """Calling :meth:`clear` and reset all stats """
         self.clear()
         self.status = StoreStatus()
+
+    def __len__(self):
+        return len(self.items())

--- a/daemon/stores/base.py
+++ b/daemon/stores/base.py
@@ -62,7 +62,9 @@ class BaseStore(MutableMapping):
     def values(self) -> Sequence[Union['WorkspaceItem', 'ContainerItem']]:
         return self.status.items.values()
 
-    def items(self) -> Sequence[Tuple['DaemonID', Union['WorkspaceItem', 'ContainerItem']]]:
+    def items(
+        self,
+    ) -> Sequence[Tuple['DaemonID', Union['WorkspaceItem', 'ContainerItem']]]:
         return self.status.items.items()
 
     def __getitem__(self, key: DaemonID) -> Union['WorkspaceItem', 'ContainerItem']:
@@ -81,6 +83,7 @@ class BaseStore(MutableMapping):
         """
         self.status.items[key] = value
         self.status.num_add += 1
+        self.status.size += 1
         self.status.time_updated = datetime.now()
 
     def __delitem__(self, key: DaemonID) -> None:
@@ -92,6 +95,7 @@ class BaseStore(MutableMapping):
         .. #noqa: DAR201"""
         self.status.items.pop(key)
         self.status.num_del += 1
+        self.status.size -= 1
         self.status.time_updated = datetime.now()
 
     def __setstate__(self, state: Dict):
@@ -102,7 +106,7 @@ class BaseStore(MutableMapping):
             time_updated=state.get('time_updated', now),
             num_add=state.get('num_add', 0),
             num_del=state.get('num_del', 0),
-            items=state.get('items', {})
+            items=state.get('items', {}),
         )
 
     def __getstate__(self) -> Dict:

--- a/daemon/stores/workspaces.py
+++ b/daemon/stores/workspaces.py
@@ -13,7 +13,12 @@ from ..models import DaemonID
 from ..dockerize import Dockerizer
 from ..helper import get_workspace_path, id_cleaner, random_port_range
 from ..excepts import Runtime400Exception
-from ..models.workspaces import WorkspaceArguments, WorkspaceItem, WorkspaceMetadata, WorkspaceStoreStatus
+from ..models.workspaces import (
+    WorkspaceArguments,
+    WorkspaceItem,
+    WorkspaceMetadata,
+    WorkspaceStoreStatus,
+)
 from ..models.enums import DaemonBuild, PythonVersion
 from .. import __rootdir__, __dockerfiles__, jinad_args
 
@@ -90,12 +95,11 @@ class DaemonFile:
 
     @property
     def dockerargs(self) -> Dict:
-        return {
-            'PY_VERSION': self.python.value,
-            'PIP_REQUIREMENTS': self.requirements
-        } if self.build == DaemonBuild.DEVEL else {
-            'PY_VERSION': self.python.name.lower()
-        }
+        return (
+            {'PY_VERSION': self.python.value, 'PIP_REQUIREMENTS': self.requirements}
+            if self.build == DaemonBuild.DEVEL
+            else {'PY_VERSION': self.python.name.lower()}
+        )
 
     def process_file(self) -> None:
         # Checks if a file .jinad exists in the workspace
@@ -161,26 +165,25 @@ class WorkspaceStore(BaseStore):
         self._handle_files(workspace_id=id, files=files)
         daemon_file = DaemonFile(workdir=workdir)
         network_id = Dockerizer.network(workspace_id=id)
-        image_id = Dockerizer.build(
-            workspace_id=id, daemon_file=daemon_file
-        )
+        image_id = Dockerizer.build(workspace_id=id, daemon_file=daemon_file)
         _min, _max = random_port_range()
         return workdir, daemon_file, network_id, image_id, _min, _max
 
-    def _set_id(self, id, files, workdir, daemon_file, network_id,
-                image_id, _min, _max):
+    def _set_id(
+        self, id, files, workdir, daemon_file, network_id, image_id, _min, _max
+    ):
         # Move this to the Consumer thread
         if id in self:
             if files:
-                self[id].arguments.files.extend(
-                    [f.filename for f in files]
-                )
+                self[id].arguments.files.extend([f.filename for f in files])
             self[id].arguments.jinad = {
                 'build': daemon_file.build,
                 'dockerfile': daemon_file.dockerfile,
             }
             self[id].metadata.image_id = image_id
-            self[id].arguments.requirements = daemon_file.requirements
+            self[id].arguments.requirements = list(
+                filter(None, daemon_file.requirements.split(' '))
+            )
             self._logger.success(
                 f'Workspace {colored(str(id), "cyan")} is added to store'
             )
@@ -191,7 +194,7 @@ class WorkspaceStore(BaseStore):
                     image_name=id.tag,
                     network=id_cleaner(network_id),
                     ports={'min': _min, 'max': _max},
-                    workdir=workdir
+                    workdir=workdir,
                 ),
                 arguments=WorkspaceArguments(
                     files=[f.filename for f in files] if files else [],
@@ -199,26 +202,33 @@ class WorkspaceStore(BaseStore):
                         'build': daemon_file.build,
                         'dockerfile': daemon_file.dockerfile,
                     },
-                    requirements=daemon_file.requirements
-                )
+                    requirements=list(
+                        filter(None, daemon_file.requirements.split(' '))
+                    ),
+                ),
             )
-            self._logger.success(
-                f'Workspace {colored(str(id), "cyan")} is updated'
-            )
+            self._logger.success(f'Workspace {colored(str(id), "cyan")} is updated')
         return id
 
     @BaseStore.dump
     def add(self, files: List[UploadFile], **kwargs):
         try:
             id = DaemonID('jworkspace')
-            workdir, daemon_file, network_id, image_id, _min, _max = \
-                self.bob_the_builder(id, files)
+            (
+                workdir,
+                daemon_file,
+                network_id,
+                image_id,
+                _min,
+                _max,
+            ) = self.bob_the_builder(id, files)
         except Exception as e:
             self._logger.error(f'{e!r}')
             raise
         else:
-            return self._set_id(id, files, workdir, daemon_file,
-                                network_id, image_id, _min, _max)
+            return self._set_id(
+                id, files, workdir, daemon_file, network_id, image_id, _min, _max
+            )
 
     @BaseStore.dump
     def update(
@@ -226,14 +236,21 @@ class WorkspaceStore(BaseStore):
     ) -> DaemonID:
         # TODO: Handle POST vs PUT here
         try:
-            workdir, daemon_file, network_id, image_id, _min, _max = \
-                self.bob_the_builder(id, files)
+            (
+                workdir,
+                daemon_file,
+                network_id,
+                image_id,
+                _min,
+                _max,
+            ) = self.bob_the_builder(id, files)
         except Exception as e:
             self._logger.error(f'{e!r}')
             raise
         else:
-            return self._set_id(id, files, workdir, daemon_file,
-                                network_id, image_id, _min, _max)
+            return self._set_id(
+                id, files, workdir, daemon_file, network_id, image_id, _min, _max
+            )
 
     @BaseStore.dump
     def delete(self, id: DaemonID, **kwargs):

--- a/daemon/stores/workspaces.py
+++ b/daemon/stores/workspaces.py
@@ -181,9 +181,7 @@ class WorkspaceStore(BaseStore):
                 'dockerfile': daemon_file.dockerfile,
             }
             self[id].metadata.image_id = image_id
-            self[id].arguments.requirements = list(
-                filter(None, daemon_file.requirements.split(' '))
-            )
+            self[id].arguments.requirements = daemon_file.requirements
             self._logger.success(
                 f'Workspace {colored(str(id), "cyan")} is added to store'
             )
@@ -202,9 +200,7 @@ class WorkspaceStore(BaseStore):
                         'build': daemon_file.build,
                         'dockerfile': daemon_file.dockerfile,
                     },
-                    requirements=list(
-                        filter(None, daemon_file.requirements.split(' '))
-                    ),
+                    requirements=daemon_file.requirements,
                 ),
             )
             self._logger.success(f'Workspace {colored(str(id), "cyan")} is updated')

--- a/tests/daemon/unit/stores/test_workspacestore.py
+++ b/tests/daemon/unit/stores/test_workspacestore.py
@@ -18,12 +18,12 @@ def test_workspace_store(filepath):
     store = WorkspaceStore()
     workspace_id = store.add(files=[UploadFile(filepath)])
 
-    assert store.status.size == 1
+    assert len(store) == 1
     assert store.status.num_add == 1
-    assert len(list(store.status.items.values())[0].arguments.files) == 1
+    assert len(list(store.values())[0].arguments.files) == 1
 
     store.delete(workspace_id)
 
     assert store.status.num_add == 1
     assert store.status.num_del == 1
-    assert store.status.size == 0
+    assert len(store) == 0

--- a/tests/daemon/unit/stores/test_workspacestore.py
+++ b/tests/daemon/unit/stores/test_workspacestore.py
@@ -1,0 +1,29 @@
+import os
+
+import pytest
+from fastapi import UploadFile
+
+from daemon.stores import WorkspaceStore
+
+
+@pytest.fixture(scope='function')
+def filepath(tmpdir):
+    temp_filepath = os.path.join(tmpdir, 'input_file.csv')
+    with open(temp_filepath, 'w') as file:
+        file.write('hello')
+    return temp_filepath
+
+
+def test_workspace_store(filepath):
+    store = WorkspaceStore()
+    workspace_id = store.add(files=[UploadFile(filepath)])
+
+    assert store.status.size == 1
+    assert store.status.num_add == 1
+    assert len(list(store.status.items.values())[0].arguments.files) == 1
+
+    store.delete(workspace_id)
+
+    assert store.status.num_add == 1
+    assert store.status.num_del == 1
+    assert store.status.size == 0


### PR DESCRIPTION
sorry for the large diff, the black prehook did the formatting.

relevant changes are:

- https://github.com/jina-ai/jina/pull/2505/files#diff-37ce282b4c82b8fba0f0fa251dcd66a6800e19984e046661f523ccacc95dbe91R185
- https://github.com/jina-ai/jina/pull/2505/files#diff-37ce282b4c82b8fba0f0fa251dcd66a6800e19984e046661f523ccacc95dbe91R206
- https://github.com/jina-ai/jina/pull/2505/files#diff-eb700ccf4382124005490360e31674bb156310e0a5bf05c607777b2f0f00e72dR86
- https://github.com/jina-ai/jina/pull/2505/files#diff-eb700ccf4382124005490360e31674bb156310e0a5bf05c607777b2f0f00e72dR98
- 

What this PR actually changes:

- fix empty requirements (before it failed because we expect a list in the pydantic model but it was space separated string)
- fix some metadata for the workflow store (size)
- add some very basic test