### PR TITLE
test: added a test for docmatrix in the tail pea

### DIFF
--- a/scripts/black.sh
+++ b/scripts/black.sh
@@ -5,6 +5,7 @@ echo we ignore non-*.py files and files generated from protobuf
 excluded_files=(
    jina/proto/jina_pb2.py
    jina/proto/jina_pb2_grpc.py
+   tests/
 )
 for changed_file in $CHANGED_FILES; do
   if [[ ${changed_file} == *.py ]] && ! [[ " ${excluded_files[@]} " =~ " ${changed_file} " ]]; then

--- a/scripts/black.sh
+++ b/scripts/black.sh
@@ -5,7 +5,6 @@ echo we ignore non-*.py files and files generated from protobuf
 excluded_files=(
    jina/proto/jina_pb2.py
    jina/proto/jina_pb2_grpc.py
-   tests/
 )
 for changed_file in $CHANGED_FILES; do
   if [[ ${changed_file} == *.py ]] && ! [[ " ${excluded_files[@]} " =~ " ${changed_file} " ]]; then

--- a/tests/integration/v2_api/test_docs_matrix_tail_pea.py
+++ b/tests/integration/v2_api/test_docs_matrix_tail_pea.py
@@ -6,9 +6,10 @@ from jina.types.arrays.chunk import ChunkArray
 
 
 class DummyExecutor(Executor):
-    def __init__(self, mode, *args, **kwargs):
+    def __init__(self, mode=None, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._mode = str(mode)
+        if mode:
+            self._mode = str(mode)
 
     @requests
     def do_something(self, docs, **kwargs):
@@ -48,10 +49,9 @@ class ChunkMerger(Executor):
 
 
 @pytest.mark.timeout(5)
-@pytest.mark.parametrize('replicas_shards', [(1, 1), (2, 2)])
-def test_sharding_tail_pea(replicas_shards):
+@pytest.mark.parametrize('num_replicas, num_shards', [(1, 1), (2, 2)])
+def test_sharding_tail_pea(num_replicas, num_shards):
     """TODO(Maximilian): Make (1, 2) and (2, 1) also workable"""
-    num_shards, num_replicas = replicas_shards
 
     f = Flow().add(
         uses=DummyExecutor,

--- a/tests/integration/v2_api/test_docs_matrix_tail_pea.py
+++ b/tests/integration/v2_api/test_docs_matrix_tail_pea.py
@@ -1,0 +1,41 @@
+import pytest
+from collections import OrderedDict
+from jina import Document, DocumentArray, Executor, Flow, requests
+
+
+@pytest.mark.timeout(5)
+@pytest.mark.parametrize('replicas_shards', [(1, 1), (2, 2)])
+def test_sharding_tail_pea(replicas_shards):
+    """TODO(Maximilian): Make (1, 2) and (2, 1) also workable"""
+    num_shards, num_replicas = replicas_shards
+
+    class DummyExecutor(Executor):
+        @requests
+        def do_something(self, docs, **kwargs):
+            print('Hello World!')
+
+    class MatchMerger(Executor):
+        @requests
+        def merge(self, docs_matrix, **kwargs):
+            results = OrderedDict()
+            for docs in docs_matrix:
+                for doc in docs:
+                    if doc.id in results:
+                        results[doc.id].matches.extend(doc.matches)
+                    else:
+                        results[doc.id] = doc
+            return DocumentArray(results.values())
+
+    f = Flow().add(
+        uses=DummyExecutor,
+        replicas=num_replicas,
+        shards=num_shards,
+        uses_after=MatchMerger,
+    )
+    with f:
+        results = f.post(
+            on='/search',
+            inputs=Document(matches=[Document()]),
+            return_results=True,
+        )
+        assert len(results[0].docs[0].matches) == num_shards


### PR DESCRIPTION
This is a test showcasing, how a `MatchMerger` in a TailPea could look like. Beware, that replica/sharding for `(1,2)` and `(2,1)` are broken. That needs to be fixed before 2.0 release.