### PR TITLE
refactor: add progress bar while push/pull

### DIFF
--- a/extra-requirements.txt
+++ b/extra-requirements.txt
@@ -27,7 +27,6 @@ fluent-logger:              logging, http, sse, dashboard, devel, cicd, daemon
 docker:                     devel, cicd, network, hub, daemon
 pathspec:                   devel, cicd, hub
 requests:                   http, devel, cicd, daemon, hub
-requests_toolbelt:          http, devel, cicd, daemon, hub
 torch>=1.1.0:               framework, cicd, chatbot, multimodal
 transformers>=2.6.0:        nlp, cicd, chatbot, multimodal
 tensorflow>=2.0:            framework, cicd

--- a/extra-requirements.txt
+++ b/extra-requirements.txt
@@ -27,6 +27,7 @@ fluent-logger:              logging, http, sse, dashboard, devel, cicd, daemon
 docker:                     devel, cicd, network, hub, daemon
 pathspec:                   devel, cicd, hub
 requests:                   http, devel, cicd, daemon, hub
+requests_toolbelt:          http, devel, cicd, daemon, hub
 torch>=1.1.0:               framework, cicd, chatbot, multimodal
 transformers>=2.6.0:        nlp, cicd, chatbot, multimodal
 tensorflow>=2.0:            framework, cicd

--- a/jina/hubble/helper.py
+++ b/jina/hubble/helper.py
@@ -194,7 +194,7 @@ def download_with_resume(
             for chunk in r.iter_content(32 * block_size):
                 f.write(chunk)
                 if pbar:
-                    pbar.update(progress=len(chunk))
+                    pbar.update(steps=len(chunk))
 
     if filename is None:
         filename = url.split('/')[-1]

--- a/jina/hubble/helper.py
+++ b/jina/hubble/helper.py
@@ -15,6 +15,7 @@ from .. import __resources_path__
 from ..importer import ImportExtensions
 from ..logging.predefined import default_logger
 from ..logging.profile import ProgressBar
+from .progress_bar import Spinner
 
 
 @lru_cache()
@@ -173,14 +174,14 @@ def download_with_resume(
         import requests
 
     def _download(
-        url, target, resume_byte_pos: int = None, pbar: Optional[ProgressBar] = None
+        url, target, resume_byte_pos: int = None, pbar: Optional[Spinner] = None
     ):
         resume_header = (
             {'Range': f'bytes={resume_byte_pos}-'} if resume_byte_pos else None
         )
 
         if pbar and resume_byte_pos:
-            pbar.update(resume_byte_pos)
+            pbar.update()
 
         try:
             r = requests.get(url, stream=True, headers=resume_header)
@@ -194,7 +195,7 @@ def download_with_resume(
             for chunk in r.iter_content(32 * block_size):
                 f.write(chunk)
                 if pbar:
-                    pbar.update(steps=len(chunk))
+                    pbar.update()
 
     if filename is None:
         filename = url.split('/')[-1]
@@ -212,7 +213,7 @@ def download_with_resume(
         if file_size_online > file_size_offline:
             _resume_byte_pos = file_size_offline
 
-    with ProgressBar(task_name='Pulling') as p_bar:
+    with Spinner(task_name='Pulling') as p_bar:
         _download(url, filepath, _resume_byte_pos, p_bar)
 
     if md5sum and not md5file(filepath) == md5sum:

--- a/jina/hubble/hubio.py
+++ b/jina/hubble/hubio.py
@@ -79,7 +79,6 @@ class HubIO:
 
         with ImportExtensions(required=True):
             import requests
-            import requests_toolbelt
 
         pkg_path = Path(self.args.path)
         if not pkg_path.exists():
@@ -99,12 +98,14 @@ class HubIO:
 
             # upload the archived package
             form_data = {
-                'public': '1' if getattr(self.args, 'public', None) else '0',
-                'private': '1' if getattr(self.args, 'private', None) else '0',
+                'public': 'True' if getattr(self.args, 'public', None) else 'False',
+                'private': 'True' if getattr(self.args, 'private', None) else 'False',
                 'md5sum': md5_digest,
-                # 'force': self.args.force,
-                # 'secret': self.args.secret,
             }
+            if self.args.force:
+                form_data['force'] = self.args.force
+            if self.args.secret:
+                form_data['secret'] = self.args.secret
 
             method = 'put' if self.args.force else 'post'
 
@@ -114,13 +115,6 @@ class HubIO:
                 f'Pushing to {hubble_url} ({method.upper()})',
                 self.logger,
             ):
-                # resp = getattr(requests, method)(
-                #     hubble_url,
-                #     files={'file': content},
-                #     data=form_data,
-                #     headers=request_headers,
-                #     stream=True,
-                # )
                 from .helper import upload_file
 
                 resp = upload_file(

--- a/jina/hubble/hubio.py
+++ b/jina/hubble/hubio.py
@@ -96,15 +96,14 @@ class HubIO:
                 content = bytesio.getvalue()
                 md5_hash.update(content)
                 md5_digest = md5_hash.hexdigest()
-                total_size = bytesio.getbuffer().nbytes
 
             # upload the archived package
             form_data = {
                 'public': '1' if getattr(self.args, 'public', None) else '0',
                 'private': '1' if getattr(self.args, 'private', None) else '0',
                 'md5sum': md5_digest,
-                'force': self.args.force,
-                'secret': self.args.secret,
+                # 'force': self.args.force,
+                # 'secret': self.args.secret,
             }
 
             method = 'put' if self.args.force else 'post'
@@ -115,12 +114,23 @@ class HubIO:
                 f'Pushing to {hubble_url} ({method.upper()})',
                 self.logger,
             ):
-                resp = getattr(requests, method)(
+                # resp = getattr(requests, method)(
+                #     hubble_url,
+                #     files={'file': content},
+                #     data=form_data,
+                #     headers=request_headers,
+                #     stream=True,
+                # )
+                from .helper import upload_file
+
+                resp = upload_file(
                     hubble_url,
-                    files={'file': content},
-                    data=form_data,
+                    'filename',
+                    content,
+                    dict_data=form_data,
                     headers=request_headers,
                     stream=True,
+                    method=method,
                 )
 
                 result = None

--- a/jina/hubble/hubio.py
+++ b/jina/hubble/hubio.py
@@ -11,6 +11,7 @@ from urllib.parse import urlencode
 
 from .helper import archive_package, download_with_resume, parse_hub_uri, get_hubble_url
 from .hubapi import install_local, exist_local
+from .progress_bar import ProgressBar
 from ..excepts import HubDownloadError
 from ..helper import colored, get_full_version, get_readable_size, ArgNamespace
 from ..importer import ImportExtensions
@@ -78,6 +79,7 @@ class HubIO:
 
         with ImportExtensions(required=True):
             import requests
+            import requests_toolbelt
 
         pkg_path = Path(self.args.path)
         if not pkg_path.exists():
@@ -93,13 +95,13 @@ class HubIO:
                 bytesio = archive_package(pkg_path)
                 content = bytesio.getvalue()
                 md5_hash.update(content)
-
                 md5_digest = md5_hash.hexdigest()
+                total_size = bytesio.getbuffer().nbytes
 
             # upload the archived package
             form_data = {
-                'public': getattr(self.args, 'public', False),
-                'private': getattr(self.args, 'private', False),
+                'public': '1' if getattr(self.args, 'public', None) else '0',
+                'private': '1' if getattr(self.args, 'private', None) else '0',
                 'md5sum': md5_digest,
                 'force': self.args.force,
                 'secret': self.args.secret,

--- a/jina/hubble/progress_bar.py
+++ b/jina/hubble/progress_bar.py
@@ -158,9 +158,9 @@ class ProgressBar(TimeContext):
         suffix = (suffix_msg or self.suffix) % self
         line = ''.join(
             [
-                self.task_name,
+                '⏳ {:>10}'.format(colored(self.task_name, 'cyan')),
                 self.bar_prefix,
-                self.fill * num_bars,
+                colored(self.fill * num_bars, 'green'),
                 self.empty_fill * (self.bar_len - num_bars),
                 self.bar_suffix,
                 suffix,

--- a/jina/hubble/progress_bar.py
+++ b/jina/hubble/progress_bar.py
@@ -189,9 +189,32 @@ class ProgressBar(TimeContext):
 
 
 class ChargingBar(ProgressBar):
-    '''Charging Bar'''
+    """Charging Bar"""
 
     bar_prefix = ' '
     bar_suffix = ' '
     empty_fill = '∙'
     fill = '█'
+
+
+class Spinner(ProgressBar):
+    """Spinner"""
+
+    phases = ('-', '\\', '|', '/')
+
+    def update(self):
+        """Update spinner"""
+        self.completed += 1
+        i = self.completed % len(self.phases)
+        sys.stdout.write('\r')
+        line = ' '.join(
+            ['⏳ {:>10}'.format(colored(self.task_name, 'cyan')), self.phases[i]]
+        )
+        sys.stdout.write(line)
+        sys.stdout.flush()
+
+
+class PieSpinner(Spinner):
+    """PieSpinner"""
+
+    phases = ['◷', '◶', '◵', '◴']

--- a/jina/hubble/progress_bar.py
+++ b/jina/hubble/progress_bar.py
@@ -1,0 +1,181 @@
+import sys
+import time
+from typing import Optional
+from ..logging.profile import TimeContext
+from ..helper import colored, get_readable_size, get_readable_time
+
+
+class ProgressBar(TimeContext):
+    """
+    A simple progress bar.
+
+    Example:
+        .. highlight:: python
+        .. code-block:: python
+
+            with ProgressBar('loop') as bar:
+                do_busy()
+
+    :param task_name: The name of the task, will be displayed in front of the bar.
+    :param total: Number of steps in the bar. Defaults to 100.
+    :param bar_len: Total length of the bar.
+    :param logger: Jina logger
+    """
+
+    suffix = "%(completed)d/%(total)d"
+    bar_prefix = " |"
+    bar_suffix = "| "
+    empty_fill = " "
+    fill = "#"
+
+    def __init__(
+        self,
+        task_name: str,
+        total: float = 100.0,
+        bar_len: int = 32,
+        logger=None,
+    ):
+        super().__init__(task_name, logger)
+        self.task_name = task_name
+        self.total = total
+        self.bar_len = bar_len
+
+    def __getitem__(self, key):
+        if key.startswith("_"):
+            return None
+        return getattr(self, key, None)
+
+    @property
+    def percent(self) -> float:
+        """Calculate percentage complete.
+
+        :return: the percentage of completed, [0.0, 1.0]
+        """
+        return self.completed / self.total
+
+    def update(
+        self,
+        steps: Optional[float] = 1.0,
+        progress: Optional[float] = None,
+        total: Optional[float] = None,
+    ):
+        """Update progress with new values.
+
+        :param steps: Number of incremental completed steps.
+        :param progress: : Number of completed steps.
+        :param total: Total number of steps, or ``None`` to not change. Defaults to None.
+        """
+
+        if progress is not None:
+            self.completed = progress
+        else:
+            self.completed += steps
+
+        self.total = total if total is not None else self.total
+
+        sys.stdout.write("\r")
+        elapsed = time.perf_counter() - self.start
+
+        num_bars = int(max(1, self.percent * self.bar_len))
+        num_bars = num_bars % self.bar_len
+        num_bars = self.bar_len if not num_bars and self.completed else max(num_bars, 1)
+
+        suffix = self.suffix % self
+        # suffix = f'{self.completed}/{self.total}'
+        line = "".join(
+            [
+                self.task_name,
+                self.bar_prefix,
+                self.fill * num_bars,
+                self.empty_fill * (self.bar_len - num_bars),
+                self.bar_suffix,
+                suffix,
+            ]
+        )
+        sys.stdout.write(line)
+
+        # sys.stdout.write(
+        #     '{:>10} |{:<{}}| ⏱️ {:3.1f}s'.format(
+        #         colored(self.task_name, 'cyan'),
+        #         colored('█' * num_bars, 'green'),
+        #         self.bar_len + 9,
+        #         elapsed,
+        #     )
+        # )
+        if num_bars == self.bar_len:
+            sys.stdout.write("\n")
+        sys.stdout.flush()
+
+    def __enter__(self):
+        super().__enter__()
+        self.completed = -1
+        self.update()
+        return self
+
+    def _enter_msg(self):
+        pass
+
+    def _exit_msg(self):
+        sys.stdout.write(
+            f'\t{colored(f"✅ done in ⏱ {self.readable_duration}", "green")}\n'
+        )
+
+
+class ChargingBar(ProgressBar):
+    """Charging Bar"""
+
+    bar_prefix = " "
+    bar_suffix = " "
+    empty_fill = "∙"
+    fill = "█"
+
+
+class Spinner(ProgressBar):
+    """Spinner"""
+
+    phases = ("-", "\\", "|", "/")
+    hide_cursor = True
+
+    def update(
+        self,
+        steps: Optional[float] = 1.0,
+        progress: Optional[float] = None,
+        total: Optional[float] = None,
+    ):
+        """Update progress with new values.
+
+        :param steps: Number of incremental completed steps.
+        :param progress: : Number of completed steps.
+        :param total: Total number of steps, or ``None`` to not change. Defaults to None.
+        """
+
+        if progress is not None:
+            self.completed = progress
+        else:
+            self.completed += steps
+
+        self.total = total if total is not None else self.total
+
+        i = int(self.completed) % len(self.phases)
+
+        sys.stdout.write("\r")
+        elapsed = time.perf_counter() - self.start
+
+        line = " ".join([self.task_name, self.phases[i]])
+        sys.stdout.write(line)
+
+        if self.percent >= 1.0:
+            sys.stdout.write("\n")
+        sys.stdout.flush()
+
+
+class PieSpinner(Spinner):
+    """PieSpinner"""
+
+    phases = ["◷", "◶", "◵", "◴"]
+
+
+class MoonSpinner(Spinner):
+    """MoonSpinner"""
+
+    phases = ["◑", "◒", "◐", "◓"]


### PR DESCRIPTION
Create a new implementation of `ProgressBar` and `Spinner`. The original `jina.logging.profile.ProgressBar` is designed for `jina.Client`, that would not be suitable for download/uploading file.

The progress bar for uploading is show as following:

![push](https://user-images.githubusercontent.com/35718120/123902523-92bfc180-d99f-11eb-8e5a-0bce1e1a29f9.gif)

As the head request of S3 url does not contains `Content-Length`. That means we cannot get the size of download ahead. So, we use a spinner instead of progress bar for downloading

![pull](https://user-images.githubusercontent.com/35718120/123902541-99e6cf80-d99f-11eb-9a4a-2305b3b2605f.gif)



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1200479679796904/1200540369414310) by [Unito](https://www.unito.io)

Close #2754 