### PR TITLE
feat(daemon): update workspace

### DIFF
--- a/daemon/api/endpoints/workspaces.py
+++ b/daemon/api/endpoints/workspaces.py
@@ -72,12 +72,11 @@ async def _create(workspace: WorkspaceDepends = Depends(WorkspaceDepends)):
     path='/{id}',
     summary='Update files in a workspace',
     description='Return a DaemonID to the workspace, which can be used later when create Pea/Pod/Flow',
-    response_model=DaemonID,
     status_code=200,
 )
-async def _update(id: DaemonID, files: List[UploadFile] = File(None)):
+async def _update(workspace: WorkspaceDepends = Depends(WorkspaceDepends)):
     try:
-        return store.update(id=id, files=files)
+        return workspace.j
     except Exception as ex:
         raise Runtime400Exception from ex
 

--- a/daemon/files.py
+++ b/daemon/files.py
@@ -39,20 +39,20 @@ def workspace_files(
 
 
 def _merge_requirement_file(dest, f: UploadFile):
-    new_requirements = _read_requirements_file(f.file)
-    with open(dest, "r") as existing_requirements_file:
+    # Open existing requirements in binary mode
+    # UploadFile is also in binary mode
+    with open(dest, "rb") as existing_requirements_file:
         old_requirements = _read_requirements_file(existing_requirements_file)
-    old_requirements.update(new_requirements)
+    old_requirements.update(_read_requirements_file(f.file))
+    # Store merged requirements
     with open(dest, "w") as req_file:
         req_file.write("\n".join(list(old_requirements.values())))
 
 
-# TODO this is terrible, improve this pattern
 def _read_requirements_file(f):
     requirements = {}
     for line in f.readlines():
-        if type(line) != str:
-            line = line.decode("utf-8")
+        line = line.decode()
         requirements[line.split('=')[0]] = line.replace("\n", "")
     return requirements
 

--- a/daemon/tasks.py
+++ b/daemon/tasks.py
@@ -107,7 +107,7 @@ class DaemonWorker(Thread):
             store.update(
                 id=self.id,
                 value=WorkspaceItem(
-                    state=WorkspaceState.ACTIVE,
+                    state=WorkspaceState.UPDATING,
                     metadata=self.metadata,
                     arguments=self.arguments,
                 ),
@@ -124,6 +124,7 @@ class DaemonWorker(Thread):
 
             # Create a new container if necessary
             store[self.id].metadata.container_id = self.container_id
+            store[self.id].state = WorkspaceState.ACTIVE
 
             self._logger.success(
                 f'workspace {colored(str(self.id), "cyan")} is updated'

--- a/daemon/tasks.py
+++ b/daemon/tasks.py
@@ -54,13 +54,14 @@ class DaemonWorker(Thread):
 
     @cached_property
     def metadata(self):
+        image_id = self.generate_image()
         try:
             _metadata = store[self.id].metadata.copy(deep=True)
-            _metadata.image_id = self.image_id
+            _metadata.image_id = image_id
             _metadata.image_name = self.id.tag
         except AttributeError:
             _metadata = WorkspaceMetadata(
-                image_id=self.image_id,
+                image_id=image_id,
                 image_name=self.id.tag,
                 network=id_cleaner(self.network_id),
                 workdir=self.workdir,
@@ -79,8 +80,7 @@ class DaemonWorker(Thread):
     def network_id(self):
         return Dockerizer.network(workspace_id=self.id)
 
-    @cached_property
-    def image_id(self):
+    def generate_image(self):
         return Dockerizer.build(
             workspace_id=self.id, daemon_file=self.daemon_file, logger=self._logger
         )
@@ -92,10 +92,11 @@ class DaemonWorker(Thread):
                 workspace_id=self.id, daemon_file=self.daemon_file
             )
             return id_cleaner(container.id)
+        else:
+            return None
 
     def run(self) -> None:
         try:
-            # TODO: Handle diff in case of "update"
             store.update(
                 id=self.id,
                 value=WorkspaceState.UPDATING
@@ -111,8 +112,19 @@ class DaemonWorker(Thread):
                     arguments=self.arguments,
                 ),
             )
+
             # this needs to be done after the initial update, otherwise run won't find the necessary metadata
+            # If a container exists already, kill it before running again
+            previous_container = store[self.id].metadata.container_id
+            if previous_container:
+                self._logger.info(f'Deleting previous container {previous_container}')
+                store[self.id].metadata.container_id = None
+                del self.container_id
+                Dockerizer.rm_container(previous_container)
+
+            # Create a new container if necessary
             store[self.id].metadata.container_id = self.container_id
+
             self._logger.success(
                 f'workspace {colored(str(self.id), "cyan")} is updated'
             )

--- a/tests/distributed/test_against_external_daemon/blocking.jinad
+++ b/tests/distributed/test_against_external_daemon/blocking.jinad
@@ -1,0 +1,3 @@
+build = devel
+python = 3.7
+run = "sleep infinity"

--- a/tests/distributed/test_against_external_daemon/test_single_instance_custom_container.py
+++ b/tests/distributed/test_against_external_daemon/test_single_instance_custom_container.py
@@ -78,9 +78,7 @@ def _container_info(workspace_id):
 
 
 def test_delete_custom_container():
-    workspace_id = create_workspace(
-        filepaths=[os.path.join(cur_dir, '../../daemon/unit/models/good_ws/.jinad')]
-    )
+    workspace_id = create_workspace(filepaths=[os.path.join(cur_dir, 'blocking.jinad')])
     wait_for_workspace(workspace_id)
 
     # check that container was created
@@ -89,11 +87,15 @@ def test_delete_custom_container():
     assert container_id
 
     # delete container
-    response = requests.delete(
+    requests.delete(
         f'http://{CLOUD_HOST}/workspaces/{workspace_id}',
-        params={'container': True, 'everything': False},
+        params={
+            'container': True,
+            'everything': False,
+            'network': False,
+            'files': False,
+        },
     )
-    assert response.json()[0] == container_id
 
     # check that deleted container is gone
     response = requests.get(f'http://{CLOUD_HOST}/workspaces/{workspace_id}')


### PR DESCRIPTION
This reworks the workspace update endpoint. Now its possible to call PUT with a list of files which will update the workspace.
This means the requirements are updated (old and new merged), file are placed, docker image rebuild and if necessary the custom container is restarted.

I added a simple tests.
There are some ugly code parts I want to improve, but it generally should work.