### PR TITLE
remove the zed runtime argument option of class inherited from jina.executor

### DIFF
--- a/jina/parsers/peapods/runtimes/zed.py
+++ b/jina/parsers/peapods/runtimes/zed.py
@@ -22,9 +22,8 @@ def mixin_zed_runtime_parser(parser):
         help='''
             The config of the executor, it could be one of the followings:
             * an Executor-level YAML file path (.yml, .yaml, .jaml)
-            * a name of a class inherited from `jina.Executor`
             * a docker image (must start with `docker://`)
-            * the string literal of a YAML config (must start with `!`)
+            * the string literal of a YAML config (must start with `!` or `jtype: `)
             * the string literal of a JSON config
             
             When use it under Python, one can use the following values additionally:


### PR DESCRIPTION
Seems that parsing a class inherited from jina.executor in CLI is not supported 