### PR TITLE
test: added test for startup exception

### DIFF
--- a/tests/unit/flow/test_flow_except.py
+++ b/tests/unit/flow/test_flow_except.py
@@ -227,3 +227,34 @@ def test_flow_on_error_callback(restful):
     assert hit == ['error', 'always']
 
     hit.clear()
+
+
+@pytest.mark.timeout(10)
+@pytest.mark.parametrize('restful', [False, True])
+def test_flow_startup_exception_not_hanging(restful):
+    class ExceptionExecutor(Executor):
+        def __init__(self, *args, **kwargs):
+            raise Exception
+
+    f = Flow(restful=restful).add(uses=ExceptionExecutor)
+    from jina.excepts import RuntimeFailToStart
+
+    with pytest.raises(RuntimeFailToStart):
+        with f:
+            pass
+
+
+@pytest.mark.timeout(10)
+@pytest.mark.parametrize('restful', [False, True])
+def test_flow_startup_exception_not_hanging2(restful):
+    class ExceptionExecutor(Executor):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            raise Exception
+
+    f = Flow(restful=restful).add(uses=ExceptionExecutor)
+    from jina.excepts import RuntimeFailToStart
+
+    with pytest.raises(RuntimeFailToStart):
+        with f:
+            pass


### PR DESCRIPTION
This tests previous issues/github_1861 which checked, that a Flow is not hanging, when an Executor crashes during startup.