### PR TITLE
fix(ci): add env vars for docker test to ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,6 +150,30 @@ jobs:
         test-arch: ["linux/amd64", "linux/arm64"]
     steps:
       - uses: actions/checkout@v2
+      - name: Set envs and versions
+        run: |
+          echo "VCS_REF=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+          echo "BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_ENV
+          echo "JINA_VERSION=$(sed -n '/^__version__/p' ./jina/__init__.py | cut -d \' -f2)-master" >> $GITHUB_ENV
+
+          if [[ "${{ matrix.tag_pyversion }}" == "-py38" ]]; then
+            echo "PY_VERSION=3.8" >> $GITHUB_ENV
+          elif [[ "${{ matrix.tag_pyversion }}" == "-py39" ]]; then
+            echo "PY_VERSION=3.9" >> $GITHUB_ENV
+          else
+            echo "PY_VERSION=3.7" >> $GITHUB_ENV
+            echo "TAG_ALIAS=jinaai/jina:master${{ matrix.tag_stage }}" >> $GITHUB_ENV
+          fi
+
+          if [[ "${{ matrix.tag_stage }}" == "-daemon" ]]; then
+            echo "BUILD_ARG=jina_daemon" >> $GITHUB_ENV
+          elif [[ "${{ matrix.tag_stage }}" == "-devel" ]]; then
+            echo "BUILD_ARG=jina_devel" >> $GITHUB_ENV
+          elif [[ "${{ matrix.tag_stage }}" == "-standard" ]]; then
+            echo "BUILD_ARG=jina_standard" >> $GITHUB_ENV
+          else
+            echo "BUILD_ARG=jina_base" >> $GITHUB_ENV
+          fi
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v1


### PR DESCRIPTION
docker build tests are failing due to missing env vars in CI. copied them from CD.

Some failure atm: https://github.com/jina-ai/jina/pull/2828/checks?check_run_id=2964672841