### PR TITLE
feat: enforce trav paths being iterable of str

### DIFF
--- a/jina/types/arrays/traversable.py
+++ b/jina/types/arrays/traversable.py
@@ -2,6 +2,11 @@ import itertools
 from typing import Iterable
 
 
+def _check_traversal_path_type(traversal_paths):
+    if isinstance(traversal_paths, str):
+        raise ValueError('traversal_paths needs to be an Iterable[str]')
+
+
 class TraversableSequence:
     """
     A mixin used for traversing a `Sequence[Traversable]`.
@@ -28,6 +33,7 @@ class TraversableSequence:
             - [`r`, `c`]: docs in this TraversableSequence and all child-documents at granularity 1
 
         """
+        _check_traversal_path_type(traversal_paths)
 
         for p in traversal_paths:
             yield from self._traverse(self, p)
@@ -61,6 +67,8 @@ class TraversableSequence:
         :param traversal_paths: a list of string that represents the traversal path
         :yield: :class:``TraversableSequence`` containing the document of all leaves per path.
         """
+        _check_traversal_path_type(traversal_paths)
+
         for p in traversal_paths:
             yield self._flatten(self._traverse(self, p))
 
@@ -77,6 +85,8 @@ class TraversableSequence:
         :param traversal_paths: a list of string that represents the traversal path
         :return: a single :class:``TraversableSequence`` containing the document of all leaves when applying the traversal_paths.
         """
+        _check_traversal_path_type(traversal_paths)
+
         leaves = self.traverse(traversal_paths)
         return self._flatten(leaves)
 

--- a/tests/unit/types/arrays/test_documentarray.py
+++ b/tests/unit/types/arrays/test_documentarray.py
@@ -315,3 +315,23 @@ def test_da_sort_by_score():
     da.sort(key=lambda d: d.scores['euclid'].value)  # sort matches by their values
     assert da[0].id == '9'
     assert da[0].scores['euclid'].value == 1
+
+
+def test_traversal_path():
+    da = DocumentArray([Document() for _ in range(6)])
+    assert len(da) == 6
+
+    da.traverse_flat(['r'])
+
+    with pytest.raises(ValueError):
+        da.traverse_flat('r')
+
+    da.traverse(['r'])
+    with pytest.raises(ValueError):
+        for _ in da.traverse('r'):
+            pass
+
+    da.traverse(['r'])
+    with pytest.raises(ValueError):
+        for _ in da.traverse('r'):
+            pass

--- a/tests/unit/types/arrays/test_memmap.py
+++ b/tests/unit/types/arrays/test_memmap.py
@@ -73,7 +73,7 @@ def test_traverse(tmpdir, mocker):
     dam = DocumentArrayMemmap(tmpdir)
     dam.extend(random_docs(100))
     mock = mocker.Mock()
-    for c in dam.traverse_flat('c'):
+    for c in dam.traverse_flat(['c']):
         assert c.granularity == 1
         mock()
     mock.assert_called()


### PR DESCRIPTION
Consequence of discussion [here](https://jinaai.slack.com/archives/C0183GCN8AK/p1624358262177400)

We want to enforce `traversal_paths` always being `List[str]` and not `Union[List[str],str]`.

1. Easier to reason and catch
1. Easier to teach. New users don't need to understand both cases of traversing.
1. The type annotation is never actually checked, and it might fail silently, because you can traverse characters in a `str`



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1200479679796904/1200504913520864) by [Unito](https://www.unito.io)
