### PR TITLE
feat: wrap flow/pea/pod in mini JinaD

### DIFF
--- a/daemon/models/containers.py
+++ b/daemon/models/containers.py
@@ -1,5 +1,5 @@
 from typing import Dict
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from .id import DaemonID
 from .base import StoreItem, StoreStatus
@@ -24,4 +24,4 @@ class ContainerItem(StoreItem):
 
 
 class ContainerStoreStatus(StoreStatus):
-    items: Dict[DaemonID, ContainerItem]
+    items: Dict[DaemonID, ContainerItem] = Field(default_factory=dict)

--- a/daemon/models/workspaces.py
+++ b/daemon/models/workspaces.py
@@ -1,5 +1,6 @@
+from ipaddress import IPv4Address
 from typing import Dict, List, Optional
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from .id import DaemonID
 from .enums import WorkspaceState
@@ -27,4 +28,7 @@ class WorkspaceItem(StoreItem):
 
 
 class WorkspaceStoreStatus(StoreStatus):
-    items: Dict[DaemonID, WorkspaceItem]
+    ip_range_start: IPv4Address = IPv4Address('10.0.0.0')
+    subnet_size: int = 22
+    ip_range_current_offset: int = 0
+    items: Dict[DaemonID, WorkspaceItem] = Field(default_factory=dict)

--- a/daemon/stores/base.py
+++ b/daemon/stores/base.py
@@ -24,7 +24,7 @@ class BaseStore(MutableMapping):
 
     def __init__(self):
         self._logger = JinaLogger(self.__class__.__name__, **vars(jinad_args))
-        self.status = StoreStatus()
+        self.status = self.__class__._status_model()
 
     def add(self, *args, **kwargs) -> DaemonID:
         """Add a new element to the store. This method needs to be overridden by the subclass
@@ -141,7 +141,7 @@ class BaseStore(MutableMapping):
     def reset(self) -> None:
         """Calling :meth:`clear` and reset all stats """
         self.clear()
-        self.status = StoreStatus()
+        self.status = self._status_model()
 
     def __len__(self):
         return len(self.items())


### PR DESCRIPTION
Please dont review this yet, its not ready. I am using it for tracking status and some questions

TODO:

- [x] Replace direct jina entrypoint in Docker with "mini" jinad, which starts pod/pead/flow as necessary
- [x] Start the correct API from 'mini' jinad
- [ ] Forward flow/pod/pea questions from main jinad to correct mini jinad

QUESTIONS:
- How do we do the mapping for the request forwarding. There will be some orginal request like /flow/rolling_update and it needs to mapped to something like `/flows/<id>/rolling_update `?
- Atm I am adding a new entrypoint for the 'mini' jinad. That works but may confuse people as its parts of the complete Jina component. We might want to hide it more as its a very specialized use case?
- Do I need to do anything special for the log/fluentd config?