### PR TITLE
fix(ci): fix head commit ahead base commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
         with:
           python-version: 3.7
       - id: file_changes
-        uses: jitterbit/get-changed-files@v1
+        uses: Ana06/get-changed-files@v1.2
       - name: docstring check with darglint and pydocstyle
         run: ./scripts/docstrings_lint.sh
         env:
@@ -96,7 +96,7 @@ jobs:
         with:
           python-version: 3.7
       - id: file_changes
-        uses: jitterbit/get-changed-files@v1
+        uses: Ana06/get-changed-files@v1.2
       - name: check black
         run: ./scripts/black.sh
         env:


### PR DESCRIPTION
Using [this](https://github.com/jitterbit/get-changed-files/issues/19#issuecomment-854657729) action could check changed files for docstring/black without rebase/merge master back to feature brnach.

> The head commit for this push event is not ahead of the base commit. Please submit an issue on this action's GitHub repo.