### PR TITLE
refactor: remove mime type guess from remote url

### DIFF
--- a/extra-requirements.txt
+++ b/extra-requirements.txt
@@ -34,7 +34,6 @@ torchvision>=0.3.0:         framework, cv, multimodal, cicd
 Pillow:                     cv, cicd, multimodal
 lz4<3.1.2:                  devel, cicd, perf, network
 gevent:                     http, devel, cicd
-python-magic:               http, devel, cicd
 uvloop:                     devel, cicd, perf
 numpy:                      core
 pyzmq>=17.1.0:              core

--- a/jina/types/document/__init__.py
+++ b/jina/types/document/__init__.py
@@ -24,7 +24,7 @@ from google.protobuf import json_format
 from google.protobuf.field_mask_pb2 import FieldMask
 from ..struct import StructView
 from ..score.map import NamedScoreMapping
-from .converters import png_to_buffer, to_datauri, guess_mime, to_image_blob
+from .converters import png_to_buffer, to_datauri, to_image_blob
 from ..mixin import ProtoTypeMixin
 from ..ndarray.generic import NdArray, BaseSparseNdArray
 from ..score import NamedScore
@@ -841,7 +841,9 @@ class Document(ProtoTypeMixin):
         :param value: acceptable URI/URL, raise ``ValueError`` when it is not a valid URI
         """
         self._pb_body.uri = value
-        self.mime_type = guess_mime(value)
+        mime_type = mimetypes.guess_type(value)[0]
+        if mime_type:
+            self.mime_type = mime_type  # Remote http/https contents mime_type will not be recognized.
 
     @property
     def mime_type(self) -> str:

--- a/jina/types/document/__init__.py
+++ b/jina/types/document/__init__.py
@@ -791,17 +791,6 @@ class Document(ProtoTypeMixin):
         :param value: the bytes value to set the buffer
         """
         self._pb_body.buffer = value
-        if value and not self._pb_body.mime_type:
-            with ImportExtensions(
-                required=False,
-                pkg_name='python-magic',
-                help_text=f'can not sniff the MIME type '
-                f'MIME sniffing requires brew install '
-                f'libmagic (Mac)/ apt-get install libmagic1 (Linux)',
-            ):
-                import magic
-
-                self._pb_body.mime_type = magic.from_buffer(value, mime=True)
 
     @property
     def text(self):

--- a/jina/types/document/converters.py
+++ b/jina/types/document/converters.py
@@ -1,7 +1,4 @@
-import mimetypes
 import struct
-import urllib.parse
-import urllib.request
 import zlib
 
 import numpy as np
@@ -132,20 +129,3 @@ def to_datauri(
             encoded_data = quote(data)
     parts.extend([',', encoded_data])
     return ''.join(parts)
-
-
-def guess_mime(uri):
-    """
-    Guess the type of a file based on its URL.
-
-    :param uri: Data URI.
-    :return: MIME type.
-    """
-    # guess when uri points to a local file
-    m_type = mimetypes.guess_type(uri)[0]
-    # guess when uri points to a remote file
-    if not m_type and urllib.parse.urlparse(uri).scheme in {'http', 'https', 'data'}:
-        page = urllib.request.Request(uri, headers={'User-Agent': 'Mozilla/5.0'})
-        tmp = urllib.request.urlopen(page)
-        m_type = tmp.info().get_content_type()
-    return m_type

--- a/tests/unit/types/document/test_converters.py
+++ b/tests/unit/types/document/test_converters.py
@@ -39,7 +39,6 @@ def test_convert_buffer_to_blob():
     array = rand_state.random([10, 10])
     doc = Document(content=array.tobytes())
     assert doc.content_type == 'buffer'
-    assert doc.mime_type == 'application/octet-stream'
     intialiazed_buffer = doc.buffer
 
     doc.convert_buffer_to_blob()


### PR DESCRIPTION
> can we stop guess_mime from request when creating a document with uri ? it makes document creation slow and fragile [here](https://github.com/jina-ai/jina/blob/88ac3a9776a7af47cfe0716be5a8d36dde90b5db/jina/types/document/converters.py#L148)  In a EAP, I have all chunks with url field and a lot Http 404 error generated


┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1200479679796904/1200523505424299) by [Unito](https://www.unito.io)
