### PR TITLE
perf(dam): cache memmap handler

### DIFF
--- a/jina/types/arrays/memmap.py
+++ b/jina/types/arrays/memmap.py
@@ -64,12 +64,12 @@ class DocumentArrayMemmap(
         self._header_path = os.path.join(path, 'header.bin')
         self._body_path = os.path.join(path, 'body.bin')
         self._key_length = key_length
-        self._invalidated_mmap = False
-        self._last_mmap = None
+        self._invalidated_mmap = False  # a boolean flag to say mmap is invalidated, set on the change of mmap
+        self._last_mmap = None  # the last cached mmap object
         self._load_header_body()
 
     @property
-    def _mmap(self):
+    def _mmap(self) -> 'mmap':
         if self._invalidated_mmap or self._last_mmap is None:
             self._invalidated_mmap = False
             self._last_mmap = mmap.mmap(

--- a/jina/types/arrays/memmap.py
+++ b/jina/types/arrays/memmap.py
@@ -68,7 +68,7 @@ class DocumentArrayMemmap(
 
     @cached_property
     def _mmap(self):
-        return mmap.mmap(self._body_fileno, length=0)
+        return mmap.mmap(self._body_fileno, length=0, prot=mmap.PROT_READ)
 
     def reload(self):
         """Reload header of this object from the disk.
@@ -167,7 +167,7 @@ class DocumentArrayMemmap(
         if isinstance(key, str):
             pos_info = self._header_map[key]
             _, p, r, r_plus_l = pos_info
-            return Document(self._mmap[(p + r) : (p + r_plus_l)])
+            return Document(self._mmap[p + r : p + r_plus_l])
         elif isinstance(key, int):
             return self[self._int2str_id(key)]
         else:

--- a/jina/types/arrays/search_ops.py
+++ b/jina/types/arrays/search_ops.py
@@ -3,6 +3,8 @@ import random
 import operator
 from typing import Dict, Optional, Union, Tuple
 
+from ...helper import typename
+
 if False:
     from .document import DocumentArray
 
@@ -86,7 +88,7 @@ class DocumentArraySearchOpsMixin:
 
         if k > len(self):
             raise ValueError(
-                f'Sample size {k} is greater than the length of Document {len(self)}'
+                f'Sample size can not be greater than the length of {typename(self)}, but {k} > {len(self)}'
             )
         if seed is not None:
             random.seed(seed)

--- a/tests/unit/types/arrays/test_memmap.py
+++ b/tests/unit/types/arrays/test_memmap.py
@@ -246,3 +246,18 @@ def test_memmap_physical_size(tmpdir):
     assert da.physical_size == 0
     da.append(Document())
     assert da.physical_size > 0
+
+
+def test_memmap_append(tmpdir):
+    da = DocumentArrayMemmap(tmpdir)
+    d0 = Document(text='hello')
+    da.append(d0)
+    assert da[0] == d0
+    d1 = Document(text='world')
+    da.append(d1)
+    assert da[1] == d1
+
+    da2 = DocumentArrayMemmap(tmpdir)
+    assert len(da2) == 2
+    assert da2[0] == d0
+    assert da2[1] == d1

--- a/tests/unit/types/arrays/test_memmap.py
+++ b/tests/unit/types/arrays/test_memmap.py
@@ -248,7 +248,7 @@ def test_memmap_physical_size(tmpdir):
     assert da.physical_size > 0
 
 
-def test_memmap_append(tmpdir):
+def test_memmap_mutate(tmpdir):
     da = DocumentArrayMemmap(tmpdir)
     d0 = Document(text='hello')
     da.append(d0)
@@ -261,3 +261,6 @@ def test_memmap_append(tmpdir):
     assert len(da2) == 2
     assert da2[0] == d0
     assert da2[1] == d1
+
+    da.clear()
+    assert not len(da)


### PR DESCRIPTION
inlining `mmap.mmap` instead of opening it everytime saves about 30% time

on this branch:
```
get embedding ...	get embedding takes 4 seconds (4.64s)
get embedding ...	get embedding takes 4 seconds (4.84s)
get embedding ...	get embedding takes 4 seconds (4.68s)
```

on master (2aee836):
```
get embedding ...	get embedding takes 7 seconds (7.41s)
get embedding ...	get embedding takes 6 seconds (6.66s)
get embedding ...	get embedding takes 6 seconds (6.27s)

```

```python
from jina.logging.profile import TimeContext
from jina.types.arrays.memmap import DocumentArrayMemmap
from tests import random_docs

dam1 = DocumentArrayMemmap('./dam2')
dam1.clear()
dam1.extend(random_docs(100000))

with TimeContext('get embedding'):
    a = dam1.get_attributes('embedding')
    assert len(a) == 100000
```