### PR TITLE
feat(logging): skip unnecessary log message constructions

### DIFF
--- a/jina/logging/logger.py
+++ b/jina/logging/logger.py
@@ -94,6 +94,7 @@ class JinaLogger:
         self.critical = self.logger.critical
         self.error = self.logger.error
         self.info = self.logger.info
+        self.debug_enabled = self.logger.isEnabledFor(logging.DEBUG)
 
     @property
     def handlers(self):

--- a/jina/peapods/runtimes/gateway/prefetch.py
+++ b/jina/peapods/runtimes/gateway/prefetch.py
@@ -127,11 +127,12 @@ class PrefetchCaller:
             onrecv_task = []
             # the following code "interleaves" prefetch_task and onrecv_task, when one dries, it switches to the other
             while prefetch_task:
-                self.logger.debug(
-                    f'send: {self.zmqlet.msg_sent} '
-                    f'recv: {self.zmqlet.msg_recv} '
-                    f'pending: {self.zmqlet.msg_sent - self.zmqlet.msg_recv}'
-                )
+                if self.logger.debug_enabled:
+                    self.logger.debug(
+                        f'send: {self.zmqlet.msg_sent} '
+                        f'recv: {self.zmqlet.msg_recv} '
+                        f'pending: {self.zmqlet.msg_sent - self.zmqlet.msg_recv}'
+                    )
                 onrecv_task.clear()
                 for r in asyncio.as_completed(prefetch_task):
                     yield await r


### PR DESCRIPTION
When processing data requests (which is a quite frequent task) we construct some log messages in every case for debug logging purpose. This happens even when debug logging is disabled. I think that is wasteful and should be avoided. 
The easiest way to avoid this is to check for the log level and only construct the log message if necessary. This is also recommended in the [Python documentation](https://docs.python.org/3/howto/logging.html#optimization).
The idea for this came up in this pr: https://github.com/jina-ai/jina/pull/2865

I only changed it for a few cases in this PR which happen quite often and should inflict the most costs for us. Other cases (Initialization and control messages) should not happen often enough that its worth to introduce this check there, I think.