### PR TITLE
test: added a test to showcase how shards and parallel are synonyms

### DIFF
--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -37,6 +37,17 @@ def test_parse_env_map():
     assert a.env == {'key1': 'value1', 'key2': 'value2', 'key3': 3}
 
 
+def test_shards_parallel_synonym():
+    a = set_pod_parser().parse_args(['--shards', '2'])
+    assert a.parallel == 2
+
+    a = set_pod_parser().parse_args(['--parallel', '2'])
+    assert a.parallel == 2
+
+    a = set_pod_parser().parse_args([])
+    assert a.parallel == 1
+
+
 def test_ping():
     a1 = set_pea_parser().parse_args([])
     a2 = set_ping_parser().parse_args(

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -40,12 +40,18 @@ def test_parse_env_map():
 def test_shards_parallel_synonym():
     a = set_pod_parser().parse_args(['--shards', '2'])
     assert a.parallel == 2
+    with pytest.raises(AttributeError):
+        a.shards
 
     a = set_pod_parser().parse_args(['--parallel', '2'])
     assert a.parallel == 2
+    with pytest.raises(AttributeError):
+        a.shards
 
     a = set_pod_parser().parse_args([])
     assert a.parallel == 1
+    with pytest.raises(AttributeError):
+        a.shards
 
 
 def test_ping():


### PR DESCRIPTION
`--shards` and `--parallel` can be used as synonyms by the user. However internally, only `args.parallel` works. This is good for now and this test should just showcase it.

In the future, we might change the internal representation from `.parallel` to `.shards`, since it is the semantically correct way. Anyhow, since `replicas` do not work correctly without shards (this is a bug(!)), I would keep the old naming yet.