### PR TITLE
fix: cannot get embedding from reloaded DocumentArrayMemmap

### DIFF
--- a/jina/types/arrays/memmap.py
+++ b/jina/types/arrays/memmap.py
@@ -82,7 +82,7 @@ class DocumentArrayMemmap(TraversableSequence, DocumentArrayGetAttrMixin, Itr):
         open(self._body_path, mode).close()
 
         self._header = open(self._header_path, 'r+b')
-        self._body = open(self._body_path, 'r+b')
+        self._body = open(self._body_path, 'a+b')
 
         tmp = np.frombuffer(
             self._header.read(),
@@ -147,7 +147,7 @@ class DocumentArrayMemmap(TraversableSequence, DocumentArrayGetAttrMixin, Itr):
             ).tobytes()
         )
         self._header_map[doc.id] = (len(self._header_map), p, r, r + l)
-        self._start = p + r + l
+        self._start = p + r + l  # <==> self._start = self._start + l
         self._body.write(value)
         if flush:
             self._header.flush()

--- a/tests/unit/types/arrays/test_memmap.py
+++ b/tests/unit/types/arrays/test_memmap.py
@@ -173,3 +173,19 @@ def test_convert_dm_to_dam(tmpdir, mocker):
     mock.assert_called()
     assert len(da) == 0
     assert len(dam) == 100
+
+
+@pytest.mark.parametrize('embed_dim', [10, 10000])
+def test_extend_and_get_attribute(tmpdir, embed_dim):
+    dam = DocumentArrayMemmap(tmpdir)
+    docs = list(random_docs(100, start_id=0, embed_dim=embed_dim))
+    dam.extend(docs)
+
+    dam2 = DocumentArrayMemmap(tmpdir)
+    x = dam2.get_attributes('embedding')
+    assert len(dam2) == 100
+
+    docs = list(random_docs(100, start_id=100, embed_dim=embed_dim))
+    dam2.extend(docs)
+    x = dam2.get_attributes('embedding')
+    assert len(dam2) == 200

--- a/tests/unit/types/arrays/test_memmap.py
+++ b/tests/unit/types/arrays/test_memmap.py
@@ -184,8 +184,11 @@ def test_extend_and_get_attribute(tmpdir, embed_dim):
     dam2 = DocumentArrayMemmap(tmpdir)
     x = dam2.get_attributes('embedding')
     assert len(dam2) == 100
-
+    assert len(x) == 100
+    assert x[0].shape == (embed_dim,)
     docs = list(random_docs(100, start_id=100, embed_dim=embed_dim))
     dam2.extend(docs)
     x = dam2.get_attributes('embedding')
     assert len(dam2) == 200
+    assert len(x) == 200
+    assert x[0].shape == (embed_dim,)


### PR DESCRIPTION
This PR aims to close issue #2944 . Thank you.