### PR TITLE
ci: fix fluentd with jinad image

### DIFF
--- a/Dockerfiles/debianx.Dockerfile
+++ b/Dockerfiles/debianx.Dockerfile
@@ -69,9 +69,9 @@ ENTRYPOINT ["jina"]
 
 FROM jina AS jina_daemon
 
-ARG APT_PACKAGES="ruby-dev gcc libc-dev make"
+ARG APT_PACKAGES="gcc libc-dev make"
 
-RUN apt-get update && apt-get install --no-install-recommends -y ${APT_PACKAGES} && \
+RUN apt-get update && apt-get install --no-install-recommends -y ruby-dev ${APT_PACKAGES} && \
     gem install fluentd --no-doc && \
     apt-get remove -y --auto-remove ${APT_PACKAGES} && \
     apt-get autoremove && apt-get clean && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
During cleanup we were uninstalling ruby, hence fluentd was not working in jinad container. This PR fixes it 