### PR TITLE
feat: daemon custom container

### DIFF
--- a/daemon/api/endpoints/workspaces.py
+++ b/daemon/api/endpoints/workspaces.py
@@ -31,11 +31,18 @@ async def _clear_all():
     path='/{id}',
     summary='Deleting an existing Workspace',
 )
-async def _delete(id: DaemonID):
+async def _delete(id: DaemonID, container_only: bool = False):
     try:
-        store.delete(id=id, everything=True)
+        if container_only:
+            return store.delete_container_only(id=id)
+        else:
+            return store.delete(id=id)
     except KeyError:
         raise HTTPException(status_code=404, detail=f'{id} not found in {store!r}')
+    except ValueError:
+        raise HTTPException(
+            status_code=404, detail=f'There is no container to kill in {store!r}'
+        )
 
 
 @router.post(

--- a/daemon/api/endpoints/workspaces.py
+++ b/daemon/api/endpoints/workspaces.py
@@ -31,9 +31,21 @@ async def _clear_all():
     path='/{id}',
     summary='Deleting an existing Workspace',
 )
-async def _delete(id: DaemonID, container: bool = False):
+async def _delete(
+    id: DaemonID,
+    container: bool = False,
+    network: bool = False,
+    files: bool = False,
+    everything: bool = True,
+):
     try:
-        return store.delete(id=id, container=container)
+        return store.delete(
+            id=id,
+            container=container,
+            network=network,
+            files=files,
+            everything=everything,
+        )
     except KeyError:
         raise HTTPException(status_code=404, detail=f'{id} not found in {store!r}')
     except ValueError:

--- a/daemon/api/endpoints/workspaces.py
+++ b/daemon/api/endpoints/workspaces.py
@@ -31,12 +31,9 @@ async def _clear_all():
     path='/{id}',
     summary='Deleting an existing Workspace',
 )
-async def _delete(id: DaemonID, container_only: bool = False):
+async def _delete(id: DaemonID, container: bool = False):
     try:
-        if container_only:
-            return store.delete_container_only(id=id)
-        else:
-            return store.delete(id=id)
+        return store.delete(id=id, container=container)
     except KeyError:
         raise HTTPException(status_code=404, detail=f'{id} not found in {store!r}')
     except ValueError:

--- a/daemon/files.py
+++ b/daemon/files.py
@@ -167,5 +167,6 @@ class DaemonFile:
     def __repr__(self) -> str:
         return (
             f'DaemonFile(build={self.build}, python={self.python}, run={self.run}, '
-            f'context={self.dockercontext}, args={self.dockerargs})'
+            f'context={self.dockercontext}, args={self.dockerargs}), '
+            f'ports={self.ports}'
         )

--- a/daemon/files.py
+++ b/daemon/files.py
@@ -52,6 +52,7 @@ class DaemonFile:
         self._build = DaemonBuild.default
         self._python = PythonVersion.default
         self._run = ''
+        self._ports = []
         self.process_file()
 
     @property
@@ -89,6 +90,14 @@ class DaemonFile:
     @run.setter
     def run(self, run: str):
         self._run = run
+
+    @property
+    def ports(self) -> List[int]:
+        return self._ports
+
+    @ports.setter
+    def ports(self, ports: List[int]):
+        self._ports = ports
 
     @cached_property
     def requirements(self) -> str:
@@ -148,6 +157,12 @@ class DaemonFile:
         self.build = params.get('build')
         self.python = params.get('python')
         self.run = params.get('run', '')
+        try:
+            ports_string = params.get('ports', '')
+            self.ports = list(map(int, filter(None, ports_string.split(','))))
+        except ValueError:
+            self._logger.warning(f'invalid value `{ports_string}` passed for \'ports\'')
+            self.ports = []
 
     def __repr__(self) -> str:
         return (

--- a/daemon/models/workspaces.py
+++ b/daemon/models/workspaces.py
@@ -19,6 +19,7 @@ class WorkspaceMetadata(BaseModel):
     network: str
     ports: Dict[str, int]
     workdir: str
+    container_id: Optional[str]
 
 
 class WorkspaceItem(StoreItem):

--- a/daemon/stores/workspaces.py
+++ b/daemon/stores/workspaces.py
@@ -95,20 +95,3 @@ class WorkspaceStore(BaseStore):
             )
             deleted_entities.append(id)
         return deleted_entities
-
-    @BaseStore.dump
-    def delete_container_only(self, id: DaemonID):
-        if id not in self:
-            raise KeyError(f'{colored(str(id), "cyan")} not found in store.')
-        container_id = self[id].metadata.container_id
-        if not container_id:
-            raise ValueError(
-                f'There is no container to kill for store {colored(str(id), "cyan")}'
-            )
-
-        Dockerizer.rm_container(container_id)
-        self._logger.success(
-            f'{colored(container_id, "cyan")} is killed and removed from the store.'
-        )
-        self[id].metadata.container_id = None
-        return container_id

--- a/daemon/stores/workspaces.py
+++ b/daemon/stores/workspaces.py
@@ -53,8 +53,21 @@ class WorkspaceStore(BaseStore):
         return id
 
     @BaseStore.dump
-    def delete(self, id: DaemonID, container: bool, **kwargs):
+    def delete(
+        self,
+        id: DaemonID,
+        container: bool,
+        network: bool,
+        files: bool,
+        everything: bool,
+        **kwargs,
+    ):
         deleted_entities = []
+        if everything:
+            container = True
+            network = True
+            files = True
+
         if id not in self:
             raise KeyError(f'{colored(str(id), "cyan")} not found in store.')
 
@@ -72,11 +85,15 @@ class WorkspaceStore(BaseStore):
             self[id].metadata.container_id = None
             deleted_entities.append(container_id)
 
-        Dockerizer.rm_image(id=self[id].metadata.image_id)
-        Dockerizer.rm_network(id=self[id].metadata.network)
-        del self[id]
-        self._logger.success(f'{colored(str(id), "cyan")} is released from the store.')
-        deleted_entities.append(id)
+        # TODO: add network and file deletion
+        if everything:
+            Dockerizer.rm_image(id=self[id].metadata.image_id)
+            Dockerizer.rm_network(id=self[id].metadata.network)
+            del self[id]
+            self._logger.success(
+                f'{colored(str(id), "cyan")} is released from the store.'
+            )
+            deleted_entities.append(id)
         return deleted_entities
 
     @BaseStore.dump

--- a/daemon/stores/workspaces.py
+++ b/daemon/stores/workspaces.py
@@ -60,3 +60,21 @@ class WorkspaceStore(BaseStore):
         Dockerizer.rm_network(id=self[id].metadata.network)
         del self[id]
         self._logger.success(f'{colored(str(id), "cyan")} is released from the store.')
+        return id
+
+    @BaseStore.dump
+    def delete_container_only(self, id: DaemonID):
+        if id not in self:
+            raise KeyError(f'{colored(str(id), "cyan")} not found in store.')
+        container_id = self[id].metadata.container_id
+        if not container_id:
+            raise ValueError(
+                f'There is no container to kill for store {colored(str(id), "cyan")}'
+            )
+
+        Dockerizer.rm_container(container_id)
+        self._logger.success(
+            f'{colored(container_id, "cyan")} is killed and removed from the store.'
+        )
+        self[id].metadata.container_id = None
+        return container_id

--- a/tests/daemon/unit/models/good_ws/.jinad
+++ b/tests/daemon/unit/models/good_ws/.jinad
@@ -1,4 +1,4 @@
 build = devel
 python = 3.7
-ports = 12345,123456
-run = "echo Hello"
+ports = 12345,12344
+run = echo Hello

--- a/tests/daemon/unit/models/good_ws/.jinad
+++ b/tests/daemon/unit/models/good_ws/.jinad
@@ -1,3 +1,4 @@
 build = devel
 python = 3.7
+ports = 12345,123456
 run = "echo Hello"

--- a/tests/daemon/unit/models/good_ws_filename/sample.jinad
+++ b/tests/daemon/unit/models/good_ws_filename/sample.jinad
@@ -1,3 +1,4 @@
 build = gpu
 python = 3.9
 invalid_key = invalid_value
+ports = 12345,123456

--- a/tests/daemon/unit/models/good_ws_multiple_files/.jinad
+++ b/tests/daemon/unit/models/good_ws_multiple_files/.jinad
@@ -1,3 +1,4 @@
 build = devel
 python = 3.7
 run = "echo Hello"
+ports = 12345,123456

--- a/tests/daemon/unit/models/good_ws_multiple_files/sample.jinad
+++ b/tests/daemon/unit/models/good_ws_multiple_files/sample.jinad
@@ -1,3 +1,4 @@
 build = gpu
 python = 3.9
 invalid_key = invalid_value
+ports = 12345,123456

--- a/tests/daemon/unit/models/good_ws_wrong_values/sample.jinad
+++ b/tests/daemon/unit/models/good_ws_wrong_values/sample.jinad
@@ -1,2 +1,3 @@
 build = abc
 python = 3.6
+ports = thats_wrong

--- a/tests/daemon/unit/models/test_jinad_file.py
+++ b/tests/daemon/unit/models/test_jinad_file.py
@@ -10,12 +10,12 @@ cur_dir = os.path.dirname(os.path.abspath(__file__))
 @pytest.mark.parametrize(
     'workdir, expected_response',
     [
-        ('good_ws', ('devel', '3.7', '"echo Hello"')),
-        ('good_ws_filename', ('gpu', '3.9', '')),
-        ('good_ws_nofile', ('devel', '3.8', '')),
-        ('good_ws_emptyfile', ('devel', '3.8', '')),
-        ('good_ws_multiple_files', ('devel', '3.7', '"echo Hello"')),
-        ('good_ws_wrong_values', ('devel', '3.8', '')),
+        ('good_ws', ('devel', '3.7', '"echo Hello"', [12345, 123456])),
+        ('good_ws_filename', ('gpu', '3.9', '', [12345, 123456])),
+        ('good_ws_nofile', ('devel', '3.8', '', [])),
+        ('good_ws_emptyfile', ('devel', '3.8', '', [])),
+        ('good_ws_multiple_files', ('devel', '3.7', '"echo Hello"', [12345, 123456])),
+        ('good_ws_wrong_values', ('devel', '3.8', '', [])),
     ],
 )
 def test_jinad_good_ws(workdir, expected_response):
@@ -23,6 +23,7 @@ def test_jinad_good_ws(workdir, expected_response):
     assert d.build == expected_response[0]
     assert d.python == expected_response[1]
     assert d.run == expected_response[2]
+    assert d.ports == expected_response[3]
 
 
 @pytest.mark.parametrize('workdir', ['bad_ws_multiple_files'])

--- a/tests/distributed/test_against_external_daemon/no_run.jinad
+++ b/tests/distributed/test_against_external_daemon/no_run.jinad
@@ -1,0 +1,3 @@
+build = devel
+python = 3.7
+ports = 12345,12344

--- a/tests/distributed/test_against_external_daemon/test_single_instance.py
+++ b/tests/distributed/test_against_external_daemon/test_single_instance.py
@@ -1,13 +1,9 @@
 import os
 
-import docker
-import numpy as np
 import pytest
-import requests
 
 from jina import Flow, Document
 from tests import random_docs
-from tests.distributed.helpers import wait_for_workspace, create_workspace
 
 cur_dir = os.path.dirname(os.path.abspath(__file__))
 
@@ -129,24 +125,3 @@ def test_create_pea_timeout(parallels):
     )
     with f:
         f.index(inputs=random_docs(10))
-
-
-def test_create_custom_container():
-    workspace_id = create_workspace(
-        filepaths=[os.path.join(cur_dir, '../../daemon/unit/models/good_ws/.jinad')]
-    )
-    wait_for_workspace(workspace_id)
-
-    container_id = requests.get(
-        f'http://{CLOUD_HOST}/workspaces/{workspace_id}'
-    ).json()['metadata']['container_id']
-    assert container_id
-    container = docker.from_env().containers.get(container_id)
-    assert container.name == workspace_id
-
-    workspace_id = create_workspace(filepaths=[os.path.join(cur_dir, 'no_run.jinad')])
-    wait_for_workspace(workspace_id)
-    container_id = requests.get(
-        f'http://{CLOUD_HOST}/workspaces/{workspace_id}'
-    ).json()['metadata']['container_id']
-    assert not container_id

--- a/tests/distributed/test_against_external_daemon/test_single_instance.py
+++ b/tests/distributed/test_against_external_daemon/test_single_instance.py
@@ -1,10 +1,13 @@
 import os
 
+import docker
 import numpy as np
 import pytest
+import requests
 
 from jina import Flow, Document
 from tests import random_docs
+from tests.distributed.helpers import wait_for_workspace, create_workspace
 
 cur_dir = os.path.dirname(os.path.abspath(__file__))
 
@@ -126,3 +129,24 @@ def test_create_pea_timeout(parallels):
     )
     with f:
         f.index(inputs=random_docs(10))
+
+
+def test_create_custom_container():
+    workspace_id = create_workspace(
+        filepaths=[os.path.join(cur_dir, '../../daemon/unit/models/good_ws/.jinad')]
+    )
+    wait_for_workspace(workspace_id)
+
+    container_id = requests.get(
+        f'http://{CLOUD_HOST}/workspaces/{workspace_id}'
+    ).json()['metadata']['container_id']
+    assert container_id
+    container = docker.from_env().containers.get(container_id)
+    assert container.name == workspace_id
+
+    workspace_id = create_workspace(filepaths=[os.path.join(cur_dir, 'no_run.jinad')])
+    wait_for_workspace(workspace_id)
+    container_id = requests.get(
+        f'http://{CLOUD_HOST}/workspaces/{workspace_id}'
+    ).json()['metadata']['container_id']
+    assert not container_id

--- a/tests/distributed/test_against_external_daemon/test_single_instance_custom_container.py
+++ b/tests/distributed/test_against_external_daemon/test_single_instance_custom_container.py
@@ -1,0 +1,56 @@
+import os
+
+import docker
+import requests
+
+from tests.distributed.helpers import create_workspace, wait_for_workspace
+
+cur_dir = os.path.dirname(os.path.abspath(__file__))
+
+CLOUD_HOST = 'localhost:8000'  # consider it as the staged version
+
+
+def test_create_custom_container():
+    workspace_id = create_workspace(
+        filepaths=[os.path.join(cur_dir, '../../daemon/unit/models/good_ws/.jinad')]
+    )
+    wait_for_workspace(workspace_id)
+
+    container_id = requests.get(
+        f'http://{CLOUD_HOST}/workspaces/{workspace_id}'
+    ).json()['metadata']['container_id']
+    assert container_id
+    container = docker.from_env().containers.get(container_id)
+    assert container.name == workspace_id
+
+    workspace_id = create_workspace(filepaths=[os.path.join(cur_dir, 'no_run.jinad')])
+    wait_for_workspace(workspace_id)
+    container_id = requests.get(
+        f'http://{CLOUD_HOST}/workspaces/{workspace_id}'
+    ).json()['metadata']['container_id']
+    assert not container_id
+
+
+def test_delete_custom_container():
+    workspace_id = create_workspace(
+        filepaths=[os.path.join(cur_dir, '../../daemon/unit/models/good_ws/.jinad')]
+    )
+    wait_for_workspace(workspace_id)
+
+    # check that container was created
+    response = requests.get(f'http://{CLOUD_HOST}/workspaces/{workspace_id}')
+    container_id = response.json()['metadata']['container_id']
+    assert container_id
+
+    # delete container
+    response = requests.delete(
+        f'http://{CLOUD_HOST}/workspaces/{workspace_id}',
+        params={'container': True, 'everything': False},
+    )
+    assert response.json()[0] == container_id
+
+    # check that deleted container is gone
+    response = requests.get(f'http://{CLOUD_HOST}/workspaces/{workspace_id}')
+    assert response.status_code == 200
+    container_id = response.json()['metadata']['container_id']
+    assert not container_id


### PR DESCRIPTION
Draft PR for showcasing custom container creation on workspace creation.
With this PR jinad will start a container with workspace creation if a jinad file is used with a run command.

Missing in this PR:
- [ ] Lifecycle management (recreate on updates)
- [x] Stop container on delete (also add option to only stop the container and not delete workspace)
- [x] tests