### PR TITLE
refactor: refactor is ready

### DIFF
--- a/jina/excepts.py
+++ b/jina/excepts.py
@@ -118,3 +118,7 @@ class SocketTypeError(Exception):
 
 class RoutingTableCyclicError(Exception):
     """Raised when the routing graph has cycles."""
+
+
+class RuntimeRunForeverEarlyError(Exception):
+    """Raised when an error occurs when starting the run_forever of Runtime"""

--- a/jina/helper.py
+++ b/jina/helper.py
@@ -48,6 +48,8 @@ __all__ = [
     'countdown',
     'CatchAllCleanupContextManager',
     'download_mermaid_url',
+    'get_readable_size',
+    'get_or_reuse_loop',
 ]
 
 

--- a/jina/peapods/peas/__init__.py
+++ b/jina/peapods/peas/__init__.py
@@ -8,7 +8,7 @@ from typing import Any, Tuple
 from .helper import _get_event, ConditionalEvent
 from ... import __stop_msg__, __ready_msg__, __default_host__, __docker_host__
 from ...enums import PeaRoleType, RuntimeBackendType, SocketType, GatewayProtocolType
-from ...excepts import RuntimeFailToStart
+from ...excepts import RuntimeFailToStart, RuntimeRunForeverEarlyError
 from ...helper import typename
 from ...hubble.helper import is_valid_huburi, parse_hub_uri
 from ...hubble.hubapi import resolve_local
@@ -41,6 +41,7 @@ class BasePea:
         self.name = self.args.name or self.__class__.__name__
         self.is_ready = _get_event(self.worker)
         self.is_shutdown = _get_event(self.worker)
+        self.is_started = _get_event(self.worker)
         self.ready_or_shutdown = ConditionalEvent(
             getattr(args, 'runtime_backend', RuntimeBackendType.THREAD),
             events_list=[self.is_ready, self.is_shutdown],
@@ -170,12 +171,11 @@ class BasePea:
                 exc_info=not self.args.quiet_error,
             )
         else:
-            self.is_ready.set()
+            self.is_started.set()
             with runtime:
                 runtime.run_forever()
         finally:
             self.is_shutdown.set()
-            self.is_ready.clear()
             self._unset_envs()
 
     def activate_runtime(self):
@@ -217,7 +217,10 @@ class BasePea:
         if self.ready_or_shutdown.event.wait(_timeout):
             if self.is_shutdown.is_set():
                 # return too early and the shutdown is set, means something fails!!
-                raise RuntimeFailToStart
+                if not self.is_started.is_set():
+                    raise RuntimeFailToStart
+                else:
+                    raise RuntimeRunForeverEarlyError
             else:
                 self.logger.success(__ready_msg__)
         else:
@@ -265,10 +268,21 @@ class BasePea:
             # here shutdown has been set already, therefore `run` will gracefully finish
             pass
         else:
-            # terminate is needed because sometimes, we arrive to the close logic before the `is_ready` is even set.
+            # sometimes, we arrive to the close logic before the `is_ready` is even set.
             # Observed with `gateway` when Pods fail to start
-            self.terminate()
-            time.sleep(0.1)
+            self.logger.warning(
+                'Pea is being closed before being ready. Most likely some other Pea in the Flow or Pod'
+                'failed to start'
+            )
+            if self.is_ready.wait(timeout=0.1):
+                self._cancel_runtime()
+            else:
+                self.logger.warning(
+                    'Terminating process after waiting for readiness signal for graceful shutdown'
+                )
+                # Just last resource, terminate it
+                self.terminate()
+                time.sleep(0.1)
         self.logger.debug(__stop_msg__)
         self.logger.close()
 

--- a/jina/peapods/peas/__init__.py
+++ b/jina/peapods/peas/__init__.py
@@ -145,7 +145,9 @@ class BasePea:
             if self.runtime_cls == JinadRuntime
             else self._zed_runtime_ctrl_address
         )
-        return self.runtime_cls(self.args, ctrl_addr=ctrl_addr)
+        return self.runtime_cls(
+            self.args, ctrl_addr=ctrl_addr, ready_event=self.is_ready
+        )
 
     def run(self):
         """Method representing the :class:`BaseRuntime` activity.

--- a/jina/peapods/runtimes/base.py
+++ b/jina/peapods/runtimes/base.py
@@ -73,7 +73,7 @@ class BaseRuntime:
         else:
             self.name = self.__class__.__name__
         self.logger = JinaLogger(self.name, **vars(self.args))
-        self.is_ready = ready_event
+        self.is_ready_event = ready_event
 
     def run_forever(self):
         """Running the blocking procedure inside ``S``. Note, once this method is called,
@@ -94,6 +94,7 @@ class BaseRuntime:
         You can tidy up things here.  Optional in subclasses. The default implementation does nothing.
         """
         self.logger.close()
+        self.is_ready_event.clear()
 
     def __enter__(self):
         return self

--- a/jina/peapods/runtimes/container/__init__.py
+++ b/jina/peapods/runtimes/container/__init__.py
@@ -16,8 +16,8 @@ from ....helper import ArgNamespace, slugify
 class ContainerRuntime(ZMQRuntime):
     """Runtime procedure for container."""
 
-    def __init__(self, args: 'argparse.Namespace', ctrl_addr: str):
-        super().__init__(args, ctrl_addr)
+    def __init__(self, args: 'argparse.Namespace', ctrl_addr: str, **kwargs):
+        super().__init__(args, ctrl_addr, **kwargs)
         self._set_network_for_dind_linux()
         self._docker_run()
         while self._is_container_alive and not self.is_ready:

--- a/jina/peapods/runtimes/container/__init__.py
+++ b/jina/peapods/runtimes/container/__init__.py
@@ -41,6 +41,7 @@ class ContainerRuntime(ZMQRuntime):
 
     def run_forever(self):
         """Stream the logs while running."""
+        self.is_ready_event.set()
         self._stream_logs()
 
     def _set_network_for_dind_linux(self):

--- a/jina/peapods/runtimes/gateway/grpc/__init__.py
+++ b/jina/peapods/runtimes/gateway/grpc/__init__.py
@@ -55,5 +55,6 @@ class GRPCRuntime(AsyncNewLoopRuntime):
 
     async def async_run_forever(self):
         """The async running of server."""
+        self.is_ready_event.set()
         await self.server.wait_for_termination()
         self.zmqlet.close()

--- a/jina/peapods/runtimes/gateway/http/__init__.py
+++ b/jina/peapods/runtimes/gateway/http/__init__.py
@@ -60,6 +60,7 @@ class HTTPRuntime(AsyncNewLoopRuntime):
 
     async def async_run_forever(self):
         """Running method of ther server."""
+        self.is_ready_event.set()
         await self._server.serve()
 
     async def async_cancel(self):

--- a/jina/peapods/runtimes/gateway/websocket/__init__.py
+++ b/jina/peapods/runtimes/gateway/websocket/__init__.py
@@ -61,6 +61,7 @@ class WebSocketRuntime(AsyncNewLoopRuntime):
 
     async def async_run_forever(self):
         """Running method of ther server."""
+        self.is_ready_event.set()
         await self._server.serve()
 
     async def async_cancel(self):

--- a/jina/peapods/runtimes/jinad/__init__.py
+++ b/jina/peapods/runtimes/jinad/__init__.py
@@ -41,6 +41,7 @@ class JinadRuntime(AsyncZMQRuntime):
         """
         Streams log messages using websocket from remote server
         """
+        self.is_ready_event.set()
         self._logging_task = asyncio.create_task(
             self._sleep_forever()
             if self.args.quiet_remote_logs

--- a/jina/peapods/runtimes/jinad/__init__.py
+++ b/jina/peapods/runtimes/jinad/__init__.py
@@ -13,8 +13,8 @@ from ....helper import cached_property, colored
 class JinadRuntime(AsyncZMQRuntime):
     """Runtime procedure for Jinad."""
 
-    def __init__(self, args: 'argparse.Namespace', ctrl_addr: str):
-        super().__init__(args, ctrl_addr)
+    def __init__(self, args: 'argparse.Namespace', ctrl_addr: str, **kwargs):
+        super().__init__(args, ctrl_addr, **kwargs)
         # Need the `proper` control address to send `activate` and `deactivate` signals, from the pea in the `main`
         # process.
         self.host = args.host

--- a/jina/peapods/runtimes/zmq/base.py
+++ b/jina/peapods/runtimes/zmq/base.py
@@ -8,8 +8,8 @@ from ...zmq import send_ctrl_message
 class ZMQRuntime(BaseRuntime, ABC):
     """Runtime procedure leveraging ZMQ."""
 
-    def __init__(self, args: 'argparse.Namespace', ctrl_addr: str):
-        super().__init__(args)
+    def __init__(self, args: 'argparse.Namespace', ctrl_addr: str, **kwargs):
+        super().__init__(args, **kwargs)
         self.ctrl_addr = ctrl_addr
 
     @property

--- a/jina/peapods/runtimes/zmq/zed.py
+++ b/jina/peapods/runtimes/zmq/zed.py
@@ -32,13 +32,14 @@ from ....types.routing.table import RoutingTable
 class ZEDRuntime(ZMQRuntime):
     """Runtime procedure leveraging :class:`ZmqStreamlet` for Executor."""
 
-    def __init__(self, args: argparse.Namespace, ctrl_addr: str):
+    def __init__(self, args: argparse.Namespace, ctrl_addr: str, **kwargs):
         """Initialize private parameters and execute private loading functions.
 
         :param args: args from CLI
         :param ctrl_addr: control port address
+        :param kwargs: extra keyword arguments
         """
-        super().__init__(args, ctrl_addr)
+        super().__init__(args, ctrl_addr, **kwargs)
         self._id = random_identity()
         self._last_active_time = time.perf_counter()
 

--- a/jina/peapods/runtimes/zmq/zed.py
+++ b/jina/peapods/runtimes/zmq/zed.py
@@ -54,28 +54,31 @@ class ZEDRuntime(ZMQRuntime):
         # idle_dealer_ids only becomes non-None when it receives IDLE ControlRequest
         self._idle_dealer_ids = set()
 
-        self._load_zmqlet()
+        self._load_zmqstreamlet()
         self._load_plugins()
         self._load_executor()
 
     def run_forever(self):
         """Start the `ZmqStreamlet`."""
-        self._zmqlet.start(self._msg_callback)
+        self._zmqstreamlet.start(self._msg_callback)
 
     def teardown(self):
         """Close the `ZmqStreamlet` and `Executor`."""
-        self._zmqlet.close()
+        self._zmqstreamlet.close()
         self._executor.close()
         super().teardown()
 
     #: Private methods required by :meth:`setup`
 
-    def _load_zmqlet(self):
+    def _load_zmqstreamlet(self):
         """Load ZMQStreamlet to this runtime."""
         # important: fix zmqstreamlet ctrl address to replace the the ctrl address generated in the main
         # process/thread
-        self._zmqlet = ZmqStreamlet(
-            self.args, logger=self.logger, ctrl_addr=self.ctrl_addr
+        self._zmqstreamlet = ZmqStreamlet(
+            args=self.args,
+            logger=self.logger,
+            ctrl_addr=self.ctrl_addr,
+            ready_event=self.is_ready_event,
         )
 
     def _load_executor(self):
@@ -108,7 +111,6 @@ class ZEDRuntime(ZMQRuntime):
             PathImporter.add_modules(*self.args.py_modules)
 
     #: Private methods required by :meth:`teardown`
-
     def _check_memory_watermark(self):
         """Check the memory watermark."""
         if used_memory() > self.args.memory_hwm > 0:
@@ -186,12 +188,13 @@ class ZEDRuntime(ZMQRuntime):
             parsed_params.update(**specific_parameters)
         return parsed_params
 
-    def _handle(self, msg: 'Message') -> 'ZEDRuntime':
+    def _handle(self) -> 'ZEDRuntime':
         """Register the current message to this pea, so that all message-related properties are up-to-date, including
         :attr:`request`, :attr:`prev_requests`, :attr:`message`, :attr:`prev_messages`. And then call the executor to handle
         this message if its envelope's  status is not ERROR, else skip handling of message.
 
-        :param msg: the message received
+        .. note::
+            Handle does not handle explicitly message because it may wait for different messages when different parts are expected
         :return: ZEDRuntime procedure.
         """
 
@@ -208,7 +211,7 @@ class ZEDRuntime(ZMQRuntime):
 
             # when no available dealer, pause the pollin from upstream
             if not self._idle_dealer_ids:
-                self._zmqlet.pause_pollin()
+                self._zmqstreamlet.pause_pollin()
 
         if (
             self.envelope.header.exec_endpoint not in self._executor.requests
@@ -255,7 +258,7 @@ class ZEDRuntime(ZMQRuntime):
             self.request.parameters = vars(self.args)
         elif self.request.command == 'IDLE':
             self._idle_dealer_ids.add(self.envelope.receiver_id)
-            self._zmqlet.resume_pollin()
+            self._zmqstreamlet.resume_pollin()
             self.logger.debug(
                 f'{self.envelope.receiver_id} is idle, now I know these idle peas {self._idle_dealer_ids}'
             )
@@ -263,9 +266,9 @@ class ZEDRuntime(ZMQRuntime):
             if self.envelope.receiver_id in self._idle_dealer_ids:
                 self._idle_dealer_ids.remove(self.envelope.receiver_id)
         elif self.request.command == 'ACTIVATE':
-            self._zmqlet._send_idle_to_router()
+            self._zmqstreamlet._send_idle_to_router()
         elif self.request.command == 'DEACTIVATE':
-            self._zmqlet._send_cancel_to_router()
+            self._zmqstreamlet._send_cancel_to_router()
         else:
             raise UnknownControlCommand(
                 f'don\'t know how to handle {self.request.command}'
@@ -273,7 +276,7 @@ class ZEDRuntime(ZMQRuntime):
 
     def _callback(self, msg: 'Message'):
         self.is_post_hook_done = False  #: if the post_hook is called
-        self._pre_hook(msg)._handle(msg)._post_hook(msg)
+        self._pre_hook(msg)._handle()._post_hook(msg)
         self.is_post_hook_done = True
         return msg
 
@@ -287,21 +290,21 @@ class ZEDRuntime(ZMQRuntime):
         try:
             # notice how executor related exceptions are handled here
             # generally unless executor throws an OSError, the exception are caught and solved inplace
-            self._zmqlet.send_message(self._callback(msg))
+            self._zmqstreamlet.send_message(self._callback(msg))
         except RuntimeTerminated:
             # this is the proper way to end when a terminate signal is sent
-            self._zmqlet.send_message(msg)
-            self._zmqlet.close()
+            self._zmqstreamlet.send_message(msg)
+            self._zmqstreamlet.close()
         except KeyboardInterrupt as kbex:
             # save executor
             self.logger.debug(f'{kbex!r} causes the breaking from the event loop')
-            self._zmqlet.send_message(msg)
-            self._zmqlet.close(flush=False)
+            self._zmqstreamlet.send_message(msg)
+            self._zmqstreamlet.close(flush=False)
         except (SystemError, zmq.error.ZMQError) as ex:
             # save executor
             self.logger.debug(f'{ex!r} causes the breaking from the event loop')
-            self._zmqlet.send_message(msg)
-            self._zmqlet.close()
+            self._zmqstreamlet.send_message(msg)
+            self._zmqstreamlet.close()
         except MemoryOverHighWatermark:
             self.logger.critical(
                 f'memory usage {used_memory()} GB is above the high-watermark: {self.args.memory_hwm} GB'
@@ -333,7 +336,7 @@ class ZEDRuntime(ZMQRuntime):
                     exc_info=not self.args.quiet_error,
                 )
 
-            self._zmqlet.send_message(msg)
+            self._zmqstreamlet.send_message(msg)
 
     #: Some class-specific properties
 

--- a/tests/unit/peapods/peas/test_pea.py
+++ b/tests/unit/peapods/peas/test_pea.py
@@ -3,7 +3,7 @@ import time
 
 import pytest
 
-from jina.excepts import RuntimeFailToStart
+from jina.excepts import RuntimeFailToStart, RuntimeRunForeverEarlyError
 from jina.executors import BaseExecutor
 from jina.parsers import set_pea_parser
 from jina.peapods import Pea
@@ -37,14 +37,18 @@ def test_base_pea_with_runtime_bad_init(mocker):
     cancel_spy.assert_not_called()
 
 
-def test_base_pea_with_runtime_bad_run_forever(mocker):
+def test_base_pea_with_runtime_bad_run_forever_after_ready(mocker):
     class Pea1(Pea):
         def __init__(self, args):
             super().__init__(args)
             self.runtime_cls = BaseRuntime
 
+    def mock_run_forever(runtime):
+        runtime.is_ready_event.set()
+        bad_func()
+
     arg = set_pea_parser().parse_args(['--runtime-backend', 'thread'])
-    mocker.patch.object(BaseRuntime, 'run_forever', bad_func)
+    mocker.patch.object(BaseRuntime, 'run_forever', mock_run_forever)
     teardown_spy = mocker.spy(BaseRuntime, 'teardown')
     cancel_spy = mocker.spy(Pea, '_cancel_runtime')
     run_spy = mocker.spy(BaseRuntime, 'run_forever')
@@ -53,10 +57,34 @@ def test_base_pea_with_runtime_bad_run_forever(mocker):
         pass
 
     # teardown should be called, cancel should not be called
-
     teardown_spy.assert_called()
     run_spy.assert_called()
     cancel_spy.assert_called()
+
+
+def test_base_pea_with_runtime_bad_run_forever_before_ready(mocker):
+    class Pea1(Pea):
+        def __init__(self, args):
+            super().__init__(args)
+            self.runtime_cls = BaseRuntime
+
+    def mock_run_forever(runtime):
+        bad_func()
+
+    arg = set_pea_parser().parse_args(['--runtime-backend', 'thread'])
+    mocker.patch.object(BaseRuntime, 'run_forever', mock_run_forever)
+    teardown_spy = mocker.spy(BaseRuntime, 'teardown')
+    cancel_spy = mocker.spy(Pea, '_cancel_runtime')
+    run_spy = mocker.spy(BaseRuntime, 'run_forever')
+
+    with pytest.raises(RuntimeRunForeverEarlyError):
+        with Pea1(arg):
+            pass
+
+    # teardown should be called, cancel should not be called
+    teardown_spy.assert_called()
+    run_spy.assert_called()
+    cancel_spy.assert_not_called()
 
 
 def test_base_pea_with_runtime_bad_teardown(mocker):
@@ -65,7 +93,11 @@ def test_base_pea_with_runtime_bad_teardown(mocker):
             super().__init__(args)
             self.runtime_cls = BaseRuntime
 
-    mocker.patch.object(BaseRuntime, 'run_forever', lambda x: time.sleep(3))
+    def mock_run_forever(runtime):
+        runtime.is_ready_event.set()
+        time.sleep(3)
+
+    mocker.patch.object(BaseRuntime, 'run_forever', mock_run_forever)
     mocker.patch.object(BaseRuntime, 'teardown', lambda x: bad_func)
     teardown_spy = mocker.spy(BaseRuntime, 'teardown')
     cancel_spy = mocker.spy(Pea, '_cancel_runtime')
@@ -88,7 +120,11 @@ def test_base_pea_with_runtime_bad_cancel(mocker):
             super().__init__(args)
             self.runtime_cls = BaseRuntime
 
-    mocker.patch.object(BaseRuntime, 'run_forever', lambda x: time.sleep(3))
+    def mock_run_forever(runtime):
+        runtime.is_ready_event.set()
+        time.sleep(3)
+
+    mocker.patch.object(BaseRuntime, 'run_forever', mock_run_forever)
     mocker.patch.object(Pea, '_cancel_runtime', bad_func)
 
     teardown_spy = mocker.spy(BaseRuntime, 'teardown')
@@ -97,6 +133,7 @@ def test_base_pea_with_runtime_bad_cancel(mocker):
 
     arg = set_pea_parser().parse_args(['--runtime-backend', 'thread'])
     with Pea1(arg):
+        time.sleep(0.1)
         pass
 
     teardown_spy.assert_called()

--- a/tests/unit/peapods/runtimes/container/test_container_runtime.py
+++ b/tests/unit/peapods/runtimes/container/test_container_runtime.py
@@ -1,6 +1,7 @@
 import os
 import time
 from sys import platform
+import multiprocessing
 
 import pytest
 
@@ -272,7 +273,7 @@ def test_pass_arbitrary_kwargs(monkeypatch, mocker):
             'environment: ["VAR1=BAR", "VAR2=FOO"]',
         ]
     )
-    _ = ContainerRuntime(args, ctrl_addr='')
+    _ = ContainerRuntime(args, ctrl_addr='', ready_event=multiprocessing.Event())
     expected_args = {'hello': 0, 'ports': None, 'environment': ['VAR1=BAR', 'VAR2=FOO']}
     mock.assert_called_with(**expected_args)
 

--- a/tests/unit/peapods/zmq/test_dynamic_routing.py
+++ b/tests/unit/peapods/zmq/test_dynamic_routing.py
@@ -3,6 +3,7 @@ import threading
 import time
 
 import pytest
+import multiprocessing
 from google.protobuf import json_format
 
 from jina.helper import random_identity
@@ -213,9 +214,13 @@ def test_double_dynamic_routing_zmqstreamlet():
     args3 = get_args()
 
     logger = logging.getLogger('zmq-test')
-    with ZmqStreamlet(args1, logger) as z1, ZmqStreamlet(
-        args2, logger
-    ) as z2, ZmqStreamlet(args3, logger) as z3:
+    with ZmqStreamlet(
+        args=args1, ready_event=multiprocessing.Event(), logger=logger
+    ) as z1, ZmqStreamlet(
+        args=args2, ready_event=multiprocessing.Event(), logger=logger
+    ) as z2, ZmqStreamlet(
+        args=args3, ready_event=multiprocessing.Event(), logger=logger
+    ) as z3:
         assert z1.msg_sent == 0
         assert z2.msg_sent == 0
         assert z3.msg_sent == 0

--- a/tests/unit/peapods/zmq/test_zmq_addr.py
+++ b/tests/unit/peapods/zmq/test_zmq_addr.py
@@ -1,5 +1,7 @@
 import pytest
 
+import multiprocessing
+
 from jina.peapods.runtimes.zmq.base import ZMQRuntime
 from jina.peapods.zmq import Zmqlet
 from jina.parsers import set_pod_parser
@@ -35,7 +37,9 @@ def zmq_args_dict(zmq_args_argparse):
 
 @pytest.fixture
 def runtime(zmq_args_argparse):
-    return ZMQRuntime(args=zmq_args_argparse, ctrl_addr='')
+    return ZMQRuntime(
+        args=zmq_args_argparse, ctrl_addr='', ready_event=multiprocessing.Event()
+    )
 
 
 @pytest.fixture
@@ -47,7 +51,9 @@ def ctrl_messages():
 
 @pytest.fixture(params=['zmq_args_dict', 'zmq_args_argparse'])
 def test_init(request):
-    runtime = ZMQRuntime(args=request.param, ctrl_addr='')
+    runtime = ZMQRuntime(
+        args=request.param, ctrl_addr='', ready_event=multiprocessing.Event()
+    )
     assert runtime.host == '0.0.0.0'
     assert runtime.port_expose == 45678
 


### PR DESCRIPTION
**Changes introduced**
We are currently setting `is_ready` before the runtime is actually really ready to handle traffic. This PR gives the responsability to set `is_ready` flag to the `runtime` and tries to make sure that `is_ready` is more meaningful.

It also allows us to avoid the need to call `terminate` and have a potentially more grateful shutdown