### PR TITLE
fix(tests): remove hard coded ports in rolling update test

### DIFF
--- a/tests/integration/rolling_update/test_rolling_update.py
+++ b/tests/integration/rolling_update/test_rolling_update.py
@@ -208,10 +208,6 @@ def test_port_configuration(replicas_and_parallel):
             name=f'pod{i}',
             replicas=replicas,
             parallel=parallel,
-            port_in=f'51{i}00',
-            # info: needs to be set in this test since the test is asserting pod args with pod tail args
-            port_out=f'51{i + 1}10',
-            # outside this test, it don't have to be set. Due to dynamic routing, it is irrelevant.
             copy_flow=False,
         )
 


### PR DESCRIPTION
This PR removes the hard coded ports in the rolling update test. We can not do it as it was before as it might conflict with arbitrary other ports.
I am not sure why we set it like this before though. 