### PR TITLE
fix: fix override_with or override_metas

### DIFF
--- a/jina/jaml/__init__.py
+++ b/jina/jaml/__init__.py
@@ -514,16 +514,17 @@ class JAMLCompatible(metaclass=JAMLCompatibleType):
                     with_params = no_tag_yml.get('with', None)
                     if with_params:
                         with_params.update(**override_with)
+                        no_tag_yml.update(with_params)
                     else:
-                        with_params = override_with
-                    no_tag_yml.update(with_params)
+                        no_tag_yml['with'] = override_with
                 if override_metas is not None:
                     metas_params = no_tag_yml.get('metas', None)
                     if metas_params:
                         metas_params.update(**override_metas)
+                        no_tag_yml.update(metas_params)
                     else:
-                        metas_params = override_metas
-                    no_tag_yml.update(metas_params)
+                        no_tag_yml['metas'] = override_metas
+
             else:
                 raise BadConfigSource(
                     f'can not construct {cls} from an empty {source}. nothing to read from there'

--- a/tests/integration/override_config_params/zed/test_override_config_params.py
+++ b/tests/integration/override_config_params/zed/test_override_config_params.py
@@ -9,17 +9,25 @@ cur_dir = os.path.dirname(os.path.abspath(__file__))
 @pytest.fixture()
 def flow(request):
     flow_src = request.param
-    if flow_src == 'yml':
+    if flow_src == 'flow-yml':
         return Flow().load_config(os.path.join(cur_dir, 'flow.yml'))
-    elif flow_src == 'python':
+    elif flow_src == 'uses-yml':
         return Flow(return_results=True).add(
             uses=os.path.join(cur_dir, 'default_config.yml'),
             override_with={'param1': 50, 'param2': 30},
             override_metas={'workspace': 'different_workspace'},
         )
+    elif flow_src == 'class':
+        from .executor import Override
+
+        return Flow(return_results=True).add(
+            uses=Override,
+            override_with={'param1': 50, 'param2': 30, 'param3': 10},
+            override_metas={'workspace': 'different_workspace', 'name': 'name'},
+        )
 
 
-@pytest.mark.parametrize('flow', ['yml', 'python'], indirect=['flow'])
+@pytest.mark.parametrize('flow', ['flow-yml', 'uses-yml', 'class'], indirect=['flow'])
 def test_override_config_params(flow):
     with flow:
         resps = flow.search(inputs=[Document()], return_results=True)

--- a/tests/integration/override_executor_specific_params/test_specific_params.py
+++ b/tests/integration/override_executor_specific_params/test_specific_params.py
@@ -1,7 +1,6 @@
 from typing import Dict
 
 from jina import Flow, DocumentArray, Document, Executor, requests
-from tests import validate_callback
 
 ORIGINAL_PARAMS = {'param1': 50, 'param2': 60, 'exec_name': {'param1': 'changed'}}
 OVERRIDEN_POD1_PARAMS = {


### PR DESCRIPTION
**Changes introduced**
Override_with and override_metas could not work when `uses` is called on a class or without `with` or `metas` config



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1200479679796904/1200537376904538) by [Unito](https://www.unito.io)
