### PR TITLE
revert: bring explicit AsyncFlow class back

### DIFF
--- a/.github/2.0/cookbooks/Flow.md
+++ b/.github/2.0/cookbooks/Flow.md
@@ -597,21 +597,37 @@ This is useful to control `Executor` objects in the runtime.
 
 ### Asynchronous Flow
 
-There is also an "async version" of the `Flow` object, given by `Flow(asyncio=True)`.
+`AsyncFlow` is an "async version" of the `Flow` class.
 
-The quote mark represents the explicit async when using the Flow.
+The quote mark represents the explicit async when using `AsyncFlow`.
 
 While synchronous from outside, `Flow` also runs asynchronously under the hood: it manages the eventloop(s) for
-scheduling the jobs. If the user wants more control over the eventloop, then `Flow(asyncio=True)` can be used.
+scheduling the jobs. If the user wants more control over the eventloop, then `AsyncFlow` can be used.
 
-Unlike `Flow` object, `Flow(asyncio=True)` object accepts input and output functions
+To create an `AsyncFlow`, simply
+
+```python
+from jina import AsyncFlow
+
+f = AsyncFlow()
+```
+
+There is also a sugary syntax `Flow(asyncio=True)` for initiating an `AsyncFlow` object.
+
+```python
+from jina import Flow
+
+f = Flow(asyncio=True)
+```
+
+Unlike `Flow`, `AsyncFlow` accepts input and output functions
 as [async generators](https://www.python.org/dev/peps/pep-0525/). This is useful when your data sources involve other
 asynchronous libraries (e.g. motor for MongoDB):
 
 ```python
 import asyncio
 
-from jina import Flow, Document
+from jina import AsyncFlow, Document
 
 
 async def async_inputs():
@@ -620,18 +636,18 @@ async def async_inputs():
         await asyncio.sleep(0.1)
 
 
-with Flow(asyncio=True).add() as f:
+with AsyncFlow().add() as f:
     async for resp in f.post('/', async_inputs):
         print(resp)
 ```
 
-`Flow(asyncio=True)` is particularly useful when Jina and another heavy-lifting job are running concurrently:
+`AsyncFlow` is particularly useful when Jina and another heavy-lifting job are running concurrently:
 
 ```python
 import time
 import asyncio
 
-from jina import Flow, Executor, requests
+from jina import AsyncFlow, Executor, requests
 
 
 class HeavyWork(Executor):
@@ -642,7 +658,7 @@ class HeavyWork(Executor):
 
 
 async def run_async_flow_5s():
-    with Flow(asyncio=True).add(uses=HeavyWork) as f:
+    with AsyncFlow().add(uses=HeavyWork) as f:
         async for resp in f.post('/'):
             print(resp)
 
@@ -661,8 +677,7 @@ if __name__ == '__main__':
     asyncio.run(concurrent_main())
 ```
 
-`Flow(asyncio=True)` is very useful when using Jina inside a Jupyter Notebook, where it can run out-of-the-box.
-
+`AsyncFlow` is very useful when using Jina inside a Jupyter Notebook, where it can run out-of-the-box.
 
 
 ## Flow as a Service

--- a/jina/__init__.py
+++ b/jina/__init__.py
@@ -166,6 +166,7 @@ from jina.executors.decorators import requests
 
 # Flow
 from jina.flow.base import Flow
+from jina.flow.asyncio import AsyncFlow
 
 __all__ = [_s for _s in dir() if not _s.startswith('_')]
 __all__.extend(_names_with_underscore)

--- a/jina/flow/asyncio.py
+++ b/jina/flow/asyncio.py
@@ -1,0 +1,43 @@
+from .base import Flow
+from ..clients.mixin import AsyncPostMixin
+
+
+class AsyncFlow(AsyncPostMixin, Flow):
+    """
+    :class:`AsyncFlow` is the asynchronous version of the :class:`Flow`. They share the same interface, except
+    in :class:`AsyncFlow` :meth:`train`, :meth:`index`, :meth:`search` methods are coroutines
+    (i.e. declared with the async/await syntax), simply calling them will not schedule them to be executed.
+    To actually run a coroutine, user need to put them in an eventloop, e.g. via ``asyncio.run()``,
+    ``asyncio.create_task()``.
+
+    :class:`AsyncFlow` can be very useful in
+    the integration settings, where Jina/Jina Flow is NOT the main logic, but rather served as a part of other program.
+    In this case, users often do not want to let Jina control the ``asyncio.eventloop``. On contrary, :class:`Flow`
+    is controlling and wrapping the eventloop internally, making the Flow looks synchronous from outside.
+
+    In particular, :class:`AsyncFlow` makes Jina usage in Jupyter Notebook more natural and reliable.
+    For example, the following code
+    will use the eventloop that already spawned in Jupyter/ipython to run Jina Flow (instead of creating a new one).
+
+    .. highlight:: python
+    .. code-block:: python
+
+        from jina import AsyncFlow
+        from jina.types.document.generators import from_ndarray
+        import numpy as np
+
+        with AsyncFlow().add() as f:
+            await f.index(from_ndarray(np.random.random([5, 4])), on_done=print)
+
+    Notice that the above code will NOT work in standard Python REPL, as only Jupyter/ipython implements "autoawait".
+
+    .. seealso::
+        Asynchronous in REPL: Autoawait
+
+        https://ipython.readthedocs.io/en/stable/interactive/autoawait.html
+
+    Another example is when using Jina as an integration. Say you have another IO-bounded job ``heavylifting()``, you
+    can use this feature to schedule Jina ``index()`` and ``heavylifting()`` concurrently.
+
+    One can think of :class:`Flow` as Jina-managed eventloop, whereas :class:`AsyncFlow` is self-managed eventloop.
+    """

--- a/tests/unit/flow/test_asyncflow.py
+++ b/tests/unit/flow/test_asyncflow.py
@@ -5,6 +5,7 @@ import numpy as np
 import pytest
 
 from jina import Document, Flow
+from jina.flow.asyncio import AsyncFlow
 from jina.logging.profile import TimeContext
 from jina.types.document.generators import from_ndarray
 from jina.types.request import Response
@@ -37,9 +38,10 @@ def documents(start_index, end_index):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize('restful', [False])
-async def test_run_async_flow(restful, mocker):
+@pytest.mark.parametrize('flow_cls', [Flow, AsyncFlow])
+async def test_run_async_flow(restful, mocker, flow_cls):
     r_val = mocker.Mock()
-    with Flow(restful=restful, asyncio=True).add() as f:
+    with flow_cls(restful=restful, asyncio=True).add() as f:
         async for r in f.index(
             from_ndarray(np.random.random([num_docs, 4])), on_done=r_val
         ):
@@ -72,7 +74,7 @@ async def async_input_function2():
 )
 async def test_run_async_flow_async_input(restful, inputs, mocker):
     r_val = mocker.Mock()
-    with Flow(restful=restful, asyncio=True).add() as f:
+    with AsyncFlow(asyncio=True).add() as f:
         async for r in f.index(inputs, on_done=r_val):
             assert isinstance(r, Response)
     validate_callback(r_val, validate)
@@ -136,8 +138,11 @@ async def test_run_async_flow_other_task_concurrent(restful):
 @pytest.mark.asyncio
 @pytest.mark.parametrize('return_results', [False])
 @pytest.mark.parametrize('restful', [False])
-async def test_return_results_async_flow(return_results, restful):
-    with Flow(restful=restful, asyncio=True, return_results=return_results).add() as f:
+@pytest.mark.parametrize('flow_cls', [Flow, AsyncFlow])
+async def test_return_results_async_flow(return_results, restful, flow_cls):
+    with flow_cls(
+        restful=restful, asyncio=True, return_results=return_results
+    ).add() as f:
         async for r in f.index(from_ndarray(np.random.random([10, 2]))):
             assert isinstance(r, Response)
 
@@ -146,14 +151,20 @@ async def test_return_results_async_flow(return_results, restful):
 @pytest.mark.parametrize('return_results', [False, True])
 @pytest.mark.parametrize('restful', [False])
 @pytest.mark.parametrize('flow_api', ['delete', 'index', 'update', 'search'])
-async def test_return_results_async_flow_crud(return_results, restful, flow_api):
-    with Flow(restful=restful, asyncio=True, return_results=return_results).add() as f:
+@pytest.mark.parametrize('flow_cls', [Flow, AsyncFlow])
+async def test_return_results_async_flow_crud(
+    return_results, restful, flow_api, flow_cls
+):
+    with flow_cls(
+        restful=restful, asyncio=True, return_results=return_results
+    ).add() as f:
         async for r in getattr(f, flow_api)(documents(0, 10)):
             assert isinstance(r, Response)
 
 
 @pytest.mark.asyncio
-async def test_async_flow_empty_data():
+@pytest.mark.parametrize('flow_cls', [Flow, AsyncFlow])
+async def test_async_flow_empty_data(flow_cls):
     from jina import Executor, requests
 
     class MyExec(Executor):
@@ -161,6 +172,6 @@ async def test_async_flow_empty_data():
         def foo(self, parameters, **kwargs):
             assert parameters['hello'] == 'world'
 
-    with Flow(asyncio=True).add(uses=MyExec) as f:
+    with flow_cls(asyncio=True).add(uses=MyExec) as f:
         async for r in f.post('/hello', parameters={'hello': 'world'}):
             assert isinstance(r, Response)


### PR DESCRIPTION
- bring `AsyncFlow` class back
- sugary syntax `Flow(asyncio=True)` swallows the IDE type hint on `async`, therefore it is not really the best practice. 
- the unified interface is still required if user care more about consistency rather than type hint