### PR TITLE
refactor: remove unneeded func

### DIFF
--- a/jina/peapods/pods/__init__.py
+++ b/jina/peapods/pods/__init__.py
@@ -112,13 +112,6 @@ class BasePod(ExitFIFO):
         """
         raise NotImplementedError
 
-    def close(self):
-        """Stop all :class:`BasePea` in this BasePod.
-
-        .. # noqa: DAR201
-        """
-        self.__exit__(None, None, None)
-
     @staticmethod
     def _set_upload_files(args):
         # sets args.upload_files at the pod level so that peas inherit from it.


### PR DESCRIPTION
**Why this change**
JinaD calls close of the object which actually is another way of closing the ExitStack. (Removing this makes it clear that `Flows` and `Pods` behave the same way from JinaD perspective