### PR TITLE
refactor: no copy on append

### DIFF
--- a/jina/types/arrays/chunk.py
+++ b/jina/types/arrays/chunk.py
@@ -25,11 +25,10 @@ class ChunkArray(DocumentArray):
         self._ref_doc = reference_doc
         super().__init__(doc_views)
 
-    def append(self, document: 'Document', copy: bool = True, **kwargs) -> 'Document':
+    def append(self, document: 'Document', **kwargs) -> 'Document':
         """Add a sub-document (i.e chunk) to the current Document.
 
         :param document: Sub-document to be appended
-        :param copy: If set, then copy the original Document. Otherwise the original Document may get modified
         :param kwargs: additional keyword arguments
         :return: the newly added sub-document in :class:`Document` view
         :rtype: :class:`Document`
@@ -38,22 +37,14 @@ class ChunkArray(DocumentArray):
             Comparing to :attr:`DocumentArray.append()`, this method adds more safeguard to
             make sure the added chunk is legit.
         """
-
-        if copy:
-            from ..document import Document
-
-            chunk = Document(document, copy=True)
-        else:
-            # note: this is faster than Document(document, copy=False)
-            chunk = document
-
+        super().append(document)
+        chunk = self[-1]
+        if not chunk.mime_type:
+            chunk.mime_type = self._ref_doc.mime_type
         chunk.set_attributes(
             parent_id=self._ref_doc.id, granularity=self.granularity, **kwargs
         )
 
-        if not chunk.mime_type:
-            chunk.mime_type = self._ref_doc.mime_type
-        super().append(chunk)
         return chunk
 
     def extend(self, iterable: Iterable['Document']) -> None:

--- a/jina/types/arrays/match.py
+++ b/jina/types/arrays/match.py
@@ -17,28 +17,20 @@ class MatchArray(DocumentArray):
         self._ref_doc = reference_doc
         super().__init__(doc_views)
 
-    def append(self, document: 'Document', copy: bool = True, **kwargs) -> 'Document':
+    def append(self, document: 'Document', **kwargs) -> 'Document':
         """Add a matched document to the current Document.
 
         :param document: Sub-document to be added
-        :param copy: If set, then copy the original Document. Otherwise the original Document may get modified
         :param kwargs: Extra key value arguments
         :return: the newly added sub-document in :class:`Document` view
         :rtype: :class:`Document` view
         """
-        if copy:
-            from ..document import Document
-
-            match = Document(document, copy=True)
-        else:
-            # note: this is faster than Document(document, copy=False)
-            match = document
-
+        super().append(document)
+        match = self[-1]
         match.set_attributes(
             granularity=self.granularity, adjacency=self.adjacency, **kwargs
         )
 
-        super().append(match)
         return match
 
     @property

--- a/jina/types/arrays/neural_ops.py
+++ b/jina/types/arrays/neural_ops.py
@@ -85,7 +85,7 @@ class DocumentArrayNeuralOpsMixin:
                 if d.id in self:
                     d = Document(d, copy=True)
                     d.pop('matches')
-                _q.matches.append(d, scores={metric_name: _dist}, copy=False)
+                _q.matches.append(d, scores={metric_name: _dist})
 
     def _match(self, darray, cdist, limit, normalization, metric_name):
         """
@@ -135,8 +135,8 @@ class DocumentArrayNeuralOpsMixin:
         :param limit: the maximum number of matches, when not given
                       all Documents in `another` are considered as matches
         :param normalization: a tuple [a, b] to be used with min-max normalization,
-                                the min distance will be rescaled to `a`, the max distance will be rescaled to `b`
-                                all values will be rescaled into range `[a, b]`.
+                              the min distance will be rescaled to `a`, the max distance will be rescaled to `b`
+                              all values will be rescaled into range `[a, b]`.
         :param batch_size: length of the chunks loaded into memory from darray.
         :param metric_name: if provided, then match result will be marked with this string.
         :return: distances and indices


### PR DESCRIPTION
Regading how `append` to Matches behave, I do not see any point on offering `copy` option. I think is better to add it to the list, and then edit afterwards