### PR TITLE
fix: update cache after del

### DIFF
--- a/jina/types/arrays/document.py
+++ b/jina/types/arrays/document.py
@@ -46,7 +46,7 @@ if False:
 
 
 class DocumentArrayGetAttrMixin:
-    """A mixin that provides attributes getter in bulk """
+    """A mixin that provides attributes getter in bulk"""
 
     @abstractmethod
     def __iter__(self):
@@ -170,6 +170,7 @@ class DocumentArray(
             del self._pb_body[index]
         elif isinstance(index, str):
             del self[self._id_to_index[index]]
+            del self._id_to_index[index]
         elif isinstance(index, slice):
             del self._pb_body[index]
         else:
@@ -239,8 +240,9 @@ class DocumentArray(
 
     def clear(self):
         """Clear the data of :class:`DocumentArray`"""
-        while len(self._pb_body) > 0:
-            self._pb_body.pop()
+        for item in self._pb_body:
+            del self._id_to_index[item.id]
+            self._pb_body.remove(item)
 
     def reverse(self):
         """In-place reverse the sequence."""

--- a/jina/types/arrays/document.py
+++ b/jina/types/arrays/document.py
@@ -170,7 +170,6 @@ class DocumentArray(
             del self._pb_body[index]
         elif isinstance(index, str):
             del self[self._id_to_index[index]]
-            del self._id_to_index[index]
         elif isinstance(index, slice):
             del self._pb_body[index]
         else:
@@ -240,9 +239,9 @@ class DocumentArray(
 
     def clear(self):
         """Clear the data of :class:`DocumentArray`"""
-        for item in self._pb_body:
-            del self._id_to_index[item.id]
-            self._pb_body.remove(item)
+        while len(self._pb_body) > 0:
+            self._pb_body.pop()
+        self._id_to_index.clear()
 
     def reverse(self):
         """In-place reverse the sequence."""

--- a/tests/unit/types/arrays/test_documentarray.py
+++ b/tests/unit/types/arrays/test_documentarray.py
@@ -315,3 +315,19 @@ def test_da_sort_by_score():
     da.sort(key=lambda d: d.scores['euclid'].value)  # sort matches by their values
     assert da[0].id == '9'
     assert da[0].scores['euclid'].value == 1
+
+
+def test_da_contains():
+    da = DocumentArray()
+    d1 = Document(id=1)
+    d2 = Document(id=2)
+    da.extend([d1, d2])
+    assert d1.id in da
+    assert d2.id in da
+    da.clear()
+    assert d1.id not in da
+    da.extend([d1, d2])
+    del da[0]
+    assert d1.id not in da
+    del da['2']
+    assert d2.id not in da

--- a/tests/unit/types/arrays/test_documentarray.py
+++ b/tests/unit/types/arrays/test_documentarray.py
@@ -322,7 +322,6 @@ def test_da_contains():
     d1 = Document(id=1)
     d2 = Document(id='2')
     da.extend([d1, d2])
-    print(da._id_to_index)
     assert d1.id in da
     assert d2.id in da
     da.clear()

--- a/tests/unit/types/arrays/test_documentarray.py
+++ b/tests/unit/types/arrays/test_documentarray.py
@@ -320,14 +320,11 @@ def test_da_sort_by_score():
 def test_da_contains():
     da = DocumentArray()
     d1 = Document(id=1)
-    d2 = Document(id=2)
+    d2 = Document(id='2')
     da.extend([d1, d2])
+    print(da._id_to_index)
     assert d1.id in da
     assert d2.id in da
     da.clear()
     assert d1.id not in da
-    da.extend([d1, d2])
-    del da[0]
-    assert d1.id not in da
-    del da['2']
     assert d2.id not in da


### PR DESCRIPTION
`__contains__` logic in `document array` is heavily affected by `cached_property`. In this PR, want to raise the concern about the issue. `cached_property` has affected everything, such as `insert`, `add`, `iadd`, `del`, `append`, `extend` and `clear` (fixed in this PR). This makes the `contains` logic fragile.


```python
da = DocumentArray()
d1 = Document(id=1)
d2 = Document(id='2')
da.extend([d1, d2])
assert d1.id in da
assert d2.id in da
da.clear()
assert d1.id not in da
da.extend([d1, d2])
assert d1.id in da
assert d2.id in da
del da[0]
assert d1.id not in da
del da['2']
assert d2.id not in da
```


┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1200479679796904/1200501954355568) by [Unito](https://www.unito.io)
