### PR TITLE
test: added remote local test

### DIFF
--- a/jina/peapods/zmq/__init__.py
+++ b/jina/peapods/zmq/__init__.py
@@ -785,7 +785,8 @@ def _parse_from_frames(sock_type, frames: List[bytes]) -> 'Message':
         frames = [b' '] + frames
     elif sock_type == zmq.ROUTER:
         # the router appends dealer id when receive it, we need to remove it
-        frames.pop(0)
+        if len(frames) == 4:
+            frames.pop(0)
 
     return Message(frames[1], frames[2])
 

--- a/jina/peapods/zmq/__init__.py
+++ b/jina/peapods/zmq/__init__.py
@@ -70,6 +70,9 @@ class Zmqlet:
         self.msg_sent = 0
         self.is_closed = False
         self.is_polling_paused = False
+        self.in_sock_type = None
+        self.out_sock_type = None
+        self.ctrl_sock_type = None
         self.opened_socks = []  # this must be here for `close()`
         (
             self.ctx,

--- a/tests/unit/test_echostream.py
+++ b/tests/unit/test_echostream.py
@@ -1,8 +1,7 @@
-import logging
-
 import pytest
 
 from jina import Flow
+from jina.logging.logger import JinaLogger
 from jina.parsers import set_pea_parser
 from jina.peapods.peas import BasePea
 from jina.peapods.zmq import Zmqlet
@@ -47,7 +46,7 @@ def test_simple_zmqlet():
         ]
     )
 
-    logger = logging.getLogger('zmq-test')
+    logger = JinaLogger('zmq-test')
     with BasePea(args2), Zmqlet(args, logger) as z:
         req = jina_pb2.RequestProto()
         req.request_id = random_identity()


### PR DESCRIPTION
This adds a test for sending data from remote back to local via the `remote: ROUTER-BIND` and `local: ROUTER-CONNECT`, where the remote sends data via the bounded sockets.

It also fixes a remaining bug, where the empty frame way removed by accident.

This closes #2782 