### PR TITLE
feat(daemon): remove workspace id from logging requests

### DIFF
--- a/daemon/api/endpoints/logs.py
+++ b/daemon/api/endpoints/logs.py
@@ -21,9 +21,15 @@ from ...stores import get_store_from_id
 router = APIRouter(tags=['logs'])
 
 
-@router.get(path='/logs/log_id}')
+@router.get(path='/logs/{log_id}')
 async def _export_logs(log_id: DaemonID):
-    filepath, workspace_id = _get_log_file_path(log_id)
+    try:
+        filepath, workspace_id = _get_log_file_path(log_id)
+    except KeyError:
+        raise HTTPException(
+            status_code=404,
+            detail=f'log file {log_id} not found in {get_store_from_id(log_id)._kind} store',
+        )
     if not Path(filepath).is_file():
         raise HTTPException(
             status_code=404,

--- a/daemon/helper.py
+++ b/daemon/helper.py
@@ -81,3 +81,16 @@ def jina_workspace(workspace_id: 'DaemonID'):
             os.environ['JINA_LOG_WORKSPACE'] = old_var
         else:
             os.environ.pop('JINA_LOG_WORKSPACE')
+
+
+def get_log_file_path(log_id):
+    from .models.enums import IDLiterals
+    from .stores import get_store_from_id
+
+    if IDLiterals.JWORKSPACE == log_id.jtype:
+        workspace_id = log_id
+        filepath = get_workspace_path(log_id, 'logs', 'logging.log')
+    else:
+        workspace_id = get_store_from_id(log_id)[log_id].workspace_id
+        filepath = get_workspace_path(workspace_id, 'logs', log_id, 'logging.log')
+    return filepath, workspace_id

--- a/daemon/stores/__init__.py
+++ b/daemon/stores/__init__.py
@@ -4,7 +4,10 @@ from .. import jinad_args
 from .peas import PeaStore
 from .pods import PodStore
 from .flows import FlowStore
+from .base import BaseStore
 from .workspaces import WorkspaceStore
+from ..models import DaemonID
+from ..models.enums import IDLiterals
 
 if TYPE_CHECKING:
     from .partial import PartialStore
@@ -44,3 +47,15 @@ pod_store: PodStore = _get_store('pod')
 flow_store: FlowStore = _get_store('flow')
 workspace_store: WorkspaceStore = _get_store('workspace')
 partial_store = _get_partial_store()
+
+def get_store_from_id(entity_id: DaemonID) -> BaseStore:
+    if entity_id.jtype == IDLiterals.JPOD:
+        return pod_store
+    elif entity_id.jtype == IDLiterals.JPEA:
+        return pea_store
+    elif entity_id.jtype == IDLiterals.JFLOW:
+        return flow_store
+    elif entity_id.jtype == IDLiterals.JWORKSPACE:
+        return workspace_store
+    else:
+        return None

--- a/tests/daemon/unit/api/endpoints/test_logs.py
+++ b/tests/daemon/unit/api/endpoints/test_logs.py
@@ -1,10 +1,13 @@
 import os
 import json
 import time
-from daemon.stores.helper import get_workspace_path
-from daemon.api.endpoints import logs
-from daemon import jinad_args
 
+from daemon.helper import get_workspace_path
+from daemon.models import DaemonID
+from daemon.models.containers import ContainerArguments
+from daemon.stores import flow_store
+from daemon.models import ContainerItem
+from daemon.models.containers import ContainerMetadata
 
 log_content = """
 {"host":"ubuntu","process":"32539","type":"INFO","name":"encode1","uptime":"20210124215151","context":"encode1","workspace_path":"/tmp/jinad/32aa7734-fbb8-4e7a-9f76-46221b512648","log_id":"16ef0bd7-e534-42e7-9076-87a3f585933c","message":"starting jina.peapods.runtimes.zmq.zed.ZEDRuntime..."}
@@ -13,42 +16,58 @@ log_content = """
 {"host":"ubuntu","process":"32546","type":"INFO","name":"encode2","uptime":"20210124215151","context":"encode2","workspace_path":"/tmp/jinad/32aa7734-fbb8-4e7a-9f76-46221b512648","log_id":"16ef0bd7-e534-42e7-9076-87a3f585933c","message":"starting jina.peapods.runtimes.zmq.zed.ZEDRuntime..."}
 """
 
-workspace_id = 'acd2fa50-02a6-452d-add7-ff987810c741'
-flow_id = 'f0f90a3d-d2d9-4646-96d5-2560886f6ef0'
-nonexisting_id = 'fff90a3d-d2d9-4646-96d5-2560886ffff0'
+workspace_id = DaemonID('jworkspace')
+flow_id = DaemonID('jflow')
+nonexisting_id = DaemonID('jflow')
 
 
 def _write_to_logfile(content, append=False):
     with open(
-        get_workspace_path(workspace_id, flow_id, 'logging.log'),
+        get_workspace_path(workspace_id, 'logs', flow_id, 'logging.log'),
         'a' if append else 'w+',
     ) as f:
         f.writelines(content)
 
 
+def _write_to_workspace_logfile(content, append=False):
+    with open(
+        get_workspace_path(workspace_id, 'logs', 'logging.log'),
+        'a' if append else 'w+',
+    ) as f:
+        f.writelines(content)
+
+
+def _create_flow():
+    flow_store[flow_id] = ContainerItem(
+        metadata=ContainerMetadata(
+            container_id='container_id',
+            container_name='container_name',
+            image_id='image_id',
+            network='',
+            ports={},
+            rest_api_uri='',
+        ),
+        arguments=ContainerArguments(command='command'),
+        workspace_id=workspace_id,
+    )
+
+
 def setup_module():
     print('setup', get_workspace_path(workspace_id, flow_id))
-    os.makedirs(get_workspace_path(workspace_id, flow_id), exist_ok=True)
+    _create_flow()
+    os.makedirs(get_workspace_path(workspace_id, 'logs', flow_id), exist_ok=True)
     _write_to_logfile(log_content)
-
-
-def test_logs_invalid_workspace(fastapi_client):
-    response = fastapi_client.get(f'/logs/{nonexisting_id}/{flow_id}')
-    assert response.status_code == 404
+    _write_to_workspace_logfile(log_content)
 
 
 def test_logs_invalid_flow(fastapi_client):
-    response = fastapi_client.get(f'/logs/{workspace_id}/{nonexisting_id}')
-    assert response.status_code == 404
-
-
-def test_logs_wrong_order(fastapi_client):
-    response = fastapi_client.get(f'/logs/{flow_id}/{workspace_id}')
+    response = fastapi_client.get(f'/logs/{nonexisting_id}')
     assert response.status_code == 404
 
 
 def test_logs_correct_log(fastapi_client):
-    response = fastapi_client.get(f'/logs/{workspace_id}/{flow_id}')
+
+    response = fastapi_client.get(f'/logs/{flow_id}')
     assert response.status_code == 200
     assert response.text == log_content
 
@@ -56,7 +75,7 @@ def test_logs_correct_log(fastapi_client):
 def test_logstream_missing(fastapi_client):
     received = None
     with fastapi_client.websocket_connect(
-        f'/logstream/{workspace_id}/{nonexisting_id}?timeout=3'
+        f'/logstream/{nonexisting_id}?timeout=3'
     ) as websocket:
         try:
             received = websocket.receive_json()
@@ -69,11 +88,22 @@ def test_logstream_missing(fastapi_client):
 def test_logstream_valid(fastapi_client):
     line = '{"host":"test-host","process":"12034","type":"INFO","name":"Flow","uptime":"2021-04-02T20:58:10.819138","context":"Flow","workspace_path":"...","log_id":"...","message":"1 Pods (i.e. 1 Peas) are running in this Flow"}\n'
     received = None
+
     with fastapi_client.websocket_connect(
-        f'/logstream/{workspace_id}/{flow_id}?timeout=3'
+        f'/logstream/{flow_id}?timeout=3'
     ) as websocket:
         time.sleep(0.25)
         _write_to_logfile(line, True)
+        received = websocket.receive_json()
+    assert received is not None
+    assert received == json.loads(line)
+
+    with fastapi_client.websocket_connect(
+        f'/logstream/{workspace_id}?timeout=3'
+    ) as websocket:
+        time.sleep(0.25)
+        _write_to_workspace_logfile(line, True)
+
         received = websocket.receive_json()
     assert received is not None
     assert received == json.loads(line)

--- a/tests/daemon/unit/api/endpoints/test_logs.py
+++ b/tests/daemon/unit/api/endpoints/test_logs.py
@@ -46,6 +46,7 @@ def _create_flow():
             network='',
             ports={},
             rest_api_uri='',
+            host="",
         ),
         arguments=ContainerArguments(command='command'),
         workspace_id=workspace_id,


### PR DESCRIPTION
This remove the workspace_id as a parameter from the log requests. The workspace id is found automatically by checking the entity id and then looking up the workspace in the correct store.