### PR TITLE
feat(daemon): expose rolling update for flow

### DIFF
--- a/daemon/stores/partial.py
+++ b/daemon/stores/partial.py
@@ -112,9 +112,7 @@ class PartialFlowStore(PartialStore):
             if kind == UpdateOperation.ROLLING_UPDATE:
                 self.object.rolling_update(pod_name=pod_name, dump_path=dump_path)
             elif kind == UpdateOperation.DUMP:
-                raise NotImplementedError(
-                    f' sending post request does not work because asyncio loop is occupied'
-                )
+                self.object.dump(pod_name=pod_name, dump_path=dump_path, shards=shards)
         except Exception as e:
             self._logger.error(f'{e!r}')
             raise

--- a/daemon/stores/partial.py
+++ b/daemon/stores/partial.py
@@ -107,7 +107,21 @@ class PartialFlowStore(PartialStore):
             self._logger.success(f'{colored(id, "cyan")} is created')
             return self.item
 
-    def update(self, kind, dump_path, pod_name, shards, **kwargs) -> PartialFlowItem:
+    def update(
+        self,
+        kind: UpdateOperation,
+        dump_path: str,
+        pod_name: str,
+        shards: int,
+        **kwargs,
+    ) -> PartialFlowItem:
+        """Runs an update operation on the Flow.
+        :param kind: type of update command to execute (dump/rolling_update)
+        :param dump_path: the path to which to dump on disk
+        :param pod_name: pod to target with the dump request
+        :param shards: nr of shards to dump for
+        :return: Item describing the Flow object
+        """
         try:
             if kind == UpdateOperation.ROLLING_UPDATE:
                 self.object.rolling_update(pod_name=pod_name, dump_path=dump_path)


### PR DESCRIPTION
This exposes the dump/rolling_update commands on a flow via jinad api.

This depends on this PR: https://github.com/jina-ai/jina/pull/2657 - This one is actually against master, maybe we change it to daemon-2.0 as well? Otherwise this PR will be incomplete until we merge with master.

I did not add any tests yet as they would fail until we have the master changes anyway.
Also there is an existing test case for this: https://github.com/jina-ai/jina/blob/master/tests/distributed/test_remote_flow_dump_rolling_update/test_dump_dbms_remote.py
