### PR TITLE
fix(logs): info logs input, out, ctrl port

### DIFF
--- a/jina/peapods/zmq/__init__.py
+++ b/jina/peapods/zmq/__init__.py
@@ -195,7 +195,7 @@ class Zmqlet:
             else:
                 out_sock, out_addr = None, None
 
-            self.logger.debug(
+            self.logger.info(
                 f'input {colored(in_addr, "yellow")} ({self.args.socket_in.name}) '
                 f'output {colored(out_addr, "yellow")} ({self.args.socket_out.name}) '
                 f'control over {colored(ctrl_addr, "yellow")} ({SocketType.PAIR_BIND.name})'


### PR DESCRIPTION
**Changes introduced**
This log must be helpful for external pods, also it gives less the feeling of a blocked executor



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1200479679796904/1200537650891463) by [Unito](https://www.unito.io)
