### PR TITLE
fix: rolling update test

### DIFF
--- a/daemon/models/workspaces.py
+++ b/daemon/models/workspaces.py
@@ -1,5 +1,5 @@
 from ipaddress import IPv4Address
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Set
 from pydantic import BaseModel, Field
 
 from .id import DaemonID
@@ -19,6 +19,7 @@ class WorkspaceMetadata(BaseModel):
     network: str
     workdir: str
     container_id: Optional[str]
+    managed_objects: Set[DaemonID] = Field(default_factory=set)
 
 
 class WorkspaceItem(StoreItem):

--- a/daemon/stores/containers.py
+++ b/daemon/stores/containers.py
@@ -116,6 +116,8 @@ class ContainerStore(BaseStore):
             self._logger.success(
                 f'{colored(id, "green")} is added to workspace {colored(workspace_id, "green")}'
             )
+
+            workspace_store[workspace_id].metadata.managed_objects.add(id)
             return id
 
     @BaseStore.dump
@@ -123,5 +125,9 @@ class ContainerStore(BaseStore):
         if id not in self:
             raise KeyError(f'{colored(id, "red")} not found in store.')
         Dockerizer.rm_container(id=self[id].metadata.container_id)
+        workspace_id = self[id].workspace_id
         del self[id]
+        from . import workspace_store
+
+        workspace_store[workspace_id].metadata.managed_objects.remove(id)
         self._logger.success(f'{colored(id, "green")} is released from the store.')

--- a/daemon/stores/workspaces.py
+++ b/daemon/stores/workspaces.py
@@ -131,6 +131,14 @@ class WorkspaceStore(BaseStore):
         if id not in self:
             raise KeyError(f'{colored(str(id), "cyan")} not found in store.')
 
+        # Peas/Pods/Flows need to be deleted before networks, files etc can be deleted
+        if everything:
+            from . import get_store_from_id
+
+            ids_to_delete = list(self[id].metadata.managed_objects)
+            for managed_object in ids_to_delete:
+                get_store_from_id(managed_object).delete(id=managed_object)
+
         if container:
             self.rm_container(id)
         if network:

--- a/tests/distributed/helpers.py
+++ b/tests/distributed/helpers.py
@@ -125,3 +125,11 @@ def create_flow(
     print(f'Checking if the flow creation is succeeded: {r.json()}')
     assert r.status_code == 201
     return r.json()
+
+
+def container_ip(container_name: str) -> str:
+    import docker
+
+    client = docker.from_env()
+    container = client.containers.get(container_name)
+    return container.attrs['NetworkSettings']['Networks']['jina_default']['IPAddress']

--- a/tests/distributed/test_remote_flow_dump_rolling_update/docker-compose.yml
+++ b/tests/distributed/test_remote_flow_dump_rolling_update/docker-compose.yml
@@ -2,13 +2,18 @@ version: "3.3"
 services:
   jinad:
     image: test_remote_flow_dump_reload
+    container_name: test_remote_flow_dump_reload
+    command: --store
     build:
       context: .
       dockerfile: Dockerfiles/debianx.Dockerfile
     ports:
       - "8001:8000"
-      - "9000:9000"
-      - "9001:9001"
       - "45678:45678"
     expose:
       - 10000-60000
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - /tmp/jinad:/tmp/jinad
+    extra_hosts:
+      - "host.docker.internal:host-gateway"

--- a/tests/distributed/test_remote_flow_dump_rolling_update/pods/indexer_query.yml
+++ b/tests/distributed/test_remote_flow_dump_rolling_update/pods/indexer_query.yml
@@ -1,6 +1,6 @@
 jtype: CompoundQueryExecutor
 with:
-  dump_path: /tmp/dump # TEMPORARY SOLUTION UNTIL WE FIND HOW TO RESTART WITH DUMP_PATH
+  dump_path: /workspace/dump # TEMPORARY SOLUTION UNTIL WE FIND HOW TO RESTART WITH DUMP_PATH
 metas:
   name: compound_indexer
   workspace: workspace_query


### PR DESCRIPTION
This PR fixes two things in daemon 2.0:

- Delete flow/pod/pea when workspaces are deleted
- Adjust the existing integration test for rolling update so that it passes with all the changes. (tests/distributed/test_remote_flow_dump_rolling_update/)