### PR TITLE
feat: custom endpoints

### DIFF
--- a/jina/helper.py
+++ b/jina/helper.py
@@ -11,16 +11,15 @@ import time
 import uuid
 import warnings
 from argparse import ArgumentParser, Namespace
-from contextlib import contextmanager
 from datetime import datetime
 from itertools import islice
-from pathlib import Path
 from types import SimpleNamespace
 from typing import (
     Tuple,
     Optional,
     Iterator,
     Any,
+    Callable,
     Union,
     List,
     Dict,
@@ -1163,12 +1162,18 @@ def dunder_get(_dict: Any, key: str) -> Any:
 
 if False:
     from fastapi import FastAPI
+    from jina.peapods.runtimes.asyncio.rest.models import JinaRequestModel
+    from starlette.responses import StreamingResponse
 
 
-def extend_rest_interface(app: 'FastAPI') -> 'FastAPI':
+def extend_rest_interface(
+    app: 'FastAPI',
+    client: Optional[Callable[['JinaRequestModel', str], 'StreamingResponse']] = None,
+) -> 'FastAPI':
     """Extend Jina built-in FastAPI instance with customized APIs, routing, etc.
 
     :param app: the built-in FastAPI instance given by Jina
+    :param client: function to send requests to the Flow
     :return: the extended FastAPI instance
 
     .. highlight:: python

--- a/jina/parsers/peapods/runtimes/remote.py
+++ b/jina/parsers/peapods/runtimes/remote.py
@@ -74,6 +74,12 @@ def mixin_rest_server_parser(parser=None):
         help='If set, use this to specify float field valid digits.',
     )
 
+    gp.add_argument(
+        'use_default_endpoints',
+        default=True,
+        help='If set, use the default endpoints for index, update, delete, search',
+    )
+
 
 def mixin_grpc_server_parser(parser=None):
     """Add the options for gRPC

--- a/jina/peapods/runtimes/asyncio/rest/__init__.py
+++ b/jina/peapods/runtimes/asyncio/rest/__init__.py
@@ -1,4 +1,4 @@
-from .app import get_fastapi_app
+from .app import AppWrapper
 from ..base import AsyncNewLoopRuntime
 from .....importer import ImportExtensions
 
@@ -53,9 +53,19 @@ class RESTRuntime(AsyncNewLoopRuntime):
         from .....helper import extend_rest_interface
         import os
 
+        app_wrapper = AppWrapper(self.args, self.logger)
+        fastapi_app = app_wrapper.get_fastapi_app()
+        print(
+            '# extend_rest_interface.__code__.co_argcount',
+            extend_rest_interface.__code__.co_argcount,
+        )
+        if extend_rest_interface.__code__.co_argcount == 2:
+            fastapi_app = extend_rest_interface(fastapi_app, app_wrapper.send_request)
+        else:
+            fastapi_app = extend_rest_interface(fastapi_app)
         self._server = UviServer(
             config=Config(
-                app=extend_rest_interface(get_fastapi_app(self.args, self.logger)),
+                app=fastapi_app,
                 host=self.args.host,
                 port=self.args.port_expose,
                 ws='wsproto',

--- a/jina/peapods/runtimes/asyncio/rest/app.py
+++ b/jina/peapods/runtimes/asyncio/rest/app.py
@@ -1,9 +1,10 @@
 import argparse
 import asyncio
-from typing import Any, Optional
+from typing import Any
 
 from google.protobuf.json_format import MessageToJson
 
+from .models import JinaRequestModel
 from ..grpc.async_call import AsyncPrefetchCall
 from ....zmq import AsyncZmqlet
 from ..... import __version__
@@ -17,325 +18,360 @@ from .....types.message import Message
 from .....types.request import Request
 
 
-def get_fastapi_app(args: 'argparse.Namespace', logger: 'JinaLogger'):
+class AppWrapper:
     """
-    Get the app from FastAPI as the REST interface.
+    Wrapper for FastAPI handling the connection to the Jina Flow
 
     :param args: passed arguments.
     :param logger: Jina logger.
-    :return: fastapi app
     """
-    with ImportExtensions(required=True):
-        from fastapi import FastAPI, WebSocket
-        from fastapi.responses import JSONResponse
-        from fastapi.middleware.cors import CORSMiddleware
-        from starlette.endpoints import WebSocketEndpoint
-        from starlette import status
-        from starlette.types import Receive, Scope, Send
-        from starlette.responses import StreamingResponse
-        from .models import (
-            JinaStatusModel,
-            JinaIndexRequestModel,
-            JinaDeleteRequestModel,
-            JinaUpdateRequestModel,
-            JinaSearchRequestModel,
-            JinaRequestModel,
-        )
 
-    app = FastAPI(
-        title='Jina',
-        description='REST interface for Jina',
-        version=__version__,
-    )
-    app.add_middleware(
-        CORSMiddleware,
-        allow_origins=['*'],
-        allow_credentials=True,
-        allow_methods=['*'],
-        allow_headers=['*'],
-    )
-    zmqlet = AsyncZmqlet(args, default_logger)
-    servicer = AsyncPrefetchCall(args, zmqlet)
+    def __init__(self, args: 'argparse.Namespace', logger: 'JinaLogger'):
+        self.args = args
+        self.logger = logger
+        self.zmqlet = AsyncZmqlet(args, default_logger)
+        self.servicer = AsyncPrefetchCall(args, self.zmqlet)
 
-    def error(reason, status_code):
+    def send_request(self, body: JinaRequestModel, endpoint: str = None):
+        """Send requests and receive the results
+        :param body: request model which has to be used when sending data to the Flow
+        :param endpoint: endpoint where the requests are sent
+
+        :return: async response generator
         """
-        Get the error code.
-
-        :param reason: content of error
-        :param status_code: status code
-        :return: error in JSON response
-        """
-        return JSONResponse(content={'reason': reason}, status_code=status_code)
-
-    @app.on_event('shutdown')
-    def _shutdown():
-        zmqlet.close()
-
-    @app.on_event('startup')
-    async def startup():
-        """Log the host information when start the server."""
-        default_logger.info(
-            f'''
-    Jina REST interface
-    💬 Swagger UI:\thttp://localhost:{args.port_expose}/docs
-    📚 Redoc     :\thttp://localhost:{args.port_expose}/redoc
-        '''
-        )
-        from jina import __ready_msg__
-
-        default_logger.success(__ready_msg__)
-
-    @app.get(
-        path='/status',
-        summary='Get the status of Jina',
-        response_model=JinaStatusModel,
-        tags=['Management'],
-    )
-    async def _status():
-        _info = get_full_version()
-        return {
-            'jina': _info[0],
-            'envs': _info[1],
-            'used_memory': used_memory_readable(),
-        }
-
-    @app.post(
-        path='/post/{endpoint:path}',
-        summary='Post a data request to some endpoint',
-        tags=['Data Request'],
-        response_model=JinaRequestModel,
-    )
-    async def post(endpoint: str, body: Optional[JinaRequestModel] = None):
-        """
-        Request mode service and return results in JSON, a deprecated interface.
-
-        :param endpoint: the executor endpoint
-        :param body: the Request body.
-        :return: Results in JSONresponse.
-        """
-
-        bd = body.dict() if body else {'data': None}
-        bd['exec_endpoint'] = endpoint
-        return StreamingResponse(
-            result_in_stream(request_generator(**bd)), media_type='application/json'
-        )
-
-    @app.post(
-        path='/index',
-        summary='Post a data request to `/index` endpoint',
-        tags=['Sugary CRUD'],
-        response_model=JinaIndexRequestModel,
-    )
-    async def index_api(body: JinaIndexRequestModel):
-        """
-        Index API to index documents.
-
-        :param body: index request.
-        :return: Response of the results.
-        """
-
         bd = body.dict()
-        return StreamingResponse(
-            result_in_stream(request_generator(**bd)), media_type='application/json'
-        )
+        if endpoint:
+            bd['exec_endpoint'] = endpoint
+        return self.call_servicer(request_generator(**bd))
 
-    @app.post(
-        path='/search',
-        summary='Post a data request to `/search` endpoint',
-        tags=['Sugary CRUD'],
-        response_model=JinaSearchRequestModel,
-    )
-    async def search_api(body: JinaSearchRequestModel):
-        """
-        Search API to search documents.
+    def _generate_response(self, body: JinaRequestModel, endpoint: str = None):
+        with ImportExtensions(required=True):
+            from starlette.responses import StreamingResponse
+        response = self.send_request(body, endpoint)
+        json_responses = self.convert_to_json(response)
+        return StreamingResponse(json_responses, media_type='application/json')
 
-        :param body: search request.
-        :return: Response of the results.
-        """
-
-        bd = body.dict()
-        return StreamingResponse(
-            result_in_stream(request_generator(**bd)), media_type='application/json'
-        )
-
-    @app.put(
-        path='/update',
-        summary='Post a data request to `/update` endpoint',
-        tags=['Sugary CRUD'],
-        response_model=JinaUpdateRequestModel,
-    )
-    async def update_api(body: JinaUpdateRequestModel):
-        """
-        Update API to update documents.
-
-        :param body: update request.
-        :return: Response of the results.
-        """
-
-        bd = body.dict()
-        return StreamingResponse(
-            result_in_stream(request_generator(**bd)), media_type='application/json'
-        )
-
-    @app.delete(
-        path='/delete',
-        summary='Post a data request to `/delete` endpoint',
-        tags=['Sugary CRUD'],
-        response_model=JinaDeleteRequestModel,
-    )
-    async def delete_api(body: JinaDeleteRequestModel):
-        """
-        Delete API to delete documents.
-
-        :param body: delete request.
-        :return: Response of the results.
-        """
-
-        bd = body.dict()
-        return StreamingResponse(
-            result_in_stream(request_generator(**bd)), media_type='application/json'
-        )
-
-    async def result_in_stream(req_iter):
+    async def call_servicer(self, req_iter):
         """
         Streams results from AsyncPrefetchCall as json
 
         :param req_iter: request iterator
         :yield: result
         """
-        async for k in servicer.Call(request_iterator=req_iter, context=None):
+        async for k in self.servicer.Call(request_iterator=req_iter, context=None):
+            yield k
+
+    async def convert_to_json(self, req_iter):
+        """
+        Streams results from AsyncPrefetchCall as json
+
+        :param req_iter: request iterator
+        :yield: result
+        """
+        async for k in req_iter:
             yield MessageToJson(
                 k,
-                including_default_value_fields=args.including_default_value_fields,
+                including_default_value_fields=self.args.including_default_value_fields,
                 preserving_proto_field_name=True,
-                sort_keys=args.sort_keys,
-                use_integers_for_enums=args.use_integers_for_enums,
-                float_precision=args.float_precision,
+                sort_keys=self.args.sort_keys,
+                use_integers_for_enums=self.args.use_integers_for_enums,
+                float_precision=self.args.float_precision,
             )
 
-    @app.websocket_route(path='/stream')
-    class StreamingEndpoint(WebSocketEndpoint):
+    def get_fastapi_app(self):
         """
-        :meth:`handle_receive()`
-            Await a message on :meth:`websocket.receive()`
-            Send the message to zmqlet via :meth:`zmqlet.send_message()` and await
-        :meth:`handle_send()`
-            Await a message on :meth:`zmqlet.recv_message()`
-            Send the message back to client via :meth:`websocket.send()` and await
-        :meth:`dispatch()`
-            Awaits on concurrent tasks :meth:`handle_receive()` & :meth:`handle_send()`
-            This makes sure gateway is nonblocking
-        Await exit strategy:
-            :meth:`handle_receive()` keeps track of num_requests received
-            :meth:`handle_send()` keeps track of num_responses sent
-            Client sends a final message: `bytes(True)` to indicate request iterator is empty
-            Server exits out of await when `(num_requests == num_responses != 0 and is_req_empty)`
+        Get the default fastapi app
+
+        :return: FastAPI app
         """
-
-        encoding = None
-
-        def __init__(self, scope: 'Scope', receive: 'Receive', send: 'Send') -> None:
-            super().__init__(scope, receive, send)
-            self.args = args
-            self.name = args.name or self.__class__.__name__
-            self._id = random_identity()
-            self.client_encoding = None
-
-        async def dispatch(self) -> None:
-            """Awaits on concurrent tasks :meth:`handle_receive()` & :meth:`handle_send()`"""
-            websocket = WebSocket(self.scope, receive=self.receive, send=self.send)
-            await self.on_connect(websocket)
-            close_code = status.WS_1000_NORMAL_CLOSURE
-
-            await asyncio.gather(
-                self.handle_receive(websocket=websocket, close_code=close_code),
+        with ImportExtensions(required=True):
+            from fastapi import FastAPI, WebSocket
+            from fastapi.responses import JSONResponse
+            from fastapi.middleware.cors import CORSMiddleware
+            from starlette.endpoints import WebSocketEndpoint
+            from starlette import status
+            from starlette.types import Receive, Scope, Send
+            from .models import (
+                JinaStatusModel,
+                JinaIndexRequestModel,
+                JinaDeleteRequestModel,
+                JinaUpdateRequestModel,
+                JinaSearchRequestModel,
+                JinaRequestModel,
             )
 
-        async def on_connect(self, websocket: WebSocket) -> None:
-            """
-            Await the websocket to accept and log the information.
+        app = FastAPI(
+            title='Jina',
+            description='REST interface for Jina',
+            version=__version__,
+        )
 
-            :param websocket: connected websocket
-            """
-            # TODO(Deepankar): To enable multiple concurrent clients,
-            # Register each client - https://fastapi.tiangolo.com/advanced/websockets/#handling-disconnections-and-multiple-clients
-            # And move class variables to instance variable
-            await websocket.accept()
-            self.client_info = f'{websocket.client.host}:{websocket.client.port}'
-            logger.success(
-                f'Client {self.client_info} connected to stream requests via websockets'
+        @app.on_event('shutdown')
+        def _shutdown():
+            self.zmqlet.close()
+
+        @app.on_event('startup')
+        async def startup():
+            """Log the host information when start the server."""
+            default_logger.info(
+                f'''
+    Jina REST interface
+    💬 Swagger UI:\thttp://localhost:{self.args.port_expose}/docs
+    📚 Redoc     :\thttp://localhost:{self.args.port_expose}/redoc
+                '''
+            )
+            from jina import __ready_msg__
+
+            default_logger.success(__ready_msg__)
+
+        @app.get(
+            path='/status',
+            summary='Get the status of Jina',
+            response_model=JinaStatusModel,
+            tags=['Management'],
+        )
+        async def _status():
+            _info = get_full_version()
+            return {
+                'jina': _info[0],
+                'envs': _info[1],
+                'used_memory': used_memory_readable(),
+            }
+
+        if self.args.use_default_endpoints:
+            app.add_middleware(
+                CORSMiddleware,
+                allow_origins=['*'],
+                allow_credentials=True,
+                allow_methods=['*'],
+                allow_headers=['*'],
             )
 
-        async def handle_receive(self, websocket: WebSocket, close_code: int) -> None:
-            """
-            Await a message on :meth:`websocket.receive()`
-            Send the message to zmqlet via :meth:`zmqlet.send_message()` and await
-
-            :param websocket: WebSocket connection between clinet sand server.
-            :param close_code: close code
-            """
-
-            def handle_route(msg: 'Message') -> 'Request':
+            def error(reason, status_code):
                 """
-                Add route information to `message`.
+                Get the error code.
 
-                :param msg: receive message
-                :return: message response with route information
+                :param reason: content of error
+                :param status_code: status code
+                :return: error in JSON response
                 """
-                msg.add_route(self.name, self._id)
-                return msg.response
+                return JSONResponse(content={'reason': reason}, status_code=status_code)
 
-            try:
-                while True:
-                    message = await websocket.receive()
-                    if message['type'] == 'websocket.receive':
-                        data = await self.decode(websocket, message)
-                        if data == bytes(True):
-                            await asyncio.sleep(0.1)
-                            continue
-                        await zmqlet.send_message(
-                            Message(None, Request(data), 'gateway', **vars(self.args))
-                        )
-                        response = await zmqlet.recv_message(callback=handle_route)
-                        if self.client_encoding == 'bytes':
-                            await websocket.send_bytes(response.SerializeToString())
-                        else:
-                            await websocket.send_json(response.json())
-                    elif message['type'] == 'websocket.disconnect':
-                        close_code = int(
-                            message.get('code', status.WS_1000_NORMAL_CLOSURE)
-                        )
-                        break
-            except Exception as exc:
-                close_code = status.WS_1011_INTERNAL_ERROR
-                logger.error(f'Got an exception in handle_receive: {exc!r}')
-                raise
-            finally:
-                await self.on_disconnect(websocket, close_code)
+            @app.post(
+                path='/post/{endpoint:path}',
+                summary='Post a data request to some endpoint',
+                tags=['Data Request'],
+                response_model=JinaRequestModel,
+            )
+            async def post(endpoint: str, body: JinaRequestModel):
+                """
+                Request mode service and return results in JSON, a deprecated interface.
 
-        async def decode(self, websocket: WebSocket, message: Message) -> Any:
+                :param endpoint: the executor endpoint
+                :param body: the Request body.
+                :return: Results in JSONresponse.
+                """
+
+                return self._generate_response(body, endpoint)
+
+            @app.post(
+                path='/index',
+                summary='Post a data request to `/index` endpoint',
+                tags=['Sugary CRUD'],
+                response_model=JinaIndexRequestModel,
+            )
+            async def index_api(body: JinaIndexRequestModel):
+                """
+                Index API to index documents.
+
+                :param body: index request.
+                :return: Response of the results.
+                """
+
+                return self._generate_response(body)
+
+            @app.post(
+                path='/search',
+                summary='Post a data request to `/search` endpoint',
+                tags=['Sugary CRUD'],
+                response_model=JinaSearchRequestModel,
+            )
+            async def search_api(body: JinaSearchRequestModel):
+                """
+                Search API to search documents.
+
+                :param body: search request.
+                :return: Response of the results.
+                """
+
+                return self._generate_response(body)
+
+            @app.put(
+                path='/update',
+                summary='Post a data request to `/update` endpoint',
+                tags=['Sugary CRUD'],
+                response_model=JinaUpdateRequestModel,
+            )
+            async def update_api(body: JinaUpdateRequestModel):
+                """
+                Update API to update documents.
+
+                :param body: update request.
+                :return: Response of the results.
+                """
+
+                return self._generate_response(body)
+
+            @app.delete(
+                path='/delete',
+                summary='Post a data request to `/delete` endpoint',
+                tags=['Sugary CRUD'],
+                response_model=JinaDeleteRequestModel,
+            )
+            async def delete_api(body: JinaDeleteRequestModel):
+                """
+                Delete API to delete documents.
+
+                :param body: delete request.
+                :return: Response of the results.
+                """
+
+                return self._generate_response(body)
+
+        logger = self.logger
+        zmqlet = self.zmqlet
+
+        @app.websocket_route(path='/stream')
+        class StreamingEndpoint(WebSocketEndpoint):
             """
-            Decode the text or bytes format `message`
-
-            :param websocket: WebSocket connection.
-            :param message: Jina `Message`.
-            :return: decoded message.
+            :meth:`handle_receive()`
+                Await a message on :meth:`websocket.receive()`
+                Send the message to zmqlet via :meth:`zmqlet.send_message()` and await
+            :meth:`handle_send()`
+                Await a message on :meth:`zmqlet.recv_message()`
+                Send the message back to client via :meth:`websocket.send()` and await
+            :meth:`dispatch()`
+                Awaits on concurrent tasks :meth:`handle_receive()` & :meth:`handle_send()`
+                This makes sure gateway is nonblocking
+            Await exit strategy:
+                :meth:`handle_receive()` keeps track of num_requests received
+                :meth:`handle_send()` keeps track of num_responses sent
+                Client sends a final message: `bytes(True)` to indicate request iterator is empty
+                Server exits out of await when `(num_requests == num_responses != 0 and is_req_empty)`
             """
-            if 'text' in message or 'json' in message:
-                self.client_encoding = 'text'
 
-            if 'bytes' in message:
-                self.client_encoding = 'bytes'
+            encoding = None
 
-            return await super().decode(websocket, message)
+            def __init__(
+                self, scope: 'Scope', receive: 'Receive', send: 'Send'
+            ) -> None:
+                super().__init__(scope, receive, send)
+                self.args = self.args
+                self.name = self.args.name or self.__class__.__name__
+                self._id = random_identity()
+                self.client_encoding = None
 
-        async def on_disconnect(self, websocket: WebSocket, close_code: int) -> None:
-            """
-            Log the information when client is disconnected.
+            async def dispatch(self) -> None:
+                """Awaits on concurrent tasks :meth:`handle_receive()` & :meth:`handle_send()`"""
+                websocket = WebSocket(self.scope, receive=self.receive, send=self.send)
+                await self.on_connect(websocket)
+                close_code = status.WS_1000_NORMAL_CLOSURE
 
-            :param websocket: disconnected websocket
-            :param close_code: close code
-            """
-            logger.info(f'Client {self.client_info} got disconnected!')
+                await asyncio.gather(
+                    self.handle_receive(websocket=websocket, close_code=close_code),
+                )
 
-    return app
+            async def on_connect(self, websocket: WebSocket) -> None:
+                """
+                Await the websocket to accept and log the information.
+
+                :param websocket: connected websocket
+                """
+                # TODO(Deepankar): To enable multiple concurrent clients,
+                # Register each client - https://fastapi.tiangolo.com/advanced/websockets/#handling-disconnections-and-multiple-clients
+                # And move class variables to instance variable
+                await websocket.accept()
+                self.client_info = f'{websocket.client.host}:{websocket.client.port}'
+                logger.success(
+                    f'Client {self.client_info} connected to stream requests via websockets'
+                )
+
+            async def handle_receive(
+                self, websocket: WebSocket, close_code: int
+            ) -> None:
+                """
+                Await a message on :meth:`websocket.receive()`
+                Send the message to zmqlet via :meth:`zmqlet.send_message()` and await
+
+                :param websocket: WebSocket connection between clinet sand server.
+                :param close_code: close code
+                """
+
+                def handle_route(msg: 'Message') -> 'Request':
+                    """
+                    Add route information to `message`.
+
+                    :param msg: receive message
+                    :return: message response with route information
+                    """
+                    msg.add_route(self.name, self._id)
+                    return msg.response
+
+                try:
+                    while True:
+                        message = await websocket.receive()
+                        if message['type'] == 'websocket.receive':
+                            data = await self.decode(websocket, message)
+                            if data == bytes(True):
+                                await asyncio.sleep(0.1)
+                                continue
+                            await zmqlet.send_message(
+                                Message(
+                                    None, Request(data), 'gateway', **vars(self.args)
+                                )
+                            )
+                            response = await zmqlet.recv_message(callback=handle_route)
+                            if self.client_encoding == 'bytes':
+                                await websocket.send_bytes(response.SerializeToString())
+                            else:
+                                await websocket.send_json(response.json())
+                        elif message['type'] == 'websocket.disconnect':
+                            close_code = int(
+                                message.get('code', status.WS_1000_NORMAL_CLOSURE)
+                            )
+                            break
+                except Exception as exc:
+                    close_code = status.WS_1011_INTERNAL_ERROR
+                    logger.error(f'Got an exception in handle_receive: {exc!r}')
+                    raise
+                finally:
+                    await self.on_disconnect(websocket, close_code)
+
+            async def decode(self, websocket: WebSocket, message: Message) -> Any:
+                """
+                Decode the text or bytes format `message`
+
+                :param websocket: WebSocket connection.
+                :param message: Jina `Message`.
+                :return: decoded message.
+                """
+                if 'text' in message or 'json' in message:
+                    self.client_encoding = 'text'
+
+                if 'bytes' in message:
+                    self.client_encoding = 'bytes'
+
+                return await super().decode(websocket, message)
+
+            async def on_disconnect(
+                self, websocket: WebSocket, close_code: int
+            ) -> None:
+                """
+                Log the information when client is disconnected.
+
+                :param websocket: disconnected websocket
+                :param close_code: close code
+                """
+                logger.info(f'Client {self.client_info} got disconnected!')
+
+        return app

--- a/tests/unit/test_extend_fastapi.py
+++ b/tests/unit/test_extend_fastapi.py
@@ -1,7 +1,12 @@
+import json
+
 import requests
+from pydantic import BaseModel
+from starlette.responses import StreamingResponse
 
 import jina.helper
 from jina import Flow
+from jina.peapods.runtimes.asyncio.rest.models import JinaRequestModel
 
 
 def test_extend_fastapi():
@@ -19,3 +24,46 @@ def test_extend_fastapi():
         response = requests.get(f'http://localhost:{f.port_expose}/hello')
         assert response.status_code == 200
         assert response.json() == {'msg': 'hello world'}
+
+
+def test_extend_fastapi_send_documents():
+    class CustomRequestModel(BaseModel):
+        custom_request_attribute: str
+
+    class CustomResponseModel(BaseModel):
+        custom_response_attribute: str
+
+    def map_request(request):
+        return JinaRequestModel(data=[request.custom_request_attribute])
+
+    async def map_response(search_resp):
+        async for x in search_resp:
+            yield json.dumps(
+                CustomResponseModel(
+                    custom_response_attribute=x.data.docs[0].text
+                ).dict()
+            )
+
+    def extend_rest_function(app, send_request):
+        @app.post(
+            path='/hello_flow',
+            response_model=CustomResponseModel,
+        )
+        async def search_docs(body: CustomRequestModel):
+            search_req = map_request(body)
+            search_resp = send_request(search_req, 'hello_flow')
+            final_response = map_response(search_resp)
+            return StreamingResponse(final_response, media_type='application/json')
+
+        return app
+
+    jina.helper.extend_rest_interface = extend_rest_function
+    f = Flow(restful=True)
+
+    with f:
+        response = requests.post(
+            f'http://localhost:{f.port_expose}/hello_flow',
+            json={'custom_request_attribute': 'example_text'},
+        )
+        assert response.status_code == 200
+        assert response.json() == {'custom_response_attribute': 'example_text'}


### PR DESCRIPTION
Currently, it is possible to have custom endpoints by using the `extend_rest_interface` method.
However, it is not possible to setup endpoints which have custom logic but sending requests through the flow as well.
This implementation aims to solve this by providing `send_data` method in the `extend_rest_interface`.
It works now, but I have the feeling there must be a better way of doing it.

custom request and response model.
![image](https://user-images.githubusercontent.com/11627845/121824245-147ad400-ccab-11eb-940c-b5d619b135ed.png)
