### PR TITLE
fix: make hubble executor work in container

### DIFF
--- a/jina/hubble/hubio.py
+++ b/jina/hubble/hubio.py
@@ -50,7 +50,6 @@ class HubIO:
         else:
             self.args = ArgNamespace.kwargs2namespace(kwargs, set_hub_parser())
         self.logger = JinaLogger(self.__class__.__name__, **vars(args))
-        self._load_docker_client()
 
         with ImportExtensions(required=True):
             import rich
@@ -319,6 +318,7 @@ with f:
                 )
 
                 if scheme == 'jinahub+docker':
+                    self._load_docker_client()
                     st.update(f'Pulling {executor.image_name}...')
                     self._client.images.pull(executor.image_name)
                     return f'docker://{executor.image_name}'


### PR DESCRIPTION
As mentioned by @alexcg1 , the usages of `.add(uses=jinahub://dummy_executor)` cannot work in docker container.