### PR TITLE
feat: info loglevel rest

### DIFF
--- a/jina/peapods/runtimes/asyncio/rest/__init__.py
+++ b/jina/peapods/runtimes/asyncio/rest/__init__.py
@@ -51,6 +51,7 @@ class RESTRuntime(AsyncNewLoopRuntime):
         # as 'wsproto' is less performant and adds another dependency.
 
         from .....helper import extend_rest_interface
+        import os
 
         self._server = UviServer(
             config=Config(
@@ -58,7 +59,7 @@ class RESTRuntime(AsyncNewLoopRuntime):
                 host=self.args.host,
                 port=self.args.port_expose,
                 ws='wsproto',
-                log_level='info',
+                log_level=os.getenv('JINA_LOG_LEVEL', 'error'),
             )
         )
         await self._server.setup()

--- a/jina/peapods/runtimes/asyncio/rest/__init__.py
+++ b/jina/peapods/runtimes/asyncio/rest/__init__.py
@@ -58,7 +58,7 @@ class RESTRuntime(AsyncNewLoopRuntime):
                 host=self.args.host,
                 port=self.args.port_expose,
                 ws='wsproto',
-                log_level='critical',
+                log_level='info',
             )
         )
         await self._server.setup()

--- a/jina/peapods/runtimes/asyncio/rest/__init__.py
+++ b/jina/peapods/runtimes/asyncio/rest/__init__.py
@@ -59,7 +59,7 @@ class RESTRuntime(AsyncNewLoopRuntime):
                 host=self.args.host,
                 port=self.args.port_expose,
                 ws='wsproto',
-                log_level=os.getenv('JINA_LOG_LEVEL', 'error'),
+                log_level=os.getenv('JINA_LOG_LEVEL', 'error').lower(),
             )
         )
         await self._server.setup()


### PR DESCRIPTION
When creating custom REST endpoints, we get not any logs. Also, exceptions are silently ignored.

Having the logs helps debugging the application.
Example:

```
INFO:     127.0.0.1:51113 - "POST /search_docs HTTP/1.1" 200 OK
```