### PR TITLE
perf: save a single snapshot of warning filters and use it

### DIFF
--- a/jina/types/document/helper.py
+++ b/jina/types/document/helper.py
@@ -1,4 +1,6 @@
 import functools
+import warnings
+from copy import copy
 from typing import Iterable, List
 
 __all__ = ['DocGroundtruthPair']
@@ -82,3 +84,11 @@ def versioned(fn):
         return fn(self, *args, **kwargs)
 
     return wrapper
+
+
+def get_warning_filters(action, message, category):
+    filters = copy(warnings.filters)
+    warnings.filterwarnings(action, message, category=category)
+    protobuf_filters = warnings.filters
+    warnings.filters = filters
+    return protobuf_filters


### PR DESCRIPTION
Document's constructor uses `warnings.filterwarnings` which compiles a regex expression and performs remove/insert operations.
In the code snippet 2, `warnings.filterwarnings` consumes 9% of the total time.

![image](https://user-images.githubusercontent.com/15269265/129724673-87744f1e-8334-4f91-9e2e-7f5a2748f6ed.png)
The goal of this PR is to compile and construct the warnings filter once, save it as a snapshot and then use it each time it's needed.

Benchmark:
1) create a DAM with random docs:
```python
from jina.types.arrays.memmap import DocumentArrayMemmap
from tests import random_docs

dam = DocumentArrayMemmap('mydam')
dam.extend(random_docs(100000))
```

2) test iteration:
```python
from jina.logging.profile import TimeContext
from jina.types.arrays.memmap import DocumentArrayMemmap

dam = DocumentArrayMemmap('mydam')
with TimeContext('iter'):
    for doc in dam:
        pass
```
on master: `iter ...	iter takes 5 seconds (5.28s)`
on feature branch: `iter ...	iter takes 4 seconds (4.22s)`