### PR TITLE
fix: open path as file for DictReader

### DIFF
--- a/jina/types/document/generators.py
+++ b/jina/types/document/generators.py
@@ -106,7 +106,7 @@ def from_csv(
     """
     from ..document import Document
 
-    lines = csv.DictReader(fp)
+    lines = csv.DictReader(open(fp))
     for value in _subsample(lines, size, sampling_rate):
         if 'groundtruth' in value and 'document' in value:
             yield Document(value['document'], field_resolver), Document(


### PR DESCRIPTION
🐛 **Bug Fix** `jina.types.document.generators.from_csv` was not behaving as expected or as documented.


### Purpose
- Makes `from_csv` behave as [expected and documented: ](https://github.com/jina-ai/jina/blob/master/.github/2.0/cookbooks/Document.md#construct-from-json-csv-ndarray-and-files)
> from_csv - Yield Document from a CSV file. Each line is a Document object
- `from_csv` takes `fp: Iterable[str]` and is documented as `:param fp: file paths` however it is passed directly to csv.DictReader(fp).
- [However csv.DictReader() takes a file not a string.](https://docs.python.org/3/library/csv.html#csv.DictReader) 
- Hence if `from_csv` is given a string path, it does not yield Documents correctly, instead it tries to yield the path string as Documents.


### Mentions
- Discussed with @florian-hoenicke and Pei-Shan at weekly Jina-MLH maintainer meeting.
- Came up when working on [protein_search](https://github.com/georgeamccarthy/protein_search) with @fissoreg

### Recreate

Create `app.py` with

```
from jina import DocumentArray
from jina.types.document.generators import from_csv

da = DocumentArray(
    from_csv("example_data.csv", field_resolver={"Name": "text"})
)

for d in da:
    print(d)
```

Create `example_data.csv` with

```
Name
George
Gian
Mable
```

Before change `python app.py` prints

```
{'id': '2f7b0cc6-e5af-11eb-9174-1e00d23adf51', 'tags': {'e': 'x'}, 'content_hash': '1cdf8d85c151209c'}
{'id': '2f7b2f4e-e5af-11eb-9174-1e00d23adf51', 'tags': {'e': 'a'}, 'content_hash': 'e07c484b04c14a3e'}
{'id': '2f7b3548-e5af-11eb-9174-1e00d23adf51', 'tags': {'e': 'm'}, 'content_hash': 'cabd9a82bf030bbd'}
{'id': '2f7b3a20-e5af-11eb-9174-1e00d23adf51', 'tags': {'e': 'p'}, 'content_hash': 'a343518e4bc62320'}
{'id': '2f7b3ea8-e5af-11eb-9174-1e00d23adf51', 'tags': {'e': 'l'}, 'content_hash': 'a790cf78e61bd2ab'}
{'id': '2f7b4312-e5af-11eb-9174-1e00d23adf51', 'tags': {'e': 'e'}, 'content_hash': '9ecb4fbaf4f87b84'}
{'id': '2f7b477c-e5af-11eb-9174-1e00d23adf51', 'tags': {'e': '_'}, 'content_hash': '2092d99a84ea60b9'}
{'id': '2f7b4c04-e5af-11eb-9174-1e00d23adf51', 'tags': {'e': 'd'}, 'content_hash': '0745985bbc0c789c'}
{'id': '2f7b503c-e5af-11eb-9174-1e00d23adf51', 'tags': {'e': 'a'}, 'content_hash': 'e07c484b04c14a3e'}
{'id': '2f7b5460-e5af-11eb-9174-1e00d23adf51', 'tags': {'e': 't'}, 'content_hash': '9de8fdeb8a8f6503'}
{'id': '2f7b5898-e5af-11eb-9174-1e00d23adf51', 'tags': {'e': 'a'}, 'content_hash': 'e07c484b04c14a3e'}
{'id': '2f7b5ce4-e5af-11eb-9174-1e00d23adf51', 'tags': {'e': '.'}, 'content_hash': '996076630c89b68a'}
{'id': '2f7b60fe-e5af-11eb-9174-1e00d23adf51', 'tags': {'e': 'c'}, 'content_hash': '5a446e2e6a821b74'}
{'id': '2f7b6518-e5af-11eb-9174-1e00d23adf51', 'tags': {'e': 's'}, 'content_hash': 'f5928cb47f90f3df'}
{'id': '2f7b6928-e5af-11eb-9174-1e00d23adf51', 'tags': {'e': 'v'}, 'content_hash': '2506fbb5bbf76bbd'}
```

Notice how the path has been gobbled up by DictReader.

After this change `python app.py` prints

```
{'id': '0e01a874-e5b0-11eb-82ce-1e00d23adf51', 'text': 'George', 'content_hash': 'd4d3f2f18e2bf4c0'}
{'id': '0e01d7f4-e5b0-11eb-82ce-1e00d23adf51', 'text': 'Gian', 'content_hash': '1b20aee0af11cf46'}
{'id': '0e01db96-e5b0-11eb-82ce-1e00d23adf51', 'text': 'Mable', 'content_hash': '8f416cbfebd3cf3c'}
```

(fixed)