### PR TITLE
refactor(document): do not hash content if copy is true

### DIFF
--- a/jina/types/document/__init__.py
+++ b/jina/types/document/__init__.py
@@ -291,7 +291,7 @@ class Document(ProtoTypeMixin):
             )
         self.set_attributes(**kwargs)
         self._mermaid_id = random_identity()  #: for mermaid visualize id
-        if hash_content:
+        if hash_content and not copy:
             self.update_content_hash()
 
     def pop(self, *fields) -> None:


### PR DESCRIPTION
with this change, we could speed up `match` and Document creation with `copy` with almost 45% of the time

```shell
py-spy> Sampling process 100 times a second. Press Control-C to exit.

0:00:23.514182

py-spy> Stopped sampling because process exitted
py-spy> Wrote flamegraph data to 'profile.svg'. Samples: 2446 Errors: 0
(venv) jina|refactor-copy-without-hash⚡ ⇒ sudo py-spy record -o profile1.svg -- python test.py
py-spy> Sampling process 100 times a second. Press Control-C to exit.

0:00:14.911232

py-spy> Stopped sampling because process exitted
py-spy> Wrote flamegraph data to 'profile1.svg'. Samples: 1639 Errors: 0
```