### PR TITLE
refactor: try to speed up update content hash

### DIFF
--- a/jina/types/document/__init__.py
+++ b/jina/types/document/__init__.py
@@ -448,7 +448,7 @@ class Document(ProtoTypeMixin):
         FieldMask(paths=fields_to_hash).MergeMessage(self._pb_body, masked_d)
 
         self._pb_body.content_hash = blake2b(
-            masked_d.SerializeToString(), digest_size=DIGEST_SIZE
+            masked_d.SerializePartialToString(), digest_size=DIGEST_SIZE
         ).hexdigest()
 
     @property

--- a/jina/types/document/__init__.py
+++ b/jina/types/document/__init__.py
@@ -428,25 +428,27 @@ class Document(ProtoTypeMixin):
 
     def update_content_hash(
         self,
-        exclude_fields: Tuple[str] = (
-            'id',
-            'chunks',
-            'matches',
-            'content_hash',
-            'parent_id',
-            'evaluations',
-            'scores',
+        fields: Tuple[str] = (
+            'text',
+            'blob',
+            'buffer',
+            'embedding',
+            'uri',
+            'tags',
+            'mime_type',
+            'granularity',
+            'adjacency',
         ),
     ) -> None:
         """Update the document hash according to its content.
 
-        :param exclude_fields: a tuple of field names that excluded when computing content hash.
+        :param fields: a tuple of field names that inclusive when computing content hash.
         """
         masked_d = jina_pb2.DocumentProto()
         present_fields = {
             field_descriptor.name for field_descriptor, _ in self._pb_body.ListFields()
         }
-        fields_to_hash = present_fields.difference(exclude_fields)
+        fields_to_hash = present_fields.intersection(fields)
         FieldMask(paths=fields_to_hash).MergeMessage(self._pb_body, masked_d)
         self._pb_body.content_hash = blake2b(
             masked_d.SerializePartialToString(), digest_size=DIGEST_SIZE

--- a/jina/types/document/__init__.py
+++ b/jina/types/document/__init__.py
@@ -434,6 +434,8 @@ class Document(ProtoTypeMixin):
             'matches',
             'content_hash',
             'parent_id',
+            'evaluations',
+            'scores',
         ),
     ) -> None:
         """Update the document hash according to its content.
@@ -446,9 +448,8 @@ class Document(ProtoTypeMixin):
         }
         fields_to_hash = present_fields.difference(exclude_fields)
         FieldMask(paths=fields_to_hash).MergeMessage(self._pb_body, masked_d)
-
         self._pb_body.content_hash = blake2b(
-            masked_d.SerializePartialToString(), digest_size=DIGEST_SIZE
+            masked_d.SerializeToString(), digest_size=DIGEST_SIZE
         ).hexdigest()
 
     @property

--- a/jina/types/document/__init__.py
+++ b/jina/types/document/__init__.py
@@ -449,7 +449,7 @@ class Document(ProtoTypeMixin):
         fields_to_hash = present_fields.difference(exclude_fields)
         FieldMask(paths=fields_to_hash).MergeMessage(self._pb_body, masked_d)
         self._pb_body.content_hash = blake2b(
-            masked_d.SerializeToString(), digest_size=DIGEST_SIZE
+            masked_d.SerializePartialToString(), digest_size=DIGEST_SIZE
         ).hexdigest()
 
     @property

--- a/jina/types/document/multimodal.py
+++ b/jina/types/document/multimodal.py
@@ -141,13 +141,23 @@ class MultimodalDocument(Document):
 
     def update_content_hash(
         self,
-        exclude_fields: Tuple[str] = ('id', 'matches', 'content_hash'),
-        include_fields: Optional[Tuple[str]] = None,
+        fields: Tuple[str] = (
+            'text',
+            'blob',
+            'buffer',
+            'embedding',
+            'uri',
+            'tags',
+            'mime_type',
+            'granularity',
+            'adjacency',
+            'parent_id',
+            'chunks',
+        ),
     ) -> None:
         """
         Update content hash of the document by including ``chunks`` when computing the hash
 
-         :param exclude_fields: a tuple of field names that excluded when computing content hash
-        :param include_fields: a tuple of field names that included when computing content hash
+        :param fields: a tuple of field names that included when computing content hash
         """
-        super().update_content_hash(exclude_fields, include_fields)
+        super().update_content_hash(fields)

--- a/tests/unit/types/document/test_document.py
+++ b/tests/unit/types/document/test_document.py
@@ -1092,9 +1092,3 @@ def test_tags_update_nested_lists():
     assert d.tags['hey']['list'][1] is True
     assert d.tags['hey']['list'][2]['inlist'] == 'not here'
     assert d.tags['hoy'][0] == 1
-
-
-def test_update_content_hash():
-    docs = random_docs(10000)
-    for doc in docs:
-        doc.update_content_hash()

--- a/tests/unit/types/document/test_document.py
+++ b/tests/unit/types/document/test_document.py
@@ -328,54 +328,6 @@ def test_content_hash_not_dependent_on_chunks_or_matches():
     assert doc1.content_hash == doc4.content_hash
 
 
-def test_include_scalar():
-    d1 = Document()
-    d1.text = 'hello'
-    dd1 = Document()
-    d1.chunks.append(dd1)
-    d1.update_content_hash(include_fields=('text',), exclude_fields=None)
-
-    d2 = Document()
-    d2.text = 'hello'
-    d2.update_content_hash(include_fields=('text',), exclude_fields=None)
-
-    assert d1.content_hash == d2.content_hash
-
-    # change text should result in diff hash
-    d2.text = 'world'
-    d2.update_content_hash(include_fields=('text',), exclude_fields=None)
-    assert d1.content_hash != d2.content_hash
-
-
-def test_include_repeated_fields():
-    def build_document(chunk=None):
-        d = Document()
-        d.chunks.append(chunk)
-        d.chunks[0].update_content_hash(
-            exclude_fields=('parent_id', 'id', 'content_hash')
-        )
-        d.chunks[0].parent_id = 0
-        d.update_content_hash(include_fields=('chunks',), exclude_fields=None)
-        return d
-
-    c = Document()
-    d1 = build_document(chunk=c)
-    d2 = build_document(chunk=c)
-
-    assert d1.chunks[0].content_hash == d2.chunks[0].content_hash
-    assert d1.content_hash == d2.content_hash
-
-    # change text should result in same hash
-    d2.text = 'world'
-    d2.update_content_hash(include_fields=('chunks',), exclude_fields=None)
-    assert d1.content_hash == d2.content_hash
-
-    # change chunks should result in diff hash
-    d2.chunks.clear()
-    d2.update_content_hash(include_fields=('chunks',), exclude_fields=None)
-    assert d1.content_hash != d2.content_hash
-
-
 @pytest.mark.parametrize('from_str', [True, False])
 @pytest.mark.parametrize(
     'd_src',
@@ -1140,3 +1092,9 @@ def test_tags_update_nested_lists():
     assert d.tags['hey']['list'][1] is True
     assert d.tags['hey']['list'][2]['inlist'] == 'not here'
     assert d.tags['hoy'][0] == 1
+
+
+def test_update_content_hash():
+    docs = random_docs(10000)
+    for doc in docs:
+        doc.update_content_hash()

--- a/tests/unit/types/document/test_document.py
+++ b/tests/unit/types/document/test_document.py
@@ -1040,6 +1040,33 @@ def test_content_hash():
     d7 = Document(d2)
     assert d6.content_hash == d2.content_hash == d7.content_hash
 
+    # test hash image
+    d8 = Document(blob=np.array([1, 3, 5]))
+    d9 = Document(blob=np.array([2, 4, 6]))
+    d10 = Document(blob=np.array([1, 3, 5]))
+    assert d8.content_hash != d9.content_hash
+    assert d8.content_hash == d10.content_hash
+
+    # test hash buffer
+    d11 = Document(content=b'buffer1')
+    d12 = Document(content=b'buffer2')
+    d13 = Document(content=b'buffer1')
+    assert d11.content_hash != d12.content_hash
+    assert d11.content_hash == d13.content_hash
+
+    # document with more fields
+    d14 = Document(
+        uri='http://test1.com', tags={'key1': 'value1'}, granularity=2, adjacency=2
+    )
+    d15 = Document(
+        uri='http://test2.com', tags={'key1': 'value2'}, granularity=3, adjacency=2
+    )
+    d16 = Document(
+        uri='http://test2.com', tags={'key1': 'value2'}, granularity=3, adjacency=2
+    )
+    assert d14.content_hash != d15.content_hash
+    assert d15.content_hash == d16.content_hash
+
     nr = 10
     with TimeContext(f'creating {nr} docs without hashing content at init'):
         da = DocumentArray()


### PR DESCRIPTION
the idea:
1. when calling `update_content_hash`, we actually never change parameters, so `include_fields` never being used except test. We also get rid of the mutually exclusive check.
2. maybe this is a better solution for hashing, we don’t specify `exclude_fields` ,but specify `fields`  necessary for hashing, safer
2. `CopyFrom` and `FieldMask` is expensive, we manage to only use `FieldMask` without creating the `empty_proto`
3. `SerializeToString ` = `SerializePartialToString ` + check if message is initialised, we initialise the pb message in the first line of the method, so checking is unnecessary please refer to [here](https://googleapis.dev/python/protobuf/latest/google/protobuf/message.html#google.protobuf.message.Message.SerializePartialToString). 