### PR TITLE
changed tag for pip install, from standard to http

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ fragmented, multi-vendor, generic legacy tools.
 
 ## Install
 
-- via PyPI: `pip install -U "jina[standard]"`
+- via PyPI: `pip install -U "jina[http]"`
 - via Docker: `docker run jinaai/jina:latest`
 
 <details>


### PR DESCRIPTION
standard tag will work after a new release.

So maybe ok to let this drop as new release maybe coming shortly.
But as of the time of submitting this PR, the standard tag results in error. Details in this slack discussion

https://jina-ai.slack.com/archives/CTH1CMP8V/p1625148905234200