### PR TITLE
fix: keep uvi server alive

### DIFF
--- a/jina/peapods/runtimes/gateway/http/__init__.py
+++ b/jina/peapods/runtimes/gateway/http/__init__.py
@@ -54,6 +54,7 @@ class HTTPRuntime(AsyncNewLoopRuntime):
                 host=self.args.host,
                 port=self.args.port_expose,
                 log_level=os.getenv('JINA_LOG_LEVEL', 'error').lower(),
+                timeout_keep_alive=0
             )
         )
         await self._server.setup()


### PR DESCRIPTION
When deploying executors on Kubernetes, we experienced that the service is crashing after some time with an internal error.
Recommended way of solving the issue:
https://github.com/encode/uvicorn/issues/344#issuecomment-529363216

logs:
```
WARNING:  Invalid HTTP request received.
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/uvicorn/protocols/http/h11_impl.py", line 136, in handle_events
    event = self.conn.next_event()
  File "/usr/local/lib/python3.7/site-packages/h11/_connection.py", line 443, in next_event
    exc._reraise_as_remote_protocol_error()
  File "/usr/local/lib/python3.7/site-packages/h11/_util.py", line 76, in _reraise_as_remote_protocol_error
    raise self
  File "/usr/local/lib/python3.7/site-packages/h11/_connection.py", line 425, in next_event
    event = self._extract_next_receive_event()
  File "/usr/local/lib/python3.7/site-packages/h11/_connection.py", line 367, in _extract_next_receive_event
    event = self._reader(self._receive_buffer)
  File "/usr/local/lib/python3.7/site-packages/h11/_readers.py", line 76, in maybe_read_from_IDLE_client
    headers=list(_decode_header_lines(lines[1:])), _parsed=True, **matches
  File "/usr/local/lib/python3.7/site-packages/h11/_events.py", line 71, in __init__
    self._validate()
  File "/usr/local/lib/python3.7/site-packages/h11/_events.py", line 140, in _validate
    raise LocalProtocolError("Missing mandatory Host: header")
h11._util.RemoteProtocolError: Missing mandatory Host: header
INFO:     10.0.0.1:7676 - "GET / HTTP/1.1" 404 Not Found
INFO:     10.0.0.1:28161 - "GET / HTTP/1.1" 404 Not Found
INFO:     10.0.0.1:55411 - "POST /index HTTP/1.1" 200 OK
INFO:     10.0.0.1:43535 - "POST /index HTTP/1.1" 200 OK
INFO:     10.0.0.1:6713 - "POST /index HTTP/1.1" 200 OK
INFO:     10.0.0.1:51027 - "POST /index HTTP/1.1" 200 OK
INFO:     10.0.0.1:37067 - "GET / HTTP/1.1" 404 Not Found
INFO:     10.0.0.1:50118 - "GET /invoker/readonly HTTP/1.1" 404 Not Found
INFO:     10.0.0.1:23843 - "GET / HTTP/1.1" 404 Not Found
INFO:     10.0.0.1:47572 - "GET /login HTTP/1.1" 404 Not Found
INFO:     10.0.0.1:37460 - "GET /jenkins/login HTTP/1.1" 404 Not Found
INFO:     10.0.0.1:15066 - "GET /manager/html HTTP/1.1" 404 Not Found
WARNING:  Invalid HTTP request received.
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/uvicorn/protocols/http/h11_impl.py", line 136, in handle_events
    event = self.conn.next_event()
  File "/usr/local/lib/python3.7/site-packages/h11/_connection.py", line 443, in next_event
    exc._reraise_as_remote_protocol_error()
  File "/usr/local/lib/python3.7/site-packages/h11/_util.py", line 76, in _reraise_as_remote_protocol_error
    raise self
  File "/usr/local/lib/python3.7/site-packages/h11/_connection.py", line 425, in next_event
    event = self._extract_next_receive_event()
  File "/usr/local/lib/python3.7/site-packages/h11/_connection.py", line 367, in _extract_next_receive_event
    event = self._reader(self._receive_buffer)
  File "/usr/local/lib/python3.7/site-packages/h11/_readers.py", line 68, in maybe_read_from_IDLE_client
    raise LocalProtocolError("illegal request line")
h11._util.RemoteProtocolError: illegal request line
INFO:     10.0.0.1:42358 - "GET /c/ HTTP/1.1" 404 Not Found
INFO:     10.0.0.1:46533 - "GET / HTTP/1.1" 404 Not Found
INFO:     10.0.0.1:41644 - "GET / HTTP/1.1" 404 Not Found
WARNING:  Invalid HTTP request received.
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/uvicorn/protocols/http/h11_impl.py", line 136, in handle_events
    event = self.conn.next_event()
  File "/usr/local/lib/python3.7/site-packages/h11/_connection.py", line 443, in next_event
    exc._reraise_as_remote_protocol_error()
  File "/usr/local/lib/python3.7/site-packages/h11/_util.py", line 76, in _reraise_as_remote_protocol_error
    raise self
  File "/usr/local/lib/python3.7/site-packages/h11/_connection.py", line 425, in next_event
    event = self._extract_next_receive_event()
  File "/usr/local/lib/python3.7/site-packages/h11/_connection.py", line 367, in _extract_next_receive_event
    event = self._reader(self._receive_buffer)
  File "/usr/local/lib/python3.7/site-packages/h11/_readers.py", line 76, in maybe_read_from_IDLE_client
    headers=list(_decode_header_lines(lines[1:])), _parsed=True, **matches
  File "/usr/local/lib/python3.7/site-packages/h11/_events.py", line 71, in __init__
    self._validate()
  File "/usr/local/lib/python3.7/site-packages/h11/_events.py", line 140, in _validate
    raise LocalProtocolError("Missing mandatory Host: header")
h11._util.RemoteProtocolError: Missing mandatory Host: header
WARNING:  Invalid HTTP request received.
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/uvicorn/protocols/http/h11_impl.py", line 136, in handle_events
    event = self.conn.next_event()
  File "/usr/local/lib/python3.7/site-packages/h11/_connection.py", line 443, in next_event
    exc._reraise_as_remote_protocol_error()
  File "/usr/local/lib/python3.7/site-packages/h11/_util.py", line 76, in _reraise_as_remote_protocol_error
    raise self
  File "/usr/local/lib/python3.7/site-packages/h11/_connection.py", line 425, in next_event
    event = self._extract_next_receive_event()
  File "/usr/local/lib/python3.7/site-packages/h11/_connection.py", line 367, in _extract_next_receive_event
    event = self._reader(self._receive_buffer)
  File "/usr/local/lib/python3.7/site-packages/h11/_readers.py", line 76, in maybe_read_from_IDLE_client
    headers=list(_decode_header_lines(lines[1:])), _parsed=True, **matches
  File "/usr/local/lib/python3.7/site-packages/h11/_events.py", line 71, in __init__
    self._validate()
  File "/usr/local/lib/python3.7/site-packages/h11/_events.py", line 140, in _validate
    raise LocalProtocolError("Missing mandatory Host: header")
h11._util.RemoteProtocolError: Missing mandatory Host: header
INFO:     10.0.0.1:18561 - "POST /index HTTP/1.1" 500 Internal Server Error
ERROR:    Exception in ASGI application
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/uvicorn/protocols/http/h11_impl.py", line 369, in run_asgi
    result = await app(self.scope, self.receive, self.send)
  File "/usr/local/lib/python3.7/site-packages/uvicorn/middleware/proxy_headers.py", line 59, in __call__
    return await self.app(scope, receive, send)
  File "/usr/local/lib/python3.7/site-packages/fastapi/applications.py", line 199, in __call__
    await super().__call__(scope, receive, send)
  File "/usr/local/lib/python3.7/site-packages/starlette/applications.py", line 112, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/usr/local/lib/python3.7/site-packages/starlette/middleware/errors.py", line 181, in __call__
    raise exc from None
  File "/usr/local/lib/python3.7/site-packages/starlette/middleware/errors.py", line 159, in __call__
    await self.app(scope, receive, _send)
  File "/usr/local/lib/python3.7/site-packages/starlette/exceptions.py", line 82, in __call__
    raise exc from None
  File "/usr/local/lib/python3.7/site-packages/starlette/exceptions.py", line 71, in __call__
    await self.app(scope, receive, sender)
  File "/usr/local/lib/python3.7/site-packages/starlette/routing.py", line 580, in __call__
    await route.handle(scope, receive, send)
  File "/usr/local/lib/python3.7/site-packages/starlette/routing.py", line 241, in handle
    await self.app(scope, receive, send)
  File "/usr/local/lib/python3.7/site-packages/starlette/routing.py", line 52, in app
    response = await func(request)
  File "/usr/local/lib/python3.7/site-packages/fastapi/routing.py", line 217, in app
    dependant=dependant, values=values, is_coroutine=is_coroutine
  File "/usr/local/lib/python3.7/site-packages/fastapi/routing.py", line 149, in run_endpoint_function
    return await dependant.call(**values)
  File "/usr/local/lib/python3.7/site-packages/jina/peapods/runtimes/gateway/http/app.py", line 149, in foo
    return await _get_singleton_result(request_generator(**bd))
  File "/usr/local/lib/python3.7/site-packages/jina/peapods/runtimes/gateway/http/app.py", line 201, in _get_singleton_result
    async for k in servicer.send(request_iterator=req_iter):
  File "/usr/local/lib/python3.7/site-packages/jina/peapods/runtimes/gateway/prefetch.py", line 76, in send
    'PrefetchCaller receive task not running, can not send messages'
RuntimeError: PrefetchCaller receive task not running, can not send messages
INFO:     10.0.0.1:19271 - "GET / HTTP/1.0" 404 Not Found


```