### PR TITLE
test: make high order matches useful agian

### DIFF
--- a/tests/integration/high_order_matches/test_document.py
+++ b/tests/integration/high_order_matches/test_document.py
@@ -1,14 +1,9 @@
-import os
-import shutil
-
-import pytest
-
 from jina.flow import Flow
 from jina import Document, Executor, requests
-from tests import validate_callback
 
 
-def validate(req):
+def validate_results(results):
+    req = results[0]
     assert len(req.docs) == 1
     assert len(req.docs[0].matches) == 5
     assert len(req.docs[0].matches[0].matches) == 5
@@ -16,31 +11,46 @@ def validate(req):
     assert len(req.docs[0].matches[0].matches[0].matches) == 0
 
 
-class MyExecutor(Executor):
-    def __init__(self, **kwargs):
+class MatchAdder(Executor):
+    def __init__(self, traversal_paths=('r',), **kwargs):
         super().__init__(**kwargs)
-        self.doc = self.requests
+        self._traversal_paths = traversal_paths
 
     @requests(on='index')
     def index(self, docs, **kwargs):
-        self.doc = docs[0]
-        for match in self.doc.matches:
-            for i in range(5):
-                match.matches.append(Document())
-
-        return None
+        for path_docs in docs.traverse(self._traversal_paths):
+            for doc in path_docs:
+                for i in range(5):
+                    doc.matches.append(Document())
 
 
-def test_high_order_matches(mocker):
-    response_mock = mocker.Mock()
+def test_single_executor():
 
-    f = Flow().add(uses=MyExecutor)
+    f = Flow().add(
+        uses={'jtype': 'MatchAdder', 'with': {'traversal_paths': ['r', 'm']}}
+    )
 
     with f:
-        f.post(
+        results = f.post(
             on='index',
-            inputs=Document(matches=[Document() for i in range(5)]),
-            on_done=response_mock,
+            inputs=Document(),
+            return_results=True,
         )
+    validate_results(results)
 
-    validate_callback(response_mock, validate)
+
+def test_multi_executor():
+
+    f = (
+        Flow()
+        .add(uses={'jtype': 'MatchAdder', 'with': {'traversal_paths': ['r']}})
+        .add(uses={'jtype': 'MatchAdder', 'with': {'traversal_paths': ['m']}})
+    )
+
+    with f:
+        results = f.post(
+            on='index',
+            inputs=Document(),
+            return_results=True,
+        )
+    validate_results(results)


### PR DESCRIPTION
Adopted high-order-matches test in order to test configurable `traversal_paths` again. Cleaned up some unused code.