### PR TITLE
fix: match with same documents

### DIFF
--- a/jina/types/arrays/neural_ops.py
+++ b/jina/types/arrays/neural_ops.py
@@ -75,7 +75,7 @@ class DocumentArrayNeuralOpsMixin:
             if isinstance(normalization, (tuple, list)):
                 dist = minmax_normalize(dist, normalization)
 
-        source_docarray_ids = [d.id for d in self]
+        source_docarray_ids = {d.id for d in self}
         m_name = metric_name or (metric.__name__ if callable(metric) else metric)
         for _q, _ids, _dists in zip(self, idx, dist):
             _q.matches.clear()

--- a/jina/types/arrays/neural_ops.py
+++ b/jina/types/arrays/neural_ops.py
@@ -75,7 +75,6 @@ class DocumentArrayNeuralOpsMixin:
             if isinstance(normalization, (tuple, list)):
                 dist = minmax_normalize(dist, normalization)
 
-        source_docarray_ids = {d.id for d in self}
         m_name = metric_name or (metric.__name__ if callable(metric) else metric)
         for _q, _ids, _dists in zip(self, idx, dist):
             _q.matches.clear()
@@ -84,7 +83,7 @@ class DocumentArrayNeuralOpsMixin:
                 # Note, when match self with other, or both of them share the same Document
                 # we might have recursive matches .
                 # checkout https://github.com/jina-ai/jina/issues/3034
-                if d.id in source_docarray_ids:
-                    d.matches.clear()
+                if d.id in self:
+                    d.pop('matches')
                 d.scores[m_name] = _dist
                 _q.matches.append(d)

--- a/jina/types/arrays/neural_ops.py
+++ b/jina/types/arrays/neural_ops.py
@@ -81,8 +81,9 @@ class DocumentArrayNeuralOpsMixin:
             _q.matches.clear()
             for _id, _dist in zip(_ids, _dists):
                 d = Document(darray[int(_id)], copy=True)
-                # Note, when match self with other, and both of them have the same Document
-                # we might bring incosistency matches
+                # Note, when match self with other, or both of them share the same Document
+                # we might have recursive matches .
+                # checkout https://github.com/jina-ai/jina/issues/3034
                 if d.id in source_docarray_ids:
                     d.matches.clear()
                 d.scores[m_name] = _dist

--- a/jina/types/arrays/neural_ops.py
+++ b/jina/types/arrays/neural_ops.py
@@ -75,10 +75,15 @@ class DocumentArrayNeuralOpsMixin:
             if isinstance(normalization, (tuple, list)):
                 dist = minmax_normalize(dist, normalization)
 
+        source_docarray_ids = [d.id for d in self]
         m_name = metric_name or (metric.__name__ if callable(metric) else metric)
         for _q, _ids, _dists in zip(self, idx, dist):
             _q.matches.clear()
             for _id, _dist in zip(_ids, _dists):
                 d = Document(darray[int(_id)], copy=True)
+                # Note, when match self with other, and both of them have the same Document
+                # we might bring incosistency matches
+                if d.id in source_docarray_ids:
+                    d.matches.clear()
                 d.scores[m_name] = _dist
                 _q.matches.append(d)

--- a/jina/types/document/__init__.py
+++ b/jina/types/document/__init__.py
@@ -291,7 +291,7 @@ class Document(ProtoTypeMixin):
             )
         self.set_attributes(**kwargs)
         self._mermaid_id = random_identity()  #: for mermaid visualize id
-        if hash_content:
+        if hash_content and not copy:
             self.update_content_hash()
 
     def pop(self, *fields) -> None:
@@ -868,6 +868,9 @@ class Document(ProtoTypeMixin):
     def __enter__(self):
         return self
 
+    def __eq__(self, other):
+        return self.proto == other.proto
+
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.update_content_hash()
 
@@ -1200,10 +1203,10 @@ class Document(ProtoTypeMixin):
 
         mermaid_str = (
             """
-                            %%{init: {'theme': 'base', 'themeVariables': { 'primaryColor': '#FFC666'}}}%%
-                            classDiagram
-                        
-                                    """
+                                %%{init: {'theme': 'base', 'themeVariables': { 'primaryColor': '#FFC666'}}}%%
+                                classDiagram
+
+                                        """
             + self.__mermaid_str__()
         )
 

--- a/tests/unit/types/arrays/test_neural_ops.py
+++ b/tests/unit/types/arrays/test_neural_ops.py
@@ -256,3 +256,28 @@ def test_2arity_function(docarrays_for_embedding_distance_computation):
     for d in D1:
         for m in d.matches:
             assert 'dotp' in m.scores
+
+
+def test_match_inclusive():
+    """Call match function, while the other :class:`DocumentArray` is itself
+    or have same :class:`Document`.
+    """
+    # The document array da1 match with itself.
+    da1 = DocumentArray(
+        [
+            Document(embedding=np.array([1, 2, 3])),
+            Document(embedding=np.array([1, 0, 1])),
+            Document(embedding=np.array([1, 1, 2])),
+        ]
+    )
+
+    da1.match(da1)
+    assert len(da1) == 3
+    traversed = da1.traverse_flat(traversal_paths=['m', 'mm', 'mmm'])
+    assert len(traversed) == 9
+    # The document array da2 shares same documents with da1
+    da2 = DocumentArray([Document(embedding=np.array([4, 1, 3])), da1[0], da1[1]])
+    da1.match(da2)
+    assert len(da2) == 3
+    traversed = da1.traverse_flat(traversal_paths=['m', 'mm', 'mmm'])
+    assert len(traversed) == 9


### PR DESCRIPTION
for #3034 , I would not say it's a bug, it's a side effect. Calling match on same document does not really make sense. But here is a workaround. not a perfect solution, but works. Feel free to close this if there is a better solution

before: 
![1D590F4A-B5CB-47C4-81F5-A30E53B4354B](https://user-images.githubusercontent.com/9794489/127504037-55dbd220-f967-4ee0-9760-c224bae83bf5.png)


after:

![3FE4B9E8-90EF-4729-9F1B-687952086F2E](https://user-images.githubusercontent.com/9794489/127504110-b9ee317c-144a-40d9-8ebe-544e8bf24711.png)
