### PR TITLE
feat: add helper for getting parameter from req to executor

### DIFF
--- a/jina/helper.py
+++ b/jina/helper.py
@@ -1217,3 +1217,18 @@ def get_ci_vendor() -> Optional[str]:
                 for k in c['env']:
                     if k in os.environ:
                         return c['constant']
+
+
+def get_request_executor_parameter(parameters, exec_name, param_key):
+    """get request parameters, first by executor.metas.name, then by parameter key
+
+    :param parameters: the dictionary with the parameters
+    :param exec_name: the name of the executor
+    :param param_key: the key we want
+    :return: the value of the param_key
+    """
+    root = parameters
+    if exec_name:
+        root = parameters.get(exec_name, {})
+    v = root.get(param_key, parameters.get(param_key, None))
+    return v

--- a/tests/unit/test_helper.py
+++ b/tests/unit/test_helper.py
@@ -19,6 +19,7 @@ from jina.helper import (
     find_request_binding,
     dunder_get,
     get_ci_vendor,
+    get_request_executor_parameter,
 )
 from jina.jaml.helper import complete_path
 from jina.logging.predefined import default_logger
@@ -321,3 +322,14 @@ def test_find_request_binding():
 )
 def test_ci_vendor():
     assert get_ci_vendor() == 'GITHUB_ACTIONS'
+
+
+def test_get_request_executor_parameter():
+    params = {}
+    assert get_request_executor_parameter(params, None, 'some_key') is None
+
+    params = {'some_key': 2}
+    assert get_request_executor_parameter(params, None, 'some_key') == 2
+
+    params = {'some_key': 2, 'some_name': {'some_key': 3}}
+    assert get_request_executor_parameter(params, 'some_name', 'some_key') == 3


### PR DESCRIPTION
Helper method to retrieve either param or executor.metas.name.param from a parameters Dict in an endpoint



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1200479679796904/1200500170751991) by [Unito](https://www.unito.io)
