### PR TITLE
fix: fail to import on armv8 

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -177,7 +177,7 @@ jobs:
         with:
           context: .
           file: Dockerfiles/debianx.Dockerfile
-          platforms: linux/armhf,linux/amd64,linux/arm/v6,linux/arm/v8
+          platforms: linux/armhf,linux/amd64,linux/arm/v6,linux/arm64
           push: true
           tags: jinaai/jina:master${{ matrix.tag_pyversion }}${{ matrix.tag_stage }}, ${{env.TAG_ALIAS}}
           build-args: BUILD_DATE, JINA_VERSION, VCS_REF, PY_VERSION

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -177,7 +177,7 @@ jobs:
         with:
           context: .
           file: Dockerfiles/debianx.Dockerfile
-          platforms: linux/armhf,linux/amd64,linux/arm/v6
+          platforms: linux/armhf,linux/amd64,linux/arm/v6,linux/arm/v8
           push: true
           tags: jinaai/jina:master${{ matrix.tag_pyversion }}${{ matrix.tag_stage }}, ${{env.TAG_ALIAS}}
           build-args: BUILD_DATE, JINA_VERSION, VCS_REF, PY_VERSION

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,7 +138,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test-arch: ["linux/armhf", "linux/arm/v6", "linux/arm/arm64"]
+        test-arch: ["linux/armhf", "linux/arm/v6", "linux/arm64"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Docker Buildx

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ 3.7 ]
         test-arch: ["linux/armhf", "linux/arm/v6", "linux/arm/v8"]
     steps:
       - uses: actions/checkout@v2
@@ -142,8 +141,8 @@ jobs:
         with:
           context: .
           file: Dockerfiles/debianx.Dockerfile
-          platforms: ${{ matrix.test-path }}
-          push: true
+          platforms: ${{ matrix.test-arch }}
+          push: false
           tags: jinaai/jina-multi-arch:test-pip
           target: jina_devel
           build-args: BUILD_DATE, JINA_VERSION, VCS_REF, PY_VERSION

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test-arch: ["linux/amd64", "linux/armhf", "linux/arm/v6", "linux/arm64"]
+        test-arch: ["linux/amd64", "linux/arm64"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Docker Buildx
@@ -151,8 +151,8 @@ jobs:
           tags: localhost:5000/jina/multiarch:latest
           target: jina_devel
           build-args: BUILD_DATE, JINA_VERSION, VCS_REF, PY_VERSION
-#      - run: |
-#          docker run --platform ${{ matrix.test-arch }} localhost:5000/jina/multiarch:latest -v
+      - run: |
+          docker run --platform ${{ matrix.test-arch }} localhost:5000/jina/multiarch:latest -v
 
   core-test:
     needs: [prep-testbed, commit-lint, lint-flake-8]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,29 @@ jobs:
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
+  docker-arm-image-test:
+    needs: commit-lint
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [ 3.7 ]
+        test-arch: ["linux/armhf", "linux/arm/v6", "linux/arm/v8"]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: Dockerfiles/debianx.Dockerfile
+          platforms: ${{ matrix.test-path }}
+          push: true
+          tags: jinaai/jina-multi-arch:test-pip
+          target: jina_devel
+          build-args: BUILD_DATE, JINA_VERSION, VCS_REF, PY_VERSION
+      - run: |
+        docker run jinaai/jina-multi-arch:test-pip hello fashion
+
   core-test:
     needs: [prep-testbed, commit-lint, lint-flake-8]
     runs-on: ubuntu-20.04
@@ -198,7 +221,7 @@ jobs:
 
   # just for blocking the merge until all parallel core-test are successful
   success-all-test:
-    needs: [core-test, docker-image-test, check-docstring, check-black]
+    needs: [core-test, docker-image-test, check-docstring, check-black, docker-arm-image-test]
     if: always()
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,19 @@ jobs:
         test-arch: ["linux/armhf", "linux/arm/v6", "linux/arm/v8"]
     steps:
       - uses: actions/checkout@v2
-      - name: Build and push
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          install: true
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_DEVBOT_USER }}
+          password: ${{ secrets.DOCKERHUB_DEVBOT_TOKEN }}
+      - run: |
+          docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+      - name: Build and test
         uses: docker/build-push-action@v2
         with:
           context: .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,19 +117,6 @@ jobs:
   docker-image-test:
     needs: commit-lint
     runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v2
-      - run: |
-          echo "PIP_TAG='[devel]'" >> $GITHUB_ENV
-      - run: |
-          docker build -f Dockerfiles/pip.Dockerfile -t jinaai/jina:test-pip .
-          docker run jinaai/jina:test-pip hello fashion
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-
-  docker-arm-image-test:
-    needs: commit-lint
-    runs-on: ubuntu-20.04
     services:
       registry:
         image: registry:2
@@ -138,7 +125,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test-arch: ["linux/armhf", "linux/arm/v6", "linux/arm64"]
+        test-arch: ["linux/amd64", "linux/armhf", "linux/arm/v6", "linux/arm64"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Docker Buildx
@@ -165,7 +152,7 @@ jobs:
           target: jina_devel
           build-args: BUILD_DATE, JINA_VERSION, VCS_REF, PY_VERSION
       - run: |
-          docker run --platform ${{ matrix.test-arch }} localhost:5000/jina/multiarch:latest hello fashion
+          docker run --platform ${{ matrix.test-arch }} localhost:5000/jina/multiarch:latest -v
 
   core-test:
     needs: [prep-testbed, commit-lint, lint-flake-8]
@@ -238,7 +225,7 @@ jobs:
 
   # just for blocking the merge until all parallel core-test are successful
   success-all-test:
-    needs: [core-test, docker-image-test, check-docstring, check-black, docker-arm-image-test]
+    needs: [core-test, docker-image-test, check-docstring, check-black]
     if: always()
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,7 @@ jobs:
           target: jina_devel
           build-args: BUILD_DATE, JINA_VERSION, VCS_REF, PY_VERSION
       - run: |
-        docker run jinaai/jina-multi-arch:test-pip hello fashion
+          docker run jinaai/jina-multi-arch:test-pip hello fashion
 
   core-test:
     needs: [prep-testbed, commit-lint, lint-flake-8]
@@ -220,7 +220,7 @@ jobs:
 
   # just for blocking the merge until all parallel core-test are successful
   success-all-test:
-    needs: [core-test, docker-image-test, check-docstring, check-black]
+    needs: [core-test, docker-image-test, check-docstring, check-black, docker-arm-image-test]
     if: always()
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,7 +165,7 @@ jobs:
           target: jina_devel
           build-args: BUILD_DATE, JINA_VERSION, VCS_REF, PY_VERSION
       - run: |
-          docker run localhost:5000/jina/multiarch:latest hello fashion
+          docker run --platform ${{ matrix.test-arch }} localhost:5000/jina/multiarch:latest hello fashion
 
   core-test:
     needs: [prep-testbed, commit-lint, lint-flake-8]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,11 @@ jobs:
   docker-arm-image-test:
     needs: commit-lint
     runs-on: ubuntu-20.04
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
     strategy:
       fail-fast: false
       matrix:
@@ -141,6 +146,7 @@ jobs:
         uses: docker/setup-buildx-action@v1
         with:
           install: true
+          driver-opts: network=host
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:
@@ -154,12 +160,12 @@ jobs:
           context: .
           file: Dockerfiles/debianx.Dockerfile
           platforms: ${{ matrix.test-arch }}
-          push: false
-          tags: jinaai/jina-multi-arch:test-pip
+          push: true
+          tags: localhost:5000/jina/multiarch:latest
           target: jina_devel
           build-args: BUILD_DATE, JINA_VERSION, VCS_REF, PY_VERSION
       - run: |
-          docker run jinaai/jina-multi-arch:test-pip hello fashion
+          docker run localhost:5000/jina/multiarch:latest hello fashion
 
   core-test:
     needs: [prep-testbed, commit-lint, lint-flake-8]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,28 @@ jobs:
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
+  docker-arm-image-test:
+    needs: commit-lint
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        test-arch: ["linux/armhf", "linux/arm/v6", "linux/arm/v8"]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: Dockerfiles/debianx.Dockerfile
+          platforms: ${{ matrix.test-arch }}
+          push: false
+          tags: jinaai/jina-multi-arch:test-pip
+          target: jina_devel
+          build-args: BUILD_DATE, JINA_VERSION, VCS_REF, PY_VERSION
+      - run: |
+        docker run jinaai/jina-multi-arch:test-pip hello fashion
+
   core-test:
     needs: [prep-testbed, commit-lint, lint-flake-8]
     runs-on: ubuntu-20.04
@@ -198,7 +220,7 @@ jobs:
 
   # just for blocking the merge until all parallel core-test are successful
   success-all-test:
-    needs: [core-test, docker-image-test, check-docstring, check-black, docker-arm-image-test]
+    needs: [core-test, docker-image-test, check-docstring, check-black]
     if: always()
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,7 +138,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test-arch: ["linux/armhf", "linux/arm/v6", "linux/arm/v8"]
+        test-arch: ["linux/armhf", "linux/arm/v6", "linux/arm/arm64"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Docker Buildx

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,28 +127,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
-  docker-arm-image-test:
-    needs: commit-lint
-    runs-on: ubuntu-20.04
-    strategy:
-      fail-fast: false
-      matrix:
-        test-arch: ["linux/armhf", "linux/arm/v6", "linux/arm/v8"]
-    steps:
-      - uses: actions/checkout@v2
-      - name: Build and push
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          file: Dockerfiles/debianx.Dockerfile
-          platforms: ${{ matrix.test-arch }}
-          push: false
-          tags: jinaai/jina-multi-arch:test-pip
-          target: jina_devel
-          build-args: BUILD_DATE, JINA_VERSION, VCS_REF, PY_VERSION
-      - run: |
-        docker run jinaai/jina-multi-arch:test-pip hello fashion
-
   core-test:
     needs: [prep-testbed, commit-lint, lint-flake-8]
     runs-on: ubuntu-20.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,8 +151,8 @@ jobs:
           tags: localhost:5000/jina/multiarch:latest
           target: jina_devel
           build-args: BUILD_DATE, JINA_VERSION, VCS_REF, PY_VERSION
-      - run: |
-          docker run --platform ${{ matrix.test-arch }} localhost:5000/jina/multiarch:latest -v
+#      - run: |
+#          docker run --platform ${{ matrix.test-arch }} localhost:5000/jina/multiarch:latest -v
 
   core-test:
     needs: [prep-testbed, commit-lint, lint-flake-8]

--- a/.github/workflows/force-docker-build.yml
+++ b/.github/workflows/force-docker-build.yml
@@ -75,7 +75,7 @@ jobs:
         with:
           context: .
           file: Dockerfiles/debianx.Dockerfile
-          platforms: linux/armhf,linux/amd64,linux/arm/v6
+          platforms: linux/armhf,linux/amd64,linux/arm/v6,linux/arm/v8
           push: true
           tags: jinaai/jina:${{env.JINA_VERSION}}${{ matrix.tag_pyversion }}${{ matrix.tag_stage }}, ${{env.TAG_ALIAS}}
           build-args: BUILD_DATE, JINA_VERSION, VCS_REF, PY_VERSION

--- a/.github/workflows/force-docker-build.yml
+++ b/.github/workflows/force-docker-build.yml
@@ -75,7 +75,7 @@ jobs:
         with:
           context: .
           file: Dockerfiles/debianx.Dockerfile
-          platforms: linux/armhf,linux/amd64,linux/arm/v6,linux/arm/v8
+          platforms: linux/armhf,linux/amd64,linux/arm/v6,linux/arm64
           push: true
           tags: jinaai/jina:${{env.JINA_VERSION}}${{ matrix.tag_pyversion }}${{ matrix.tag_stage }}, ${{env.TAG_ALIAS}}
           build-args: BUILD_DATE, JINA_VERSION, VCS_REF, PY_VERSION

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -185,7 +185,7 @@ jobs:
         with:
           context: .
           file: Dockerfiles/debianx.Dockerfile
-          platforms: linux/armhf,linux/amd64,linux/arm/v6,linux/arm/v8
+          platforms: linux/armhf,linux/amd64,linux/arm/v6,linux/arm64
           push: true
           tags: jinaai/jina:latest${{ matrix.tag_pyversion }}${{ matrix.tag_stage }}, jinaai/jina:${{env.JINA_VERSION}}${{ matrix.tag_pyversion }}${{ matrix.tag_stage }}, jinaai/jina:${{env.JINA_MINOR_VERSION}}${{ matrix.tag_pyversion }}${{ matrix.tag_stage }}, ${{env.TAG_ALIAS}}
           build-args: BUILD_DATE, JINA_VERSION, VCS_REF, PY_VERSION

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -185,7 +185,7 @@ jobs:
         with:
           context: .
           file: Dockerfiles/debianx.Dockerfile
-          platforms: linux/armhf,linux/amd64,linux/arm/v6
+          platforms: linux/armhf,linux/amd64,linux/arm/v6,linux/arm/v8
           push: true
           tags: jinaai/jina:latest${{ matrix.tag_pyversion }}${{ matrix.tag_stage }}, jinaai/jina:${{env.JINA_VERSION}}${{ matrix.tag_pyversion }}${{ matrix.tag_stage }}, jinaai/jina:${{env.JINA_MINOR_VERSION}}${{ matrix.tag_pyversion }}${{ matrix.tag_stage }}, ${{env.TAG_ALIAS}}
           build-args: BUILD_DATE, JINA_VERSION, VCS_REF, PY_VERSION

--- a/Dockerfiles/debianx.Dockerfile
+++ b/Dockerfiles/debianx.Dockerfile
@@ -15,6 +15,7 @@ ARG BUILD_DATE
 ARG JINA_VERSION
 ARG PIP_TAG
 ARG PIP_EXTRA_INDEX_URL="https://www.piwheels.org/simple"
+ARG TARGETPLATFORM
 
 LABEL org.opencontainers.image.created=${BUILD_DATE} \
       org.opencontainers.image.authors="dev-team@jina.ai" \
@@ -45,7 +46,7 @@ RUN ln -s locale.h /usr/include/xlocale.h && \
     cd /jina && \
     pip install . --compile --extra-index-url ${PIP_EXTRA_INDEX_URL} && \
     if [ -n "${PIP_TAG}" ]; then pip install ".[${PIP_TAG}]" --compile --extra-index-url $PIP_EXTRA_INDEX_URL; fi && \
-    if [ "${PY_VERSION}" = "linux/arm64" ]; then apt-get remove -y --auto-remove ${JINA_COMPILERS}; fi && \
+    if [ "${TARGETPLATFORM}" = "linux/arm64" ]; then apt-get remove -y --auto-remove ${JINA_COMPILERS}; fi && \
     apt-get autoremove && apt-get clean && rm -rf /var/lib/apt/lists/* && \
     rm -rf /tmp/* && rm -rf /jina && rm /usr/include/xlocale.h
 

--- a/Dockerfiles/debianx.Dockerfile
+++ b/Dockerfiles/debianx.Dockerfile
@@ -43,7 +43,7 @@ COPY . /jina/
 
 RUN ln -s locale.h /usr/include/xlocale.h && \
     if [ "${TARGETPLATFORM}" = "linux/arm64" ] || [ "${TARGETPLATFORM}" = "linux/arm/v8" ]; then apt-get update && apt-get install --no-install-recommends -y ${JINA_COMPILERS}; fi && \
-    if [ "${TARGETPLATFORM}" = "linux/armhf" ] || [ "${TARGETPLATFORM}" = "linux/arm/v6" ]; then apt-get update && apt-get install --no-install-recommends -y python3-numpy; fi && \
+    if [ "${TARGETPLATFORM}" = "linux/armhf" ] || [ "${TARGETPLATFORM}" = "linux/arm/v6" ]; then apt-get update && apt-get install --no-install-recommends -y libatlas-base-dev; fi && \
     cd /jina && \
     pip install . --compile --extra-index-url ${PIP_EXTRA_INDEX_URL} && \
     if [ -n "${PIP_TAG}" ]; then pip install ".[${PIP_TAG}]" --compile --extra-index-url $PIP_EXTRA_INDEX_URL; fi && \

--- a/Dockerfiles/debianx.Dockerfile
+++ b/Dockerfiles/debianx.Dockerfile
@@ -43,7 +43,7 @@ COPY . /jina/
 
 RUN ln -s locale.h /usr/include/xlocale.h && \
     if [ "${TARGETPLATFORM}" = "linux/arm64" ] || [ "${TARGETPLATFORM}" = "linux/arm/v8" ]; then apt-get update && apt-get install --no-install-recommends -y ${JINA_COMPILERS}; fi && \
-    if [ "${TARGETPLATFORM}" = "linux/armhf" ] || [ "${TARGETPLATFORM}" = "linux/arm/v6" ]; then apt-get update && apt-get install --no-install-recommends -y libatlas-base-dev; fi && \
+    if [ "${TARGETPLATFORM}" = "linux/armhf" ] || [ "${TARGETPLATFORM}" = "linux/arm/v6" ]; then apt-get update && apt-get install --no-install-recommends -y python3-numpy; fi && \
     cd /jina && \
     pip install . --compile --extra-index-url ${PIP_EXTRA_INDEX_URL} && \
     if [ -n "${PIP_TAG}" ]; then pip install ".[${PIP_TAG}]" --compile --extra-index-url $PIP_EXTRA_INDEX_URL; fi && \

--- a/Dockerfiles/debianx.Dockerfile
+++ b/Dockerfiles/debianx.Dockerfile
@@ -41,9 +41,11 @@ ENV JINA_COMPILERS="gcc libc-dev make" \
 COPY . /jina/
 
 RUN ln -s locale.h /usr/include/xlocale.h && \
+    if [ "${TARGETPLATFORM}" = "linux/arm64" ]; then apt-get update && apt-get install --no-install-recommends -y ${JINA_COMPILERS}; fi && \
     cd /jina && \
     pip install . --compile --extra-index-url ${PIP_EXTRA_INDEX_URL} && \
     if [ -n "${PIP_TAG}" ]; then pip install ".[${PIP_TAG}]" --compile --extra-index-url $PIP_EXTRA_INDEX_URL; fi && \
+    if [ "${PY_VERSION}" = "linux/arm64" ]; then apt-get remove -y --auto-remove ${JINA_COMPILERS}; fi && \
     apt-get autoremove && apt-get clean && rm -rf /var/lib/apt/lists/* && \
     rm -rf /tmp/* && rm -rf /jina && rm /usr/include/xlocale.h
 

--- a/Dockerfiles/debianx.Dockerfile
+++ b/Dockerfiles/debianx.Dockerfile
@@ -43,6 +43,7 @@ COPY . /jina/
 
 RUN ln -s locale.h /usr/include/xlocale.h && \
     if [ "${TARGETPLATFORM}" = "linux/arm64" ] || [ "${TARGETPLATFORM}" = "linux/arm/v8" ]; then apt-get update && apt-get install --no-install-recommends -y ${JINA_COMPILERS}; fi && \
+    if [ "${TARGETPLATFORM}" = "linux/armhf" ] || [ "${TARGETPLATFORM}" = "linux/arm/v6" ]; then apt-get update && apt-get install --no-install-recommends -y libatlas-base-dev; fi && \
     cd /jina && \
     pip install . --compile --extra-index-url ${PIP_EXTRA_INDEX_URL} && \
     if [ -n "${PIP_TAG}" ]; then pip install ".[${PIP_TAG}]" --compile --extra-index-url $PIP_EXTRA_INDEX_URL; fi && \

--- a/Dockerfiles/debianx.Dockerfile
+++ b/Dockerfiles/debianx.Dockerfile
@@ -42,11 +42,11 @@ ENV JINA_COMPILERS="gcc libc-dev make" \
 COPY . /jina/
 
 RUN ln -s locale.h /usr/include/xlocale.h && \
-    if [ "${TARGETPLATFORM}" = "linux/arm64" ]; then apt-get update && apt-get install --no-install-recommends -y ${JINA_COMPILERS}; fi && \
+    if [ "${TARGETPLATFORM}" = "linux/arm64" ] || [ "${TARGETPLATFORM}" = "linux/arm/v8" ]; then apt-get update && apt-get install --no-install-recommends -y ${JINA_COMPILERS}; fi && \
     cd /jina && \
     pip install . --compile --extra-index-url ${PIP_EXTRA_INDEX_URL} && \
     if [ -n "${PIP_TAG}" ]; then pip install ".[${PIP_TAG}]" --compile --extra-index-url $PIP_EXTRA_INDEX_URL; fi && \
-    if [ "${TARGETPLATFORM}" = "linux/arm64" ]; then apt-get remove -y --auto-remove ${JINA_COMPILERS}; fi && \
+    if [ "${TARGETPLATFORM}" = "linux/arm64" ] || [ "${TARGETPLATFORM}" = "linux/arm/v8" ]; then apt-get remove -y --auto-remove ${JINA_COMPILERS}; fi && \
     apt-get autoremove && apt-get clean && rm -rf /var/lib/apt/lists/* && \
     rm -rf /tmp/* && rm -rf /jina && rm /usr/include/xlocale.h
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ $ docker run jinaai/jina:master -v
 <details>
 <summary>📦 More installation options</summary>
 
-| <br><sub><sup>x86/64,arm/v6,v7,[v8 (Apple M1)](https://github.com/jina-ai/jina/issues/1781)</sup></sub> | On Linux/macOS & Python 3.7/3.8/3.9 | Docker Users|
+| <br><sub><sup>x86/64,arm/v6,v7,v8 (Apple M1)</sup></sub> | On Linux/macOS & Python 3.7/3.8/3.9 | Docker Users|
 | --- | --- | --- |
 | Standard | `pip install --pre jina` | `docker run jinaai/jina:master` |
 | <sub><a href="https://api.jina.ai/daemon/">Daemon</a></sub> | <sub>`pip install --pre "jina[daemon]"`</sub> | <sub>`docker run --network=host jinaai/jina:master-daemon`</sub> |

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ $ docker run jinaai/jina:master -v
 <details>
 <summary>📦 More installation options</summary>
 
-| <br><sub><sup>x86/64,arm/v6,v7,v8 (Apple M1)</sup></sub> | On Linux/macOS & Python 3.7/3.8/3.9 | Docker Users|
+| <br><sub><sup>x86/64,arm64,v6,v7,Apple M1</sup></sub> | On Linux/macOS & Python 3.7/3.8/3.9 | Docker Users|
 | --- | --- | --- |
 | Standard | `pip install --pre jina` | `docker run jinaai/jina:master` |
 | <sub><a href="https://api.jina.ai/daemon/">Daemon</a></sub> | <sub>`pip install --pre "jina[daemon]"`</sub> | <sub>`docker run --network=host jinaai/jina:master-daemon`</sub> |

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -66,7 +66,7 @@ The following example shows how Jina is released from 0.9 to 0.9.2 according to 
 
 ## Docker image versioning
 
-Our univeral Docker image is ready-to-use on linux/amd64, linux/armv7+, linux/arm/v6, linux/arm/v8. The Docker image name always starts with `jinaai/jina` followed by a tag composed of three parts:
+Our univeral Docker image is ready-to-use on linux/amd64, linux/armv7+, linux/arm/v6, linux/arm64. The Docker image name always starts with `jinaai/jina` followed by a tag composed of three parts:
 
 ```text
 jinaai/jina:{version}{python_version}{extra}

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -66,7 +66,7 @@ The following example shows how Jina is released from 0.9 to 0.9.2 according to 
 
 ## Docker image versioning
 
-Our univeral Docker image is ready-to-use on linux/amd64, linux/armv7+, linux/arm/v6. The Docker image name always starts with `jinaai/jina` followed by a tag composed of three parts:
+Our univeral Docker image is ready-to-use on linux/amd64, linux/armv7+, linux/arm/v6, linux/arm/v8. The Docker image name always starts with `jinaai/jina` followed by a tag composed of three parts:
 
 ```text
 jinaai/jina:{version}{python_version}{extra}

--- a/jina/__init__.py
+++ b/jina/__init__.py
@@ -154,6 +154,9 @@ _set_nofile()
 
 # ONLY FIRST CLASS CITIZENS ARE ALLOWED HERE, namely Document, Executor Flow
 
+# Client
+from jina.clients import Client
+
 # Document
 from jina.types.document import Document
 from jina.types.arrays.document import DocumentArray
@@ -165,9 +168,6 @@ from jina.executors.decorators import requests
 # Flow
 from jina.flow import Flow
 from jina.flow.asyncio import AsyncFlow
-
-# Client
-from jina.clients import Client
 
 __all__ = [_s for _s in dir() if not _s.startswith('_')]
 __all__.extend(_names_with_underscore)

--- a/jina/clients/request/helper.py
+++ b/jina/clients/request/helper.py
@@ -1,10 +1,10 @@
 """Module for helper functions for clients."""
 from typing import Tuple
 
-from ... import Document
 from ...enums import DataInputType
 from ...excepts import BadDocType, BadRequestType
 from ...types.request import Request
+from ...types.document import Document
 
 
 def _new_data_request_from_batch(

--- a/jina/executors/decorators.py
+++ b/jina/executors/decorators.py
@@ -13,7 +13,7 @@ from typing import (
 )
 
 from .metas import get_default_metas
-from .. import DocumentArray
+from ..types.arrays import DocumentArray
 from ..helper import convert_tuple_to_list
 
 

--- a/jina/helloworld/fashion/app.py
+++ b/jina/helloworld/fashion/app.py
@@ -2,7 +2,6 @@ import os
 from pathlib import Path
 
 from jina import Flow
-from jina.helper import countdown
 from jina.parsers.helloworld import set_hw_parser
 
 if __name__ == '__main__':
@@ -12,7 +11,6 @@ if __name__ == '__main__':
         download_data,
         index_generator,
         query_generator,
-        colored,
     )
     from executors import MyEncoder, MyIndexer, MyEvaluator
 else:
@@ -22,7 +20,6 @@ else:
         download_data,
         index_generator,
         query_generator,
-        colored,
     )
     from .executors import MyEncoder, MyIndexer, MyEvaluator
 
@@ -83,16 +80,6 @@ def hello_world(args):
         f.index(
             index_generator(num_docs=targets['index']['data'].shape[0], target=targets),
             request_size=args.request_size,
-        )
-
-        # wait for couple of seconds
-        countdown(
-            3,
-            reason=colored(
-                'behold! im going to switch to query mode',
-                'cyan',
-                attrs=['underline', 'bold', 'reverse'],
-            ),
         )
 
         # f.search(

--- a/jina/types/arrays/document.py
+++ b/jina/types/arrays/document.py
@@ -342,7 +342,7 @@ class DocumentArray(TraversableSequence, MutableSequence, Itr):
             file_ctx = open(file)
 
         with file_ctx as fp:
-            from jina import Document
+            from ..document import Document
 
             da = DocumentArray()
             for v in fp:

--- a/jina/types/document/generators.py
+++ b/jina/types/document/generators.py
@@ -30,7 +30,7 @@ def from_ndarray(
         This function should not be directly used, use :meth:`Flow.index_ndarray`, :meth:`Flow.search_ndarray` instead
     """
 
-    from jina import Document
+    from ..document import Document
 
     if shuffle:
         # shuffle for random query
@@ -65,7 +65,7 @@ def from_files(
     .. note::
         This function should not be directly used, use :meth:`Flow.index_files`, :meth:`Flow.search_files` instead
     """
-    from jina import Document
+    from ..document import Document
 
     if read_mode not in {'r', 'rb', None}:
         raise RuntimeError(f'read_mode should be "r", "rb" or None, got {read_mode}')
@@ -107,7 +107,7 @@ def from_csv(
     :yield: documents
 
     """
-    from jina import Document
+    from ..document import Document
 
     lines = csv.DictReader(fp)
     for value in _subsample(lines, size, sampling_rate):
@@ -136,7 +136,7 @@ def from_ndjson(
     :yield: documents
 
     """
-    from jina import Document
+    from ..document import Document
 
     for line in _subsample(fp, size, sampling_rate):
         value = json.loads(line)


### PR DESCRIPTION
It's a strange bug caused `import grpc`, yet i'm not sure it is really the upstream problem.

As mentioned in #2447 , running `jina -v` on armv8 throws the exception immediately:
```
free(): invalid pointer
Aborted
```

After some inspections, I found the cause is `import grpc`. To reproduce, **(only on armv8)**, 

-  adding `import grpc` _before_ these lines of `jina/__init__.py`
  ```python
from jina.types.document import Document
from jina.types.arrays.document import DocumentArray
  ``` 
passes.

-  adding `import grpc` _after_ these lines of `jina/__init__.py`
  ```python
from jina.types.document import Document
from jina.types.arrays.document import DocumentArray
  ``` 
fails.

Unfortunately, I don't have time to dig in on this, but this PR at least figured out this issue and fix #2447 



