### PR TITLE
perf(types): remove warning logic in binary doc construction

### DIFF
--- a/jina/types/document/__init__.py
+++ b/jina/types/document/__init__.py
@@ -5,7 +5,6 @@ import mimetypes
 import os
 import urllib.parse
 import urllib.request
-import warnings
 from hashlib import blake2b
 from typing import (
     Iterable,
@@ -1179,10 +1178,10 @@ class Document(ProtoTypeMixin, VersionedMixin):
 
         mermaid_str = (
             """
-                                %%{init: {'theme': 'base', 'themeVariables': { 'primaryColor': '#FFC666'}}}%%
-                                classDiagram
-
-                                        """
+                                    %%{init: {'theme': 'base', 'themeVariables': { 'primaryColor': '#FFC666'}}}%%
+                                    classDiagram
+    
+                                            """
             + self.__mermaid_str__()
         )
 

--- a/jina/types/document/__init__.py
+++ b/jina/types/document/__init__.py
@@ -291,20 +291,7 @@ class Document(ProtoTypeMixin, VersionedMixin):
                                 {k: document[k] for k in _remainder}
                             )
             elif isinstance(document, bytes):
-                # directly parsing from binary string gives large false-positive
-                # fortunately protobuf throws a warning when the parsing seems go wrong
-                # the context manager below converts this warning into exception and throw it
-                # properly
-                with warnings.catch_warnings():
-                    warnings.filterwarnings(
-                        'error', 'Unexpected end-group tag', category=RuntimeWarning
-                    )
-                    try:
-                        self._pb_body.ParseFromString(document)
-                    except RuntimeWarning as ex:
-                        raise BadDocType(
-                            f'fail to construct a document from {document}'
-                        ) from ex
+                self._pb_body.ParseFromString(document)
             elif isinstance(document, Document):
                 if copy:
                     self._pb_body.CopyFrom(document.proto)

--- a/tests/unit/clients/python/test_request.py
+++ b/tests/unit/clients/python/test_request.py
@@ -64,10 +64,6 @@ def test_data_type_builder_auto(input_type):
     assert d.text == '123'
     assert t == DataInputType.CONTENT
 
-    d, t = _new_doc_from_data(b'45678', input_type)
-    assert t == DataInputType.CONTENT
-    assert d.buffer == b'45678'
-
     d, t = _new_doc_from_data(b'123', input_type)
     assert t == DataInputType.CONTENT
     assert d.buffer == b'123'


### PR DESCRIPTION
background: https://github.com/jina-ai/jina/pull/3193#pullrequestreview-731999252

close #3193 

```
➜  jina git:(master) ✗ python toy39.py
get embedding ...	get embedding takes 4 seconds (4.49s)

➜  jina git:(perf-rm-warn-logic) ✗ python toy39.py
get embedding ...	get embedding takes 3 seconds (3.99s)
```