### PR TITLE
fix(importer): add custom sys meta path finder

### DIFF
--- a/jina/importer.py
+++ b/jina/importer.py
@@ -96,12 +96,12 @@ class ImportExtensions:
                 return True  # suppress the error
 
 
-class ModuleLoader(Loader):
-    """A custom module loader"""
+class ExtensionFileLoader(Loader):
+    """Loader for extension modules."""
 
     @classmethod
     def exec_module(cls, module):
-        """load module into memory
+        """Initialize an extension module
 
         :param module: a namespace module
         """
@@ -111,19 +111,19 @@ class ModuleLoader(Loader):
             module.__path__ = [load_path[: -len(init_file) - 1]]
 
 
-_loader = ModuleLoader()
+_loader = ExtensionFileLoader()
 
 
-class PathFinder:
-    """A custom source file path finder"""
+class ExtensionPathFinder:
+    """Meta path finder for extentions modules"""
 
-    __path__ = None
+    __path__ = '.'
 
     @classmethod
-    def find_spec(cls, name, paths, target=None):
-        """find moduel spec from given paths
+    def find_spec(cls, fullname, paths=None, target=None):
+        """Try to find a spec for the specified module.
 
-        :param name: module full name
+        :param fullname: module full name
         :param paths: the search paths
         :param target: the target
         :return: a module spec
@@ -131,7 +131,7 @@ class PathFinder:
         from importlib.machinery import ModuleSpec
 
         # TODO: read PEP 420
-        last_module = name.split('.')[-1]
+        last_module = fullname.split('.')[-1]
         if paths is None:
             paths = [cls.__path__]
         for path in paths:
@@ -141,9 +141,9 @@ class PathFinder:
             module_path = full_path + '.py'
 
             if os.path.exists(init_path) and not os.path.exists(module_path):
-                return ModuleSpec(name, _loader, origin=init_path)
+                return ModuleSpec(fullname, _loader, origin=init_path)
             elif os.path.exists(module_path):
-                return ModuleSpec(name, _loader, origin=module_path)
+                return ModuleSpec(fullname, _loader, origin=module_path)
         return None
 
 

--- a/jina/jaml/__init__.py
+++ b/jina/jaml/__init__.py
@@ -1,3 +1,4 @@
+import sys
 import os
 import re
 import tempfile
@@ -534,10 +535,22 @@ class JAMLCompatible(metaclass=JAMLCompatibleType):
                 no_tag_yml = JAML.expand_dict(no_tag_yml, context)
             if allow_py_modules:
                 # also add YAML parent path to the search paths
+                if s_path:
+                    # inject PathFinder
+                    from ..importer import PathFinder
+
+                    PathFinder.__path__ = os.path.dirname(s_path)
+                    sys.meta_path.append(PathFinder())
+
                 load_py_modules(
                     no_tag_yml,
                     extra_search_paths=(os.path.dirname(s_path),) if s_path else None,
                 )
+
+                if s_path:
+                    # clean PathFinder
+                    sys.meta_path.pop()
+
             from ..flow.base import Flow
 
             if issubclass(cls, Flow):

--- a/jina/jaml/__init__.py
+++ b/jina/jaml/__init__.py
@@ -536,11 +536,11 @@ class JAMLCompatible(metaclass=JAMLCompatibleType):
             if allow_py_modules:
                 # also add YAML parent path to the search paths
                 if s_path:
-                    # inject PathFinder
-                    from ..importer import PathFinder
+                    # append ExtensionPathFinder into sys.meta_path
+                    from ..importer import ExtensionPathFinder
 
-                    PathFinder.__path__ = os.path.dirname(s_path)
-                    sys.meta_path.append(PathFinder())
+                    ExtensionPathFinder.__path__ = os.path.dirname(s_path)
+                    sys.meta_path.append(ExtensionPathFinder())
 
                 load_py_modules(
                     no_tag_yml,
@@ -548,7 +548,7 @@ class JAMLCompatible(metaclass=JAMLCompatibleType):
                 )
 
                 if s_path:
-                    # clean PathFinder
+                    # pop ExtensionPathFinder from sys.meta_path
                     sys.meta_path.pop()
 
             from ..flow.base import Flow


### PR DESCRIPTION
This PR aims at fixing the (internal) extra dependency issues in our hub . 

For instance, base on the executor from  https://github.com/jina-ai/executor-audio-VGGishEncoder/tree/fix-module-not-found , i found some weird observations. 
```
from jina import Executor, Flow
from jina.executors import BaseExecutor
import threading

# # => case1: works
# from vggish_audio_encoder import VggishAudioEncoder
# encoder = VggishAudioEncoder()

# # => case2: works
# def run():
#     encoder = BaseExecutor.load_config('config.yml')
# threading.Thread(target=run).start()

# # => case3: works
encoder = BaseExecutor.load_config('config.yml')

# # => case4: works
# f = Flow().add(uses='config.yml')
# with f:
#     f.block()
```
All of the use cases above work perfectly. However, if we want to use `jina executor/pod/pea`  cli to load executor, we will get errors:
```
jina executor --uses config.yml   # => Failed, throw exception: `vggish` module cannot be found
```
