### PR TITLE
fix: missing sampling args in generator of from_lines

### DIFF
--- a/jina/types/document/generators.py
+++ b/jina/types/document/generators.py
@@ -176,14 +176,14 @@ def from_lines(
         file_type = os.path.splitext(filepath)[1]
         with open(filepath, read_mode) as f:
             if file_type in _jsonl_ext:
-                yield from from_ndjson(f)
+                yield from from_ndjson(f, field_resolver, size, sampling_rate)
             elif file_type in _csv_ext:
                 yield from from_csv(f, field_resolver, size, sampling_rate)
             else:
                 yield from _subsample(f, size, sampling_rate)
     elif lines:
         if line_format == 'json':
-            yield from from_ndjson(lines)
+            yield from from_ndjson(lines, field_resolver, size, sampling_rate)
         elif line_format == 'csv':
             yield from from_csv(lines, field_resolver, size, sampling_rate)
         else:

--- a/tests/unit/clients/python/test_io.py
+++ b/tests/unit/clients/python/test_io.py
@@ -75,10 +75,56 @@ def test_input_lines_with_empty_filepath_and_lines():
 
 
 def test_input_lines_with_jsonlines_docs():
-    result = list(from_lines(filepath='tests/unit/clients/python/docs.jsonlines'))
+    result = list(from_lines(filepath=os.path.join(cur_dir, 'docs.jsonlines')))
     assert len(result) == 2
     assert result[0].text == "a"
     assert result[1].text == "b"
+
+
+@pytest.mark.parametrize(
+    'size, sampling_rate',
+    [
+        (None, None),
+        (1, None),
+        (None, 0.5),
+    ],
+)
+def test_input_lines_with_jsonlines_file(size, sampling_rate):
+    result = list(
+        from_lines(
+            filepath=os.path.join(cur_dir, 'docs.jsonlines'),
+            size=size,
+            sampling_rate=sampling_rate,
+        )
+    )
+    assert len(result) == size if size is not None else 2
+    if sampling_rate is None:
+        assert result[0].text == "a"
+        if size is None:
+            assert result[1].text == "b"
+
+
+@pytest.mark.parametrize(
+    'size, sampling_rate',
+    [
+        (None, None),
+        (1, None),
+        (None, 0.5),
+    ],
+)
+def test_input_lines_with_jsonslines(size, sampling_rate):
+    with open(os.path.join(cur_dir, 'docs.jsonlines')) as fp:
+        lines = fp.readlines()
+    result = list(
+        from_lines(
+            lines=lines, line_format='json', size=size, sampling_rate=sampling_rate
+        )
+    )
+    assert len(result) == size if size is not None else 2
+    if sampling_rate is None:
+        assert result[0].text == "a"
+        if size is None:
+            assert result[1].text == "b"
 
 
 def test_input_lines_with_jsonlines_docs_groundtruth():


### PR DESCRIPTION
A clone PR from https://github.com/jina-ai/jina/pull/2492