### PR TITLE
fix: allow more versions of dgl

### DIFF
--- a/extra-requirements.txt
+++ b/extra-requirements.txt
@@ -68,6 +68,6 @@ pytest-custom_exit_code:    test
 bs4:                        cicd
 aiostream:                  standard, daemon, devel
 jsonschema:                 cicd
-dgl==0.6.1:                 devel
+dgl>=0.6.1:                 devel
 black==20.8b1:              test
 matplotlib>=3.3.1:          devel

--- a/jina/resources/extra-requirements.txt
+++ b/jina/resources/extra-requirements.txt
@@ -68,6 +68,6 @@ pytest-custom_exit_code:    test
 bs4:                        cicd
 aiostream:                  standard, daemon, devel
 jsonschema:                 cicd
-dgl==0.6.1:                 devel
+dgl>=0.6.1:                 devel
 black==20.8b1:              test
 matplotlib>=3.3.1:          devel


### PR DESCRIPTION
The DGL version on `extra-requirements.txt` is hardcoded and more modern versions can be used.