### PR TITLE
feat: unknown args loggin

### DIFF
--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -14,12 +14,9 @@ def _get_run_args(print_args: bool = True):
         args, unknown = parser.parse_known_args()
 
         if unknown:
-            import warnings
+            from ..parsers.helper import warn_unknown_args
 
-            warnings.warn(
-                f'ignored unknown argument: {unknown}, '
-                f'this may be caused by the mismatched version on Jina'
-            )
+            warn_unknown_args(unknown)
 
         if args.cli not in silent_print and print_args:
             from jina.helper import colored

--- a/jina/flow/base.py
+++ b/jina/flow/base.py
@@ -675,7 +675,7 @@ class Flow(PostMixin, JAMLCompatible, ExitStack, metaclass=FlowType):
         if pod_role == PodRoleType.GATEWAY:
             parser = set_gateway_parser()
 
-        args = ArgNamespace.kwargs2namespace(kwargs, parser)
+        args = ArgNamespace.kwargs2namespace(kwargs, parser, True)
 
         if args.grpc_data_requests and args.runtime_cls == 'ZEDRuntime':
             args.runtime_cls = 'GRPCDataRuntime'

--- a/jina/flow/base.py
+++ b/jina/flow/base.py
@@ -300,7 +300,7 @@ class Flow(PostMixin, JAMLCompatible, ExitStack, metaclass=FlowType):
 
         _flow_parser = set_flow_parser()
         if args is None:
-            args = ArgNamespace.kwargs2namespace(kwargs, _flow_parser)
+            args = ArgNamespace.kwargs2namespace(kwargs, _flow_parser, True)
         self.args = args
         # common args should be the ones that can not be parsed by _flow_parser
         known_keys = vars(args)

--- a/jina/helper.py
+++ b/jina/helper.py
@@ -671,13 +671,16 @@ class ArgNamespace:
 
     @staticmethod
     def kwargs2namespace(
-        kwargs: Dict[str, Union[str, int, bool]], parser: ArgumentParser
+        kwargs: Dict[str, Union[str, int, bool]],
+        parser: ArgumentParser,
+        log_unknown: bool = False,
     ) -> Namespace:
         """
         Convert dict to a namespace.
 
         :param kwargs: dictionary of key-values to be converted
         :param parser: the parser for building kwargs into a namespace
+        :param log_unkown: True, if unknown arguments should be logged
         :return: argument list
         """
         args = ArgNamespace.kwargs2list(kwargs)
@@ -687,6 +690,13 @@ class ArgNamespace:
             raise ValueError(
                 f'bad arguments "{args}" with parser {parser}, '
                 'you may want to double check your args '
+            )
+        if log_unknown and unknown_args:
+            from jina.logging.predefined import default_logger
+
+            default_logger.warning(
+                f'ignored unknown arguments: {unknown_args}, '
+                f'this may be caused by the mismatched version on Jina'
             )
         return p_args
 

--- a/jina/helper.py
+++ b/jina/helper.py
@@ -680,7 +680,7 @@ class ArgNamespace:
 
         :param kwargs: dictionary of key-values to be converted
         :param parser: the parser for building kwargs into a namespace
-        :param log_unkown: True, if unknown arguments should be logged
+        :param warn_unknown: True, if unknown arguments should be logged
         :return: argument list
         """
         args = ArgNamespace.kwargs2list(kwargs)

--- a/jina/helper.py
+++ b/jina/helper.py
@@ -673,7 +673,7 @@ class ArgNamespace:
     def kwargs2namespace(
         kwargs: Dict[str, Union[str, int, bool]],
         parser: ArgumentParser,
-        log_unknown: bool = False,
+        warn_unknown: bool = False,
     ) -> Namespace:
         """
         Convert dict to a namespace.
@@ -691,13 +691,11 @@ class ArgNamespace:
                 f'bad arguments "{args}" with parser {parser}, '
                 'you may want to double check your args '
             )
-        if log_unknown and unknown_args:
-            from jina.logging.predefined import default_logger
+        if warn_unknown and unknown_args:
+            from .parsers.helper import warn_unknown_args
 
-            default_logger.warning(
-                f'ignored unknown arguments: {unknown_args}, '
-                f'this may be caused by the mismatched version on Jina'
-            )
+            warn_unknown_args(unknown_args)
+
         return p_args
 
     @staticmethod

--- a/jina/jaml/parsers/flow/v1.py
+++ b/jina/jaml/parsers/flow/v1.py
@@ -6,6 +6,7 @@ from ....enums import PodRoleType
 from .... import Flow
 from ....helper import expand_env_var, ArgNamespace
 from ....parsers import set_pod_parser, set_gateway_parser
+from ....parsers.helper import warn_unknown_args
 
 
 def _get_taboo():
@@ -71,6 +72,10 @@ class V1Parser(VersionedYAMLParser):
                 method = p_pod_attr.get('method', 'add')
                 # support methods: add, needs, inspect
                 getattr(obj, method)(**p_pod_attr, copy_flow=False)
+        unknown_args = set(data.keys()) - {'executors', 'with', 'version'}
+        if unknown_args:
+            warn_unknown_args(unknown_args)
+
         return obj
 
     def dump(self, data: 'Flow') -> Dict:

--- a/jina/parsers/helper.py
+++ b/jina/parsers/helper.py
@@ -2,7 +2,7 @@
 import argparse
 import os
 import warnings
-from typing import Tuple
+from typing import Tuple, List
 
 _SHOW_ALL_ARGS = 'JINA_FULL_CLI' in os.environ
 if _SHOW_ALL_ARGS:
@@ -16,7 +16,11 @@ if _SHOW_ALL_ARGS:
 DEPRECATED_ARGS_MAPPING = {'override_with': 'uses_with'}
 
 
-def warn_unknown_args(unknown_args):
+def warn_unknown_args(unknown_args: List[str]):
+    """Creates warnings for all given arguments.
+
+    :param unknown_args: arguments that are unknown to Jina
+    """
     for arg in unknown_args:
         normalized_arg = arg.replace('--', '').replace('-', '_')
         if normalized_arg in DEPRECATED_ARGS_MAPPING:

--- a/jina/parsers/helper.py
+++ b/jina/parsers/helper.py
@@ -1,6 +1,7 @@
 """Module for helper functions in the parser"""
 import argparse
 import os
+import warnings
 from typing import Tuple
 
 _SHOW_ALL_ARGS = 'JINA_FULL_CLI' in os.environ
@@ -10,6 +11,23 @@ if _SHOW_ALL_ARGS:
     default_logger.warning(
         f'Setting {_SHOW_ALL_ARGS} will make remote Peas with sharding not work when using JinaD'
     )
+
+
+DEPRECATED_ARGS_MAPPING = {'override_with': 'uses_with'}
+
+
+def warn_unknown_args(unknown_args):
+    for arg in unknown_args:
+        normalized_arg = arg.replace('--', '').replace('-', '_')
+        if normalized_arg in DEPRECATED_ARGS_MAPPING:
+            new_argument = DEPRECATED_ARGS_MAPPING[normalized_arg]
+            if '-' in arg:
+                new_argument = new_argument.replace('_', '-')
+            warnings.warn(
+                f'''Ignored the deprecated argument '{arg}'. Please use '{new_argument}'.'''
+            )
+        else:
+            warnings.warn(f'ignored unknown argument: {arg}')
 
 
 def add_arg_group(parser, title):

--- a/tests/unit/parsers/test_warnings.py
+++ b/tests/unit/parsers/test_warnings.py
@@ -1,0 +1,69 @@
+import pytest
+
+from jina import Flow, Executor
+
+
+class MyExecutor(Executor):
+    def __init__(self, foo=50, *args, **kwargs):
+        print(foo)
+        super().__init__(*args, **kwargs)
+
+
+def test_flow_warnings():
+    yaml = '''jtype: Flow
+version: 1
+foo: bar
+    '''
+    with pytest.warns(UserWarning, match='ignored unknown') as record:
+        Flow().load_config(yaml)
+    assert len(record) == 1
+    assert record[0].message.args[0].startswith('ignored unknown')
+
+
+def test_flow_with_warnings():
+    yaml = '''jtype: Flow
+version: 1
+with:
+    foo: bar
+    '''
+    with pytest.warns(UserWarning, match='ignored unknown') as record:
+        Flow().load_config(yaml)
+    assert len(record) == 2
+    assert record[0].message.args[0].startswith('ignored unknown')
+
+
+def test_executor_warnings():
+    yaml = '''jtype: Flow
+version: 1
+executors:
+    - foo: bar
+    '''
+    with pytest.warns(UserWarning, match='ignored unknown') as record:
+        Flow().load_config(yaml)
+    assert len(record) == 2
+    assert record[0].message.args[0].startswith('ignored unknown')
+
+
+def test_executor_with_warnings():
+    yaml = '''jtype: Flow
+version: 1
+executors:
+    - with:
+        foo: bar
+    '''
+    with pytest.warns(UserWarning, match='ignored unknown') as record:
+        Flow().load_config(yaml)
+    assert len(record) == 2
+    assert record[0].message.args[0].startswith('ignored unknown')
+
+
+def test_executor_uses_with_works():
+    yaml = '''jtype: Flow
+version: 1
+executors:
+    - uses_with:
+        foo: bar
+    '''
+    with pytest.warns(None, match='ignored unknown') as record:
+        Flow().load_config(yaml)
+    assert len(record) == 0


### PR DESCRIPTION
This will log a warning, when an unknown argument is used via the JAML syntax inside the Pod arguments. See the tests for examples with warnings.

I am not sure if `warn_unknown_args` and `DEPRECATED_ARGS_MAPPING` belongs into `jina/parsers/helper.py`. Happy about other suggestions