### PR TITLE
fix(core): prevent peas from hanging on close

### DIFF
--- a/jina/peapods/peas/__init__.py
+++ b/jina/peapods/peas/__init__.py
@@ -115,8 +115,7 @@ class BasePea:
         :param args: extra positional arguments to pass to join
         :param kwargs: extra keyword arguments to pass to join
         """
-        if self.worker.is_alive():
-            self.worker.join(*args, **kwargs)
+        self.worker.join(*args, **kwargs)
 
     def terminate(self):
         """Terminate the Pea.


### PR DESCRIPTION
We noticed that this [test](https://github.com/jina-ai/jina/blob/master/tests/daemon/unit/api/endpoints/test_common.py#L159) was failing a lot (but randomly) in [ci](https://github.com/jina-ai/jina/pull/2799/checks?check_run_id=2950566069)

I was running this test locally a lot and saw it less often, but it happened as well occasionally. The reason for the failure is that the flow closing hangs, which does so because the Pea closing hangs.
After discussion with @JoanFM we decided to remove the alive check the process as it seems to be unnecessary and was just added recently and may be the reason for the issue.
Another possible workaround was a `time.sleep() `after terminating a Pea, but we would rather try to avoid this.

I was running this changed version locally hundreds of time and did not encounter the issue anymore.

