### PR TITLE
refactor(setup): make standard deps as the default deps

### DIFF
--- a/.github/workflows/force-docker-build.yml
+++ b/.github/workflows/force-docker-build.yml
@@ -43,6 +43,14 @@ jobs:
             echo "BUILD_TARGET=jina" >> $GITHUB_ENV
           fi
 
+          if [[ "${{ matrix.pip_tag }}" == "perf" ]]; then
+            echo "PIP_INSTALL_PERF=1" >> $GITHUB_ENV
+          fi
+
+          if [[ "${{ matrix.pip_tag }}" == "" ]]; then
+            echo "PIP_INSTALL_CORE=1" >> $GITHUB_ENV
+          fi
+
           JINA_VERSION=$(sed -n '/^__version__/p' ./jina/__init__.py | cut -d \' -f2)
           V_JINA_VERSION=v${JINA_VERSION}
           JINA_MINOR_VERSION=${JINA_VERSION%.*}
@@ -140,6 +148,8 @@ jobs:
             BUILD_DATE=${{env.BUILD_DATE}}
             JINA_VERSION=${{env.JINA_VERSION}}
             VCS_REF=${{env.VCS_REF}}
+            PIP_INSTALL_CORE=${{env.JINA_PIP_INSTALL_CORE}}
+            PIP_INSTALL_PERF=${{env.JINA_PIP_INSTALL_PERF}}
             PY_VERSION=${{matrix.py_version}}
             PIP_TAG=${{matrix.pip_tag}}
           target: ${{env.BUILD_TARGET}}

--- a/Dockerfiles/debianx.Dockerfile
+++ b/Dockerfiles/debianx.Dockerfile
@@ -17,6 +17,8 @@ ARG BUILD_DATE
 ARG JINA_VERSION
 ARG TARGETPLATFORM
 ARG PIP_EXTRA_INDEX_URL="https://www.piwheels.org/simple"
+ARG PIP_INSTALL_CORE
+ARG PIP_INSTALL_PERF
 
 # constant, wont invalidate cache
 LABEL org.opencontainers.image.vendor="Jina AI Limited" \
@@ -29,7 +31,9 @@ LABEL org.opencontainers.image.vendor="Jina AI Limited" \
 
 # constant, wont invalidate cache
 ENV PIP_NO_CACHE_DIR=1 \
-    PIP_DISABLE_PIP_VERSION_CHECK=1
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    JINA_PIP_INSTALL_CORE=PIP_INSTALL_CORE \
+    JINA_PIP_INSTALL_PERF=PIP_INSTALL_PERF
 
 # change on extra-requirements.txt, setup.py will invalid the cache
 COPY extra-requirements.txt setup.py /tmp/

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ fragmented, multi-vendor, generic legacy tools.
 
 ## Install
 
-- via PyPI: `pip install -U "jina[standard]"`
+- via PyPI: `pip install -U jina`
 - via Docker: `docker run jinaai/jina:latest`
 
 <details>
@@ -52,8 +52,8 @@ fragmented, multi-vendor, generic legacy tools.
 
 | On x86/64, arm64/v6/v7 | Linux/macOS with Python 3.7/3.8/3.9 | Docker Users |
 | --- | --- | --- |
-| Minimum <br>(no HTTP, WebSocket, Docker support) | `pip install jina` | `docker run jinaai/jina:latest` |
-| Minimum but more performant <br>(use `uvloop` & `lz4`) | `pip install jina[perf]` | `docker run jinaai/jina:latest-perf` |
+| Minimum <br>(no HTTP, WebSocket, Docker support) | `JINA_PIP_INSTALL_CORE=1 pip install jina` | `docker run jinaai/jina:latest` |
+| Minimum but more performant <br>(use `uvloop` & `lz4`) | `JINA_PIP_INSTALL_PERF=1 pip install jina` | `docker run jinaai/jina:latest-perf` |
 | With <a href="https://api.jina.ai/daemon/">Daemon</a> | `pip install "jina[daemon]"` | `docker run --network=host jinaai/jina:latest-daemon` |
 | Full development dependencies | `pip install "jina[devel]"` | `docker run jinaai/jina:latest-devel` |
 | Pre-release<br>(all tags above can be added)| <sub>`pip install --pre jina` | `docker run jinaai/jina:master` |

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -34,7 +34,7 @@ The term "final release" is relative to "developmental release" as described bel
 
 `pip install -U jina` only installs the core dependencies of Jina.
 
-The recommended way of installing Jina is `pip install -U "jina[standard]"`
+The recommended way of installing Jina is `pip install -U jina`
 
 `"standard"` include extra dependencies that enables:
 - Jina Hub + Docker support
@@ -103,7 +103,7 @@ jinaai/jina:{version}{python_version}{extra}
     - `-py39` for Python 3.9;
 - `{extra}`: the extra dependency installed along with Jina. Possible values:
     - ` `: Jina is installed inside the image via `pip install jina`;
-    - `-standard`: Jina is installed inside the image via `pip install "jina[standard]"`. It includes all recommended dependencies;  
+    - `-standard`: Jina is installed inside the image via `pip install jina`. It includes all recommended dependencies;  
     - `-devel`: Jina is installed inside the image via `pip install "jina[devel]"`. It includes `standard` plus some extra dependencies;
     - `-daemon`: Jina is installed inside the image via `pip install "jina[dameon]"` along with `fluentd`; **and the entrypoint is set to `jinad`**.
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 import sys
+import os
 from os import path
 
 from setuptools import find_packages
@@ -117,6 +118,26 @@ def get_extra_requires(path, add_all=True):
 
 all_deps = get_extra_requires('extra-requirements.txt')
 
+core_deps = all_deps['core']
+perf_deps = all_deps['perf']
+standard_deps = all_deps['standard']
+
+if os.name == 'nt':
+    # uvloop & lz4 can not be run on windows
+    standard_deps.difference_update(perf_deps)
+    standard_deps.update(core_deps)
+
+# by default, final deps is the standard deps, unless specified by env otherwise
+final_deps = standard_deps
+
+# Use env var to enable a minimum installation of Jina
+# JINA_PIP_INSTALL_CORE=1 pip install jina
+# JINA_PIP_INSTALL_PERF=1 pip install jina
+if 'JINA_PIP_INSTALL_CORE' in os.environ:
+    final_deps = core_deps
+elif 'JINA_PIP_INSTALL_PERF' in os.environ:
+    final_deps = perf_deps
+
 setup(
     name=pkg_name,
     packages=find_packages(),
@@ -132,7 +153,7 @@ setup(
     long_description_content_type='text/markdown',
     zip_safe=False,
     setup_requires=['setuptools>=18.0', 'wheel'],
-    install_requires=list(all_deps['core']),
+    install_requires=list(final_deps),
     extras_require=all_deps,
     entry_points={
         'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -120,7 +120,7 @@ all_deps = get_extra_requires('extra-requirements.txt')
 
 core_deps = all_deps['core']
 perf_deps = all_deps['perf']
-standard_deps = all_deps['standard']
+standard_deps = all_deps['standard'].union(core_deps).union(perf_deps)
 
 if os.name == 'nt':
     # uvloop & lz4 can not be run on windows


### PR DESCRIPTION
`pip install jina` now corresponds to old `pip install "jina[standard]"`


Note "decremental" extras is not supported by pypi as [discussion here](https://jinaai.slack.com/archives/C018QC7Q4CU/p1626703322033300?thread_ts=1626697209.032200&cid=C018QC7Q4CU)
so this PR uses env var to enable a minimum installation of Jina

```bash
JINA_PIP_INSTALL_CORE=1 pip install jina  # => old pip install jina
JINA_PIP_INSTALL_PERF=1 pip install jina  # => old pip install jina[perf]
```