### PR TITLE
fix(tests): storm client test case

### DIFF
--- a/tests/integration/concurrent_clients/test_concurrent_clients.py
+++ b/tests/integration/concurrent_clients/test_concurrent_clients.py
@@ -1,0 +1,59 @@
+import pytest
+
+from jina import Flow, Executor, requests, DocumentArray, Document
+from jina.types.request import Response
+import threading, queue
+import random
+import time
+from functools import partial
+from jina import Client, Document
+
+
+class MyExecutor(Executor):
+    @requests(on='/ping')
+    def ping(self, docs: DocumentArray, **kwargs):
+        time.sleep(3 * random.random())
+
+
+@pytest.mark.parametrize('protocal', ['http', 'grpc'])
+@pytest.mark.parametrize('parallel', [10])
+@pytest.mark.parametrize('polling', ['ANY', 'ALL'])
+@pytest.mark.parametrize('prefetch', [10])
+@pytest.mark.parametrize('concurrent', [25])
+def test_concurrent_clients(concurrent, protocal, parallel, polling, prefetch):
+    # def pong(peer_hash, resp: Response):
+    #     for d in resp.docs:
+    #         print(f'{d.text} vs {peer_hash}')
+    #         assert d.text == peer_hash
+
+    tasks = queue.Queue()
+
+    def peer_client(port, protocal, peer_hash):
+        c = Client(protocol=protocal, port_expose=port)
+        for _ in range(10):
+            tasks.put(peer_hash)
+            resps = c.post('/ping', Document(text=peer_hash), return_results=True)
+            for r in resps:
+                for d in r.docs:
+                    if d.text != peer_hash:
+                        return
+            tasks.task_done()
+
+    thread_pool = []
+    for peer_id in range(concurrent):
+        t = threading.Thread(
+            target=partial(peer_client, '12345', protocal, str(peer_id)), daemon=True
+        )
+        thread_pool.append(t)
+
+    f = Flow(protocol=protocal, port_expose='12345', prefetch=prefetch).add(
+        uses=MyExecutor, parallel=parallel, polling=polling
+    )
+
+    with f:
+        for t in thread_pool:
+            t.start()
+
+        for t in thread_pool:
+            t.join()
+    assert tasks.empty()

--- a/tests/integration/concurrent_clients/test_concurrent_clients.py
+++ b/tests/integration/concurrent_clients/test_concurrent_clients.py
@@ -1,61 +1,52 @@
 import pytest
 
-from jina import Flow, Executor, requests, DocumentArray, Document
+from jina import Flow, Executor, Client, requests, DocumentArray, Document
 from jina.types.request import Response
-import threading, queue
+import threading
 import random
 import time
 from functools import partial
-from jina import Client, Document
 
 
 class MyExecutor(Executor):
     @requests(on='/ping')
     def ping(self, docs: DocumentArray, **kwargs):
-        time.sleep(1 * random.random())
+        time.sleep(0.1 * random.random())
 
 
 @pytest.mark.parametrize('protocal', ['http', 'grpc'])
 @pytest.mark.parametrize('parallel', [10])
 @pytest.mark.parametrize('polling', ['ANY', 'ALL'])
 @pytest.mark.parametrize('prefetch', [1, 10])
-@pytest.mark.parametrize('concurrent', [10])
-def test_concurrent_clients(concurrent, protocal, parallel, polling, prefetch):
-    # def pong(peer_hash, resp: Response):
-    #     for d in resp.docs:
-    #         print(f'{d.text} vs {peer_hash}')
-    #         assert d.text == peer_hash
-
-    failed_tasks = queue.Queue()
+@pytest.mark.parametrize('concurrent', [15])
+def test_concurrent_clients(concurrent, protocal, parallel, polling, prefetch, reraise):
+    def pong(peer_hash, resp: Response):
+        for d in resp.docs:
+            with reraise:
+                assert d.text == peer_hash
 
     def peer_client(port, protocal, peer_hash):
         c = Client(protocol=protocal, port_expose=port)
-        for _ in range(100):
-            resps = c.post('/ping', Document(text=peer_hash), return_results=True)
-            for r in resps:
-                for d in r.docs:
-                    if d.text != peer_hash:
-                        failed_tasks.put(peer_hash)
-                        return
+        for _ in range(5):
+            c.post(
+                '/ping', Document(text=peer_hash), on_done=lambda r: pong(peer_hash, r)
+            )
 
     f = Flow(protocol=protocal, prefetch=prefetch).add(
         uses=MyExecutor, parallel=parallel, polling=polling
     )
-    port_expose = f.gateway_args.port_expose
-
-    thread_pool = []
-    for peer_id in range(concurrent):
-        t = threading.Thread(
-            target=partial(peer_client, port_expose, protocal, str(peer_id)),
-            daemon=True,
-        )
-        thread_pool.append(t)
 
     with f:
-        for t in thread_pool:
+        port_expose = f.port_expose
+
+        thread_pool = []
+        for peer_id in range(concurrent):
+            t = threading.Thread(
+                target=partial(peer_client, port_expose, protocal, str(peer_id)),
+                daemon=True,
+            )
             t.start()
+            thread_pool.append(t)
 
         for t in thread_pool:
             t.join()
-
-    assert failed_tasks.empty()

--- a/tests/integration/concurrent_clients/test_concurrent_clients.py
+++ b/tests/integration/concurrent_clients/test_concurrent_clients.py
@@ -12,43 +12,44 @@ from jina import Client, Document
 class MyExecutor(Executor):
     @requests(on='/ping')
     def ping(self, docs: DocumentArray, **kwargs):
-        time.sleep(3 * random.random())
+        time.sleep(1 * random.random())
 
 
 @pytest.mark.parametrize('protocal', ['http', 'grpc'])
 @pytest.mark.parametrize('parallel', [10])
 @pytest.mark.parametrize('polling', ['ANY', 'ALL'])
-@pytest.mark.parametrize('prefetch', [10])
-@pytest.mark.parametrize('concurrent', [25])
+@pytest.mark.parametrize('prefetch', [1, 10])
+@pytest.mark.parametrize('concurrent', [10])
 def test_concurrent_clients(concurrent, protocal, parallel, polling, prefetch):
     # def pong(peer_hash, resp: Response):
     #     for d in resp.docs:
     #         print(f'{d.text} vs {peer_hash}')
     #         assert d.text == peer_hash
 
-    tasks = queue.Queue()
+    failed_tasks = queue.Queue()
 
     def peer_client(port, protocal, peer_hash):
         c = Client(protocol=protocal, port_expose=port)
-        for _ in range(10):
-            tasks.put(peer_hash)
+        for _ in range(100):
             resps = c.post('/ping', Document(text=peer_hash), return_results=True)
             for r in resps:
                 for d in r.docs:
                     if d.text != peer_hash:
+                        failed_tasks.put(peer_hash)
                         return
-            tasks.task_done()
+
+    f = Flow(protocol=protocal, prefetch=prefetch).add(
+        uses=MyExecutor, parallel=parallel, polling=polling
+    )
+    port_expose = f.gateway_args.port_expose
 
     thread_pool = []
     for peer_id in range(concurrent):
         t = threading.Thread(
-            target=partial(peer_client, '12345', protocal, str(peer_id)), daemon=True
+            target=partial(peer_client, port_expose, protocal, str(peer_id)),
+            daemon=True,
         )
         thread_pool.append(t)
-
-    f = Flow(protocol=protocal, port_expose='12345', prefetch=prefetch).add(
-        uses=MyExecutor, parallel=parallel, polling=polling
-    )
 
     with f:
         for t in thread_pool:
@@ -56,4 +57,5 @@ def test_concurrent_clients(concurrent, protocal, parallel, polling, prefetch):
 
         for t in thread_pool:
             t.join()
-    assert tasks.empty()
+
+    assert failed_tasks.empty()

--- a/tests/storm/echo_flow.py
+++ b/tests/storm/echo_flow.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 import time
 import random
 import sys
@@ -16,8 +17,9 @@ class MyExecutor(Executor):
 @click.option('--polling', default='ANY')
 @click.option('--parallel', default=15)
 @click.option('--protocal', default='http')
-def cli(port, protocal, parallel, polling):
-    f = Flow(protocol=protocal, port_expose=port).add(
+@click.option('--prefetch', default=50)
+def cli(port, protocal, parallel, polling, prefetch):
+    f = Flow(protocol=protocal, port_expose=port, prefetch=prefetch).add(
         uses=MyExecutor, parallel=parallel, polling=polling
     )
     with f:

--- a/tests/storm/echo_flow.py
+++ b/tests/storm/echo_flow.py
@@ -1,0 +1,28 @@
+import time
+import random
+import sys
+import click
+from jina import Flow, Executor, DocumentArray, requests
+
+
+class MyExecutor(Executor):
+    @requests(on='/ping')
+    def ping(self, docs: DocumentArray, **kwargs):
+        time.sleep(3 * random.random())
+
+
+@click.command()
+@click.argument('port', default=60896)
+@click.option('--polling', default='ANY')
+@click.option('--parallel', default=15)
+@click.option('--protocal', default='http')
+def cli(port, protocal, parallel, polling):
+    f = Flow(protocol=protocal, port_expose=port).add(
+        uses=MyExecutor, parallel=parallel, polling=polling
+    )
+    with f:
+        f.block()
+
+
+if __name__ == '__main__':
+    cli()

--- a/tests/storm/storm_client.py
+++ b/tests/storm/storm_client.py
@@ -1,0 +1,47 @@
+import click
+import sys
+import time
+from functools import partial
+
+from jina import Client, Document
+
+from jina.types.request import Response
+
+
+def pong(peer_hash, resp: Response):
+    for d in resp.docs:
+        if d.text != peer_hash:
+            print(f'⚠️  mismatch: {peer_hash} vs {d.text}')
+    sys.stdout.write('#')
+    sys.stdout.flush()
+
+
+def peer_client(port, protocal, peer_hash):
+    c = Client(protocol=protocal, port_expose=port)
+    while True:
+        c.post('/ping', Document(text=peer_hash), on_done=lambda x: pong(peer_hash, x))
+        time.sleep(0.5)
+
+
+@click.command()
+@click.argument('port', default=60896)
+@click.option('--concurrent', default=10)
+@click.option('--protocal', default='http')
+def cli(port, protocal, concurrent):
+    import threading
+
+    pool = []
+    print(f'=> start the {concurrent} peer clients accesing :{port} ...')
+    for peer_id in range(concurrent):
+        t = threading.Thread(
+            target=partial(peer_client, port, protocal, str(peer_id)), daemon=True
+        )
+        t.start()
+        pool.append(t)
+
+    for t in pool:
+        t.join()
+
+
+if __name__ == '__main__':
+    cli()


### PR DESCRIPTION
Start flow
```bash
$ python python tests/storm/echo_flow.py [port] [--parallel] [--protocal] [--polling]
```

Then, run the storm test:
```bash
$ python tests/storm/storm_client.py [port] [--protocal] [--concurrent]
```

**Note**: all of the arguments have default value, so you can start the testing without providing any options.

**NEW UPDATES**
```
$ pytest  tests/integration/concurrent_clients/
```