### PR TITLE
feat: add env JINA_MP_START_METHOD for changing mp start_method

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,10 @@
+> The best way to know more about contributing and how to get started is to **[join us on Slack](https://slack.jina.ai)** and ask questions in our public channels.
+
 # Contributing to Jina
 
 Thanks for your interest in contributing to Jina. We're grateful for your initiative! ❤️
 
 I'm Alex C-G, Open Source Evangelist for Jina. I'm all about getting our new contributors up-to-speed, and that's what we'll do below.
-
-# Join Us on Slack!
-
-The best way to know more about contributing and how to get started is to **[join us on Slack](https://join.slack.com/t/jina-ai/shared_invite/zt-dkl7x8p0-rVCv~3Fdc3~Dpwx7T7XG8w)** and ask questions in our public channels.
 
 In this guide, we're going to go through the steps for each kind of contribution, and good and bad examples of what to do. We look forward to your contributions!
 
@@ -33,7 +31,8 @@ Make sure you've read through our [README](https://github.com/jina-ai/jina), [Ji
 We're happy for any contributions, code or not. If you'd like to write a blog post, record a podcast, organize a meetup, or anything else to contribute to Jina, we'd love to hear from you!
 
 * [Contribute docs](#-contributing-documentation)
-* For other contributions, please [get in touch](#-getting-support) to discuss on Slack
+* For other contributions, please [get in touch](#-getting-support) to discuss on 
+
 
 <a name="-bugs-and-issues"></a>
 ## 🐞 Bugs and Issues

--- a/jina/__init__.py
+++ b/jina/__init__.py
@@ -12,17 +12,31 @@ import os as _os
 import signal as _signal
 import sys as _sys
 import types as _types
+import warnings as _warnings
+
+
+def _warning_on_one_line(message, category, filename, lineno, *args, **kwargs):
+    return '\033[1;33m%s: %s\033[0m \033[1;30m(raised from %s:%s)\033[0m\n' % (
+        category.__name__,
+        message,
+        filename,
+        lineno,
+    )
+
+
+_warnings.formatwarning = _warning_on_one_line
 
 if _sys.version_info < (3, 7, 0) or _sys.version_info >= (3, 10, 0):
     raise OSError(f'Jina requires Python 3.7/3.8/3.9, but yours is {_sys.version_info}')
 
-# DO SOME OS-WISE PATCHES
 _start_method = _os.environ.get('JINA_MP_START_METHOD', None)
 
 if _start_method and _start_method.lower() in {'fork', 'spawn', 'forkserver'}:
     from multiprocessing import set_start_method as _set_start_method
 
     _set_start_method(_start_method.lower())
+    _warnings.warn(f'multiprocessing start method is set to `{_start_method.lower()}`')
+    _os.unsetenv('JINA_MP_START_METHOD')
 
 # fix fork error on MacOS but seems no effect? must do EXPORT manually before jina start
 _os.environ['OBJC_DISABLE_INITIALIZE_FORK_SAFETY'] = 'YES'

--- a/jina/types/arrays/neural_ops.py
+++ b/jina/types/arrays/neural_ops.py
@@ -2,8 +2,8 @@ from math import inf
 from typing import Optional, Union, Callable, Tuple
 
 import numpy as np
-from jina import Document
 
+from ... import Document
 from ...importer import ImportExtensions
 from ...math.dimensionality_reduction import PCA
 from ...math.helper import top_k, minmax_normalize
@@ -57,7 +57,6 @@ class DocumentArrayNeuralOpsMixin:
 
         X = np.stack(self.get_attributes('embedding'))
         Y = np.stack(darray.get_attributes('embedding'))
-        limit = min(limit, len(darray))
 
         if isinstance(metric, str):
             if use_scipy:
@@ -72,7 +71,7 @@ class DocumentArrayNeuralOpsMixin:
                 f'metric must be either string or a 2-arity function, received: {metric!r}'
             )
 
-        dist, idx = top_k(dists, limit, descending=False)
+        dist, idx = top_k(dists, min(limit, len(darray)), descending=False)
         if normalization is not None:
             if isinstance(normalization, (tuple, list)):
                 dist = minmax_normalize(dist, normalization)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -4,7 +4,8 @@ from typing import Iterator
 
 import numpy as np
 
-from jina import Document
+if False:
+    from jina import Document
 
 file_dir = os.path.dirname(__file__)
 sys.path.append(os.path.dirname(file_dir))
@@ -20,6 +21,8 @@ def random_docs(
     sparse_embedding=False,
     text='hello world',
 ) -> Iterator['Document']:
+    from jina import Document
+
     next_chunk_doc_id = start_id + num_docs
     for j in range(num_docs):
         doc_id = start_id + j

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
-import os
 import asyncio
+import os
 import pathlib
 import random
 import shutil
@@ -9,10 +9,6 @@ import time
 
 import pytest
 from fastapi.testclient import TestClient
-
-from jina.enums import RemoteWorkspaceState
-from jina.excepts import NoAvailablePortError
-from jina.executors.metas import get_default_metas
 
 
 @pytest.fixture(scope='function')
@@ -24,6 +20,8 @@ def random_workspace_name():
 
 @pytest.fixture(scope='function')
 def test_metas(tmpdir, random_workspace_name):
+    from jina.executors.metas import get_default_metas
+
     os.environ[random_workspace_name] = str(tmpdir)
     metas = get_default_metas()
     metas['workspace'] = os.environ[random_workspace_name]
@@ -95,6 +93,7 @@ def docker_compose(request):
 def patched_random_port(mocker):
     used_ports = set()
     from jina.helper import random_port
+    from jina.excepts import NoAvailablePortError
 
     def _random_port():
 
@@ -150,6 +149,7 @@ def _create_workspace_directly(cur_dir):
         workspace_id=workspace_id, daemon_file=daemon_file, logger=daemon_logger
     )
     network_id = Dockerizer.network(workspace_id=workspace_id)
+    from jina.enums import RemoteWorkspaceState
 
     workspace_store[workspace_id] = WorkspaceItem(
         state=RemoteWorkspaceState.ACTIVE,

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -40,6 +40,17 @@ def test_all_cli(cli):
     subprocess.check_call(['jina', cli, '--help'])
 
 
+@pytest.mark.parametrize('smethod', ['fork', 'spawn'])
+def test_all_start_method(smethod):
+    s = subprocess.check_output(
+        ['jina', '-v'],
+        env=dict(os.environ, JINA_MP_START_METHOD=smethod),
+        stderr=subprocess.STDOUT,
+    )
+    assert 'UserWarning' in s.decode()
+    assert smethod in s.decode()
+
+
 def test_parse_env_map():
     a = set_pod_parser().parse_args(['--env', 'key1=value1', '--env', 'key2=value2'])
     assert a.env == {'key1': 'value1', 'key2': 'value2'}


### PR DESCRIPTION
related to #2957 #2514

a new Jina Environment variable `JINA_MP_START_METHOD` is added to allow changing `multiprocessing` start method **_before_** loading Jina package.

this should fix Paddle on GPU problem caused by `fork`.


To reproduce:

`toy1.py`

```python
from jina import Flow, Executor, requests
import paddlehub as hub


class PaddleHubExecutor(Executor):

    def __init__(self, *args, **kwargs):
        super().__init__(*args, **kwargs)
        self.model = hub.Module(name='ernie')
        print(f' \n\n\n SUCCESS in loading model \n\n\n')

    @requests
    def encode(self, docs, **kwargs):
        print(f' here I would encode')


if __name__ == '__main__':
    f = Flow().add(uses=PaddleHubExecutor)
    with f:
        pass
```

```console
JINA_MP_START_METHOD='spawn' python toy1.py
```

```console
UserWarning: multiprocessing start method is set to `spawn` (raised from /home/han/Documents/jina/jina/__init__.py:38)
[2021-08-01 17:18:57,982] [    INFO] - Already cached /home/han/.paddlenlp/models/ernie-1.0/ernie_v1_chn_base.pdparams
W0801 17:18:57.983451  5152 device_context.cc:404] Please NOTE: device: 0, GPU Compute Capability: 7.5, Driver API Version: 11.2, Runtime API Version: 10.2
W0801 17:18:57.984760  5152 device_context.cc:422] device: 0, cuDNN Version: 8.0.
[2021-08-01 17:18:59,196] [    INFO] - Weights from pretrained model not used in ErnieModel: ['cls.predictions.layer_norm.weight', 'cls.predictions.decoder_bias', 'cls.predictions.transform.bias', 'cls.predictions.transform.weight', 'cls.predictions.layer_norm.bias']



 SUCCESS in loading model



           pod0@4982[L]:ready and listening
        gateway@4982[L]:ready and listening
           Flow@4982[I]:🎉 Flow is ready to use!
	🔗 Protocol: 		GRPC
	🏠 Local access:	0.0.0.0:47189
	🔒 Private network:	192.168.31.182:47189
```


Success 🥳 