### PR TITLE
feat: mute many log.info and log.success

### DIFF
--- a/jina/clients/base/__init__.py
+++ b/jina/clients/base/__init__.py
@@ -69,9 +69,7 @@ class BaseClient(ABC):
             from ..request import request_generator
 
             r = next(request_generator(**kwargs))
-            if isinstance(r, Request):
-                default_logger.success(f'inputs is valid')
-            else:
+            if not isinstance(r, Request):
                 raise TypeError(f'{typename(r)} is not a valid Request')
         except Exception as ex:
             default_logger.error(f'inputs is not valid!')

--- a/jina/clients/base/grpc.py
+++ b/jina/clients/base/grpc.py
@@ -41,16 +41,13 @@ class GRPCBaseClient(BaseClient):
                 ],
             ) as channel:
                 stub = jina_pb2_grpc.JinaRPCStub(channel)
-                self.logger.success(
+                self.logger.debug(
                     f'connected to {self.args.host}:{self.args.port_expose}'
                 )
 
-                if self.show_progress:
-                    cm1, cm2 = ProgressBar(), TimeContext('')
-                else:
-                    cm1, cm2 = nullcontext(), nullcontext()
+                cm1 = ProgressBar() if self.show_progress else nullcontext()
 
-                with cm1 as p_bar, cm2:
+                with cm1 as p_bar:
                     async for resp in stub.Call(req_iter):
                         resp.as_typed_request(resp.request_type)
                         resp = resp.as_response()

--- a/jina/clients/base/http.py
+++ b/jina/clients/base/http.py
@@ -57,12 +57,11 @@ class HTTPBaseClient(BaseClient):
 
         req_iter = self._get_requests(**kwargs)
         async with aiohttp.ClientSession() as session:
-            if self.show_progress:
-                cm1, cm2 = ProgressBar(), TimeContext('')
-            else:
-                cm1, cm2 = nullcontext(), nullcontext()
+
             try:
-                with cm1 as p_bar, cm2:
+                cm1 = ProgressBar() if self.show_progress else nullcontext()
+
+                with cm1 as p_bar:
                     all_responses = []
                     for req in req_iter:
                         # fix the mismatch between pydantic model and Protobuf model

--- a/jina/clients/base/websocket.py
+++ b/jina/clients/base/websocket.py
@@ -46,7 +46,7 @@ class WebSocketBaseClient(BaseClient):
             ) as websocket:
                 # To enable websockets debug logs
                 # https://websockets.readthedocs.io/en/stable/cheatsheet.html#debugging
-                self.logger.success(
+                self.logger.debug(
                     f'connected to {self.args.host}:{self.args.port_expose}'
                 )
                 self.num_requests = 0
@@ -67,12 +67,9 @@ class WebSocketBaseClient(BaseClient):
                         # There is nothing to send, disconnect gracefully
                         await websocket.close(reason='No data to send')
 
-                if self.show_progress:
-                    cm1, cm2 = ProgressBar(), TimeContext('')
-                else:
-                    cm1, cm2 = nullcontext(), nullcontext()
+                cm1 = ProgressBar() if self.show_progress else nullcontext()
 
-                with cm1 as p_bar, cm2:
+                with cm1 as p_bar:
                     # Unlike gRPC, any arbitrary function (generator) cannot be passed via websockets.
                     # Simply iterating through the `req_iter` makes the request-response sequential.
                     # To make client unblocking, :func:`send_requests` and `recv_responses` are separate tasks

--- a/jina/flow/base.py
+++ b/jina/flow/base.py
@@ -920,7 +920,7 @@ class Flow(PostMixin, JAMLCompatible, ExitStack, metaclass=FlowType):
         if GATEWAY_NAME in self._pod_nodes:
             self._pod_nodes.pop(GATEWAY_NAME)
         self._build_level = FlowBuildLevel.EMPTY
-        self.logger.success(f'Flow is closed!')
+        self.logger.debug(f'Flow is closed!')
         self.logger.close()
 
     def start(self):
@@ -961,7 +961,7 @@ class Flow(PostMixin, JAMLCompatible, ExitStack, metaclass=FlowType):
                 self.close()
                 raise
 
-        self.logger.info(
+        self.logger.debug(
             f'{self.num_pods} Pods (i.e. {self.num_peas} Peas) are running in this Flow'
         )
 
@@ -1300,7 +1300,7 @@ class Flow(PostMixin, JAMLCompatible, ExitStack, metaclass=FlowType):
 
     def _show_success_message(self):
 
-        self.logger.success(f'🎉 Flow is ready to use!')
+        self.logger.debug(f'🎉 Flow is ready to use!')
 
         address_table = [
             f'\t🔗 Protocol: \t\t{colored(self.protocol, attrs="bold")}',

--- a/jina/helloworld/chatbot/app.py
+++ b/jina/helloworld/chatbot/app.py
@@ -75,7 +75,7 @@ def hello_world(args):
         except:
             pass  # intentional pass, browser support isn't cross-platform
         finally:
-            default_logger.success(
+            default_logger.info(
                 f'You should see a demo page opened in your browser, '
                 f'if not, you may open {url_html_path} manually'
             )

--- a/jina/helloworld/fashion/helper.py
+++ b/jina/helloworld/fashion/helper.py
@@ -134,13 +134,13 @@ def write_html(html_path):
     except:
         pass  # intentional pass, browser support isn't cross-platform
     finally:
-        default_logger.success(
+        default_logger.info(
             f'You should see a "hello-world.html" opened in your browser, '
             f'if not you may open {url_html_path} manually'
         )
 
     colored_url = colored('https://opensource.jina.ai', color='cyan', attrs='underline')
-    default_logger.success(
+    default_logger.info(
         f'🤩 Intrigued? Play with "jina hello fashion --help" and learn more about Jina at {colored_url}'
     )
 

--- a/jina/helloworld/multimodal/app.py
+++ b/jina/helloworld/multimodal/app.py
@@ -74,7 +74,7 @@ def hello_world(args):
         except:
             pass  # intentional pass, browser support isn't cross-platform
         finally:
-            default_logger.success(
+            default_logger.info(
                 f'You should see a demo page opened in your browser, '
                 f'if not, you may open {url_html_path} manually'
             )

--- a/jina/logging/profile.py
+++ b/jina/logging/profile.py
@@ -241,7 +241,7 @@ class ProgressBar(TimeContext):
             self.num_docs += progress
 
         sys.stdout.write(
-            '{:>10} |{:<{}}| ⏳ {:6d} ⏱️ {:3.1f}s 🐎 {:3.0f} QPS'.format(
+            '{:>10} |{:<{}}| ⏳ {:6d} ⏱️ {:3.1f}s 🐎 {:3.1f} RPS'.format(
                 colored(self.task_name, 'cyan'),
                 colored('█' * num_bars, 'green'),
                 self.bar_len + 9,
@@ -267,5 +267,5 @@ class ProgressBar(TimeContext):
     def _exit_msg(self):
         speed = self.num_reqs / self.duration
         sys.stdout.write(
-            f'\t{colored(f"✅ done in ⏱ {self.readable_duration} 🐎 {speed:3.0f} QPS", "green")}\n'
+            f'\t{colored(f"✅ done in ⏱ {self.readable_duration} 🐎 {speed:3.1f} RPS", "green")}\n'
         )

--- a/jina/peapods/peas/__init__.py
+++ b/jina/peapods/peas/__init__.py
@@ -210,7 +210,7 @@ class BasePea:
                 # return too early and the shutdown is set, means something fails!!
                 raise RuntimeFailToStart
             else:
-                self.logger.success(__ready_msg__)
+                self.logger.debug(__ready_msg__)
         else:
             _timeout = _timeout or -1
             self.logger.warning(
@@ -256,7 +256,7 @@ class BasePea:
             # if it fails to start, the process will hang at `join`
             self.terminate()
 
-        self.logger.success(__stop_msg__)
+        self.logger.debug(__stop_msg__)
         self.logger.close()
 
     def _set_envs(self):

--- a/jina/peapods/runtimes/asyncio/prefetch.py
+++ b/jina/peapods/runtimes/asyncio/prefetch.py
@@ -72,7 +72,7 @@ class PrefetchMixin(ABC):
             onrecv_task = []
             # the following code "interleaves" prefetch_task and onrecv_task, when one dries, it switches to the other
             while prefetch_task:
-                self.logger.info(
+                self.logger.debug(
                     f'send: {self.zmqlet.msg_sent} '
                     f'recv: {self.zmqlet.msg_recv} '
                     f'pending: {self.zmqlet.msg_sent - self.zmqlet.msg_recv}'

--- a/jina/peapods/runtimes/base.py
+++ b/jina/peapods/runtimes/base.py
@@ -87,9 +87,9 @@ class BaseRuntime:
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         if exc_type == RuntimeTerminated:
-            self.logger.info(f'{self!r} is ended')
+            self.logger.debug(f'{self!r} is ended')
         elif exc_type == KeyboardInterrupt:
-            self.logger.info(f'{self!r} is interrupted by user')
+            self.logger.debug(f'{self!r} is interrupted by user')
         elif exc_type in {Exception, SystemError}:
             self.logger.error(
                 f'{exc_val!r} during {self.run_forever!r}'

--- a/jina/peapods/runtimes/jinad/client.py
+++ b/jina/peapods/runtimes/jinad/client.py
@@ -120,7 +120,7 @@ class DaemonClient:
                 f'log streaming is disabled, you won\'t see logs on the remote\n Reason: {e!r}'
             )
         except asyncio.CancelledError:
-            self.logger.info(f'log streaming is cancelled')
+            self.logger.warning(f'log streaming is cancelled')
         finally:
             for l in all_remote_loggers.values():
                 l.close()
@@ -197,7 +197,7 @@ class PeaDaemonClient(DaemonClient):
                 timeout=self.timeout,
             )
             if r.status_code == requests.codes.not_found:
-                self.logger.info(f'couldn\'t find {id} in remote {self.kind} store')
+                self.logger.warning(f'couldn\'t find {id} in remote {self.kind} store')
             return r.json()
         except requests.exceptions.RequestException as ex:
             self.logger.error(f'can\'t get status of {self.kind}: {ex!r}')

--- a/jina/peapods/runtimes/zmq/zed.py
+++ b/jina/peapods/runtimes/zmq/zed.py
@@ -135,7 +135,7 @@ class ZEDRuntime(ZMQRuntime):
         elif self.request_type == 'ControlRequest':
             info_msg += f'({self.request.command}) '
         info_msg += f'{part_str} from {msg.colored_route}'
-        self.logger.info(info_msg)
+        self.logger.debug(info_msg)
 
         if self.expect_parts > 1 and self.expect_parts > len(self.partial_requests):
             # NOTE: reduce priority is higher than chain exception
@@ -289,12 +289,12 @@ class ZEDRuntime(ZMQRuntime):
             self._zmqlet.close()
         except KeyboardInterrupt as kbex:
             # save executor
-            self.logger.info(f'{kbex!r} causes the breaking from the event loop')
+            self.logger.debug(f'{kbex!r} causes the breaking from the event loop')
             self._zmqlet.send_message(msg)
             self._zmqlet.close(flush=False)
         except (SystemError, zmq.error.ZMQError) as ex:
             # save executor
-            self.logger.info(f'{ex!r} causes the breaking from the event loop')
+            self.logger.debug(f'{ex!r} causes the breaking from the event loop')
             self._zmqlet.send_message(msg)
             self._zmqlet.close()
         except MemoryOverHighWatermark:

--- a/jina/peapods/zmq/__init__.py
+++ b/jina/peapods/zmq/__init__.py
@@ -195,7 +195,7 @@ class Zmqlet:
             else:
                 out_sock, out_addr = None, None
 
-            self.logger.info(
+            self.logger.debug(
                 f'input {colored(in_addr, "yellow")} ({self.args.socket_in.name}) '
                 f'output {colored(out_addr, "yellow")} ({self.args.socket_out.name}) '
                 f'control over {colored(ctrl_addr, "yellow")} ({SocketType.PAIR_BIND.name})'
@@ -234,7 +234,7 @@ class Zmqlet:
 
     def print_stats(self):
         """Print out the network stats of of itself """
-        self.logger.info(
+        self.logger.debug(
             f'#sent: {self.msg_sent} '
             f'#recv: {self.msg_recv} '
             f'sent_size: {get_readable_size(self.bytes_sent)} '
@@ -454,8 +454,8 @@ class ZmqStreamlet(Zmqlet):
         if not self.is_closed and self.in_sock_type == zmq.DEALER:
             try:
                 self._send_cancel_to_router(raise_exception=True)
-            except zmq.error.ZMQError as e:
-                self.logger.info(
+            except zmq.error.ZMQError:
+                self.logger.debug(
                     f'The dealer {self.name} can not unsubscribe from the router. '
                     f'In case the router is down this is expected.'
                 )


### PR DESCRIPTION
> https://jinaai.slack.com/archives/C018F60RBL5/p1624635344068600

_There are too many information on the screen as Jina running,_ it creates the following problems:
Very scary to new users.
Feel heavy. To be honest, every program (even assembly) feel super heavy if you print every line on the screen.
Too loud, belittle user. As a framework, loud log outputs gives user a impression that, "what you are building & output is insignificant, because I'm emitting a looot and they are more important! So please read my output and good luck of finding your output."

In the screenshot below (readme code snippet), the user own log output is in the redbox, take a look at the ratio there. All the other lines in the screenshot are emitted from Jina. Don't you think it is completely overwhelming?

Another argument, when we write
with open('a.txt') as fp:
  fp.write()
do we see the console logs like the following?
fp is opened successfully!
fp is written with some blah
fp is now closed
No. Then why would Jina do that?

I think 2.0 is the right time to make some INFO level log to DEBUG  and only emit when necessary. This does not only give user a cleaner console, but also
:heart: really put user's code/logic as the first priority
:ice_cube: makes our framework as transparent as Python
:unicorn_face: shows the confidence of ourself -> we are shipping robust code, we know the framework behavior without printing every line on the screen.

One may argue that, "oh, then it may slow down our own development." It won't, you just add export JINA_LOG_LEVEL=DEBUG to bashrc.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1200479679796904/1200523723043741) by [Unito](https://www.unito.io)
