### PR TITLE
feat(hubble): optimize display when create executor

### DIFF
--- a/jina/hubble/hubio.py
+++ b/jina/hubble/hubio.py
@@ -140,7 +140,7 @@ class HubIO:
 
                 uuid8 = image['id']
                 secret = image['secret']
-                docker_image = image['pullPath']
+                alias = image['alias']
                 visibility = image['visibility']
                 usage = (
                     f'jinahub://{uuid8}'
@@ -154,8 +154,12 @@ class HubIO:
                     + colored(
                         f'{secret}',
                         'cyan',
+                    )
+                    + colored(
+                        '(PLEASE KEEP IT CAREFULLY, OTHERWISE YOU WILL LOSE CONTROL OF YOUR EXECUTOR!)',
+                        'red'
                     ),
-                    f'\t🐳 Image:\t' + colored(f'{docker_image}', 'cyan'),
+                    f'\t📛 Alias:\t' + colored(f'{alias}', 'cyan') if alias else '/',
                     f'\t👀 Visibility:\t' + colored(f'{visibility}', 'cyan'),
                 ]
                 self.logger.success(

--- a/tests/unit/hubble/test_hubio.py
+++ b/tests/unit/hubble/test_hubio.py
@@ -22,7 +22,7 @@ class PostMockResponse:
                 {
                     'id': 'w7qckiqy',
                     'secret': 'f7386f9ef7ea238fd955f2de9fb254a0',
-                    'pullPath': 'jinahub/w7qckiqy:v3',
+                    'image': 'jinahub/w7qckiqy:v3',
                     'visibility': 'public',
                 }
             ],


### PR DESCRIPTION
1. Add ATTENTION words for secret
1. Add alias field
1. Remove image field. We don't want users to care about the actual docker image, which may be private and untouchable directly in the future.

Before:

![](https://user-images.githubusercontent.com/4194287/123654404-9ef13500-d860-11eb-9928-3b5d9f68ceca.png)

After:

![](https://user-images.githubusercontent.com/4194287/123654187-68b3b580-d860-11eb-8de8-becf122d1110.png)



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1200479679796904/1200531080673019) by [Unito](https://www.unito.io)
