### PR TITLE
fix: apply islice on iterator object of data in batch iterator

### DIFF
--- a/jina/helper.py
+++ b/jina/helper.py
@@ -187,8 +187,9 @@ def batch_iterator(
             yield data[_ : _ + batch_size]
     elif isinstance(data, Iterable):
         # as iterator, there is no way to know the length of it
+        iterator = iter(data)
         while True:
-            chunk = tuple(islice(data, batch_size))
+            chunk = tuple(islice(iterator, batch_size))
             if not chunk:
                 return
             yield chunk

--- a/tests/integration/issues/github_2992/test_flow.py
+++ b/tests/integration/issues/github_2992/test_flow.py
@@ -1,0 +1,17 @@
+from jina import Document, Flow
+from jina.types.arrays.memmap import DocumentArrayMemmap
+
+
+def test_dam_flow(tmpdir):
+    def _assert_called_once(response):
+        assert len(response.docs) == 1
+        assert not _assert_called_once.called
+        _assert_called_once.called = True
+
+    _assert_called_once.called = False
+
+    f = Flow().add()
+    dam = DocumentArrayMemmap(tmpdir)
+    dam.append(Document())
+    with f:
+        f.post('/', dam, on_always=_assert_called_once)

--- a/tests/integration/issues/github_2992/test_flow.py
+++ b/tests/integration/issues/github_2992/test_flow.py
@@ -3,17 +3,10 @@ from jina.types.arrays.memmap import DocumentArrayMemmap
 
 
 def test_dam_flow(tmpdir):
-    def _assert_called_once(response):
-        assert len(response.docs) == 1
-        assert not _assert_called_once.called
-        _assert_called_once.called = True
-
-    _assert_called_once.called = False
-
     f = Flow().add()
     dam = DocumentArrayMemmap(tmpdir)
     dam.append(Document())
     with f:
-        response = f.post('/', dam, on_always=_assert_called_once, return_results=True)
+        response = f.post('/', dam, return_results=True)
     assert len(response) == 1
     assert len(response[0].docs) == 1

--- a/tests/integration/issues/github_2992/test_flow.py
+++ b/tests/integration/issues/github_2992/test_flow.py
@@ -14,4 +14,5 @@ def test_dam_flow(tmpdir):
     dam = DocumentArrayMemmap(tmpdir)
     dam.append(Document())
     with f:
-        f.post('/', dam, on_always=_assert_called_once)
+        response = f.post('/', dam, on_always=_assert_called_once, return_results=True)
+    assert len(response.docs) == 1

--- a/tests/integration/issues/github_2992/test_flow.py
+++ b/tests/integration/issues/github_2992/test_flow.py
@@ -15,4 +15,5 @@ def test_dam_flow(tmpdir):
     dam.append(Document())
     with f:
         response = f.post('/', dam, on_always=_assert_called_once, return_results=True)
-    assert len(response.docs) == 1
+    assert len(response) == 1
+    assert len(response[0].docs) == 1


### PR DESCRIPTION
fixes the following example:
```
from jina.helper import batch_iterator
from jina import Document

from jina.types.arrays.memmap import DocumentArrayMemmap
dam = DocumentArrayMemmap("test_dam")

dam.append(Document())

bi = batch_iterator(dam, 3)

# prints infinitely
for batch in bi:
    for doc in batch:
        print(doc)
```