### PR TITLE
feat: add ip range management

### DIFF
--- a/daemon/models/containers.py
+++ b/daemon/models/containers.py
@@ -1,5 +1,5 @@
 from typing import Dict
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from .id import DaemonID
 from .base import StoreItem, StoreStatus
@@ -24,4 +24,4 @@ class ContainerItem(StoreItem):
 
 
 class ContainerStoreStatus(StoreStatus):
-    items: Dict[DaemonID, ContainerItem]
+    items: Dict[DaemonID, ContainerItem] = Field(default_factory=dict)

--- a/daemon/models/workspaces.py
+++ b/daemon/models/workspaces.py
@@ -1,5 +1,6 @@
+from ipaddress import IPv4Address
 from typing import Dict, List, Optional
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from .id import DaemonID
 from .enums import WorkspaceState
@@ -27,4 +28,7 @@ class WorkspaceItem(StoreItem):
 
 
 class WorkspaceStoreStatus(StoreStatus):
-    items: Dict[DaemonID, WorkspaceItem]
+    ip_range_start: IPv4Address = IPv4Address('10.0.0.0')
+    subnet_size: int = 22
+    ip_range_current_offset: int = 0
+    items: Dict[DaemonID, WorkspaceItem] = Field(default_factory=dict)

--- a/daemon/stores/base.py
+++ b/daemon/stores/base.py
@@ -24,7 +24,7 @@ class BaseStore(MutableMapping):
 
     def __init__(self):
         self._logger = JinaLogger(self.__class__.__name__, **vars(jinad_args))
-        self.status = StoreStatus()
+        self.status = self.__class__._status_model()
 
     def add(self, *args, **kwargs) -> DaemonID:
         """Add a new element to the store. This method needs to be overridden by the subclass
@@ -141,7 +141,7 @@ class BaseStore(MutableMapping):
     def reset(self) -> None:
         """Calling :meth:`clear` and reset all stats """
         self.clear()
-        self.status = StoreStatus()
+        self.status = self._status_model()
 
     def __len__(self):
         return len(self.items())


### PR DESCRIPTION
This adds a feature to jinad to manage the subnetworks assigned to the Docker networks on image creation.
Now JinaD assigns subnetworks in the 10.0.0/8 private address space (as its larger than the docker default one which is 192.168.0.0/16). Each subnet is a /22 network so we can have 1024 hosts in a flow, which should be enough for now I think.

We have now room for 16384 networks in jinad, which is the maximum number of workspaces we can create concurrently now.

Some meta data about the IP assignment gets persisted in the workspace store.
I also fixed some minor other thing (wrong store status model being created on first time creation without pickle).