### PR TITLE
refactor: rename _docs_proto from DocumentArray

### DIFF
--- a/jina/types/arrays/chunk.py
+++ b/jina/types/arrays/chunk.py
@@ -11,19 +11,19 @@ class ChunkArray(DocumentArray):
     :class:`ChunkArray` inherits from :class:`DocumentArray`.
     It's a subset of Documents.
 
-    :param docs_proto: Set of sub-documents (i.e chunks) of `reference_doc`
+    :param doc_views: Set of sub-documents (i.e chunks) of `reference_doc`
     :param reference_doc: Reference :class:`Document` for the sub-documents
     """
 
-    def __init__(self, docs_proto, reference_doc: 'Document'):
+    def __init__(self, doc_views, reference_doc: 'Document'):
         """
         Set constructor method.
 
-        :param docs_proto: protobuf representation of the chunks
+        :param doc_views: protobuf representation of the chunks
         :param reference_doc: parent document
         """
         self._ref_doc = reference_doc
-        super().__init__(docs_proto)
+        super().__init__(doc_views)
 
     def append(self, document: 'Document', **kwargs) -> 'Document':
         """Add a sub-document (i.e chunk) to the current Document.

--- a/jina/types/arrays/match.py
+++ b/jina/types/arrays/match.py
@@ -9,13 +9,13 @@ class MatchArray(DocumentArray):
     :class:`MatchArray` inherits from :class:`DocumentArray`.
     It's a subset of Documents that represents the matches
 
-    :param docs_proto: Set of matches of the `reference_doc`
+    :param doc_views: Set of matches of the `reference_doc`
     :param reference_doc: Reference :class:`Document` for the sub-documents
     """
 
-    def __init__(self, docs_proto, reference_doc: 'Document'):
+    def __init__(self, doc_views, reference_doc: 'Document'):
         self._ref_doc = reference_doc
-        super().__init__(docs_proto)
+        super().__init__(doc_views)
 
     def append(self, document: 'Document', **kwargs) -> 'Document':
         """Add a matched document to the current Document.

--- a/tests/unit/types/arrays/test_chunkarray.py
+++ b/tests/unit/types/arrays/test_chunkarray.py
@@ -39,7 +39,7 @@ def chunks(document_factory):
 
 @pytest.fixture
 def chunkarray(chunks, reference_doc):
-    return ChunkArray(docs_proto=chunks, reference_doc=reference_doc)
+    return ChunkArray(doc_views=chunks, reference_doc=reference_doc)
 
 
 def test_append_from_documents(chunkarray, document_factory, reference_doc):

--- a/tests/unit/types/arrays/test_matcharray.py
+++ b/tests/unit/types/arrays/test_matcharray.py
@@ -39,7 +39,7 @@ def matches(document_factory):
 
 @pytest.fixture
 def matcharray(matches, reference_doc):
-    return MatchArray(docs_proto=matches, reference_doc=reference_doc)
+    return MatchArray(doc_views=matches, reference_doc=reference_doc)
 
 
 def test_append_from_documents(matcharray, document_factory, reference_doc):


### PR DESCRIPTION
**Changes introcued**
Calling `_docs_proto` leads to think that these are `protobuf` objects, but they are actually different type of `DocumentViews` 