### PR TITLE
docs: cleanup readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Copy-paste the minimum example below and run it:
 import numpy as np
 from jina import Document, DocumentArray, Executor, Flow, requests
 
+
 class CharEmbed(Executor):  # a simple character embedding with mean-pooling
     offset = 32  # letter `a`
     dim = 127 - offset + 1  # last pos reserved for `UNK`
@@ -100,28 +101,48 @@ class CharEmbed(Executor):  # a simple character embedding with mean-pooling
     @requests
     def foo(self, docs: DocumentArray, **kwargs):
         for d in docs:
-            r_emb = [ord(c) - self.offset if self.offset <= ord(c) <= 127 else (self.dim - 1) for c in d.text]
+            r_emb = [
+                ord(c) - self.offset if self.offset <= ord(c) <= 127 else (self.dim - 1)
+                for c in d.text
+            ]
             d.embedding = self.char_embd[r_emb, :].mean(axis=0)  # average pooling
+
 
 class Indexer(Executor):
     _docs = DocumentArray()  # for storing all documents in memory
 
-    @requests(on='/index')
+    @requests(on="/index")
     def foo(self, docs: DocumentArray, **kwargs):
         self._docs.extend(docs)  # extend stored `docs`
 
-    @requests(on='/search')
+    @requests(on="/search")
     def bar(self, docs: DocumentArray, **kwargs):
-        q = np.stack(docs.get_attributes('embedding'))  # get all embeddings from query docs
-        d = np.stack(self._docs.get_attributes('embedding'))  # get all embeddings from stored docs
-        euclidean_dist = np.linalg.norm(q[:, None, :] - d[None, :, :], axis=-1)  # pairwise euclidean distance
+        q = np.stack(
+            docs.get_attributes("embedding")
+        )  # get all embeddings from query docs
+        d = np.stack(
+            self._docs.get_attributes("embedding")
+        )  # get all embeddings from stored docs
+        euclidean_dist = np.linalg.norm(
+            q[:, None, :] - d[None, :, :], axis=-1
+        )  # pairwise euclidean distance
         for dist, query in zip(euclidean_dist, docs):  # add & sort match
-            query.matches = [Document(self._docs[int(idx)], copy=True, score=d) for idx, d in enumerate(dist)]
-            query.matches.sort(key=lambda m: m.score.value)  # sort matches by their values
+            query.matches = [
+                Document(self._docs[int(idx)], copy=True, score=d)
+                for idx, d in enumerate(dist)
+            ]
+            query.matches.sort(
+                key=lambda m: m.score.value
+            )  # sort matches by their values
 
-f = Flow(port_expose=12345).add(uses=CharEmbed, parallel=2).add(uses=Indexer)  # build a Flow, with 2 parallel CharEmbed, tho unnecessary
+
+f = (
+    Flow(port_expose=12345).add(uses=CharEmbed, parallel=2).add(uses=Indexer)
+)  # build a Flow, with 2 parallel CharEmbed, tho unnecessary
 with f:
-    f.post('/index', (Document(text=t.strip()) for t in open(__file__) if t.strip()))  # index all lines of this file
+    f.post(
+        "/index", (Document(text=t.strip()) for t in open(__file__) if t.strip())
+    )  # index all lines of this file
     f.block()  # block for listening request
 ```
 

--- a/README.md
+++ b/README.md
@@ -117,32 +117,32 @@ class Indexer(Executor):
 
     @requests(on="/search")
     def bar(self, docs: DocumentArray, **kwargs):
-        q = np.stack(
-            docs.get_attributes("embedding")
-        )  # get all embeddings from query docs
-        d = np.stack(
-            self._docs.get_attributes("embedding")
-        )  # get all embeddings from stored docs
-        euclidean_dist = np.linalg.norm(
-            q[:, None, :] - d[None, :, :], axis=-1
-        )  # pairwise euclidean distance
-        for dist, query in zip(euclidean_dist, docs):  # add & sort match
+        # get all embeddings from query docs
+        q = np.stack(docs.get_attributes("embedding"))
+
+        # get all embeddings from stored docs
+        d = np.stack(self._docs.get_attributes("embedding"))
+
+        # pairwise euclidean distance
+        euclidean_dist = np.linalg.norm(q[:, None, :] - d[None, :, :], axis=-1)
+
+        # add & sort match
+        for dist, query in zip(euclidean_dist, docs):
             query.matches = [
                 Document(self._docs[int(idx)], copy=True, score=d)
                 for idx, d in enumerate(dist)
             ]
-            query.matches.sort(
-                key=lambda m: m.score.value
-            )  # sort matches by their values
+
+            # sort matches by their values
+            query.matches.sort(key=lambda m: m.score.value)
 
 
-f = (
-    Flow(port_expose=12345).add(uses=CharEmbed, parallel=2).add(uses=Indexer)
-)  # build a Flow, with 2 parallel CharEmbed, tho unnecessary
+# build a Flow, with 2 parallel CharEmbed, tho unnecessary
+f = Flow(port_expose=12345).add(uses=CharEmbed, parallel=2).add(uses=Indexer)
+
+# index all lines of this file
 with f:
-    f.post(
-        "/index", (Document(text=t.strip()) for t in open(__file__) if t.strip())
-    )  # index all lines of this file
+    f.post("/index", (Document(text=t.strip()) for t in open(__file__) if t.strip()))
     f.block()  # block for listening request
 ```
 

--- a/README.md
+++ b/README.md
@@ -160,10 +160,9 @@ c.post('/search', Document(text='request(on=something)'), on_done=print_matches)
 It finds the lines most similar to "`request(on=something)`" from the server code snippet and prints the following:  
 
 ```text
-         Client@1608[S]:connected to the gateway at localhost:12345!
-[0]0.168526: "@requests(on='/index')"
-[1]0.181676: "@requests(on='/search')"
-[2]0.192049: "query.matches = [Document(self._docs[int(idx)], copy=True, score=d) for idx, d in enumerate(dist)]"
+[0]0.168526: "@requests(on="/index")"
+[1]0.181676: "@requests(on="/search")"
+[2]0.187047: "q = np.stack(docs.get_attributes("embedding"))"
 ```
 <sup>😔 Doesn't work? Our bad! <a href="https://github.com/jina-ai/jina/issues/new?assignees=&labels=kind%2Fbug&template=---found-a-bug-and-i-solved-it.md&title=">Please report it here.</a></sup>
 


### PR DESCRIPTION
The example code in the README requires horizontal scrolling. This PR limits the line length so that all code is shown. I also simplified the example.

NB This PR should not be merged as-is, because `CharEmbed` (which this PR changes to `StringEmbed` is shown in a graphic above the code example.