### PR TITLE
fix: websocket crashing

### DIFF
--- a/jina/clients/websocket.py
+++ b/jina/clients/websocket.py
@@ -54,7 +54,7 @@ class WebSocketClientMixin(BaseClient, ABC):
             # https://websockets.readthedocs.io/en/stable/api.html?highlight=1009#module-websockets.protocol
 
             async with websockets.connect(
-                f'ws://{client_info}/stream', max_size=None
+                f'ws://{client_info}/stream', max_size=None, ping_interval=None
             ) as websocket:
                 # To enable websockets debug logs
                 # https://websockets.readthedocs.io/en/stable/cheatsheet.html#debugging


### PR DESCRIPTION
This is a bug that we encountered in the delphai eap project.
We get this error every time at some point in the middle of indexing our data:
```
WebSocketClient@9113[E]:Got following error while streaming requests via websocket: ConnectionClosedError('code = 1006 (connection closed abnormally [internal]), no reason')
```

The indexing then crashes and the rest of the data is not indexed.

I fixed the error in this PR by introducing an argument `ping_interval=None` to the websocket connection call, which fixes the problem.

I am not entirely sure if this argument has any implications on other code, what it does is basically skipping the ping step on the websocket.

The solution was found here: [Stackoverflow](https://stackoverflow.com/questions/54101923/1006-connection-closed-abnormally-error-with-python-3-7-websockets)