### PR TITLE
test: timeout control adjusting for ci

### DIFF
--- a/jina/parsers/peapods/runtimes/zmq.py
+++ b/jina/parsers/peapods/runtimes/zmq.py
@@ -31,7 +31,7 @@ def mixin_zmq_runtime_parser(parser):
     gp.add_argument(
         '--timeout-ctrl',
         type=int,
-        default=5000,
+        default=int(os.getenv('JINA_DEFAULT_TIMEOUT_CTRL', '5000')),
         help='The timeout in milliseconds of the control request, -1 for waiting forever',
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -176,3 +176,8 @@ def test_envs(tmpdir):
 @pytest.fixture(autouse=True)
 def test_log_level(monkeypatch):
     monkeypatch.setenv('JINA_LOG_LEVEL', 'DEBUG')
+
+
+@pytest.fixture(autouse=True)
+def test_timeout_ctrl_time(monkeypatch):
+    monkeypatch.setenv('JINA_DEFAULT_TIMEOUT_CTRL', '500')

--- a/tests/integration/rolling_update/test_rolling_update.py
+++ b/tests/integration/rolling_update/test_rolling_update.py
@@ -75,7 +75,7 @@ def test_normal(docs):
         assert len(set(shard_list)) == NUM_SHARDS
 
 
-@pytest.mark.timeout(30)
+@pytest.mark.timeout(60)
 def test_simple_run(docs):
     flow = Flow().add(
         name='pod1',
@@ -90,7 +90,7 @@ def test_simple_run(docs):
 
 
 @pytest.mark.repeat(5)
-@pytest.mark.timeout(30)
+@pytest.mark.timeout(60)
 def test_thread_run(docs, mocker, reraise):
     def update_rolling(flow, pod_name):
         with reraise:
@@ -119,7 +119,7 @@ def test_thread_run(docs, mocker, reraise):
 
 
 @pytest.mark.repeat(5)
-@pytest.mark.timeout(30)
+@pytest.mark.timeout(60)
 def test_vector_indexer_thread(config, docs, mocker, reraise):
     def update_rolling(flow, pod_name):
         with reraise:

--- a/tests/integration/v2_api/test_docs_matrix_tail_pea.py
+++ b/tests/integration/v2_api/test_docs_matrix_tail_pea.py
@@ -49,7 +49,7 @@ class ChunkMerger(Executor):
         return DocumentArray(list(results.values()))
 
 
-@pytest.mark.timeout(5)
+@pytest.mark.timeout(60)
 @pytest.mark.parametrize('num_replicas, num_shards', [(1, 1), (2, 2)])
 def test_sharding_tail_pea(num_replicas, num_shards):
     """TODO(Maximilian): Make (1, 2) and (2, 1) also workable"""

--- a/tests/unit/clients/python/test_client.py
+++ b/tests/unit/clients/python/test_client.py
@@ -132,7 +132,7 @@ def test_client_csv(protocol, mocker, func_name):
 
 
 # Timeout is necessary to fail in case of hanging client requests
-@pytest.mark.timeout(5)
+@pytest.mark.timeout(60)
 def test_client_websocket(mocker, flow_with_websocket):
     with flow_with_websocket:
         time.sleep(0.5)


### PR DESCRIPTION
I thin the reason for most of our CI timeouts is because TERMINATE is not properly sent in the first attempt and having TIMEOUT_CTRL at such a large value and have short `mark.timeout` makes the ratio of timeouts very high without having any inherent bug