### PR TITLE
fix(logging): change debug color to grey

### DIFF
--- a/jina/logging/formatter.py
+++ b/jina/logging/formatter.py
@@ -15,7 +15,7 @@ class ColorFormatter(Formatter):
     """Format the log into colored logs based on the log-level."""
 
     MAPPING = {
-        LogVerbosity.DEBUG: dict(color='black', attrs=['bold']),  # grey
+        LogVerbosity.DEBUG: dict(color='white', attrs=['bold']),  # grey
         LogVerbosity.INFO: dict(),
         LogVerbosity.SUCCESS: dict(color='green'),
         LogVerbosity.WARNING: dict(color='yellow'),


### PR DESCRIPTION
This changes the debug color from black to grey. It says white here in the PR but the result looks actually grey for me.

see top right
![Screenshot from 2021-07-06 11-52-48](https://user-images.githubusercontent.com/6544965/124580723-b62bb600-de50-11eb-9212-e6075aec2c64.png)
