### PR TITLE
fix: document update with fields do not have support setter

### DIFF
--- a/jina/types/document/__init__.py
+++ b/jina/types/document/__init__.py
@@ -385,7 +385,10 @@ class Document(ProtoTypeMixin):
                 destination._pb_body.tags.update(source.tags)
             else:
                 destination._pb_body.ClearField(field)
-                setattr(destination, field, getattr(source, field))
+                try:
+                    setattr(destination, field, getattr(source, field))
+                except AttributeError:  # some fields such as `content_hash` do not have a setter method.
+                    setattr(destination._pb_body, field, getattr(source, field))
 
     def update(
         self,

--- a/tests/unit/types/document/test_document.py
+++ b/tests/unit/types/document/test_document.py
@@ -824,6 +824,13 @@ def test_doc_update_given_fields_and_source_has_more_attributes(test_docs):
     assert doc1.chunks != doc2.chunks
 
 
+def test_doc_update_given_content_hash_updated(test_docs):
+    doc1, doc2 = test_docs
+    doc1.update_content_hash()
+    doc2.update(doc1)
+    assert doc1.content_hash == doc2.content_hash
+
+
 def test_document_pretty_dict():
     doc = Document(
         blob=np.array([[0, 1, 2], [2, 1, 0]]),


### PR DESCRIPTION
This PR fix #2613 .