### PR TITLE
test: add unit tests for document generators

### DIFF
--- a/jina/types/document/generators.py
+++ b/jina/types/document/generators.py
@@ -88,14 +88,14 @@ def from_files(
 
 
 def from_csv(
-    fp: Iterable[str],
+    csv_file: Iterable[str],
     field_resolver: Optional[Dict[str, str]] = None,
     size: Optional[int] = None,
     sampling_rate: Optional[float] = None,
 ) -> Generator['Document', None, None]:
     """Generator function for CSV. Yields documents.
 
-    :param fp: file paths
+    :param csv_file: csv file descriptor object
     :param field_resolver: a map from field names defined in ``document`` (JSON, dict) to the field
             names defined in Protobuf. This is only used when the given ``document`` is
             a JSON string or a Python dict.
@@ -106,7 +106,7 @@ def from_csv(
     """
     from ..document import Document
 
-    lines = csv.DictReader(fp)
+    lines = csv.DictReader(csv_file)
     for value in _subsample(lines, size, sampling_rate):
         if 'groundtruth' in value and 'document' in value:
             yield Document(value['document'], field_resolver), Document(
@@ -117,14 +117,14 @@ def from_csv(
 
 
 def from_ndjson(
-    fp: Iterable[str],
+    ndjson_file: Iterable[str],
     field_resolver: Optional[Dict[str, str]] = None,
     size: Optional[int] = None,
     sampling_rate: Optional[float] = None,
 ) -> Generator['Document', None, None]:
     """Generator function for line separated JSON. Yields documents.
 
-    :param fp: file paths
+    :param ndjson_file: a ndjson file descriptor object or a list of json strings
     :param field_resolver: a map from field names defined in ``document`` (JSON, dict) to the field
             names defined in Protobuf. This is only used when the given ``document`` is
             a JSON string or a Python dict.
@@ -135,7 +135,7 @@ def from_ndjson(
     """
     from ..document import Document
 
-    for line in _subsample(fp, size, sampling_rate):
+    for line in _subsample(ndjson_file, size, sampling_rate):
         value = json.loads(line)
         if 'groundtruth' in value and 'document' in value:
             yield Document(value['document'], field_resolver), Document(

--- a/tests/unit/types/document/test_generators.py
+++ b/tests/unit/types/document/test_generators.py
@@ -1,0 +1,86 @@
+from jina.types.document.generators import from_ndarray, from_ndjson
+
+import numpy as np
+import pytest
+
+
+@pytest.mark.parametrize(
+    'input_ndarray, shuffle',
+    [(np.arange(12).reshape((3, 4)), True), (np.arange(1).reshape((1, 1)), True)],
+)
+def test_from_ndarray(input_ndarray, shuffle):
+    docs = list(from_ndarray(input_ndarray, shuffle=shuffle))
+    if shuffle:
+        docs = sorted(docs, key=lambda x: x.blob[0])
+
+    assert len(docs) == len(input_ndarray)
+    for idx, doc in enumerate(docs):
+        assert doc.content_type == 'blob'
+        np.testing.assert_array_equal(doc.blob, input_ndarray[idx])
+        np.testing.assert_array_equal(doc.content, input_ndarray[idx])
+
+    docs = list(from_ndarray(input_ndarray, size=1))
+    assert len(docs) == 1
+
+
+@pytest.mark.parametrize(
+    'input_dicts, field_resolver, content_types, content_keys, tags_list',
+    [
+        ([{'text': 'text'}], None, ['text'], ['text'], [[]]),
+        (
+            [{'text': 'text', 'text2': 'text2'}],
+            {'text2': 'text'},
+            ['text'],
+            ['text2'],
+            [[]],
+        ),
+        ([{'uri': 'https://github.com/jina-ai'}], None, ['uri'], ['uri'], [[]]),
+        (
+            [{'blob': np.arange(4).reshape((2, 2)).tolist()}],
+            None,
+            ['blob'],
+            ['blob'],
+            [[]],
+        ),
+        (
+            [
+                {
+                    'text': 'text',
+                    'tag_label_1': 'tag1',
+                },
+                {'uri': 'https://github.com/jina-ai', 'tag_label_2': 'tag2'},
+                {'blob': np.arange(4).reshape((2, 2)).tolist(), 'tag_label_3': 'tag3'},
+            ],
+            None,
+            ['text', 'uri', 'blob'],
+            ['text', 'uri', 'blob'],
+            [
+                ['tag_label_1'],
+                ['tag_label_2'],
+                ['tag_label_3'],
+            ],
+        ),
+    ],
+)
+def test_from_ndjson(
+    input_dicts, field_resolver, content_types, content_keys, tags_list
+):
+    import json
+
+    input_ndjson = [json.dumps(dict) for dict in input_dicts]
+    docs = list(from_ndjson(input_ndjson, field_resolver=field_resolver))
+
+    assert len(docs) == len(input_ndjson)
+    for idx, doc in enumerate(docs):
+        content_type = content_types[idx]
+        content_key = content_keys[idx]
+        np.testing.assert_equal(
+            getattr(doc, content_type), input_dicts[idx][content_key]
+        )
+        np.testing.assert_equal(doc.content, input_dicts[idx][content_key])
+        for tag_field in tags_list[idx]:
+            assert doc.tags[tag_field] == input_dicts[idx][tag_field]
+        assert doc.content_type == content_type
+
+    docs = list(from_ndjson(input_ndjson, size=1))
+    assert len(docs) == 1


### PR DESCRIPTION
added unit tests as requested in #692 
Currently, some document generators are tested with other components and not by itself. 
Added unit tests for these generators in this PR.

Also renamed some argument names in generators to better reflect the input types.

did not test axis parameter, possible bug / unclear usage, issue here #2735



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1200479679796904/1200506822722036) by [Unito](https://www.unito.io)
