### PR TITLE
fix(core): dont respond to cancel and idle

### DIFF
--- a/jina/peapods/runtimes/zmq/zed.py
+++ b/jina/peapods/runtimes/zmq/zed.py
@@ -310,7 +310,10 @@ class ZEDRuntime(ZMQRuntime):
         try:
             # notice how executor related exceptions are handled here
             # generally unless executor throws an OSError, the exception are caught and solved inplace
-            self._zmqstreamlet.send_message(self._callback(msg))
+            processed_msg = self._callback(msg)
+            # dont sent responses for CLOSE and IDLE control requests
+            if msg.is_data_request or msg.request.command not in ['CLOSE', 'IDLE']:
+                self._zmqstreamlet.send_message(processed_msg)
         except RuntimeTerminated:
             # this is the proper way to end when a terminate signal is sent
             self._zmqstreamlet.send_message(msg)

--- a/jina/peapods/runtimes/zmq/zed.py
+++ b/jina/peapods/runtimes/zmq/zed.py
@@ -312,7 +312,7 @@ class ZEDRuntime(ZMQRuntime):
             # generally unless executor throws an OSError, the exception are caught and solved inplace
             processed_msg = self._callback(msg)
             # dont sent responses for CLOSE and IDLE control requests
-            if msg.is_data_request or msg.request.command not in ['CLOSE', 'IDLE']:
+            if msg.is_data_request or msg.request.command not in ['CANCEL', 'IDLE']:
                 self._zmqstreamlet.send_message(processed_msg)
         except RuntimeTerminated:
             # this is the proper way to end when a terminate signal is sent

--- a/jina/peapods/runtimes/zmq/zed.py
+++ b/jina/peapods/runtimes/zmq/zed.py
@@ -311,7 +311,7 @@ class ZEDRuntime(ZMQRuntime):
             # notice how executor related exceptions are handled here
             # generally unless executor throws an OSError, the exception are caught and solved inplace
             processed_msg = self._callback(msg)
-            # dont sent responses for CLOSE and IDLE control requests
+            # dont sent responses for CANCEL and IDLE control requests
             if msg.is_data_request or msg.request.command not in ['CANCEL', 'IDLE']:
                 self._zmqstreamlet.send_message(processed_msg)
         except RuntimeTerminated:

--- a/tests/unit/peapods/peas/test_pea.py
+++ b/tests/unit/peapods/peas/test_pea.py
@@ -242,7 +242,7 @@ def test_gateway_args(protocol, expected):
     assert p.runtime_cls.__name__ == expected
 
 
-@pytest.mark.timeout(5)
+@pytest.mark.timeout(30)
 @pytest.mark.slow
 def test_idle_does_not_create_response():
     args = set_pea_parser().parse_args([])

--- a/tests/unit/peapods/peas/test_pea.py
+++ b/tests/unit/peapods/peas/test_pea.py
@@ -2,12 +2,14 @@ import os
 import time
 
 import pytest
+import zmq
 
 from jina.excepts import RuntimeFailToStart, RuntimeRunForeverEarlyError
 from jina.executors import BaseExecutor
 from jina.parsers import set_gateway_parser, set_pea_parser
 from jina.peapods import Pea
 from jina.peapods.runtimes.zmq.zed import ZEDRuntime
+from jina.types.message.common import ControlMessage
 
 
 def bad_func(*args, **kwargs):
@@ -238,3 +240,19 @@ def test_gateway_args(protocol, expected):
     )
     p = Pea(args)
     assert p.runtime_cls.__name__ == expected
+
+
+@pytest.mark.timeout(5)
+@pytest.mark.slow
+def test_idle_does_not_create_response():
+    args = set_pea_parser().parse_args([])
+
+    with Pea(args) as p:
+        msg = ControlMessage('IDLE', pod_name='fake_pod')
+
+        with zmq.Context().socket(zmq.PAIR) as socket:
+            socket.connect(f'tcp://localhost:{p.args.port_ctrl}')
+            socket.send_multipart(msg.dump())
+            event = socket.poll(timeout=1000)
+
+            assert not event


### PR DESCRIPTION
Skip sending responses to IDLE and CANCEL requests.

The test only tests IDLE unfortunately, but CANCEL actually impacts the tested pod so I could not use that one.

Fixes https://github.com/jina-ai/jina/issues/2930