### PR TITLE
ci: add git to jinad docker image

### DIFF
--- a/Dockerfiles/debianx.Dockerfile
+++ b/Dockerfiles/debianx.Dockerfile
@@ -71,7 +71,7 @@ FROM jina AS jina_daemon
 
 ARG APT_PACKAGES="gcc libc-dev make"
 
-RUN apt-get update && apt-get install --no-install-recommends -y ruby-dev ${APT_PACKAGES} && \
+RUN apt-get update && apt-get install --no-install-recommends -y git ruby-dev ${APT_PACKAGES} && \
     gem install fluentd --no-doc && \
     apt-get remove -y --auto-remove ${APT_PACKAGES} && \
     apt-get autoremove && apt-get clean && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
pypi dependencies can include setup.py files from git, that would need `git` cli to be installed. Currently, jinad doesn't support adding custom commands during workspace building, hence there's no other way to install `git` cli except including it in the base docker image (only for `-daemon`)