### PR TITLE
feat: support offline executors

### DIFF
--- a/jina/hubble/helper.py
+++ b/jina/hubble/helper.py
@@ -5,6 +5,7 @@ import io
 import json
 import os
 import shelve
+import urllib
 import zipfile
 from functools import lru_cache, wraps
 from pathlib import Path
@@ -253,15 +254,13 @@ def upload_file(
     return response
 
 
-def disk_cache(
-    exceptions: Iterable[Exception],
+def disk_cache_offline(
     cache_file: str = 'disk_cache.db',
     message: str = 'Calling {func_name} failed, using cached results',
 ):
     """
-    Decorator which caches a function in disk and uses cache when an exception is raised
+    Decorator which caches a function in disk and uses cache when a urllib.error.URLError exception is raised
 
-    :param exceptions: exceptions used to trigger using the cache
     :param cache_file: the cache file
     :param message: the warning message shown when defaulting to cache. Use "{func_name}" if you want to print
         the function name
@@ -277,7 +276,7 @@ def disk_cache(
                 try:
                     result = func(*args, **kwargs)
                     cache_db[call_hash] = result
-                except exceptions:
+                except urllib.error.URLError:
                     if call_hash in cache_db:
                         default_logger.warning(message.format(func_name=func.__name__))
                         return cache_db[call_hash]

--- a/jina/hubble/helper.py
+++ b/jina/hubble/helper.py
@@ -272,7 +272,7 @@ def disk_cache(
     def decorator(func):
         @wraps(func)
         def wrapper(*args, **kwargs):
-            call_hash = f'{func.__name__}({", ".join(args)})'
+            call_hash = f'{func.__name__}({", ".join(map(str, args))})'
             with shelve.open(cache_file) as cache_db:
                 try:
                     result = func(*args, **kwargs)

--- a/jina/hubble/helper.py
+++ b/jina/hubble/helper.py
@@ -256,7 +256,7 @@ def upload_file(
 def disk_cache(
     exceptions: Iterable[Exception],
     cache_file: str = 'disk_cache.db',
-    message: str = "Calling {func_name} failed, using cached results",
+    message: str = 'Calling {func_name} failed, using cached results',
 ):
     """
     Decorator which caches a function in disk and uses cache when an exception is raised

--- a/jina/hubble/helper.py
+++ b/jina/hubble/helper.py
@@ -253,12 +253,18 @@ def upload_file(
     return response
 
 
-def disk_cache(exceptions: Iterable[Exception], cache_file: str = 'disk_cache.db'):
+def disk_cache(
+    exceptions: Iterable[Exception],
+    cache_file: str = 'disk_cache.db',
+    message: str = "Calling {func_name} failed, using cached results",
+):
     """
     Decorator which caches a function in disk and uses cache when an exception is raised
 
     :param exceptions: exceptions used to trigger using the cache
     :param cache_file: the cache file
+    :param message: the warning message shown when defaulting to cache. Use "{func_name}" if you want to print
+        the function name
 
     :return: function decorator
     """
@@ -273,6 +279,7 @@ def disk_cache(exceptions: Iterable[Exception], cache_file: str = 'disk_cache.db
                     cache_db[call_hash] = result
                 except exceptions:
                     if call_hash in cache_db:
+                        default_logger.warning(message.format(func_name=func.__name__))
                         return cache_db[call_hash]
                     else:
                         raise

--- a/jina/hubble/hubio.py
+++ b/jina/hubble/hubio.py
@@ -17,7 +17,7 @@ from .helper import (
     parse_hub_uri,
     get_hubble_url,
     upload_file,
-    disk_cache,
+    disk_cache_offline,
 )
 from .hubapi import install_local, resolve_local, load_secret, dump_secret, get_lockfile
 from ..helper import get_full_version, ArgNamespace
@@ -269,7 +269,7 @@ with f:
         console.print(p1, p2, p3, p4)
 
     @staticmethod
-    @disk_cache((urllib.error.URLError,), cache_file=str(_cache_file))
+    @disk_cache_offline(cache_file=str(_cache_file))
     def _fetch_meta(
         name: str,
         tag: Optional[str] = None,

--- a/jina/hubble/hubio.py
+++ b/jina/hubble/hubio.py
@@ -10,7 +10,6 @@ from pathlib import Path
 from typing import Optional, Dict
 from urllib.parse import urlencode
 
-import docker
 
 from .helper import (
     archive_package,
@@ -319,6 +318,9 @@ with f:
         :return: the `uses` string
         """
         from rich.console import Console
+
+        with ImportExtensions(required=True):
+            import docker
 
         console = Console()
         cached_zip_filepath = None

--- a/jina/hubble/hubio.py
+++ b/jina/hubble/hubio.py
@@ -343,14 +343,12 @@ with f:
                     st.update(f'Pulling {executor.image_name}...')
                     try:
                         self._client.images.pull(executor.image_name)
-                    except docker.errors.APIError:
-                        img_not_found = False
+                    except docker.errors.APIError as api_exc:
                         try:
                             self._client.images.get(executor.image_name)
                         except docker.errors.ImageNotFound:
-                            img_not_found = True
-                        if img_not_found:
-                            raise
+                            raise api_exc
+
                     return f'docker://{executor.image_name}'
                 elif scheme == 'jinahub':
                     import filelock

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ import pathlib
 import random
 import shutil
 import string
+import tempfile
 import time
 
 import pytest
@@ -181,3 +182,9 @@ def test_log_level(monkeypatch):
 @pytest.fixture(autouse=True)
 def test_timeout_ctrl_time(monkeypatch):
     monkeypatch.setenv('JINA_DEFAULT_TIMEOUT_CTRL', '500')
+
+
+@pytest.fixture(autouse=True)
+def tmpfile(tmpdir):
+    tmpfile = f'jina_test_{next(tempfile._get_candidate_names())}.db'
+    return tmpdir / tmpfile

--- a/tests/unit/hubble/test_helper.py
+++ b/tests/unit/hubble/test_helper.py
@@ -44,11 +44,8 @@ def test_unpack_package(tmpdir, dummy_zip_file):
     helper.unpack_package(dummy_zip_file, tmpdir / 'dummp_executor')
 
 
-first_time = False
-
-
 def test_disk_cache(tmpdir):
-    global first_time
+    raise_exception = True
     tmpfile = f'jina_test_{next(tempfile._get_candidate_names())}.db'
 
     class _Exception(Exception):
@@ -56,11 +53,9 @@ def test_disk_cache(tmpdir):
 
     @disk_cache((_Exception,), cache_file=str(tmpdir / tmpfile))
     def _myfunc() -> bool:
-        global first_time
-        if not first_time:
+        if raise_exception:
             raise _Exception('Failing')
         else:
-            first_time = False
             return True
 
     # test fails
@@ -68,8 +63,10 @@ def test_disk_cache(tmpdir):
         _myfunc()
     assert 'Failing' in str(info.value)
 
-    first_time = True
-    # saves result in cache in a first try
+    raise_exception = False
+    # saves result in cache
     assert _myfunc()
+
+    raise_exception = True
     # defaults to cache
     assert _myfunc()

--- a/tests/unit/hubble/test_helper.py
+++ b/tests/unit/hubble/test_helper.py
@@ -5,6 +5,7 @@ import pytest
 import tempfile
 from pathlib import Path
 from jina.hubble import helper
+from jina.hubble.helper import disk_cache
 
 
 @pytest.fixture
@@ -41,3 +42,22 @@ def test_archive_package(tmpdir):
 
 def test_unpack_package(tmpdir, dummy_zip_file):
     helper.unpack_package(dummy_zip_file, tmpdir / 'dummp_executor')
+
+
+first_time = True
+
+
+def test_disk_cache():
+    @disk_cache((Exception,))
+    def _myfunc() -> bool:
+        global first_time
+        if not first_time:
+            raise Exception("Failing")
+        else:
+            first_time = False
+            return True
+
+    # saves result in cache in a first try
+    assert _myfunc()
+    # defaults to cache
+    assert _myfunc()

--- a/tests/unit/hubble/test_helper.py
+++ b/tests/unit/hubble/test_helper.py
@@ -44,14 +44,13 @@ def test_unpack_package(tmpdir, dummy_zip_file):
     helper.unpack_package(dummy_zip_file, tmpdir / 'dummp_executor')
 
 
-def test_disk_cache(tmpdir):
+def test_disk_cache(tmpfile):
     raise_exception = True
-    tmpfile = f'jina_test_{next(tempfile._get_candidate_names())}.db'
 
     class _Exception(Exception):
         pass
 
-    @disk_cache((_Exception,), cache_file=str(tmpdir / tmpfile))
+    @disk_cache((_Exception,), cache_file=str(tmpfile))
     def _myfunc() -> bool:
         if raise_exception:
             raise _Exception('Failing')

--- a/tests/unit/hubble/test_helper.py
+++ b/tests/unit/hubble/test_helper.py
@@ -1,11 +1,13 @@
 import os
 import json
+import urllib
+
 import pytest
 
 import tempfile
 from pathlib import Path
 from jina.hubble import helper
-from jina.hubble.helper import disk_cache
+from jina.hubble.helper import disk_cache_offline
 
 
 @pytest.fixture
@@ -47,18 +49,15 @@ def test_unpack_package(tmpdir, dummy_zip_file):
 def test_disk_cache(tmpfile):
     raise_exception = True
 
-    class _Exception(Exception):
-        pass
-
-    @disk_cache((_Exception,), cache_file=str(tmpfile))
+    @disk_cache_offline(cache_file=str(tmpfile))
     def _myfunc() -> bool:
         if raise_exception:
-            raise _Exception('Failing')
+            raise urllib.error.URLError('Failing')
         else:
             return True
 
     # test fails
-    with pytest.raises(_Exception) as info:
+    with pytest.raises(urllib.error.URLError) as info:
         _myfunc()
     assert 'Failing' in str(info.value)
 

--- a/tests/unit/hubble/test_hubio.py
+++ b/tests/unit/hubble/test_hubio.py
@@ -1,11 +1,15 @@
 import os
 import json
+import urllib
 from typing import NamedTuple
+
+import docker
 import pytest
 import requests
 import itertools
 from pathlib import Path
 
+from jina.hubble.helper import disk_cache
 from jina.hubble.hubio import HubIO, HubExecutor
 from jina.hubble import helper
 from jina.parsers.hubble import set_hub_push_parser
@@ -127,7 +131,6 @@ class DownloadMockResponse:
         self.response_code = response_code
 
     def iter_content(self, buffer=32 * 1024):
-
         zip_file = Path(__file__).parent / 'dummy_executor.zip'
         with zip_file.open('rb') as f:
             yield f.read(buffer)
@@ -172,3 +175,88 @@ def test_pull(test_envs, mocker, monkeypatch):
 
     args = set_hub_pull_parser().parse_args(['jinahub://dummy_mwu_encoder:secret'])
     HubIO(args).pull()
+
+
+class MockImageCollection:
+    def __init__(self, fail_pull: bool, fail_get: bool):
+        self.fail_pull = fail_pull
+        self.fail_get = fail_get
+
+    def pull(self, repository: str):
+        if self.fail_pull:
+            raise docker.errors.APIError('Failed pullingdocker image')
+        else:
+            return
+
+    def get(self, repository: str):
+        if self.fail_get:
+            raise docker.errors.ImageNotFound("Image not found")
+        else:
+            return
+
+
+class MockDockerClient:
+    def __init__(self, fail_pull: bool = True, fail_get: bool = True):
+        self.images = MockImageCollection(fail_pull, fail_get)
+
+
+def test_offline_pull(test_envs, mocker, monkeypatch, tmpfile):
+    mock = mocker.Mock()
+
+    fail_meta_fetch = True
+
+    @disk_cache((urllib.error.URLError,), cache_file=str(tmpfile))
+    def _mock_fetch(name, tag=None, secret=None):
+        mock(name=name)
+        if fail_meta_fetch:
+            raise urllib.error.URLError('Failed fetching meta')
+        else:
+            return HubExecutor(
+                uuid='dummy_mwu_encoder',
+                alias='alias_dummy',
+                tag='v0',
+                image_name='jinahub/pod.dummy_mwu_encoder',
+                md5sum=None,
+                visibility=True,
+                archive_url=None,
+            )
+
+    def _gen_load_docker_client(fail_pull: bool, fail_get: bool):
+        def _load_docker_client(obj):
+            obj._client = MockDockerClient(fail_pull=fail_pull, fail_get=fail_get)
+
+        return _load_docker_client
+
+    args = set_hub_pull_parser().parse_args(['jinahub+docker://dummy_mwu_encoder'])
+    monkeypatch.setattr(
+        HubIO,
+        '_load_docker_client',
+        _gen_load_docker_client(fail_pull=True, fail_get=True),
+    )
+    monkeypatch.setattr(HubIO, '_fetch_meta', _mock_fetch)
+
+    # Expect failure due to _fetch_meta
+    with pytest.raises(urllib.error.URLError):
+        HubIO(args).pull()
+
+    fail_meta_fetch = False
+    # Expect failure due to image pull
+    with pytest.raises(docker.errors.APIError):
+        HubIO(args).pull()
+
+    # expect successful pull
+    monkeypatch.setattr(
+        HubIO,
+        '_load_docker_client',
+        _gen_load_docker_client(fail_pull=False, fail_get=True),
+    )
+    assert HubIO(args).pull() == 'docker://jinahub/pod.dummy_mwu_encoder'
+
+    # expect successful pull using cached _fetch_meta response and saved image
+    fail_meta_fetch = True
+    monkeypatch.setattr(
+        HubIO,
+        '_load_docker_client',
+        _gen_load_docker_client(fail_pull=True, fail_get=False),
+    )
+    assert HubIO(args).pull() == 'docker://jinahub/pod.dummy_mwu_encoder'

--- a/tests/unit/hubble/test_hubio.py
+++ b/tests/unit/hubble/test_hubio.py
@@ -9,7 +9,7 @@ import requests
 import itertools
 from pathlib import Path
 
-from jina.hubble.helper import disk_cache
+from jina.hubble.helper import disk_cache_offline
 from jina.hubble.hubio import HubIO, HubExecutor
 from jina.hubble import helper
 from jina.parsers.hubble import set_hub_push_parser
@@ -205,7 +205,7 @@ def test_offline_pull(test_envs, mocker, monkeypatch, tmpfile):
 
     fail_meta_fetch = True
 
-    @disk_cache((urllib.error.URLError,), cache_file=str(tmpfile))
+    @disk_cache_offline(cache_file=str(tmpfile))
     def _mock_fetch(name, tag=None, secret=None):
         mock(name=name)
         if fail_meta_fetch:


### PR DESCRIPTION
- default to disk cache when fetching hubble executor meta information if there's no internet connection
- skip pulling the docker image if there's no internet connection and the docker image was already pulled