### PR TITLE
feat: add efficient access to embeddings

### DIFF
--- a/.github/2.0/cookbooks/Document.md
+++ b/.github/2.0/cookbooks/Document.md
@@ -1053,7 +1053,7 @@ np.stack(da.get_attributes('embedding'))
 
 ### Property `.embeddings`
 
-There is a faster version to extract embeddings from a `DocumentArray` or `DocumentArrayMemmap`, the property `.embeddings`. This property assumes all embeddings in the array have the same dimension. Note that
+There is a faster version to extract embeddings from a `DocumentArray` or `DocumentArrayMemmap`, the property `.embeddings`. This property assumes all embeddings in the array have the same shape and dtype. Note that
 
 ```
 da.embeddings
@@ -1066,6 +1066,8 @@ will produce the same output as `np.stack(da.get_attributes('embedding'))` but t
  [4 5 6]
  [7 8 9]]
 ```
+
+**Note: using .embeddings in a DocumenArray or DocumentArrayMemmap with different shapes or dtypes might yield to unnexpected results.**
 
 
 

--- a/.github/2.0/cookbooks/Document.md
+++ b/.github/2.0/cookbooks/Document.md
@@ -1053,7 +1053,7 @@ np.stack(da.get_attributes('embedding'))
 
 ### Property `.embeddings`
 
-There is a faster version to extract embeddings from a DocumentArray or DocumentArrayMemmap, the property `.embeddings`. This property assumes all embeddings in the array have the same dimension. Note that
+There is a faster version to extract embeddings from a `DocumentArray` or `DocumentArrayMemmap`, the property `.embeddings`. This property assumes all embeddings in the array have the same dimension. Note that
 
 ```
 da.embeddings

--- a/.github/2.0/cookbooks/Document.md
+++ b/.github/2.0/cookbooks/Document.md
@@ -1042,7 +1042,6 @@ This can be very useful when extracting a batch of embeddings:
 
 ```python
 import numpy as np
-
 np.stack(da.get_attributes('embedding'))
 ```
 
@@ -1051,6 +1050,23 @@ np.stack(da.get_attributes('embedding'))
  [4 5 6]
  [7 8 9]]
 ```
+
+### Property `.embeddings`
+
+There is a faster version to extract embeddings from a DocumentArray or DocumentArrayMemmap, the property `.embeddings`. This property assumes all embeddings in the array have the same dimension. Note that
+
+```
+da.embeddings
+```
+
+will produce the same output as `np.stack(da.get_attributes('embedding'))` but the results will be retrieved faster.
+
+```
+[[1 2 3]
+ [4 5 6]
+ [7 8 9]]
+```
+
 
 
 ### Finding closest documents between `DocumentArray` objects

--- a/jina/types/arrays/neural_ops.py
+++ b/jina/types/arrays/neural_ops.py
@@ -252,7 +252,9 @@ class DocumentArrayNeuralOpsMixin:
     def embeddings(self) -> np.ndarray:
         """Return a `np.ndarray` stacking all the `embedding` attributes as rows.
 
-        Warning: This operation assumes all embeddings have the same shape.
+        Warning: This operation assumes all embeddings have the same shape and dtype.
+                 All dtype and shape values are assumed to be equal to the values of the
+                 first element in the DocumentArray / DocumentArrayMemmap
 
         Warning: This operation currently does not support sparse arrays.
 
@@ -273,7 +275,9 @@ class DocumentArrayNeuralOpsMixin:
         Example: `self._get_embeddings(10:20)` will return 10 embeddings from positions 10 to 20
                   in the `DocumentArray` or `DocumentArrayMemmap`
 
-        Warning: This operation assumes all embeddings have the same shape.
+        Warning: This operation assumes all embeddings have the same shape and dtype.
+                 All dtype and shape values are assumed to be equal to the values of the
+                 first element in the DocumentArray / DocumentArrayMemmap
 
         Warning: This operation currently does not support sparse arrays.
 

--- a/tests/unit/types/arrays/test_neural_ops.py
+++ b/tests/unit/types/arrays/test_neural_ops.py
@@ -395,27 +395,27 @@ def test_match_inclusive_dam(tmpdir):
     assert len(list(traversed)) == 9
 
 
-def test_da_embeddings(tmpdir):
-    da = DocumentArrayMemmap(tmpdir)
-    da.extend(Document(embedding=np.array([1, 2, 3, 4])) for _ in range(100))
+def test_da_get_embeddings():
+    da = DocumentArray(random_docs(100))
     np.testing.assert_almost_equal(da.get_attributes('embedding'), da.embeddings)
 
 
-def test_da_embeddings_slice(tmpdir):
-    da = DocumentArrayMemmap(tmpdir)
-    da.extend(Document(embedding=np.array([1, 2, 3, 4])) for _ in range(100))
+def test_dam_embeddings(tmpdir):
+    dam = DocumentArrayMemmap(tmpdir)
+    dam.extend(Document(embedding=np.array([1, 2, 3, 4])) for _ in range(100))
+    np.testing.assert_almost_equal(dam.get_attributes('embedding'), dam.embeddings)
+
+
+def test_da_get_embeddings():
+    da = DocumentArray(random_docs(100))
     np.testing.assert_almost_equal(
-        da.get_attributes('embedding')[10:20], da.embeddings[10:20]
+        da.get_attributes('embedding')[10:20], da._get_embeddings(slice(10, 20))
     )
 
 
-def test_da_embeddings():
-    da = DocumentArray(random_docs(100))
-    np.testing.assert_almost_equal(da.get_attributes('embedding'), da.embeddings)
-
-
-def test_da_embeddings_slice():
-    da = DocumentArray(random_docs(100))
+def test_dam_get_embeddings(tmpdir):
+    da = DocumentArrayMemmap(tmpdir)
+    da.extend(Document(embedding=np.array([1, 2, 3, 4])) for _ in range(100))
     np.testing.assert_almost_equal(
-        da.get_attributes('embedding')[10:20], da.embeddings[10:20]
+        da.get_attributes('embedding')[10:20], da._get_embeddings(slice(10, 20))
     )

--- a/tests/unit/types/arrays/test_neural_ops.py
+++ b/tests/unit/types/arrays/test_neural_ops.py
@@ -9,6 +9,7 @@ import pytest
 from jina import Document, DocumentArray
 from jina.types.arrays.memmap import DocumentArrayMemmap
 from jina.math.dimensionality_reduction import PCA
+from tests import random_docs
 
 
 @pytest.fixture()
@@ -392,3 +393,29 @@ def test_match_inclusive_dam(tmpdir):
     assert len(da2) == 3
     traversed = dam.traverse_flat(traversal_paths=['m', 'mm', 'mmm'])
     assert len(list(traversed)) == 9
+
+
+def test_da_embeddings(tmpdir):
+    da = DocumentArrayMemmap(tmpdir)
+    da.extend(Document(embedding=np.array([1, 2, 3, 4])) for _ in range(100))
+    np.testing.assert_almost_equal(da.get_attributes('embedding'), da.embeddings)
+
+
+def test_da_embeddings_slice(tmpdir):
+    da = DocumentArrayMemmap(tmpdir)
+    da.extend(Document(embedding=np.array([1, 2, 3, 4])) for _ in range(100))
+    np.testing.assert_almost_equal(
+        da.get_attributes('embedding')[10:20], da.embeddings[10:20]
+    )
+
+
+def test_da_embeddings():
+    da = DocumentArray(random_docs(100))
+    np.testing.assert_almost_equal(da.get_attributes('embedding'), da.embeddings)
+
+
+def test_da_embeddings_slice():
+    da = DocumentArray(random_docs(100))
+    np.testing.assert_almost_equal(
+        da.get_attributes('embedding')[10:20], da.embeddings[10:20]
+    )


### PR DESCRIPTION
This PR adds a `.embeddings` property for faster acces to the embeddings of a `DocumentArray` or a `DocumentArrayMemmap` . This is done iterating over the bytes of the embeddings at proto level avoiding the creation of intermediate Python obejcts. 

This PR also provides
- A speed up of 3x on the current `.match` implementation
- A speed up of 2x on the current `.match` implementation with minibatches

### Example:

```
from jina import Document, DocumentArray
import numpy as np
d = Document(embedding=np.random.random(128))
docarray = DocumentArray([d for _ in range(100_000)])
```

Using `get_attributes`
```
%timeit np.vstack(docarray.get_attributes('embedding'))
```
```
1.65 s ± 95.8 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

Using  `.embeddings`
```
%timeit docarray.embeddings
```
```
649 ms ± 16.8 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```


### Impact on `.match`

```
d1 = Document(embedding=np.array([0,0,0,0,1]))
da_1 = DocumentArray([d1])
da_2 = DocumentArray([Document(embedding=x) for x in np.random.random((1_000_000, 5))])
```

This PR
```
%time da_1.match(da_2, metric=metric, limit=3)
5.54 s ± 209 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```
Current master branch
```
%time da_1.match(da_2, metric=metric, limit=3)
15.2 s ± 400 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```


### Impact on `.match` with batching

This PR also provides `_get_embeddings` which can be used to get a slice of the embeddings which is relevant for computing in minibatches.

With the current master branch
```
dam = DocumentArrayMemmap('./my-memmap')
dam.extend([Document(embedding=x) for x in np.random.random((100_000, 5)) ])
%timeit da_1.match(dam, metric=metric, limit=3, batch_size=10_000)
```
```
5.03 s ± 278 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```
In this PR
```
%timeit da_1.match(dam, metric=metric, limit=3, batch_size=10_000)
```
```
3.26 s ± 159 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```


### Warning 

We have to give user responsability to construct Documents in the DocumentArray  with  embeddings of the same dtype and shape. 

We need to warn users to construct DocumentArrays with embeddings of the same type.
```
d1 = Document(embedding=np.array([1,2,3]))
d2 = Document(embedding=np.array([2.2,2.,5.])
aux = DocumentArray([d1,d2] )
aux.embeddings
array([[                  1,                   2,                   3],
       [4612136378390124954, 4611686018427387904, 4617315517961601024]])
```





