### PR TITLE
refactor: change bind to all inbound

### DIFF
--- a/jina/peapods/runtimes/gateway/grpc/__init__.py
+++ b/jina/peapods/runtimes/gateway/grpc/__init__.py
@@ -2,10 +2,12 @@ import os
 
 import grpc
 
-from ..prefetch import PrefetchCaller
-from ...zmq.asyncio import AsyncNewLoopRuntime
-from ....zmq import AsyncZmqlet
+from jina import __default_host__
+
 from .....proto import jina_pb2_grpc
+from ....zmq import AsyncZmqlet
+from ...zmq.asyncio import AsyncNewLoopRuntime
+from ..prefetch import PrefetchCaller
 
 __all__ = ['GRPCRuntime']
 
@@ -42,7 +44,7 @@ class GRPCRuntime(AsyncNewLoopRuntime):
         self.zmqlet = AsyncZmqlet(self.args, logger=self.logger)
         self._prefetcher = GRPCPrefetchCall(self.args, self.zmqlet)
         jina_pb2_grpc.add_JinaRPCServicer_to_server(self._prefetcher, self.server)
-        bind_addr = f'0.0.0.0:{self.args.port_expose}'
+        bind_addr = f'{__default_host__}:{self.args.port_expose}'
         self.server.add_insecure_port(bind_addr)
         await self.server.start()
 

--- a/jina/peapods/runtimes/gateway/grpc/__init__.py
+++ b/jina/peapods/runtimes/gateway/grpc/__init__.py
@@ -42,7 +42,7 @@ class GRPCRuntime(AsyncNewLoopRuntime):
         self.zmqlet = AsyncZmqlet(self.args, logger=self.logger)
         self._prefetcher = GRPCPrefetchCall(self.args, self.zmqlet)
         jina_pb2_grpc.add_JinaRPCServicer_to_server(self._prefetcher, self.server)
-        bind_addr = f'{self.args.host}:{self.args.port_expose}'
+        bind_addr = f'0.0.0.0:{self.args.port_expose}'
         self.server.add_insecure_port(bind_addr)
         await self.server.start()
 

--- a/jina/peapods/runtimes/gateway/http/__init__.py
+++ b/jina/peapods/runtimes/gateway/http/__init__.py
@@ -1,8 +1,10 @@
 import os
 
-from .app import get_fastapi_app
-from ...zmq.asyncio import AsyncNewLoopRuntime
+from jina import __default_host__
+
 from .....importer import ImportExtensions
+from ...zmq.asyncio import AsyncNewLoopRuntime
+from .app import get_fastapi_app
 
 __all__ = ['HTTPRuntime']
 
@@ -50,7 +52,7 @@ class HTTPRuntime(AsyncNewLoopRuntime):
         self._server = UviServer(
             config=Config(
                 app=extend_rest_interface(get_fastapi_app(self.args, self.logger)),
-                host='0.0.0.0',
+                host=__default_host__,
                 port=self.args.port_expose,
                 log_level=os.getenv('JINA_LOG_LEVEL', 'error').lower(),
             )

--- a/jina/peapods/runtimes/gateway/http/__init__.py
+++ b/jina/peapods/runtimes/gateway/http/__init__.py
@@ -50,7 +50,7 @@ class HTTPRuntime(AsyncNewLoopRuntime):
         self._server = UviServer(
             config=Config(
                 app=extend_rest_interface(get_fastapi_app(self.args, self.logger)),
-                host=self.args.host,
+                host='0.0.0.0',
                 port=self.args.port_expose,
                 log_level=os.getenv('JINA_LOG_LEVEL', 'error').lower(),
             )

--- a/jina/peapods/runtimes/gateway/websocket/__init__.py
+++ b/jina/peapods/runtimes/gateway/websocket/__init__.py
@@ -50,7 +50,7 @@ class WebSocketRuntime(AsyncNewLoopRuntime):
         self._server = UviServer(
             config=Config(
                 app=extend_rest_interface(get_fastapi_app(self.args, self.logger)),
-                host=self.args.host,
+                host='0.0.0.0',
                 port=self.args.port_expose,
                 ws_max_size=1024 * 1024 * 1024,
                 log_level=os.getenv('JINA_LOG_LEVEL', 'error').lower(),

--- a/jina/peapods/runtimes/gateway/websocket/__init__.py
+++ b/jina/peapods/runtimes/gateway/websocket/__init__.py
@@ -1,8 +1,10 @@
 import os
 
-from .app import get_fastapi_app
-from ...zmq.asyncio import AsyncNewLoopRuntime
+from jina import __default_host__
+
 from .....importer import ImportExtensions
+from ...zmq.asyncio import AsyncNewLoopRuntime
+from .app import get_fastapi_app
 
 __all__ = ['WebSocketRuntime']
 
@@ -50,7 +52,7 @@ class WebSocketRuntime(AsyncNewLoopRuntime):
         self._server = UviServer(
             config=Config(
                 app=extend_rest_interface(get_fastapi_app(self.args, self.logger)),
-                host='0.0.0.0',
+                host=__default_host__,
                 port=self.args.port_expose,
                 ws_max_size=1024 * 1024 * 1024,
                 log_level=os.getenv('JINA_LOG_LEVEL', 'error').lower(),


### PR DESCRIPTION
This PR introduces the following change:

For all runtimes, the gateway will bind to all inbound connections on the localhost, i.e. `0.0.0.0` instead of the parameter `args.host`. 

This change is motivated by a use-case from kubernetes where the gateway host deployment is hidden behind a kubernetes service with corresponding dns (this is a typical kubernetes pattern). 
Clients can reach the gateway via this dns from the outside but the host cannot bind to this address as it is the IP of the service not the deployment where the gateway runs.