### PR TITLE
test: added pymodules import test back

### DIFF
--- a/tests/integration/issues/github_1546/bad1/crafter.yml
+++ b/tests/integration/issues/github_1546/bad1/crafter.yml
@@ -1,0 +1,3 @@
+!BadCrafter1
+metas:
+  py_modules: custom_crafter.py # I also tried to add helper.py here

--- a/tests/integration/issues/github_1546/bad1/custom_crafter.py
+++ b/tests/integration/issues/github_1546/bad1/custom_crafter.py
@@ -1,0 +1,8 @@
+from jina import Executor
+from .helper import helper_function
+
+
+class BadCrafter1(Executor):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        print(helper_function)

--- a/tests/integration/issues/github_1546/bad1/helper.py
+++ b/tests/integration/issues/github_1546/bad1/helper.py
@@ -1,0 +1,2 @@
+def helper_function():
+    pass

--- a/tests/integration/issues/github_1546/good1/crafter.yml
+++ b/tests/integration/issues/github_1546/good1/crafter.yml
@@ -1,0 +1,5 @@
+!GoodCrafter1
+metas:
+  py_modules:
+    - helper.py
+    - custom_crafter.py

--- a/tests/integration/issues/github_1546/good1/custom_crafter.py
+++ b/tests/integration/issues/github_1546/good1/custom_crafter.py
@@ -1,0 +1,8 @@
+from jina import Executor
+from jinahub.helper import helper_function
+
+
+class GoodCrafter1(Executor):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        print(helper_function)

--- a/tests/integration/issues/github_1546/good1/helper.py
+++ b/tests/integration/issues/github_1546/good1/helper.py
@@ -1,0 +1,2 @@
+def helper_function():
+    pass

--- a/tests/integration/issues/github_1546/good2/__init__.py
+++ b/tests/integration/issues/github_1546/good2/__init__.py
@@ -1,0 +1,8 @@
+from jina import Executor
+from .helper import helper_function
+
+
+class GoodCrafter2(Executor):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        print(helper_function)

--- a/tests/integration/issues/github_1546/good2/crafter.yml
+++ b/tests/integration/issues/github_1546/good2/crafter.yml
@@ -1,0 +1,4 @@
+!GoodCrafter2
+metas:
+  py_modules:
+    - __init__.py

--- a/tests/integration/issues/github_1546/good2/helper.py
+++ b/tests/integration/issues/github_1546/good2/helper.py
@@ -1,0 +1,2 @@
+def helper_function():
+    pass

--- a/tests/integration/issues/github_1546/good3/__init__.py
+++ b/tests/integration/issues/github_1546/good3/__init__.py
@@ -1,0 +1,8 @@
+from jina import Executor
+from .helper import helper_function
+
+
+class GoodCrafter3(Executor):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        print(helper_function)

--- a/tests/integration/issues/github_1546/good3/config.yml
+++ b/tests/integration/issues/github_1546/good3/config.yml
@@ -1,0 +1,7 @@
+!GoodCrafter3
+with:
+  {}
+metas:
+  py_modules:
+    # - you can put more dependencies here
+    - __init__.py

--- a/tests/integration/issues/github_1546/good3/helper.py
+++ b/tests/integration/issues/github_1546/good3/helper.py
@@ -1,0 +1,2 @@
+def helper_function():
+    pass

--- a/tests/integration/issues/github_1546/test_pymodules_import.py
+++ b/tests/integration/issues/github_1546/test_pymodules_import.py
@@ -1,0 +1,77 @@
+import pytest
+
+from jina.executors import BaseExecutor
+
+
+def test_import_with_abs_namespace_should_pass():
+    """
+    This is a valid structure:
+        - "my_cust_module" is not a python module (lack of __init__.py under the root)
+        - to import ``foo.py``, you must to use ``from jinahub.foo import bar``
+        - ``jinahub`` is a common namespace for all plugin-modules, not changeable.
+        - ``helper.py`` needs to be put BEFORE `my_cust.py` in YAML ``py_modules``
+
+    File structure:
+
+         my_cust_module
+           |- my_cust.py
+           |- helper.py
+           |- config.yml
+                |- py_modules
+                       |- helper.py
+                       |- my_cust.py
+    """
+
+    b = BaseExecutor.load_config('good1/crafter.yml')
+    assert b.__class__.__name__ == 'GoodCrafter1'
+
+
+def test_import_with_module_structure_should_pass():
+    """
+    This is a valid structure and it is RECOMMENDED:
+        - "my_cust_module" is a python module
+        - all core logic of your customized executor goes to ``__init__.py``
+        - to import ``foo.py``, you can use relative import, e.g. ``from .foo import bar``
+        - ``helper.py`` needs to be put BEFORE `__init__.py` in YAML ``py_modules``
+
+    This is also the structure given by ``jina hub new`` CLI.
+
+    File structure:
+
+         my_cust_module
+           |- __init__.py
+           |- helper.py
+           |- config.yml
+                |- py_modules
+                       |- helper.py
+                       |- __init__.py
+    """
+    b = BaseExecutor.load_config('good2/crafter.yml')
+    assert b.__class__.__name__ == 'GoodCrafter2'
+
+
+def test_import_with_hub_structure_should_pass():
+    """
+    copy paste from hub module structure should work
+    this structure is copy-paste from: https://github.com/jina-ai/jina-hub/tree/master/crafters/image/FiveImageCropper
+
+    File structure:
+        my_cust_modul
+          |
+          |- __init__.py
+          |- helper.py
+          |- config.yml
+                |- py_modules
+                       |- helper.py
+                       |- __init.py
+    :return:
+    """
+    b = BaseExecutor.load_config('good3/config.yml')
+    assert b.__class__.__name__ == 'GoodCrafter3'
+
+
+def test_import_casual_structure_should_fail():
+    # this structure is a copy-paste from
+    # https://github.com/jina-ai/jina/issues/1546#issuecomment-751481422
+    with pytest.raises(ImportError):
+        BaseExecutor.load_config('bad1/crafter.yml')


### PR DESCRIPTION
adding integration test for pymodules back. One is not needed anymore, since full module discovery works, when `__init__.py` is added to `pymodules`