### PR TITLE
feat: add setter to embeddings

### DIFF
--- a/jina/types/arrays/memmap.py
+++ b/jina/types/arrays/memmap.py
@@ -542,6 +542,17 @@ class DocumentArrayMemmap(
 
         return embeds
 
+    @embeddings.setter
+    def embeddings(self, emb: np.ndarray):
+
+        assert len(emb) == len(self), (
+            'the number of rows in the input ({len(emb)}),'
+            'should match the number of Documents ({len(self)})'
+        )
+
+        for d, x in zip(self, emb):
+            d.embedding = x
+
     def _invalidate_embeddings_memmap(self):
         self._embeddings_memmap = None
         self._embeddings_shape = None

--- a/jina/types/arrays/neural_ops.py
+++ b/jina/types/arrays/neural_ops.py
@@ -267,12 +267,22 @@ class DocumentArrayNeuralOpsMixin:
 
         :return: embeddings stacked per row as `np.ndarray`.
         """
-
         x_mat = b''.join(d.proto.embedding.dense.buffer for d in self)
 
         return np.frombuffer(x_mat, dtype=self[0].proto.embedding.dense.dtype).reshape(
             (len(self), self[0].proto.embedding.dense.shape[0])
         )
+
+    @embeddings.setter
+    def embeddings(self, emb: np.ndarray):
+
+        assert len(emb) == len(self), (
+            'the number of rows in the input ({len(emb)}),'
+            'should match the number of Documents ({len(self)})'
+        )
+
+        for d, x in zip(self, emb):
+            d.embedding = x
 
     def _get_embeddings(self, indices: Optional[slice] = None) -> np.ndarray:
         """Return a `np.ndarray` stacking  the `embedding` attributes as rows.

--- a/jina/types/arrays/neural_ops.py
+++ b/jina/types/arrays/neural_ops.py
@@ -255,35 +255,6 @@ class DocumentArrayNeuralOpsMixin:
         else:
             plt.show()
 
-    @property
-    def embeddings(self) -> np.ndarray:
-        """Return a `np.ndarray` stacking all the `embedding` attributes as rows.
-
-        .. warning:: This operation assumes all embeddings have the same shape and dtype.
-                 All dtype and shape values are assumed to be equal to the values of the
-                 first element in the DocumentArray / DocumentArrayMemmap
-
-        .. warning:: This operation currently does not support sparse arrays.
-
-        :return: embeddings stacked per row as `np.ndarray`.
-        """
-        x_mat = b''.join(d.proto.embedding.dense.buffer for d in self)
-
-        return np.frombuffer(x_mat, dtype=self[0].proto.embedding.dense.dtype).reshape(
-            (len(self), self[0].proto.embedding.dense.shape[0])
-        )
-
-    @embeddings.setter
-    def embeddings(self, emb: np.ndarray):
-
-        assert len(emb) == len(self), (
-            'the number of rows in the input ({len(emb)}),'
-            'should match the number of Documents ({len(self)})'
-        )
-
-        for d, x in zip(self, emb):
-            d.embedding = x
-
     def _get_embeddings(self, indices: Optional[slice] = None) -> np.ndarray:
         """Return a `np.ndarray` stacking  the `embedding` attributes as rows.
         If indices is passed the embeddings from the indices are retrieved, otherwise

--- a/tests/unit/types/arrays/test_documentarray.py
+++ b/tests/unit/types/arrays/test_documentarray.py
@@ -465,3 +465,34 @@ def test_split(docarray_for_split):
     assert len(rv['a']) == 2
     rv = docarray_for_split.split('random')
     assert not rv  # wrong tag returns empty dict
+
+
+def test_da_get_embeddings():
+    da = DocumentArray(random_docs(100))
+    np.testing.assert_almost_equal(da.get_attributes('embedding'), da.embeddings)
+
+
+def test_da_get_embeddings():
+    da = DocumentArray(random_docs(100))
+    np.testing.assert_almost_equal(
+        da.get_attributes('embedding')[10:20], da._get_embeddings(slice(10, 20))
+    )
+
+
+def test_embeddings_setter_da():
+    emb = np.random.random((100, 128))
+    da = DocumentArray([Document() for _ in range(100)])
+    da.embeddings = emb
+    np.testing.assert_almost_equal(da.embeddings, emb)
+
+    for x, doc in zip(emb, da):
+        np.testing.assert_almost_equal(x, doc.embedding)
+
+
+def test_embeddings_getter_da():
+    emb = np.random.random((100, 128))
+    da = DocumentArray([Document(embedding=x) for x in emb])
+    np.testing.assert_almost_equal(da.embeddings, emb)
+
+    for x, doc in zip(emb, da):
+        np.testing.assert_almost_equal(x, doc.embedding)

--- a/tests/unit/types/arrays/test_memmap.py
+++ b/tests/unit/types/arrays/test_memmap.py
@@ -467,3 +467,38 @@ def test_split(memmap_for_split):
     assert len(rv['c']) == 2
     assert len(rv['b']) == 1
     assert len(rv['a']) == 2
+
+
+def test_dam_embeddings(tmpdir):
+    dam = DocumentArrayMemmap(tmpdir)
+    dam.extend(Document(embedding=np.array([1, 2, 3, 4])) for _ in range(100))
+    np.testing.assert_almost_equal(dam.get_attributes('embedding'), dam.embeddings)
+
+
+def test_dam_get_embeddings(tmpdir):
+    da = DocumentArrayMemmap(tmpdir)
+    da.extend(Document(embedding=np.array([1, 2, 3, 4])) for _ in range(100))
+    np.testing.assert_almost_equal(
+        da.get_attributes('embedding')[10:20], da._get_embeddings(slice(10, 20))
+    )
+
+
+def test_embeddings_setter_dam(tmpdir):
+    emb = np.random.random((100, 128))
+    dam = DocumentArrayMemmap(tmpdir)
+    dam.extend([Document() for _ in range(100)])
+    dam.embeddings = emb
+    np.testing.assert_almost_equal(dam.embeddings, emb)
+
+    for x, doc in zip(emb, dam):
+        np.testing.assert_almost_equal(x, doc.embedding)
+
+
+def test_embeddings_getter_dam(tmpdir):
+    emb = np.random.random((100, 128))
+    dam = DocumentArrayMemmap(tmpdir)
+    dam.extend([Document(embedding=x) for x in emb])
+
+    np.testing.assert_almost_equal(dam.embeddings, emb)
+    for x, doc in zip(emb, dam):
+        np.testing.assert_almost_equal(x, doc.embedding)

--- a/tests/unit/types/arrays/test_neural_ops.py
+++ b/tests/unit/types/arrays/test_neural_ops.py
@@ -425,3 +425,16 @@ def test_dam_get_embeddings(tmpdir):
     np.testing.assert_almost_equal(
         da.get_attributes('embedding')[10:20], da._get_embeddings(slice(10, 20))
     )
+
+
+def test_embeddings_setter():
+    emb = np.random.random((100, 128))
+    da = DocumentArray([Document() for _ in range(100)])
+    da.embeddings = emb
+    np.testing.assert_almost_equal(da.embeddings, emb)
+
+
+def test_embeddings_getter():
+    emb = np.random.random((100, 128))
+    da = DocumentArray([Document(embedding=x) for x in emb])
+    np.testing.assert_almost_equal(da.embeddings, emb)

--- a/tests/unit/types/arrays/test_neural_ops.py
+++ b/tests/unit/types/arrays/test_neural_ops.py
@@ -433,8 +433,14 @@ def test_embeddings_setter():
     da.embeddings = emb
     np.testing.assert_almost_equal(da.embeddings, emb)
 
+    for x, y in zip(emb, da.embeddings):
+        np.testing.assert_almost_equal(x, y)
+
 
 def test_embeddings_getter():
     emb = np.random.random((100, 128))
     da = DocumentArray([Document(embedding=x) for x in emb])
     np.testing.assert_almost_equal(da.embeddings, emb)
+
+    for x, y in zip(emb, da.embeddings):
+        np.testing.assert_almost_equal(x, y)

--- a/tests/unit/types/arrays/test_neural_ops.py
+++ b/tests/unit/types/arrays/test_neural_ops.py
@@ -427,20 +427,41 @@ def test_dam_get_embeddings(tmpdir):
     )
 
 
-def test_embeddings_setter():
+def test_embeddings_setter_da():
     emb = np.random.random((100, 128))
     da = DocumentArray([Document() for _ in range(100)])
     da.embeddings = emb
     np.testing.assert_almost_equal(da.embeddings, emb)
 
-    for x, y in zip(emb, da.embeddings):
-        np.testing.assert_almost_equal(x, y)
+    for x, doc in zip(emb, da):
+        np.testing.assert_almost_equal(x, doc.embedding)
 
 
-def test_embeddings_getter():
+def test_embeddings_setter_dam(tmpdir):
+    emb = np.random.random((100, 128))
+    dam = DocumentArrayMemmap(tmpdir)
+    dam.extend([Document() for _ in range(100)])
+    dam.embeddings = emb
+    np.testing.assert_almost_equal(dam.embeddings, emb)
+
+    for x, doc in zip(emb, dam):
+        np.testing.assert_almost_equal(x, doc.embedding)
+
+
+def test_embeddings_getter_da():
     emb = np.random.random((100, 128))
     da = DocumentArray([Document(embedding=x) for x in emb])
     np.testing.assert_almost_equal(da.embeddings, emb)
 
-    for x, y in zip(emb, da.embeddings):
-        np.testing.assert_almost_equal(x, y)
+    for x, doc in zip(emb, da):
+        np.testing.assert_almost_equal(x, doc.embedding)
+
+
+def test_embeddings_getter_dam(tmpdir):
+    emb = np.random.random((100, 128))
+    dam = DocumentArrayMemmap(tmpdir)
+    dam.extend([Document(embedding=x) for x in emb])
+
+    np.testing.assert_almost_equal(dam.embeddings, emb)
+    for x, doc in zip(emb, dam):
+        np.testing.assert_almost_equal(x, doc.embedding)

--- a/tests/unit/types/arrays/test_neural_ops.py
+++ b/tests/unit/types/arrays/test_neural_ops.py
@@ -9,7 +9,6 @@ import pytest
 from jina import Document, DocumentArray
 from jina.types.arrays.memmap import DocumentArrayMemmap
 from jina.math.dimensionality_reduction import PCA
-from tests import random_docs
 
 
 @pytest.fixture()
@@ -399,69 +398,3 @@ def test_match_inclusive_dam(tmpdir):
     assert len(da2) == 3
     traversed = dam.traverse_flat(traversal_paths=['m', 'mm', 'mmm'])
     assert len(list(traversed)) == 9
-
-
-def test_da_get_embeddings():
-    da = DocumentArray(random_docs(100))
-    np.testing.assert_almost_equal(da.get_attributes('embedding'), da.embeddings)
-
-
-def test_dam_embeddings(tmpdir):
-    dam = DocumentArrayMemmap(tmpdir)
-    dam.extend(Document(embedding=np.array([1, 2, 3, 4])) for _ in range(100))
-    np.testing.assert_almost_equal(dam.get_attributes('embedding'), dam.embeddings)
-
-
-def test_da_get_embeddings():
-    da = DocumentArray(random_docs(100))
-    np.testing.assert_almost_equal(
-        da.get_attributes('embedding')[10:20], da._get_embeddings(slice(10, 20))
-    )
-
-
-def test_dam_get_embeddings(tmpdir):
-    da = DocumentArrayMemmap(tmpdir)
-    da.extend(Document(embedding=np.array([1, 2, 3, 4])) for _ in range(100))
-    np.testing.assert_almost_equal(
-        da.get_attributes('embedding')[10:20], da._get_embeddings(slice(10, 20))
-    )
-
-
-def test_embeddings_setter_da():
-    emb = np.random.random((100, 128))
-    da = DocumentArray([Document() for _ in range(100)])
-    da.embeddings = emb
-    np.testing.assert_almost_equal(da.embeddings, emb)
-
-    for x, doc in zip(emb, da):
-        np.testing.assert_almost_equal(x, doc.embedding)
-
-
-def test_embeddings_setter_dam(tmpdir):
-    emb = np.random.random((100, 128))
-    dam = DocumentArrayMemmap(tmpdir)
-    dam.extend([Document() for _ in range(100)])
-    dam.embeddings = emb
-    np.testing.assert_almost_equal(dam.embeddings, emb)
-
-    for x, doc in zip(emb, dam):
-        np.testing.assert_almost_equal(x, doc.embedding)
-
-
-def test_embeddings_getter_da():
-    emb = np.random.random((100, 128))
-    da = DocumentArray([Document(embedding=x) for x in emb])
-    np.testing.assert_almost_equal(da.embeddings, emb)
-
-    for x, doc in zip(emb, da):
-        np.testing.assert_almost_equal(x, doc.embedding)
-
-
-def test_embeddings_getter_dam(tmpdir):
-    emb = np.random.random((100, 128))
-    dam = DocumentArrayMemmap(tmpdir)
-    dam.extend([Document(embedding=x) for x in emb])
-
-    np.testing.assert_almost_equal(dam.embeddings, emb)
-    for x, doc in zip(emb, dam):
-        np.testing.assert_almost_equal(x, doc.embedding)


### PR DESCRIPTION
Allow setting  in `.embeddings` at `DocumentArray` level