### PR TITLE
feat: add multiple scores fields and pythonic evaluations

### DIFF
--- a/.github/2.0/cookbooks/Document.md
+++ b/.github/2.0/cookbooks/Document.md
@@ -829,10 +829,8 @@ This can also be used to access nested attributes of repeated `Document` fields 
 from jina import Document
 
 doc = Document()
-doc.scores.add()
-doc.scores[0].value = 50
-doc.scores.add()
-doc.scores[1].value = 100
+doc.add_score(50)
+doc.add_score(100)
 doc.get_attributes('scores__0__value', 'scores__1__value')
 ```
 

--- a/jina/helper.py
+++ b/jina/helper.py
@@ -1150,6 +1150,8 @@ def dunder_get(_dict: Any, key: str) -> Any:
 
     if isinstance(part1, int):
         result = _dict[part1]
+    elif isinstance(_dict, Iterable):
+        result = _dict[part1]
     elif isinstance(_dict, (dict, Struct)):
         if part1 in _dict:
             result = _dict[part1]

--- a/jina/proto/jina.proto
+++ b/jina/proto/jina.proto
@@ -135,8 +135,8 @@ message DocumentProto {
     // the embedding `ndarray` of this document
     NdArrayProto embedding = 19;
 
-    // TODO: List of matching scores performed on the document, each element corresponds to a metric
-    NamedScoreProto score = 20;
+    // List of matching scores performed on the document, each element corresponds to a metric
+    repeated NamedScoreProto scores = 20;
 
     // modality, an identifier to the modality this document belongs to. In the scope of multi/cross modal search
     string modality = 21;

--- a/jina/proto/jina_pb2.py
+++ b/jina/proto/jina_pb2.py
@@ -21,7 +21,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   syntax='proto3',
   serialized_options=None,
   create_key=_descriptor._internal_create_key,
-  serialized_pb=b'\n\njina.proto\x12\x04jina\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1cgoogle/protobuf/struct.proto\"\xfd\x01\n\x11\x44\x65nseNdArrayProto\x12\x0e\n\x06\x62uffer\x18\x01 \x01(\x0c\x12\r\n\x05shape\x18\x02 \x03(\r\x12\r\n\x05\x64type\x18\x03 \x01(\t\x12>\n\x0cquantization\x18\x04 \x01(\x0e\x32(.jina.DenseNdArrayProto.QuantizationMode\x12\x0f\n\x07max_val\x18\x05 \x01(\x02\x12\x0f\n\x07min_val\x18\x06 \x01(\x02\x12\r\n\x05scale\x18\x07 \x01(\x02\x12\x16\n\x0eoriginal_dtype\x18\x08 \x01(\t\"1\n\x10QuantizationMode\x12\x08\n\x04NONE\x10\x00\x12\x08\n\x04\x46P16\x10\x01\x12\t\n\x05UINT8\x10\x02\"o\n\x0cNdArrayProto\x12(\n\x05\x64\x65nse\x18\x01 \x01(\x0b\x32\x17.jina.DenseNdArrayProtoH\x00\x12*\n\x06sparse\x18\x02 \x01(\x0b\x32\x18.jina.SparseNdArrayProtoH\x00\x42\t\n\x07\x63ontent\"|\n\x12SparseNdArrayProto\x12(\n\x07indices\x18\x01 \x01(\x0b\x32\x17.jina.DenseNdArrayProto\x12\'\n\x06values\x18\x02 \x01(\x0b\x32\x17.jina.DenseNdArrayProto\x12\x13\n\x0b\x64\x65nse_shape\x18\x03 \x03(\x03\"\x7f\n\x0fNamedScoreProto\x12\r\n\x05value\x18\x01 \x01(\x02\x12\x0f\n\x07op_name\x18\x02 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x03 \x01(\t\x12\'\n\x08operands\x18\x04 \x03(\x0b\x32\x15.jina.NamedScoreProto\x12\x0e\n\x06ref_id\x18\x05 \x01(\t\"i\n\nGraphProto\x12+\n\tadjacency\x18\x01 \x01(\x0b\x32\x18.jina.SparseNdArrayProto\x12.\n\redge_features\x18\x02 \x01(\x0b\x32\x17.google.protobuf.Struct\"\xb1\x04\n\rDocumentProto\x12\n\n\x02id\x18\x01 \x01(\t\x12\x14\n\x0c\x63ontent_hash\x18\x18 \x01(\t\x12\x13\n\x0bgranularity\x18\x0e \x01(\r\x12\x11\n\tadjacency\x18\x16 \x01(\r\x12\x11\n\tparent_id\x18\x10 \x01(\t\x12\x10\n\x06\x62uffer\x18\x03 \x01(\x0cH\x00\x12\"\n\x04\x62lob\x18\x0c \x01(\x0b\x32\x12.jina.NdArrayProtoH\x00\x12\x0e\n\x04text\x18\r \x01(\tH\x00\x12\r\n\x03uri\x18\t \x01(\tH\x00\x12!\n\x05graph\x18\x1b \x01(\x0b\x32\x10.jina.GraphProtoH\x00\x12#\n\x06\x63hunks\x18\x04 \x03(\x0b\x32\x13.jina.DocumentProto\x12\x0e\n\x06weight\x18\x05 \x01(\x02\x12$\n\x07matches\x18\x08 \x03(\x0b\x32\x13.jina.DocumentProto\x12\x11\n\tmime_type\x18\n \x01(\t\x12%\n\x04tags\x18\x0b \x01(\x0b\x32\x17.google.protobuf.Struct\x12\x10\n\x08location\x18\x11 \x03(\r\x12\x0e\n\x06offset\x18\x12 \x01(\r\x12%\n\tembedding\x18\x13 \x01(\x0b\x32\x12.jina.NdArrayProto\x12$\n\x05score\x18\x14 \x01(\x0b\x32\x15.jina.NamedScoreProto\x12\x10\n\x08modality\x18\x15 \x01(\t\x12*\n\x0b\x65valuations\x18\x17 \x03(\x0b\x32\x15.jina.NamedScoreProtoB\t\n\x07\x63ontent\"\xaa\x01\n\nRouteProto\x12\x0b\n\x03pod\x18\x01 \x01(\t\x12\x0e\n\x06pod_id\x18\x02 \x01(\t\x12.\n\nstart_time\x18\x03 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12,\n\x08\x65nd_time\x18\x04 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12!\n\x06status\x18\x05 \x01(\x0b\x32\x11.jina.StatusProto\"\x99\x04\n\rEnvelopeProto\x12\x11\n\tsender_id\x18\x01 \x01(\t\x12\x13\n\x0breceiver_id\x18\x02 \x01(\t\x12\x12\n\nrequest_id\x18\x03 \x01(\t\x12\x0f\n\x07timeout\x18\x04 \x01(\r\x12\x31\n\x07version\x18\x06 \x01(\x0b\x32 .jina.EnvelopeProto.VersionProto\x12\x14\n\x0crequest_type\x18\x07 \x01(\t\x12\x15\n\rcheck_version\x18\x08 \x01(\x08\x12<\n\x0b\x63ompression\x18\t \x01(\x0b\x32\'.jina.EnvelopeProto.CompressConfigProto\x12 \n\x06routes\x18\n \x03(\x0b\x32\x10.jina.RouteProto\x12!\n\x06status\x18\x0b \x01(\x0b\x32\x11.jina.StatusProto\x12!\n\x06header\x18\x0c \x01(\x0b\x32\x11.jina.HeaderProto\x1a\x38\n\x0cVersionProto\x12\x0c\n\x04jina\x18\x01 \x01(\t\x12\r\n\x05proto\x18\x02 \x01(\t\x12\x0b\n\x03vcs\x18\x03 \x01(\t\x1a{\n\x13\x43ompressConfigProto\x12\x11\n\talgorithm\x18\x01 \x01(\t\x12\x11\n\tmin_bytes\x18\x02 \x01(\x04\x12\x11\n\tmin_ratio\x18\x03 \x01(\x02\x12+\n\nparameters\x18\x04 \x01(\x0b\x32\x17.google.protobuf.Struct\"Q\n\x0bHeaderProto\x12\x15\n\rexec_endpoint\x18\x01 \x01(\t\x12\x15\n\rtarget_peapod\x18\x02 \x01(\t\x12\x14\n\x0cno_propagate\x18\x03 \x01(\x08\"\xcf\x02\n\x0bStatusProto\x12*\n\x04\x63ode\x18\x01 \x01(\x0e\x32\x1c.jina.StatusProto.StatusCode\x12\x13\n\x0b\x64\x65scription\x18\x02 \x01(\t\x12\x33\n\texception\x18\x03 \x01(\x0b\x32 .jina.StatusProto.ExceptionProto\x1aN\n\x0e\x45xceptionProto\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0c\n\x04\x61rgs\x18\x02 \x03(\t\x12\x0e\n\x06stacks\x18\x03 \x03(\t\x12\x10\n\x08\x65xecutor\x18\x04 \x01(\t\"z\n\nStatusCode\x12\x0b\n\x07SUCCESS\x10\x00\x12\x0b\n\x07PENDING\x10\x01\x12\t\n\x05READY\x10\x02\x12\t\n\x05\x45RROR\x10\x03\x12\x13\n\x0f\x45RROR_DUPLICATE\x10\x04\x12\x14\n\x10\x45RROR_NOTALLOWED\x10\x05\x12\x11\n\rERROR_CHAINED\x10\x06\"Z\n\x0cMessageProto\x12%\n\x08\x65nvelope\x18\x01 \x01(\x0b\x32\x13.jina.EnvelopeProto\x12#\n\x07request\x18\x02 \x01(\x0b\x32\x12.jina.RequestProto\"7\n\x12\x44ocumentArrayProto\x12!\n\x04\x64ocs\x18\x01 \x03(\x0b\x32\x13.jina.DocumentProto\"\xcf\x04\n\x0cRequestProto\x12\x12\n\nrequest_id\x18\x01 \x01(\t\x12\x39\n\x07\x63ontrol\x18\x02 \x01(\x0b\x32&.jina.RequestProto.ControlRequestProtoH\x00\x12\x33\n\x04\x64\x61ta\x18\x03 \x01(\x0b\x32#.jina.RequestProto.DataRequestProtoH\x00\x12!\n\x06header\x18\x04 \x01(\x0b\x32\x11.jina.HeaderProto\x12+\n\nparameters\x18\x05 \x01(\x0b\x32\x17.google.protobuf.Struct\x12 \n\x06routes\x18\x06 \x03(\x0b\x32\x10.jina.RouteProto\x12!\n\x06status\x18\x07 \x01(\x0b\x32\x11.jina.StatusProto\x1a`\n\x10\x44\x61taRequestProto\x12!\n\x04\x64ocs\x18\x01 \x03(\x0b\x32\x13.jina.DocumentProto\x12)\n\x0cgroundtruths\x18\x02 \x03(\x0b\x32\x13.jina.DocumentProto\x1a\xbb\x01\n\x13\x43ontrolRequestProto\x12?\n\x07\x63ommand\x18\x01 \x01(\x0e\x32..jina.RequestProto.ControlRequestProto.Command\"c\n\x07\x43ommand\x12\r\n\tTERMINATE\x10\x00\x12\n\n\x06STATUS\x10\x01\x12\x08\n\x04IDLE\x10\x02\x12\n\n\x06\x43\x41NCEL\x10\x03\x12\t\n\x05SCALE\x10\x04\x12\x0c\n\x08\x41\x43TIVATE\x10\x05\x12\x0e\n\nDEACTIVATE\x10\x06\x42\x06\n\x04\x62ody2?\n\x07JinaRPC\x12\x34\n\x04\x43\x61ll\x12\x12.jina.RequestProto\x1a\x12.jina.RequestProto\"\x00(\x01\x30\x01\x62\x06proto3'
+  serialized_pb=b'\n\njina.proto\x12\x04jina\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1cgoogle/protobuf/struct.proto\"\xfd\x01\n\x11\x44\x65nseNdArrayProto\x12\x0e\n\x06\x62uffer\x18\x01 \x01(\x0c\x12\r\n\x05shape\x18\x02 \x03(\r\x12\r\n\x05\x64type\x18\x03 \x01(\t\x12>\n\x0cquantization\x18\x04 \x01(\x0e\x32(.jina.DenseNdArrayProto.QuantizationMode\x12\x0f\n\x07max_val\x18\x05 \x01(\x02\x12\x0f\n\x07min_val\x18\x06 \x01(\x02\x12\r\n\x05scale\x18\x07 \x01(\x02\x12\x16\n\x0eoriginal_dtype\x18\x08 \x01(\t\"1\n\x10QuantizationMode\x12\x08\n\x04NONE\x10\x00\x12\x08\n\x04\x46P16\x10\x01\x12\t\n\x05UINT8\x10\x02\"o\n\x0cNdArrayProto\x12(\n\x05\x64\x65nse\x18\x01 \x01(\x0b\x32\x17.jina.DenseNdArrayProtoH\x00\x12*\n\x06sparse\x18\x02 \x01(\x0b\x32\x18.jina.SparseNdArrayProtoH\x00\x42\t\n\x07\x63ontent\"|\n\x12SparseNdArrayProto\x12(\n\x07indices\x18\x01 \x01(\x0b\x32\x17.jina.DenseNdArrayProto\x12\'\n\x06values\x18\x02 \x01(\x0b\x32\x17.jina.DenseNdArrayProto\x12\x13\n\x0b\x64\x65nse_shape\x18\x03 \x03(\x03\"\x7f\n\x0fNamedScoreProto\x12\r\n\x05value\x18\x01 \x01(\x02\x12\x0f\n\x07op_name\x18\x02 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x03 \x01(\t\x12\'\n\x08operands\x18\x04 \x03(\x0b\x32\x15.jina.NamedScoreProto\x12\x0e\n\x06ref_id\x18\x05 \x01(\t\"i\n\nGraphProto\x12+\n\tadjacency\x18\x01 \x01(\x0b\x32\x18.jina.SparseNdArrayProto\x12.\n\redge_features\x18\x02 \x01(\x0b\x32\x17.google.protobuf.Struct\"\xb2\x04\n\rDocumentProto\x12\n\n\x02id\x18\x01 \x01(\t\x12\x14\n\x0c\x63ontent_hash\x18\x18 \x01(\t\x12\x13\n\x0bgranularity\x18\x0e \x01(\r\x12\x11\n\tadjacency\x18\x16 \x01(\r\x12\x11\n\tparent_id\x18\x10 \x01(\t\x12\x10\n\x06\x62uffer\x18\x03 \x01(\x0cH\x00\x12\"\n\x04\x62lob\x18\x0c \x01(\x0b\x32\x12.jina.NdArrayProtoH\x00\x12\x0e\n\x04text\x18\r \x01(\tH\x00\x12\r\n\x03uri\x18\t \x01(\tH\x00\x12!\n\x05graph\x18\x1b \x01(\x0b\x32\x10.jina.GraphProtoH\x00\x12#\n\x06\x63hunks\x18\x04 \x03(\x0b\x32\x13.jina.DocumentProto\x12\x0e\n\x06weight\x18\x05 \x01(\x02\x12$\n\x07matches\x18\x08 \x03(\x0b\x32\x13.jina.DocumentProto\x12\x11\n\tmime_type\x18\n \x01(\t\x12%\n\x04tags\x18\x0b \x01(\x0b\x32\x17.google.protobuf.Struct\x12\x10\n\x08location\x18\x11 \x03(\r\x12\x0e\n\x06offset\x18\x12 \x01(\r\x12%\n\tembedding\x18\x13 \x01(\x0b\x32\x12.jina.NdArrayProto\x12%\n\x06scores\x18\x14 \x03(\x0b\x32\x15.jina.NamedScoreProto\x12\x10\n\x08modality\x18\x15 \x01(\t\x12*\n\x0b\x65valuations\x18\x17 \x03(\x0b\x32\x15.jina.NamedScoreProtoB\t\n\x07\x63ontent\"\xaa\x01\n\nRouteProto\x12\x0b\n\x03pod\x18\x01 \x01(\t\x12\x0e\n\x06pod_id\x18\x02 \x01(\t\x12.\n\nstart_time\x18\x03 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12,\n\x08\x65nd_time\x18\x04 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12!\n\x06status\x18\x05 \x01(\x0b\x32\x11.jina.StatusProto\"\x99\x04\n\rEnvelopeProto\x12\x11\n\tsender_id\x18\x01 \x01(\t\x12\x13\n\x0breceiver_id\x18\x02 \x01(\t\x12\x12\n\nrequest_id\x18\x03 \x01(\t\x12\x0f\n\x07timeout\x18\x04 \x01(\r\x12\x31\n\x07version\x18\x06 \x01(\x0b\x32 .jina.EnvelopeProto.VersionProto\x12\x14\n\x0crequest_type\x18\x07 \x01(\t\x12\x15\n\rcheck_version\x18\x08 \x01(\x08\x12<\n\x0b\x63ompression\x18\t \x01(\x0b\x32\'.jina.EnvelopeProto.CompressConfigProto\x12 \n\x06routes\x18\n \x03(\x0b\x32\x10.jina.RouteProto\x12!\n\x06status\x18\x0b \x01(\x0b\x32\x11.jina.StatusProto\x12!\n\x06header\x18\x0c \x01(\x0b\x32\x11.jina.HeaderProto\x1a\x38\n\x0cVersionProto\x12\x0c\n\x04jina\x18\x01 \x01(\t\x12\r\n\x05proto\x18\x02 \x01(\t\x12\x0b\n\x03vcs\x18\x03 \x01(\t\x1a{\n\x13\x43ompressConfigProto\x12\x11\n\talgorithm\x18\x01 \x01(\t\x12\x11\n\tmin_bytes\x18\x02 \x01(\x04\x12\x11\n\tmin_ratio\x18\x03 \x01(\x02\x12+\n\nparameters\x18\x04 \x01(\x0b\x32\x17.google.protobuf.Struct\"Q\n\x0bHeaderProto\x12\x15\n\rexec_endpoint\x18\x01 \x01(\t\x12\x15\n\rtarget_peapod\x18\x02 \x01(\t\x12\x14\n\x0cno_propagate\x18\x03 \x01(\x08\"\xcf\x02\n\x0bStatusProto\x12*\n\x04\x63ode\x18\x01 \x01(\x0e\x32\x1c.jina.StatusProto.StatusCode\x12\x13\n\x0b\x64\x65scription\x18\x02 \x01(\t\x12\x33\n\texception\x18\x03 \x01(\x0b\x32 .jina.StatusProto.ExceptionProto\x1aN\n\x0e\x45xceptionProto\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0c\n\x04\x61rgs\x18\x02 \x03(\t\x12\x0e\n\x06stacks\x18\x03 \x03(\t\x12\x10\n\x08\x65xecutor\x18\x04 \x01(\t\"z\n\nStatusCode\x12\x0b\n\x07SUCCESS\x10\x00\x12\x0b\n\x07PENDING\x10\x01\x12\t\n\x05READY\x10\x02\x12\t\n\x05\x45RROR\x10\x03\x12\x13\n\x0f\x45RROR_DUPLICATE\x10\x04\x12\x14\n\x10\x45RROR_NOTALLOWED\x10\x05\x12\x11\n\rERROR_CHAINED\x10\x06\"Z\n\x0cMessageProto\x12%\n\x08\x65nvelope\x18\x01 \x01(\x0b\x32\x13.jina.EnvelopeProto\x12#\n\x07request\x18\x02 \x01(\x0b\x32\x12.jina.RequestProto\"7\n\x12\x44ocumentArrayProto\x12!\n\x04\x64ocs\x18\x01 \x03(\x0b\x32\x13.jina.DocumentProto\"\xcf\x04\n\x0cRequestProto\x12\x12\n\nrequest_id\x18\x01 \x01(\t\x12\x39\n\x07\x63ontrol\x18\x02 \x01(\x0b\x32&.jina.RequestProto.ControlRequestProtoH\x00\x12\x33\n\x04\x64\x61ta\x18\x03 \x01(\x0b\x32#.jina.RequestProto.DataRequestProtoH\x00\x12!\n\x06header\x18\x04 \x01(\x0b\x32\x11.jina.HeaderProto\x12+\n\nparameters\x18\x05 \x01(\x0b\x32\x17.google.protobuf.Struct\x12 \n\x06routes\x18\x06 \x03(\x0b\x32\x10.jina.RouteProto\x12!\n\x06status\x18\x07 \x01(\x0b\x32\x11.jina.StatusProto\x1a`\n\x10\x44\x61taRequestProto\x12!\n\x04\x64ocs\x18\x01 \x03(\x0b\x32\x13.jina.DocumentProto\x12)\n\x0cgroundtruths\x18\x02 \x03(\x0b\x32\x13.jina.DocumentProto\x1a\xbb\x01\n\x13\x43ontrolRequestProto\x12?\n\x07\x63ommand\x18\x01 \x01(\x0e\x32..jina.RequestProto.ControlRequestProto.Command\"c\n\x07\x43ommand\x12\r\n\tTERMINATE\x10\x00\x12\n\n\x06STATUS\x10\x01\x12\x08\n\x04IDLE\x10\x02\x12\n\n\x06\x43\x41NCEL\x10\x03\x12\t\n\x05SCALE\x10\x04\x12\x0c\n\x08\x41\x43TIVATE\x10\x05\x12\x0e\n\nDEACTIVATE\x10\x06\x42\x06\n\x04\x62ody2?\n\x07JinaRPC\x12\x34\n\x04\x43\x61ll\x12\x12.jina.RequestProto\x1a\x12.jina.RequestProto\"\x00(\x01\x30\x01\x62\x06proto3'
   ,
   dependencies=[google_dot_protobuf_dot_timestamp__pb2.DESCRIPTOR,google_dot_protobuf_dot_struct__pb2.DESCRIPTOR,])
 
@@ -102,8 +102,8 @@ _STATUSPROTO_STATUSCODE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=2388,
-  serialized_end=2510,
+  serialized_start=2389,
+  serialized_end=2511,
 )
 _sym_db.RegisterEnumDescriptor(_STATUSPROTO_STATUSCODE)
 
@@ -152,8 +152,8 @@ _REQUESTPROTO_CONTROLREQUESTPROTO_COMMAND = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=3146,
-  serialized_end=3245,
+  serialized_start=3147,
+  serialized_end=3246,
 )
 _sym_db.RegisterEnumDescriptor(_REQUESTPROTO_CONTROLREQUESTPROTO_COMMAND)
 
@@ -564,9 +564,9 @@ _DOCUMENTPROTO = _descriptor.Descriptor(
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
     _descriptor.FieldDescriptor(
-      name='score', full_name='jina.DocumentProto.score', index=18,
-      number=20, type=11, cpp_type=10, label=1,
-      has_default_value=False, default_value=None,
+      name='scores', full_name='jina.DocumentProto.scores', index=18,
+      number=20, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
@@ -602,7 +602,7 @@ _DOCUMENTPROTO = _descriptor.Descriptor(
     fields=[]),
   ],
   serialized_start=815,
-  serialized_end=1376,
+  serialized_end=1377,
 )
 
 
@@ -661,8 +661,8 @@ _ROUTEPROTO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1379,
-  serialized_end=1549,
+  serialized_start=1380,
+  serialized_end=1550,
 )
 
 
@@ -707,8 +707,8 @@ _ENVELOPEPROTO_VERSIONPROTO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1908,
-  serialized_end=1964,
+  serialized_start=1909,
+  serialized_end=1965,
 )
 
 _ENVELOPEPROTO_COMPRESSCONFIGPROTO = _descriptor.Descriptor(
@@ -759,8 +759,8 @@ _ENVELOPEPROTO_COMPRESSCONFIGPROTO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1966,
-  serialized_end=2089,
+  serialized_start=1967,
+  serialized_end=2090,
 )
 
 _ENVELOPEPROTO = _descriptor.Descriptor(
@@ -860,8 +860,8 @@ _ENVELOPEPROTO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1552,
-  serialized_end=2089,
+  serialized_start=1553,
+  serialized_end=2090,
 )
 
 
@@ -906,8 +906,8 @@ _HEADERPROTO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2091,
-  serialized_end=2172,
+  serialized_start=2092,
+  serialized_end=2173,
 )
 
 
@@ -959,8 +959,8 @@ _STATUSPROTO_EXCEPTIONPROTO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2308,
-  serialized_end=2386,
+  serialized_start=2309,
+  serialized_end=2387,
 )
 
 _STATUSPROTO = _descriptor.Descriptor(
@@ -1005,8 +1005,8 @@ _STATUSPROTO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2175,
-  serialized_end=2510,
+  serialized_start=2176,
+  serialized_end=2511,
 )
 
 
@@ -1044,8 +1044,8 @@ _MESSAGEPROTO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2512,
-  serialized_end=2602,
+  serialized_start=2513,
+  serialized_end=2603,
 )
 
 
@@ -1076,8 +1076,8 @@ _DOCUMENTARRAYPROTO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2604,
-  serialized_end=2659,
+  serialized_start=2605,
+  serialized_end=2660,
 )
 
 
@@ -1115,8 +1115,8 @@ _REQUESTPROTO_DATAREQUESTPROTO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2959,
-  serialized_end=3055,
+  serialized_start=2960,
+  serialized_end=3056,
 )
 
 _REQUESTPROTO_CONTROLREQUESTPROTO = _descriptor.Descriptor(
@@ -1147,8 +1147,8 @@ _REQUESTPROTO_CONTROLREQUESTPROTO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3058,
-  serialized_end=3245,
+  serialized_start=3059,
+  serialized_end=3246,
 )
 
 _REQUESTPROTO = _descriptor.Descriptor(
@@ -1225,8 +1225,8 @@ _REQUESTPROTO = _descriptor.Descriptor(
       create_key=_descriptor._internal_create_key,
     fields=[]),
   ],
-  serialized_start=2662,
-  serialized_end=3253,
+  serialized_start=2663,
+  serialized_end=3254,
 )
 
 _DENSENDARRAYPROTO.fields_by_name['quantization'].enum_type = _DENSENDARRAYPROTO_QUANTIZATIONMODE
@@ -1250,7 +1250,7 @@ _DOCUMENTPROTO.fields_by_name['chunks'].message_type = _DOCUMENTPROTO
 _DOCUMENTPROTO.fields_by_name['matches'].message_type = _DOCUMENTPROTO
 _DOCUMENTPROTO.fields_by_name['tags'].message_type = google_dot_protobuf_dot_struct__pb2._STRUCT
 _DOCUMENTPROTO.fields_by_name['embedding'].message_type = _NDARRAYPROTO
-_DOCUMENTPROTO.fields_by_name['score'].message_type = _NAMEDSCOREPROTO
+_DOCUMENTPROTO.fields_by_name['scores'].message_type = _NAMEDSCOREPROTO
 _DOCUMENTPROTO.fields_by_name['evaluations'].message_type = _NAMEDSCOREPROTO
 _DOCUMENTPROTO.oneofs_by_name['content'].fields.append(
   _DOCUMENTPROTO.fields_by_name['buffer'])
@@ -1458,8 +1458,8 @@ _JINARPC = _descriptor.ServiceDescriptor(
   index=0,
   serialized_options=None,
   create_key=_descriptor._internal_create_key,
-  serialized_start=3255,
-  serialized_end=3318,
+  serialized_start=3256,
+  serialized_end=3319,
   methods=[
   _descriptor.MethodDescriptor(
     name='Call',

--- a/jina/types/arrays/match.py
+++ b/jina/types/arrays/match.py
@@ -33,7 +33,8 @@ class MatchArray(DocumentArray):
         match.set_attributes(
             granularity=self.granularity, adjacency=self.adjacency, **kwargs
         )
-        match.score.ref_id = self._ref_doc.id
+        for score in match.scores:
+            score.ref_id = self._ref_doc.id
 
         super().append(match)
         return match

--- a/jina/types/document/__init__.py
+++ b/jina/types/document/__init__.py
@@ -1018,7 +1018,6 @@ class Document(ProtoTypeMixin):
         idx = self._scores_offset_map.get(name, len(self.scores))
         if idx == len(self.scores):
             self._pb_body.scores.add()
-        print(f' value {value}')
         self._set_score(idx, value)
         self._pb_body.scores[idx].op_name = name
 

--- a/jina/types/document/__init__.py
+++ b/jina/types/document/__init__.py
@@ -1018,6 +1018,7 @@ class Document(ProtoTypeMixin):
         idx = self._scores_offset_map.get(name, len(self.scores))
         if idx == len(self.scores):
             self._pb_body.scores.add()
+        print(f' value {value}')
         self._set_score(idx, value)
         self._pb_body.scores[idx].op_name = name
 
@@ -1067,7 +1068,7 @@ class Document(ProtoTypeMixin):
         if len(self._pb_body.evaluations) > 0:
             return NamedScore(self._pb_body.evaluations[0])
 
-    @score.setter
+    @evaluation.setter
     def evaluation(
         self, value: Union[jina_pb2.NamedScoreProto, NamedScore, float, np.generic]
     ):

--- a/tests/unit/test_helper.py
+++ b/tests/unit/test_helper.py
@@ -76,6 +76,13 @@ def test_dunder_get():
     assert dunder_get(a, 'b__c') == 1
 
 
+def test_dunder_get_with_array():
+    a = SimpleNamespace()
+    a.b = {'c': {'d': [{'e': 5}, {'f': 10}]}}
+    assert dunder_get(a, 'b__c__d__0__e') == 5
+    assert dunder_get(a, 'b__c__d__1__f') == 10
+
+
 def test_check_update():
     assert _is_latest_version()
     # now mock it as old version

--- a/tests/unit/types/arrays/test_matcharray.py
+++ b/tests/unit/types/arrays/test_matcharray.py
@@ -51,7 +51,24 @@ def test_append_from_documents(matcharray, document_factory, reference_doc):
     assert rv.granularity == reference_doc.granularity
     assert rv.adjacency == reference_doc.adjacency + 1
     assert rv.mime_type == 'text/plain'
-    assert rv.score.ref_id == reference_doc.id
+    assert rv.score.ref_id == ''
+
+
+def test_append_from_documents_with_score(matcharray, document_factory, reference_doc):
+    match = document_factory.create(4, 'test 4')
+    match.add_score(50)
+    match.add_score(100)
+    rv = matcharray.append(match)
+    assert len(matcharray) == 4
+    assert matcharray[-1].text == 'test 4'
+    assert rv.text == match.text
+    assert rv.granularity == reference_doc.granularity
+    assert rv.adjacency == reference_doc.adjacency + 1
+    assert rv.mime_type == 'text/plain'
+    assert rv.scores[0].ref_id == reference_doc.id
+    assert rv.scores[0].value == 50
+    assert rv.scores[1].ref_id == reference_doc.id
+    assert rv.scores[1].value == 100
 
 
 def test_mime_type_not_reassigned():

--- a/tests/unit/types/document/test_document.py
+++ b/tests/unit/types/document/test_document.py
@@ -288,13 +288,22 @@ def test_doc_score():
     assert doc.score.ref_id == doc.id
 
 
+def test_doc_score_by_getter():
+    with Document() as doc:
+        doc.text = 'text'
+
+    doc.score.value = 50
+    assert doc.score.value == 50
+    assert doc.score.op_name == ''
+
+
 def test_doc_score_by_value():
     with Document() as doc:
         doc.text = 'text'
 
     doc.score = 50
     assert doc.score.value == 50
-    assert doc.score.op_name == 'score'
+    assert doc.score.op_name == ''
 
 
 def test_doc_score_by_name():
@@ -313,6 +322,31 @@ def test_doc_score_by_name():
     assert doc.scores[1].op_name == 'euclidean'
 
 
+def test_doc_scores_add():
+    from jina import Document
+
+    doc = Document()
+    doc.add_score(50)
+    doc.add_score(100)
+    assert doc.scores[0].value == 50
+    assert doc.scores[1].value == 100
+
+
+def test_doc_scores_same_op_name_update_only_first():
+    from jina import Document
+
+    doc = Document()
+    doc.add_score(50)
+    doc.add_score(100)
+    assert doc.scores[0].value == 50
+    assert doc.scores[1].value == 100
+    doc.scores[0].op_name = 'score'
+    doc.scores[1].op_name = 'score'
+    doc.set_score('score', 200)
+    assert doc.scores[0].value == 200
+    assert doc.scores[1].value == 100
+
+
 def test_doc_evaluation():
     from jina.types.score import NamedScore
 
@@ -327,13 +361,22 @@ def test_doc_evaluation():
     assert doc.evaluation.ref_id == doc.id
 
 
+def test_doc_evaluation_by_getter():
+    with Document() as doc:
+        doc.text = 'text'
+
+    doc.evaluation.value = 50
+    assert doc.evaluation.value == 50
+    assert doc.evaluation.op_name == ''
+
+
 def test_doc_evaluation_by_value():
     with Document() as doc:
         doc.text = 'text'
 
     doc.evaluation = 50
     assert doc.evaluation.value == 50
-    assert doc.evaluation.op_name == 'evaluation'
+    assert doc.evaluation.op_name == ''
 
 
 def test_doc_evaluation_by_name():
@@ -350,6 +393,31 @@ def test_doc_evaluation_by_name():
 
     assert doc.evaluations[1].value == 1.0
     assert doc.evaluations[1].op_name == 'recall'
+
+
+def test_doc_evaluations_add():
+    from jina import Document
+
+    doc = Document()
+    doc.add_evaluation(50)
+    doc.add_evaluation(100)
+    assert doc.evaluations[0].value == 50
+    assert doc.evaluations[1].value == 100
+
+
+def test_doc_evaluations_same_op_name_update_only_first():
+    from jina import Document
+
+    doc = Document()
+    doc.add_evaluation(50)
+    doc.add_evaluation(100)
+    assert doc.evaluations[0].value == 50
+    assert doc.evaluations[1].value == 100
+    doc.evaluations[0].op_name = 'eval'
+    doc.evaluations[1].op_name = 'eval'
+    doc.set_evaluation('eval', 200)
+    assert doc.evaluations[0].value == 200
+    assert doc.evaluations[1].value == 100
 
 
 def test_content_hash_not_dependent_on_chunks_or_matches():

--- a/tests/unit/types/document/test_document.py
+++ b/tests/unit/types/document/test_document.py
@@ -288,6 +288,70 @@ def test_doc_score():
     assert doc.score.ref_id == doc.id
 
 
+def test_doc_score_by_value():
+    with Document() as doc:
+        doc.text = 'text'
+
+    doc.score = 50
+    assert doc.score.value == 50
+    assert doc.score.op_name == 'score'
+
+
+def test_doc_score_by_name():
+    with Document() as doc:
+        doc.text = 'text'
+
+    doc.set_score('cosine', 0.5)
+    doc.set_score('euclidean', 1.0)
+    assert doc.score.value == 0.5
+    assert doc.score.op_name == 'cosine'
+
+    assert doc.scores[0].value == 0.5
+    assert doc.scores[0].op_name == 'cosine'
+
+    assert doc.scores[1].value == 1.0
+    assert doc.scores[1].op_name == 'euclidean'
+
+
+def test_doc_evaluation():
+    from jina.types.score import NamedScore
+
+    with Document() as doc:
+        doc.text = 'text'
+
+    evaluation = NamedScore(op_name='operation', value=10.0, ref_id=doc.id)
+    doc.evaluation = evaluation
+
+    assert doc.evaluation.op_name == 'operation'
+    assert doc.evaluation.value == 10.0
+    assert doc.evaluation.ref_id == doc.id
+
+
+def test_doc_evaluation_by_value():
+    with Document() as doc:
+        doc.text = 'text'
+
+    doc.evaluation = 50
+    assert doc.evaluation.value == 50
+    assert doc.evaluation.op_name == 'evaluation'
+
+
+def test_doc_evaluation_by_name():
+    with Document() as doc:
+        doc.text = 'text'
+
+    doc.set_evaluation('precision', 0.5)
+    doc.set_evaluation('recall', 1.0)
+    assert doc.evaluation.value == 0.5
+    assert doc.evaluation.op_name == 'precision'
+
+    assert doc.evaluations[0].value == 0.5
+    assert doc.evaluations[0].op_name == 'precision'
+
+    assert doc.evaluations[1].value == 1.0
+    assert doc.evaluations[1].op_name == 'recall'
+
+
 def test_content_hash_not_dependent_on_chunks_or_matches():
     doc1 = Document()
     doc1.content = 'one'

--- a/tests/unit/types/document/test_document.py
+++ b/tests/unit/types/document/test_document.py
@@ -541,7 +541,7 @@ def test_get_attr_values():
         'text',
         'tags__name',
         'tags__feature1',
-        'score__value',
+        'scores__0__value',
         'tags__c',
         'tags__id',
         'tags__inexistant',
@@ -556,7 +556,7 @@ def test_get_attr_values():
     assert res[required_keys.index('text')] == 'document'
     assert res[required_keys.index('tags__c')] == 'd'
     assert res[required_keys.index('tags__id')] == 'identity'
-    assert res[required_keys.index('score__value')] == 42
+    assert res[required_keys.index('scores__0__value')] == 42
     assert res[required_keys.index('tags__inexistant')] is None
     assert res[required_keys.index('inexistant')] is None
 

--- a/tests/unit/types/document/test_document.py
+++ b/tests/unit/types/document/test_document.py
@@ -515,7 +515,7 @@ def test_document_to_dict(expected_doc_fields, ignored_doc_fields):
 
 def test_non_empty_fields():
     d_score = Document(score=NamedScore(value=42))
-    assert d_score.non_empty_fields == ('id', 'score')
+    assert d_score.non_empty_fields == ('id', 'scores')
 
     d = Document()
     assert d.non_empty_fields == ('id',)


### PR DESCRIPTION
**Changes introduced**
This PR deals with 2 things in the same way:

- It turns `scores` into a `repeated field` in the `DocumentProto`. This makes `scores` exactly the same as `evaluations`.
- To keep the look and feel of `score` property of `Document` I mantain it so that `doc.score` always points to the first value of the `scores` list.
- Then to insert different `values` to `scores` or `evaluations` provide the interface to insert by `name` (op_name).

To be able to extract these values via `dunder` syntax, added the consideration of `lists` into the `dunder_get` method