### PR TITLE
fix: removed debug port

### DIFF
--- a/tests/unit/peapods/zmq/test_dynamic_routing.py
+++ b/tests/unit/peapods/zmq/test_dynamic_routing.py
@@ -38,9 +38,7 @@ def callback(msg):
 
 def test_simple_dynamic_routing_zmqlet():
     args1 = get_args()
-    args1.port_ctrl = 51337
     args2 = get_args()
-    args2.port_ctrl = 51338
 
     logger = logging.getLogger('zmq-test')
     with Zmqlet(args1, logger) as z1, Zmqlet(args2, logger) as z2:


### PR DESCRIPTION
These ports are the reason for random failure in CI. Forgot to remove them after debugging in the dynamic routing PR.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1200479679796904/1200534751263065) by [Unito](https://www.unito.io)
