### PR TITLE
fix(daemon): docker host internal on linux

### DIFF
--- a/daemon/dockerize.py
+++ b/daemon/dockerize.py
@@ -132,6 +132,7 @@ class Dockerizer:
                 ports=ports,
                 detach=True,
                 command=command,
+                extra_hosts={'host.docker.internal': 'host-gateway'},
             )
         except docker.errors.NotFound as e:
             cls.logger.error(


### PR DESCRIPTION
This works locally on my ubuntu 20.04 and fix the hanging tests for parallel > 1
Not sure if that breaks anything on Windows or Mac