### PR TITLE
perf(types): remove redundant copy in match function

### DIFF
--- a/jina/types/arrays/document.py
+++ b/jina/types/arrays/document.py
@@ -210,7 +210,7 @@ class DocumentArray(
         from ..document import Document
 
         if isinstance(item, int):
-            return Document(self._pb_body[item])
+            return Document(self._pb_body[item], hash_content=False)
         elif isinstance(item, str):
             return self[self._id_to_index[item]]
         elif isinstance(item, slice):

--- a/jina/types/arrays/match.py
+++ b/jina/types/arrays/match.py
@@ -17,18 +17,21 @@ class MatchArray(DocumentArray):
         self._ref_doc = reference_doc
         super().__init__(doc_views)
 
-    def append(self, document: 'Document', **kwargs) -> 'Document':
+    def append(self, document: 'Document', copy: bool = True, **kwargs) -> 'Document':
         """Add a matched document to the current Document.
 
         :param document: Sub-document to be added
-        :type document: :class: `Document
+        :param copy: If set, then copy the original Document. Otherwise the original Document may get modified
         :param kwargs: Extra key value arguments
         :return: the newly added sub-document in :class:`Document` view
         :rtype: :class:`Document` view
         """
-        from ..document import Document
+        if copy:
+            from ..document import Document
 
-        match = Document(document, copy=True)
+            match = Document(document, copy=True)
+        else:
+            match = document
 
         match.set_attributes(
             granularity=self.granularity, adjacency=self.adjacency, **kwargs

--- a/jina/types/arrays/neural_ops.py
+++ b/jina/types/arrays/neural_ops.py
@@ -81,14 +81,13 @@ class DocumentArrayNeuralOpsMixin:
         for _q, _ids, _dists in zip(self, idx, dist):
             _q.matches.clear()
             for _id, _dist in zip(_ids, _dists):
-                d = Document(darray[int(_id)], copy=True)
                 # Note, when match self with other, or both of them share the same Document
                 # we might have recursive matches .
                 # checkout https://github.com/jina-ai/jina/issues/3034
+                d = darray[int(_id)]
                 if d.id in self:
                     d.pop('matches')
-                d.scores[m_name] = _dist
-                _q.matches.append(d)
+                _q.matches.append(d, scores={m_name: _dist})
 
     def visualize(
         self,

--- a/jina/types/arrays/neural_ops.py
+++ b/jina/types/arrays/neural_ops.py
@@ -86,6 +86,7 @@ class DocumentArrayNeuralOpsMixin:
                 # checkout https://github.com/jina-ai/jina/issues/3034
                 d = darray[int(_id)]
                 if d.id in self:
+                    d = Document(d, copy=True)
                     d.pop('matches')
                 _q.matches.append(d, scores={m_name: _dist}, copy=False)
 

--- a/jina/types/arrays/neural_ops.py
+++ b/jina/types/arrays/neural_ops.py
@@ -87,7 +87,7 @@ class DocumentArrayNeuralOpsMixin:
                 d = darray[int(_id)]
                 if d.id in self:
                     d.pop('matches')
-                _q.matches.append(d, scores={m_name: _dist})
+                _q.matches.append(d, scores={m_name: _dist}, copy=False)
 
     def visualize(
         self,

--- a/jina/types/document/__init__.py
+++ b/jina/types/document/__init__.py
@@ -35,6 +35,7 @@ from ...helper import (
     random_identity,
     download_mermaid_url,
     dunder_get,
+    cached_property,
 )
 from ...importer import ImportExtensions
 from ...logging.predefined import default_logger
@@ -84,7 +85,7 @@ DocumentSourceType = TypeVar(
 
 _all_mime_types = set(mimetypes.types_map.values())
 
-_all_doc_content_keys = ('content', 'uri', 'blob', 'text', 'buffer')
+_all_doc_content_keys = {'content', 'uri', 'blob', 'text', 'buffer'}
 _all_doc_array_keys = ('blob', 'embedding')
 _special_mapped_keys = ('scores', 'evaluations')
 
@@ -290,7 +291,6 @@ class Document(ProtoTypeMixin):
                 f'Document content fields are mutually exclusive, please provide only one of {_all_doc_content_keys}'
             )
         self.set_attributes(**kwargs)
-        self._mermaid_id = random_identity()  #: for mermaid visualize id
         if hash_content and not copy:
             self.update_content_hash()
 
@@ -1334,6 +1334,14 @@ class Document(ProtoTypeMixin):
         else:
             value = dunder_get(self._pb_body, item)
         return value
+
+    @cached_property
+    def _mermaid_id(self) -> str:
+        """A unique ID for mermaid visualize id
+
+        :return: unique ID
+        """
+        return random_identity()
 
 
 def _is_uri(value: str) -> bool:


### PR DESCRIPTION
minor improvement on the efficiency of `.match`

master (https://github.com/jina-ai/jina/commit/63d59edca82003a07093016ee7c2aabfc925eac9):

```
➜  jina git:(master) ✗ python toy36.py
--- 12.913429542000001 seconds ---
➜  jina git:(master) ✗ python toy36.py
--- 13.194746499999999 seconds ---
➜  jina git:(master) ✗ python toy36.py
--- 14.238623624999999 seconds ---
```

this PR:

```
➜  jina git:(perf-minor-improve-match) ✗ python toy36.py
--- 6.968042625000001 seconds ---
➜  jina git:(perf-minor-improve-match) ✗ python toy36.py
--- 7.192200333000001 seconds ---
➜  jina git:(perf-minor-improve-match) ✗ python toy36.py
--- 6.7111269170000005 seconds ---
```

---

`toy36.py` grabbed from #3055 

```python
import time

import numpy as np

from jina import DocumentArray, Document


def main_func():
    da1 = DocumentArray()
    da2 = DocumentArray()
    for i in range(10_000):
        da1.append(Document(embedding=np.random.rand(512)))
        da2.append(Document(embedding=np.random.rand(512)))
    start_time = time.perf_counter()
    da1.match(da2, limit=10)
    print("--- %s seconds ---" % (time.perf_counter() - start_time))


main_func()

```