### PR TITLE
refactor: remove dict keys creation

### DIFF
--- a/jina/types/document/__init__.py
+++ b/jina/types/document/__init__.py
@@ -211,7 +211,7 @@ class Document(ProtoTypeMixin, VersionedMixin):
                         field_resolver.get(k, k): v for k, v in document.items()
                     }
 
-                user_fields = set(document.keys())
+                user_fields = set(document)
                 support_fields = set(
                     self.attributes(
                         include_proto_fields_camelcase=True, include_properties=False
@@ -1320,7 +1320,7 @@ def _is_datauri(value: str) -> bool:
 
 def _contains_conflicting_content(**kwargs):
     content_keys = 0
-    for k in kwargs.keys():
+    for k in kwargs:
         if k in _all_doc_content_keys:
             content_keys += 1
             if content_keys > 1:


### PR DESCRIPTION
There is no need to create a `dict_keys` object for either iterating over the keys of a dict or for generating a set of keys for a dict.

Generating `dict_keys` only slows down code if the object is only used to check if another object is there (or for iterating over keys):

```
%timeit set({'a':23}.keys())
233 ns ± 31.4 ns per loop 
%timeit set({'a':23})
127 ns ± 0.243 ns per loop 
```
