### PR TITLE
feat: add pretty print for embedding and blob

### DIFF
--- a/.github/2.0/cookbooks/Document.md
+++ b/.github/2.0/cookbooks/Document.md
@@ -36,6 +36,7 @@ Table of Contents
   - [Serialize `Document`](#serialize-document)
   - [Add Recursion to `Document`](#add-recursion-to-document)
     - [Recursive Attributes](#recursive-attributes)
+  - [Represent `Document` as Dictionary or JSON](#represent-document-as-dictionary-or-json)
   - [Visualize `Document`](#visualize-document)
   - [Add Relevancy to `Document`s](#add-relevancy-to-documents)
     - [Relevance Attributes](#relevance-attributes)
@@ -418,6 +419,75 @@ You can add **chunks** (sub-Document) and **matches** (neighbour-Document) to a 
   ```
 
 Note that both `doc.chunks` and `doc.matches` return `DocumentArray`, which we will introduce later.
+
+### Represent `Document` as Dictionary or JSON
+
+Any `Document` can be converted into a `Python dictionary` or into `Json string` by calling their `.dict()` or `.json()` methods. 
+
+```python
+import pprint
+import numpy as np
+
+from jina import Document
+
+d0 = Document(id='🐲identifier', text='I am a Jina Document', tags={'cool': True}, embedding=np.array([0, 0]))
+pprint.pprint(d0.dict())
+pprint.pprint(d0.json())
+```
+
+```text
+{'embedding': {'dense': {'buffer': 'AAAAAAAAAAAAAAAAAAAAAA==',
+                         'dtype': '<i8',
+                         'shape': [2]}},
+ 'id': '🐲identifier',
+ 'mime_type': 'text/plain',
+ 'tags': {'cool': True},
+ 'text': 'I am a Jina Document'}
+('{\n'
+ '  "embedding": {\n'
+ '    "dense": {\n'
+ '      "buffer": "AAAAAAAAAAAAAAAAAAAAAA==",\n'
+ '      "dtype": "<i8",\n'
+ '      "shape": [\n'
+ '        2\n'
+ '      ]\n'
+ '    }\n'
+ '  },\n'
+ '  "id": "identifier",\n'
+ '  "mime_type": "text/plain",\n'
+ '  "tags": {\n'
+ '    "cool": true\n'
+ '  },\n'
+ '  "text": "I am a Jina Document"\n'
+ '}')
+```
+
+As it can be observed, the output seems quite noisy when representing the `embedding`. This is because Jina `Document` stores `embeddings` in an `inner` structure
+supported by `protobuf`. In order to have a nicer representation of the `embeddings` and any `ndarray` field, you can call `dict` and `json` with the option `prettify_ndarrays=True`.
+
+```python
+import pprint
+import numpy as np
+
+from jina import Document
+
+d0 = Document(id='🐲identifier', text='I am a Jina Document', tags={'cool': True}, embedding=np.array([0, 0]))
+pprint.pprint(d0.dict(prettify_ndarrays=True))
+pprint.pprint(d0.json(prettify_ndarrays=True))
+```
+
+```text
+{'embedding': [0, 0],
+ 'id': '🐲identifier',
+ 'mime_type': 'text/plain',
+ 'tags': {'cool': True},
+ 'text': 'I am a Jina Document'}
+
+('{"embedding": [0, 0], "id": "identifier", "mime_type": '
+ '"text/plain", "tags": {"cool": true}, "text": "I am a Jina Document"}')
+```
+
+This can be useful to understand the contents of the `Document` and to send to backends that can process vectors as `lists` of values.
 
 ### Visualize `Document`
 

--- a/jina/types/document/__init__.py
+++ b/jina/types/document/__init__.py
@@ -193,6 +193,11 @@ class Document(ProtoTypeMixin):
                 if isinstance(document, str):
                     document = json.loads(document)
 
+                for key in _all_doc_array_keys:
+                    # cover when the document has been pretty-printed
+                    if isinstance(document[key], list):
+                        document[key] = NdArray(np.array(document[key])).dict()
+
                 if field_resolver:
                     document = {
                         field_resolver.get(k, k): v for k, v in document.items()
@@ -1185,6 +1190,21 @@ class Document(ProtoTypeMixin):
                 if isinstance(value, np.ndarray):
                     d[key] = value.tolist()
         return d
+
+    def json(self):
+        """Return the object in JSON string
+
+        :return: JSON string of the object
+        """
+        import json
+
+        d = super().dict()
+        for key in _all_doc_array_keys:
+            if key in d:
+                value = getattr(self, key)
+                if isinstance(value, np.ndarray):
+                    d[key] = value.tolist()
+        return json.dumps(d)
 
     @property
     def non_empty_fields(self) -> Tuple[str]:

--- a/jina/types/document/__init__.py
+++ b/jina/types/document/__init__.py
@@ -195,7 +195,7 @@ class Document(ProtoTypeMixin):
 
                 for key in _all_doc_array_keys:
                     # cover when the document has been pretty-printed
-                    if isinstance(document[key], list):
+                    if key in document and isinstance(document[key], list):
                         document[key] = NdArray(np.array(document[key])).dict()
 
                 if field_resolver:

--- a/jina/types/document/__init__.py
+++ b/jina/types/document/__init__.py
@@ -1231,7 +1231,7 @@ class Document(ProtoTypeMixin):
 
             d = super().dict(*args, **kwargs)
             self._prettify_doc_dict(d)
-            return json.dumps(d)
+            return json.dumps(d, sort_keys=True, **kwargs)
         else:
             return super().json(*args, **kwargs)
 

--- a/jina/types/document/__init__.py
+++ b/jina/types/document/__init__.py
@@ -82,6 +82,7 @@ DocumentSourceType = TypeVar(
 _all_mime_types = set(mimetypes.types_map.values())
 
 _all_doc_content_keys = ('content', 'uri', 'blob', 'text', 'buffer')
+_all_doc_array_keys = ('blob', 'embedding')
 
 
 class Document(ProtoTypeMixin):
@@ -1171,6 +1172,19 @@ class Document(ProtoTypeMixin):
             from jina.logging.predefined import default_logger
 
             default_logger.info(f'Document visualization: {url}')
+
+    def dict(self):
+        """Return the object in Python dictionary
+
+        :return: dict representation of the object
+        """
+        d = super().dict()
+        for key in _all_doc_array_keys:
+            if key in d:
+                value = getattr(self, key)
+                if isinstance(value, np.ndarray):
+                    d[key] = value.tolist()
+        return d
 
     @property
     def non_empty_fields(self) -> Tuple[str]:

--- a/tests/unit/types/document/test_document.py
+++ b/tests/unit/types/document/test_document.py
@@ -837,3 +837,23 @@ def test_doc_update_given_fields_and_source_has_more_attributes(test_docs):
     assert doc1.tags == {'a': 'b'}
     assert (doc1.embedding != doc2.embedding).all()
     assert doc1.chunks != doc2.chunks
+
+
+def test_document_pretty_dict():
+    doc = Document(
+        blob=np.array([[0, 1, 2], [2, 1, 0]]),
+        embedding=np.array([1.0, 2.0, 3.0]),
+        tags={'hello': 'world'},
+    )
+    assert doc.tags == {'hello': 'world'}
+    assert doc.blob.tolist() == [[0, 1, 2], [2, 1, 0]]
+    assert doc.embedding.tolist() == [1.0, 2.0, 3.0]
+    d = doc.dict()
+    assert d['blob'] == [[0, 1, 2], [2, 1, 0]]
+    assert d['embedding'] == [1.0, 2.0, 3.0]
+    assert d['tags'] == {'hello': 'world'}
+
+    d_reconstructed = Document(d)
+    assert d_reconstructed.tags == {'hello': 'world'}
+    assert d_reconstructed.blob.tolist() == [[0, 1, 2], [2, 1, 0]]
+    assert d_reconstructed.embedding.tolist() == [1.0, 2.0, 3.0]

--- a/tests/unit/types/document/test_document.py
+++ b/tests/unit/types/document/test_document.py
@@ -845,27 +845,33 @@ def test_document_pretty_dict():
         embedding=np.array([1.0, 2.0, 3.0]),
         tags={'hello': 'world'},
     )
-    doc.chunks.append(Document(doc, copy=True))
-    doc.matches.append(Document(doc, copy=True))
+    chunk = Document(doc, copy=True)
+    chunk.blob = np.array([[3, 4, 5], [5, 4, 3]])
+    chunk.embedding = np.array([4.0, 5.0, 6.0])
+    match = Document(doc, copy=True)
+    match.blob = np.array([[6, 7, 8], [8, 7, 6]])
+    match.embedding = np.array([7.0, 8.0, 9.0])
+    doc.chunks.append(chunk)
+    doc.matches.append(match)
     assert doc.tags == {'hello': 'world'}
     assert doc.blob.tolist() == [[0, 1, 2], [2, 1, 0]]
     assert doc.embedding.tolist() == [1.0, 2.0, 3.0]
     assert doc.chunks[0].tags == {'hello': 'world'}
-    assert doc.chunks[0].blob.tolist() == [[0, 1, 2], [2, 1, 0]]
-    assert doc.chunks[0].embedding.tolist() == [1.0, 2.0, 3.0]
+    assert doc.chunks[0].blob.tolist() == [[3, 4, 5], [5, 4, 3]]
+    assert doc.chunks[0].embedding.tolist() == [4.0, 5.0, 6.0]
     assert doc.matches[0].tags == {'hello': 'world'}
-    assert doc.matches[0].blob.tolist() == [[0, 1, 2], [2, 1, 0]]
-    assert doc.matches[0].embedding.tolist() == [1.0, 2.0, 3.0]
+    assert doc.matches[0].blob.tolist() == [[6, 7, 8], [8, 7, 6]]
+    assert doc.matches[0].embedding.tolist() == [7.0, 8.0, 9.0]
 
     d = doc.dict(prettify_ndarrays=True)
     assert d['blob'] == [[0, 1, 2], [2, 1, 0]]
     assert d['embedding'] == [1.0, 2.0, 3.0]
     assert d['tags'] == {'hello': 'world'}
-    assert d['chunks'][0]['blob'] == [[0, 1, 2], [2, 1, 0]]
-    assert d['chunks'][0]['embedding'] == [1.0, 2.0, 3.0]
+    assert d['chunks'][0]['blob'] == [[3, 4, 5], [5, 4, 3]]
+    assert d['chunks'][0]['embedding'] == [4.0, 5.0, 6.0]
     assert d['chunks'][0]['tags'] == {'hello': 'world'}
-    assert d['matches'][0]['blob'] == [[0, 1, 2], [2, 1, 0]]
-    assert d['matches'][0]['embedding'] == [1.0, 2.0, 3.0]
+    assert d['matches'][0]['blob'] == [[6, 7, 8], [8, 7, 6]]
+    assert d['matches'][0]['embedding'] == [7.0, 8.0, 9.0]
     assert d['matches'][0]['tags'] == {'hello': 'world'}
 
     d_reconstructed = Document(d)
@@ -873,11 +879,11 @@ def test_document_pretty_dict():
     assert d_reconstructed.blob.tolist() == [[0, 1, 2], [2, 1, 0]]
     assert d_reconstructed.embedding.tolist() == [1.0, 2.0, 3.0]
     assert d_reconstructed.chunks[0].tags == {'hello': 'world'}
-    assert d_reconstructed.chunks[0].blob.tolist() == [[0, 1, 2], [2, 1, 0]]
-    assert d_reconstructed.chunks[0].embedding.tolist() == [1.0, 2.0, 3.0]
+    assert d_reconstructed.chunks[0].blob.tolist() == [[3, 4, 5], [5, 4, 3]]
+    assert d_reconstructed.chunks[0].embedding.tolist() == [4.0, 5.0, 6.0]
     assert d_reconstructed.matches[0].tags == {'hello': 'world'}
-    assert d_reconstructed.matches[0].blob.tolist() == [[0, 1, 2], [2, 1, 0]]
-    assert d_reconstructed.matches[0].embedding.tolist() == [1.0, 2.0, 3.0]
+    assert d_reconstructed.matches[0].blob.tolist() == [[6, 7, 8], [8, 7, 6]]
+    assert d_reconstructed.matches[0].embedding.tolist() == [7.0, 8.0, 9.0]
 
 
 def test_document_pretty_json():

--- a/tests/unit/types/document/test_document.py
+++ b/tests/unit/types/document/test_document.py
@@ -857,3 +857,24 @@ def test_document_pretty_dict():
     assert d_reconstructed.tags == {'hello': 'world'}
     assert d_reconstructed.blob.tolist() == [[0, 1, 2], [2, 1, 0]]
     assert d_reconstructed.embedding.tolist() == [1.0, 2.0, 3.0]
+
+
+def test_document_pretty_json():
+    doc = Document(
+        blob=np.array([[0, 1, 2], [2, 1, 0]]),
+        embedding=np.array([1.0, 2.0, 3.0]),
+        tags={'hello': 'world'},
+    )
+    assert doc.tags == {'hello': 'world'}
+    assert doc.blob.tolist() == [[0, 1, 2], [2, 1, 0]]
+    assert doc.embedding.tolist() == [1.0, 2.0, 3.0]
+    doc_json = doc.json()
+    d = json.loads(doc_json)
+    assert d['blob'] == [[0, 1, 2], [2, 1, 0]]
+    assert d['embedding'] == [1.0, 2.0, 3.0]
+    assert d['tags'] == {'hello': 'world'}
+
+    d_reconstructed = Document(doc_json)
+    assert d_reconstructed.tags == {'hello': 'world'}
+    assert d_reconstructed.blob.tolist() == [[0, 1, 2], [2, 1, 0]]
+    assert d_reconstructed.embedding.tolist() == [1.0, 2.0, 3.0]

--- a/tests/unit/types/document/test_document.py
+++ b/tests/unit/types/document/test_document.py
@@ -845,18 +845,39 @@ def test_document_pretty_dict():
         embedding=np.array([1.0, 2.0, 3.0]),
         tags={'hello': 'world'},
     )
+    doc.chunks.append(Document(doc, copy=True))
+    doc.matches.append(Document(doc, copy=True))
     assert doc.tags == {'hello': 'world'}
     assert doc.blob.tolist() == [[0, 1, 2], [2, 1, 0]]
     assert doc.embedding.tolist() == [1.0, 2.0, 3.0]
+    assert doc.chunks[0].tags == {'hello': 'world'}
+    assert doc.chunks[0].blob.tolist() == [[0, 1, 2], [2, 1, 0]]
+    assert doc.chunks[0].embedding.tolist() == [1.0, 2.0, 3.0]
+    assert doc.matches[0].tags == {'hello': 'world'}
+    assert doc.matches[0].blob.tolist() == [[0, 1, 2], [2, 1, 0]]
+    assert doc.matches[0].embedding.tolist() == [1.0, 2.0, 3.0]
+
     d = doc.dict()
     assert d['blob'] == [[0, 1, 2], [2, 1, 0]]
     assert d['embedding'] == [1.0, 2.0, 3.0]
     assert d['tags'] == {'hello': 'world'}
+    assert d['chunks'][0]['blob'] == [[0, 1, 2], [2, 1, 0]]
+    assert d['chunks'][0]['embedding'] == [1.0, 2.0, 3.0]
+    assert d['chunks'][0]['tags'] == {'hello': 'world'}
+    assert d['matches'][0]['blob'] == [[0, 1, 2], [2, 1, 0]]
+    assert d['matches'][0]['embedding'] == [1.0, 2.0, 3.0]
+    assert d['matches'][0]['tags'] == {'hello': 'world'}
 
     d_reconstructed = Document(d)
     assert d_reconstructed.tags == {'hello': 'world'}
     assert d_reconstructed.blob.tolist() == [[0, 1, 2], [2, 1, 0]]
     assert d_reconstructed.embedding.tolist() == [1.0, 2.0, 3.0]
+    assert d_reconstructed.chunks[0].tags == {'hello': 'world'}
+    assert d_reconstructed.chunks[0].blob.tolist() == [[0, 1, 2], [2, 1, 0]]
+    assert d_reconstructed.chunks[0].embedding.tolist() == [1.0, 2.0, 3.0]
+    assert d_reconstructed.matches[0].tags == {'hello': 'world'}
+    assert d_reconstructed.matches[0].blob.tolist() == [[0, 1, 2], [2, 1, 0]]
+    assert d_reconstructed.matches[0].embedding.tolist() == [1.0, 2.0, 3.0]
 
 
 def test_document_pretty_json():
@@ -865,16 +886,36 @@ def test_document_pretty_json():
         embedding=np.array([1.0, 2.0, 3.0]),
         tags={'hello': 'world'},
     )
+    doc.chunks.append(Document(doc, copy=True))
+    doc.matches.append(Document(doc, copy=True))
     assert doc.tags == {'hello': 'world'}
     assert doc.blob.tolist() == [[0, 1, 2], [2, 1, 0]]
     assert doc.embedding.tolist() == [1.0, 2.0, 3.0]
+    assert doc.chunks[0].tags == {'hello': 'world'}
+    assert doc.chunks[0].blob.tolist() == [[0, 1, 2], [2, 1, 0]]
+    assert doc.chunks[0].embedding.tolist() == [1.0, 2.0, 3.0]
+    assert doc.matches[0].tags == {'hello': 'world'}
+    assert doc.matches[0].blob.tolist() == [[0, 1, 2], [2, 1, 0]]
+    assert doc.matches[0].embedding.tolist() == [1.0, 2.0, 3.0]
     doc_json = doc.json()
     d = json.loads(doc_json)
     assert d['blob'] == [[0, 1, 2], [2, 1, 0]]
     assert d['embedding'] == [1.0, 2.0, 3.0]
     assert d['tags'] == {'hello': 'world'}
+    assert d['chunks'][0]['blob'] == [[0, 1, 2], [2, 1, 0]]
+    assert d['chunks'][0]['embedding'] == [1.0, 2.0, 3.0]
+    assert d['chunks'][0]['tags'] == {'hello': 'world'}
+    assert d['matches'][0]['blob'] == [[0, 1, 2], [2, 1, 0]]
+    assert d['matches'][0]['embedding'] == [1.0, 2.0, 3.0]
+    assert d['matches'][0]['tags'] == {'hello': 'world'}
 
     d_reconstructed = Document(doc_json)
     assert d_reconstructed.tags == {'hello': 'world'}
     assert d_reconstructed.blob.tolist() == [[0, 1, 2], [2, 1, 0]]
     assert d_reconstructed.embedding.tolist() == [1.0, 2.0, 3.0]
+    assert d_reconstructed.chunks[0].tags == {'hello': 'world'}
+    assert d_reconstructed.chunks[0].blob.tolist() == [[0, 1, 2], [2, 1, 0]]
+    assert d_reconstructed.chunks[0].embedding.tolist() == [1.0, 2.0, 3.0]
+    assert d_reconstructed.matches[0].tags == {'hello': 'world'}
+    assert d_reconstructed.matches[0].blob.tolist() == [[0, 1, 2], [2, 1, 0]]
+    assert d_reconstructed.matches[0].embedding.tolist() == [1.0, 2.0, 3.0]

--- a/tests/unit/types/document/test_document.py
+++ b/tests/unit/types/document/test_document.py
@@ -857,7 +857,7 @@ def test_document_pretty_dict():
     assert doc.matches[0].blob.tolist() == [[0, 1, 2], [2, 1, 0]]
     assert doc.matches[0].embedding.tolist() == [1.0, 2.0, 3.0]
 
-    d = doc.dict()
+    d = doc.dict(prettify_ndarrays=True)
     assert d['blob'] == [[0, 1, 2], [2, 1, 0]]
     assert d['embedding'] == [1.0, 2.0, 3.0]
     assert d['tags'] == {'hello': 'world'}
@@ -897,7 +897,7 @@ def test_document_pretty_json():
     assert doc.matches[0].tags == {'hello': 'world'}
     assert doc.matches[0].blob.tolist() == [[0, 1, 2], [2, 1, 0]]
     assert doc.matches[0].embedding.tolist() == [1.0, 2.0, 3.0]
-    doc_json = doc.json()
+    doc_json = doc.json(prettify_ndarrays=True)
     d = json.loads(doc_json)
     assert d['blob'] == [[0, 1, 2], [2, 1, 0]]
     assert d['embedding'] == [1.0, 2.0, 3.0]


### PR DESCRIPTION
**Changes introcduced**
Try to have pretty dict printing for `Document`. At the same time we need to be able to build the `Document` back from a pretty dict like this.

Same would apply for `json`.

![image](https://user-images.githubusercontent.com/19825685/120275398-874e7d00-c2b1-11eb-975b-b35251157ec1.png)
