### PR TITLE
fix(daemon): fix flexible root workspace mount in docker

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -213,6 +213,8 @@ jobs:
   core-test:
     needs: prep-testbed
     runs-on: ubuntu-20.04
+    env:
+      JINA_DAEMON_BUILD: DEVEL
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -245,7 +245,6 @@ jobs:
         run: |
           if [[ "${{ matrix.test-path }}" =~ ^tests/distributed/* || "${{ matrix.test-path }}" =~ ^tests/daemon/* ]]; then
             # Build daemon for all daemon/distributed tests
-            echo "JINA_DAEMON_BUILD=DEVEL" >> $GITHUB_ENV
             docker build -f Dockerfiles/debianx.Dockerfile -t jinaai/jina:test-daemon .
             if [[ "${{ matrix.test-path }}" == "tests/distributed/test_against_external_daemon/" ]]; then
               docker run --add-host host.docker.internal:host-gateway --name jinad --env JINA_DAEMON_BUILD=DEVEL -v /var/run/docker.sock:/var/run/docker.sock -v /tmp/jinad:/tmp/jinad -p 8000:8000 -d jinaai/jina:test-daemon

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,7 +236,7 @@ jobs:
         run: |
           if [[ "${{ matrix.test-path }}" =~ ^tests/distributed/* || "${{ matrix.test-path }}" =~ ^tests/daemon/* ]]; then
             # Build daemon for all daemon/distributed tests
-            echo "JINA_DAEMON_BUILD=DEVEL" >> $GITHUB_ENV
+            export JINA_DAEMON_BUILD=DEVEL
             docker build -f Dockerfiles/debianx.Dockerfile -t jinaai/jina:test-daemon .
             if [[ "${{ matrix.test-path }}" == "tests/distributed/test_against_external_daemon/" ]]; then
               docker run --add-host host.docker.internal:host-gateway --name jinad --env JINA_DAEMON_BUILD=DEVEL -v /var/run/docker.sock:/var/run/docker.sock -v /tmp/jinad:/tmp/jinad -p 8000:8000 -d jinaai/jina:test-daemon

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,6 +208,8 @@ jobs:
   core-test:
     needs: prep-testbed
     runs-on: ubuntu-20.04
+    env:
+      JINA_DAEMON_BUILD: DEVEL
     strategy:
       fail-fast: false
       matrix:
@@ -236,7 +238,6 @@ jobs:
         run: |
           if [[ "${{ matrix.test-path }}" =~ ^tests/distributed/* || "${{ matrix.test-path }}" =~ ^tests/daemon/* ]]; then
             # Build daemon for all daemon/distributed tests
-            export JINA_DAEMON_BUILD=DEVEL
             docker build -f Dockerfiles/debianx.Dockerfile -t jinaai/jina:test-daemon .
             if [[ "${{ matrix.test-path }}" == "tests/distributed/test_against_external_daemon/" ]]; then
               docker run --add-host host.docker.internal:host-gateway --name jinad --env JINA_DAEMON_BUILD=DEVEL -v /var/run/docker.sock:/var/run/docker.sock -v /tmp/jinad:/tmp/jinad -p 8000:8000 -d jinaai/jina:test-daemon

--- a/daemon/dockerize.py
+++ b/daemon/dockerize.py
@@ -1,3 +1,4 @@
+import socket
 from typing import Dict, List, Tuple, TYPE_CHECKING, Optional
 
 import docker
@@ -254,6 +255,16 @@ class Dockerizer:
         return container, network, ports
 
     @classmethod
+    def _get_volume_host_dir(cls):
+        volumes = cls.client.containers.get(socket.gethostname()).attrs['HostConfig'][
+            'Binds'
+        ]
+        for volume in volumes:
+            if volume.split(':')[1] == __root_workspace__:
+                return volume.split(':')[0]
+        return __root_workspace__
+
+    @classmethod
     def volume(cls, workspace_id: DaemonID) -> Dict[str, Dict]:
         """
         Local volumes to be mounted inside the container during `run`.
@@ -264,7 +275,7 @@ class Dockerizer:
         :return: dict of volume mappings
         """
         return {
-            f'{__root_workspace__}/{workspace_id}': {
+            f'{cls._get_volume_host_dir()}/{workspace_id}': {
                 'bind': '/workspace',
                 'mode': 'rw',
             },

--- a/daemon/dockerize.py
+++ b/daemon/dockerize.py
@@ -256,12 +256,16 @@ class Dockerizer:
 
     @classmethod
     def _get_volume_host_dir(cls):
-        volumes = cls.client.containers.get(socket.gethostname()).attrs['HostConfig'][
-            'Binds'
-        ]
-        for volume in volumes:
-            if volume.split(':')[1] == __root_workspace__:
-                return volume.split(':')[0]
+        try:
+            volumes = cls.client.containers.get(socket.gethostname()).attrs[
+                'HostConfig'
+            ]['Binds']
+            for volume in volumes:
+                if volume.split(':')[1] == __root_workspace__:
+                    return volume.split(':')[0]
+        except:
+            # above logic only works inside docker, if it does not work we dont need it
+            pass
         return __root_workspace__
 
     @classmethod

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -82,7 +82,7 @@ def docker_compose(request):
     os.system(
         f"docker-compose -f {request.param} --project-directory . up  --build -d --remove-orphans"
     )
-    time.sleep(5)
+    time.sleep(10)
     yield
     os.system(
         f"docker-compose -f {request.param} --project-directory . down --remove-orphans"

--- a/tests/daemon/unit/models/good_ws/.jinad
+++ b/tests/daemon/unit/models/good_ws/.jinad
@@ -1,4 +1,4 @@
-build = devel
+build = default
 jina = 2.0.0.rc2
 python = 3.7
 ports = 12345,12344

--- a/tests/daemon/unit/test_files.py
+++ b/tests/daemon/unit/test_files.py
@@ -16,11 +16,11 @@ cur_filename = os.path.basename(__file__)
 @pytest.mark.parametrize(
     'workdir, expected_response',
     [
-        ('good_ws', ('devel', '3.7', 'echo Hello', [12345, 12344])),
-        ('good_ws_no_file', ('default', '3.8', '', [])),
-        ('good_ws_emptyfile', ('default', '3.8', '', [])),
+        ('good_ws', ('default', '3.7', 'echo Hello', [12345, 12344])),
+        ('good_ws_no_file', ('devel', '3.8', '', [])),
+        ('good_ws_emptyfile', ('devel', '3.8', '', [])),
         ('good_ws_multiple_files', ('devel', '3.7', 'echo Hello', [12345, 123456])),
-        ('good_ws_wrong_values', ('default', '3.8', '', [])),
+        ('good_ws_wrong_values', ('devel', '3.8', '', [])),
     ],
 )
 def test_jinad_file_workspace(workdir, expected_response):

--- a/tests/distributed/test_against_external_daemon/docker-compose.yml
+++ b/tests/distributed/test_against_external_daemon/docker-compose.yml
@@ -1,12 +1,9 @@
 version: "3.3"
 services:
   jinad:
-    image: test_upload_simple_non_standard_rootworkspace
+    image: jinaai/jina:test-daemon
     container_name: test_upload_simple_non_standard_rootworkspace
     command: --store
-    build:
-      context: .
-      dockerfile: Dockerfiles/debianx.Dockerfile
     ports:
       - "9000:8000"
       - "45678:45678"

--- a/tests/distributed/test_against_external_daemon/docker-compose.yml
+++ b/tests/distributed/test_against_external_daemon/docker-compose.yml
@@ -3,14 +3,12 @@ services:
   jinad:
     image: jinaai/jina:test-daemon
     container_name: test_upload_simple_non_standard_rootworkspace
-    command: --store
     ports:
       - "9000:8000"
-      - "45678:45678"
-    expose:
-      - 10000-60000
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - /tmp/other_jinad:/tmp/jinad
     extra_hosts:
       - "host.docker.internal:host-gateway"
+    environment:
+      - JINA_DAEMON_BUILD=DEVEL

--- a/tests/distributed/test_against_external_daemon/docker-compose.yml
+++ b/tests/distributed/test_against_external_daemon/docker-compose.yml
@@ -1,0 +1,19 @@
+version: "3.3"
+services:
+  jinad:
+    image: test_upload_simple_non_standard_rootworkspace
+    container_name: test_upload_simple_non_standard_rootworkspace
+    command: --store
+    build:
+      context: .
+      dockerfile: Dockerfiles/debianx.Dockerfile
+    ports:
+      - "9000:8000"
+      - "45678:45678"
+    expose:
+      - 10000-60000
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - /tmp/other_jinad:/tmp/jinad
+    extra_hosts:
+      - "host.docker.internal:host-gateway"

--- a/tests/distributed/test_against_external_daemon/test_remote_workspaces.py
+++ b/tests/distributed/test_against_external_daemon/test_remote_workspaces.py
@@ -124,7 +124,7 @@ def test_custom_project():
 
 @pytest.fixture()
 def docker_compose(request):
-    os.system(f'docker network prune')
+    os.system(f'docker network prune -f ')
     os.system(
         f'docker-compose -f {request.param} --project-directory . up  --build -d --remove-orphans'
     )
@@ -133,7 +133,7 @@ def docker_compose(request):
     os.system(
         f'docker-compose -f {request.param} --project-directory . down --remove-orphans'
     )
-    os.system(f'docker network prune')
+    os.system(f'docker network prune -f ')
 
 
 @pytest.mark.parametrize('docker_compose', [compose_yml], indirect=['docker_compose'])

--- a/tests/distributed/test_remote_flow_dump_rolling_update/docker-compose.yml
+++ b/tests/distributed/test_remote_flow_dump_rolling_update/docker-compose.yml
@@ -1,13 +1,10 @@
 version: "3.3"
 services:
   jinad:
-    image: test_remote_flow_dump_reload
+    image: jinaai/jina:test-daemon
     environment:
       JINA_DAEMON_BUILD: DEVEL
     container_name: test_remote_flow_dump_reload
-    build:
-      context: .
-      dockerfile: Dockerfiles/debianx.Dockerfile
     ports:
       - "8001:8000"
       - "45678:45678"


### PR DESCRIPTION
This fixes https://github.com/jina-ai/jina/issues/2768

It also fixes an issue with CI setting for jinad. We need to set some environment variable `JINA_DAEMON_BUILD` to `DEVEL` to make sure CI builds docker from the code in the PR and not from dockerhub release version. Before this was incorrect, because appending to the github env file only takes effect in the next step. We actually need it in the current step there.

JinaD now basically checks the host directory used for mounting its root workspace and will use the correct one when creating child containers (flow/peads/pods/.jinad). Before we were always mounting /tmp/jinad, which can be wrong if the user changes it.

I've added a test for this using docker compose, because I cant use the regular jinad instance as I need to control the volume mounting in other to test the correct thing here. This feels a bit akward there, but the test itself is okay and workling locally.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1200479679796904/1200536052886982) by [Unito](https://www.unito.io)
