### PR TITLE
Feat demon jinad runtime remote

### DIFF
--- a/daemon/api/endpoints/flows.py
+++ b/daemon/api/endpoints/flows.py
@@ -32,7 +32,7 @@ async def _create(flow: FlowDepends = Depends(FlowDepends)):
         return store.add(
             id=flow.id,
             workspace_id=flow.workspace_id,
-            command=flow.command,
+            params=flow.params,
             ports=flow.ports,
         )
     except Exception as ex:

--- a/daemon/api/endpoints/partial/flow.py
+++ b/daemon/api/endpoints/partial/flow.py
@@ -1,0 +1,24 @@
+from fastapi import APIRouter
+
+from .... import extra_args
+from ....models import FlowModel
+from ....models.base import StoreItem
+from ....stores import partial
+
+router = APIRouter(prefix='/flow', tags=['flow'])
+partial_flow_store: partial.FlowStore = partial.FlowStore(extra_args)
+
+
+@router.get(
+    path='', summary='Get the status of a running Flow', response_model=StoreItem
+)
+async def _status():
+    return partial_flow_store.status
+
+
+@router.get(path='/arguments', summary='Get all accept arguments of a Flow')
+async def _fetch_flow_params():
+    return FlowModel.schema()['properties']
+
+
+# TODO add rolling update or other functionality of a flow here

--- a/daemon/api/endpoints/partial/flow.py
+++ b/daemon/api/endpoints/partial/flow.py
@@ -1,12 +1,12 @@
 from fastapi import APIRouter
 
-from .... import extra_args
+from .... import nested_args
 from ....models import FlowModel
 from ....models.base import StoreItem
 from ....stores import partial
 
 router = APIRouter(prefix='/flow', tags=['flow'])
-partial_flow_store: partial.FlowStore = partial.FlowStore(extra_args)
+partial_flow_store: partial.FlowStore = partial.FlowStore(nested_args)
 
 
 @router.get(

--- a/daemon/api/endpoints/partial/pea.py
+++ b/daemon/api/endpoints/partial/pea.py
@@ -1,0 +1,22 @@
+from fastapi import APIRouter
+
+from .... import extra_args
+from ....models import PeaModel
+from ....models.base import StoreItem
+from ....stores import partial
+
+router = APIRouter(prefix='/pea', tags=['pea'])
+partial_pea_store: partial.PeaStore = partial.PeaStore(extra_args)
+
+
+@router.get(path='', summary='Get status of a running Pea', response_model=StoreItem)
+async def _status():
+    return partial_pea_store.status
+
+
+@router.get(
+    path='/arguments',
+    summary='Get all accept arguments of a Pea',
+)
+async def _fetch_pea_params():
+    return PeaModel.schema()['properties']

--- a/daemon/api/endpoints/partial/pea.py
+++ b/daemon/api/endpoints/partial/pea.py
@@ -1,12 +1,12 @@
 from fastapi import APIRouter
 
-from .... import extra_args
+from .... import nested_args
 from ....models import PeaModel
 from ....models.base import StoreItem
 from ....stores import partial
 
 router = APIRouter(prefix='/pea', tags=['pea'])
-partial_pea_store: partial.PeaStore = partial.PeaStore(extra_args)
+partial_pea_store: partial.PeaStore = partial.PeaStore(nested_args)
 
 
 @router.get(path='', summary='Get status of a running Pea', response_model=StoreItem)

--- a/daemon/api/endpoints/partial/pod.py
+++ b/daemon/api/endpoints/partial/pod.py
@@ -1,12 +1,12 @@
 from fastapi import APIRouter, HTTPException
 
-from .... import extra_args
+from .... import nested_args
 from ....models import PodModel
 from ....models.base import StoreItem
 from ....stores import partial
 
 router = APIRouter(prefix='/pod', tags=['pod'])
-partial_pod_store: partial.PodStore = partial.PodStore(extra_args)
+partial_pod_store: partial.PodStore = partial.PodStore(nested_args)
 
 
 @router.get(

--- a/daemon/api/endpoints/partial/pod.py
+++ b/daemon/api/endpoints/partial/pod.py
@@ -1,0 +1,21 @@
+from fastapi import APIRouter
+
+from .... import extra_args
+from ....models import PodModel
+from ....models.base import StoreItem
+from ....stores import partial
+
+router = APIRouter(prefix='/pod', tags=['pod'])
+partial_pod_store: partial.PodStore = partial.PodStore(extra_args)
+
+
+@router.get(
+    path='', summary='Get the status of a running Pod', response_model=StoreItem
+)
+async def _status():
+    return partial_pod_store.status
+
+
+@router.get(path='/arguments', summary='Get all accept arguments of a Pod')
+async def _fetch_pod_params():
+    return PodModel.schema()['properties']

--- a/daemon/api/endpoints/partial/pod.py
+++ b/daemon/api/endpoints/partial/pod.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException
 
 from .... import extra_args
 from ....models import PodModel
@@ -19,3 +19,13 @@ async def _status():
 @router.get(path='/arguments', summary='Get all accept arguments of a Pod')
 async def _fetch_pod_params():
     return PodModel.schema()['properties']
+
+
+@router.put(path='/rolling_update', summary='Trigger a rolling update on this Pod')
+async def _rolling_update(dump_path: str):
+    try:
+        partial_pod_store.pod.rolling_update(dump_path)
+    except AttributeError:
+        raise HTTPException(
+            status_code=405, detail=f'Pod does not support rolling update'
+        )

--- a/daemon/api/endpoints/peas.py
+++ b/daemon/api/endpoints/peas.py
@@ -35,7 +35,7 @@ async def _create(pea: PeaDepends = Depends(PeaDepends)):
         return store.add(
             id=pea.id,
             workspace_id=pea.workspace_id,
-            command=pea.command,
+            params=pea.params,
             ports=pea.ports,
         )
     except Exception as ex:

--- a/daemon/api/endpoints/pods.py
+++ b/daemon/api/endpoints/pods.py
@@ -32,7 +32,7 @@ async def _create(pod: PodDepends = Depends(PodDepends)):
         return store.add(
             id=pod.id,
             workspace_id=pod.workspace_id,
-            command=pod.command,
+            params=pod.params,
             ports=pod.ports,
         )
     except Exception as ex:

--- a/daemon/api/endpoints/pods.py
+++ b/daemon/api/endpoints/pods.py
@@ -1,3 +1,5 @@
+import requests
+
 from fastapi import Depends, APIRouter, HTTPException
 
 from ..dependencies import PodDepends
@@ -65,6 +67,17 @@ async def _delete(id: DaemonID, workspace: bool = False):
 async def _status(id: DaemonID):
     try:
         return store[id]
+    except KeyError:
+        raise HTTPException(status_code=404, detail=f'{id} not found in {store!r}')
+
+
+@router.put(path='/{id}/rolling_update', summary='Trigger a rolling update on this Pod')
+async def _rolling_update(id: DaemonID, dump_path: str):
+    try:
+        return requests.put(
+            f'{store[id].metadata.rest_api_uri}/pod/rolling_update',
+            params={'dump_path': dump_path},
+        )
     except KeyError:
         raise HTTPException(status_code=404, detail=f'{id} not found in {store!r}')
 

--- a/daemon/dockerize.py
+++ b/daemon/dockerize.py
@@ -163,7 +163,7 @@ class Dockerizer:
         #     {f'{port}/tcp': port for port in range(_min_port, _max_port + 1)}
         # )
         cls.logger.info(
-            f'Creating a container using image {_image} in network {_network}'
+            f'Creating a container using image {_image} in network {_network} and ports {ports}'
         )
         try:
             container: 'Container' = cls.client.containers.run(

--- a/daemon/dockerize.py
+++ b/daemon/dockerize.py
@@ -24,7 +24,6 @@ __flow_ready__ = 'Flow is ready to use'
 
 if TYPE_CHECKING:
     from .files import DaemonFile
-    from .models.workspaces import WorkspaceMetadata
     from docker.models.networks import Network
     from docker.models.containers import Container
     from docker.client import APIClient, DockerClient
@@ -151,7 +150,7 @@ class Dockerizer:
         command: str,
         ports: Dict,
         additional_ports: Tuple[int, int],
-    ) -> Tuple['Container', str, Dict, bool]:
+    ) -> Tuple['Container', str, Dict, bool, str]:
         from .stores import workspace_store
 
         metadata = workspace_store[workspace_id].metadata
@@ -202,7 +201,12 @@ class Dockerizer:
                 )
                 _success = True
                 break
-        return container, _network, ports, _success
+
+        updated_container = cls.client.containers.get(container.attrs["Id"])
+        ip_address = list(
+            updated_container.attrs["NetworkSettings"]["Networks"].values()
+        )[0]['IPAddress']
+        return container, _network, ports, _success, ip_address
 
     @classmethod
     def volume(cls, workspace_id: DaemonID) -> Dict[str, Dict]:

--- a/daemon/models/containers.py
+++ b/daemon/models/containers.py
@@ -15,6 +15,7 @@ class ContainerMetadata(BaseModel):
     image_id: str
     network: str
     ports: Dict
+    rest_api_uri: str
 
 
 class ContainerItem(StoreItem):

--- a/daemon/parser.py
+++ b/daemon/parser.py
@@ -23,6 +23,13 @@ def mixin_daemon_parser(parser):
         help='do not start fluentd, no log streaming',
     )
 
+    gp.add_argument(
+        '--mode',
+        type=str,
+        default=None,
+        help='Mode for partial jinad. Can be flow/pod/pea. If none provided main jinad is run.',
+    )
+
 
 def get_main_parser():
     """
@@ -59,12 +66,6 @@ def get_partial_parser():
         help='Mode for partial jinad. Can be flow/pod/pea',
     )
 
-    parser.add_argument(
-        '--rest-api-port',
-        type=str,
-        help='Port to use for exposing the flow/pod/pea',
-    )
-
     return parser
 
 
@@ -75,7 +76,7 @@ def _get_run_args(print_args: bool = True):
     parser = get_main_parser()
     from argparse import _StoreAction, _StoreTrueAction
 
-    args = parser.parse_args()
+    args, argv = parser.parse_known_args()
     if print_args:
 
         default_args = {

--- a/daemon/parser.py
+++ b/daemon/parser.py
@@ -50,6 +50,18 @@ def get_main_parser():
     return parser
 
 
+def get_partial_parser():
+    parser = set_base_parser()
+
+    parser.add_argument(
+        '--mode',
+        type=str,
+        help='Mode for partial jinad. Can be flow/pod/pea',
+    )
+
+    return parser
+
+
 def _get_run_args(print_args: bool = True):
     from jina.helper import colored
     from . import daemon_logger

--- a/daemon/parser.py
+++ b/daemon/parser.py
@@ -59,6 +59,12 @@ def get_partial_parser():
         help='Mode for partial jinad. Can be flow/pod/pea',
     )
 
+    parser.add_argument(
+        '--rest-api-port',
+        type=str,
+        help='Port to use for exposing the flow/pod/pea',
+    )
+
     return parser
 
 

--- a/daemon/stores/containers.py
+++ b/daemon/stores/containers.py
@@ -31,7 +31,10 @@ class ContainerStore(BaseStore):
                 raise KeyError(f'{workspace_id} not found in workspace store')
 
             rest_api_port = random_port()
-            command = f'jinad-partial --mode {self._kind} --rest-api-port {rest_api_port} {" ".join(ArgNamespace.kwargs2list(params.dict(exclude={"log_config"})))}'
+
+            params = params.dict(exclude={'log_config'})
+            params['port_expose'] = rest_api_port
+            command = f'jinad --mode {self._kind} {" ".join(ArgNamespace.kwargs2list(params))}'
 
             ports[f'{rest_api_port}/tcp'] = rest_api_port
 

--- a/daemon/stores/containers.py
+++ b/daemon/stores/containers.py
@@ -1,7 +1,7 @@
 from typing import Dict
 from datetime import datetime
 
-from jina.helper import colored
+from jina.helper import colored, ArgNamespace
 
 from .base import BaseStore
 from ..models import DaemonID
@@ -25,13 +25,15 @@ class ContainerStore(BaseStore):
 
     @BaseStore.dump
     def add(
-        self, id: DaemonID, workspace_id: DaemonID, command: str, ports: Dict, **kwargs
+        self, id: DaemonID, workspace_id: DaemonID, params: str, ports: Dict, **kwargs
     ):
         try:
             from . import workspace_store
 
             if workspace_id not in workspace_store:
                 raise KeyError(f'{workspace_id} not found in workspace store')
+
+            command = f'jinad-partial --mode {self._kind} {" ".join(ArgNamespace.kwargs2list(params.dict(exclude={"log_config"})))}'
 
             _container, _network, _ports, _success = Dockerizer.run(
                 workspace_id=workspace_id,

--- a/daemon/stores/containers.py
+++ b/daemon/stores/containers.py
@@ -35,7 +35,7 @@ class ContainerStore(BaseStore):
 
             ports[f'{rest_api_port}/tcp'] = rest_api_port
 
-            _container, _network, _ports, _success = Dockerizer.run(
+            _container, _network, _ports, _success, ip_address = Dockerizer.run(
                 workspace_id=workspace_id,
                 container_id=id,
                 command=command,
@@ -49,6 +49,7 @@ class ContainerStore(BaseStore):
             self._logger.error(f'{e!r}')
             raise
         else:
+
             self[id] = ContainerItem(
                 metadata=ContainerMetadata(
                     container_id=id_cleaner(_container.id),
@@ -56,6 +57,7 @@ class ContainerStore(BaseStore):
                     image_id=id_cleaner(_container.image.id),
                     network=_network,
                     ports=_ports,
+                    rest_api_uri=f'{ip_address}:{rest_api_port}',
                 ),
                 arguments=ContainerArguments(command=command),
                 workspace_id=workspace_id,

--- a/daemon/stores/partial.py
+++ b/daemon/stores/partial.py
@@ -1,0 +1,46 @@
+from daemon.models.base import StoreStatus, StoreItem
+from daemon.stores.base import BaseStore
+from jina import Flow
+from jina.parsers import set_pod_parser, set_pea_parser
+from jina.parsers.flow import set_flow_parser
+from jina.peapods.peas import BasePea
+from jina.peapods.pods.factory import PodFactory
+from jina.peapods.runtimes import ZEDRuntime
+
+
+class PartialStoreStatus(StoreStatus):
+    items: StoreItem = StoreItem()
+
+    def __len__(self):
+        return 1
+
+
+class PeaStore(BaseStore):
+    _kind = 'pea'
+    _status_model = PartialStoreStatus
+
+    def __init__(self, args) -> object:
+        super().__init__()
+        self.pea = BasePea(set_pea_parser().parse_args(args))
+        self.pea.runtime_cls = ZEDRuntime
+        self.pea.start()
+
+
+class PodStore(BaseStore):
+    _kind = 'pod'
+    _status_model = PartialStoreStatus
+
+    def __init__(self, args):
+        super().__init__()
+        self.pod = PodFactory.build_pod(set_pod_parser().parse_args(args))
+        self.pod.start()
+
+
+class FlowStore(BaseStore):
+    _kind = 'flow'
+    _status_model = PartialStoreStatus
+
+    def __init__(self, args):
+        super().__init__()
+        self.flow = Flow(set_flow_parser().parse_args(args))
+        self.flow.start()

--- a/setup.py
+++ b/setup.py
@@ -149,7 +149,11 @@ setup(
     install_requires=list(all_deps['core'].union(all_deps['perf'])),
     extras_require=all_deps,
     entry_points={
-        'console_scripts': ['jina=cli:main', 'jinad=daemon:main'],
+        'console_scripts': [
+            'jina=cli:main',
+            'jinad=daemon:main',
+            'jinad-partial=daemon:partial',
+        ],
     },
     cmdclass={
         'develop': PostDevelopCommand,

--- a/setup.py
+++ b/setup.py
@@ -152,7 +152,6 @@ setup(
         'console_scripts': [
             'jina=cli:main',
             'jinad=daemon:main',
-            'jinad-partial=daemon:partial',
         ],
     },
     cmdclass={


### PR DESCRIPTION
This is a draft for the introduction of 'mini' (partial) jinad instances. These instances start one of pod/pea/flow and the necessary store and API.
The main jinad process runs new docker containers with the partial (mini) jinad as the entrypoint. The --mode argument defines the appropriate type (pea/pod/flow). Mini Jinad will then start a partial store and the appropriate API.

As an example I also added the rolling update command to the (partial) Pod API. It can be triggered from main jinad, which will basically forward the incoming request. I did not test this as I could not manage yet to create Pods correctly.

The implementation is kind of hacky in the sense the partial stores/api feel a bit akward, especially those stores dont at too much value I think.

TODO:
- [ ] Add other necessary APIs besides rolling update
- [ ] Add rolling update to Flow api if necessary
- [ ] Some minor clean up
- [ ] Add tests for the partial APIs and the forwarding mechanism
