### PR TITLE
Ci latency tracking zerodivisionerror

### DIFF
--- a/.github/workflows/latency-tracking.yml
+++ b/.github/workflows/latency-tracking.yml
@@ -1,11 +1,11 @@
 name: CI
 
-on:
- pull_request_target:
 # on:
-#   push:
-#     branches-ignore:
-#       - '**'  # temporally ignore all
+#  pull_request_target:
+on:
+  push:
+    branches-ignore:
+      - '**'  # temporally ignore all
 
 jobs:
   latency-tracking:

--- a/.github/workflows/latency-tracking.yml
+++ b/.github/workflows/latency-tracking.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: 3.7
-      - name: Run current latency vs. last 3 versions
+      - name: Run current latency vs. last ${{ env.NUM_LAST_RELEASE }} versions
         run: |
           sudo apt-get install jq
           cd latency

--- a/.github/workflows/latency-tracking.yml
+++ b/.github/workflows/latency-tracking.yml
@@ -2,10 +2,12 @@ name: CI
 
 # on:
 #  pull_request_target:
+# on:
+#   push:
+#     branches-ignore:
+#       - '**'  # temporally ignore all
 on:
-  push:
-    branches-ignore:
-      - '**'  # temporally ignore all
+  workflow_dispatch:
 
 jobs:
   latency-tracking:


### PR DESCRIPTION
let's ignore the tracking temporally to avoid the delay for core's pr.
Then I shall fix the`ZeroDivsionError` immediately and open the tracking again.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1200479679796904/1200497144939499) by [Unito](https://www.unito.io)
