### PR TITLE
refactor: remove unused property in indexer

### DIFF
--- a/jina/helloworld/multimodal/my_executors.py
+++ b/jina/helloworld/multimodal/my_executors.py
@@ -246,12 +246,6 @@ class KeyValueIndexer(Executor):
         super().__init__(*args, **kwargs)
         self._docs = DocumentArrayMemmap(self.workspace + '/kv-idx')
 
-    @property
-    def save_path(self):
-        if not os.path.exists(self.workspace):
-            os.makedirs(self.workspace)
-        return os.path.join(self.workspace, 'kv.json')
-
     @requests(on='/index')
     def index(self, docs: DocumentArray, **kwargs):
         self._docs.extend(docs)


### PR DESCRIPTION
found this unused property when pairing with @niuzs-alan , since now we start to use `DocumentArrayMemmap`.