### PR TITLE
feat: make docs behavior consistent :boom: 

### DIFF
--- a/.github/2.0/cookbooks/Flow.md
+++ b/.github/2.0/cookbooks/Flow.md
@@ -626,8 +626,8 @@ def post(
     :param on_done: the function to be called when the :class:`Request` object is resolved.
     :param on_error: the function to be called when the :class:`Request` object is rejected.
     :param on_always: the function to be called when the :class:`Request` object is  is either resolved or rejected.
-    :param target_peapod: a regex string represent the certain peas/pods request targeted
-    :param parameters: the kwargs that will be sent to the executor
+    :param target_peapod: a regex string. Only matching Executors will process the request.
+    :param parameters: the kwargs that will be sent to the Executor
     :param request_size: the number of Documents per request. <=0 means all inputs in one request.
     :param show_progress: if set, client will show a progress bar on receiving every request.
     :param continue_on_error: if set, a Request that causes callback error will be logged only without blocking the further requests.

--- a/jina/clients/mixin.py
+++ b/jina/clients/mixin.py
@@ -32,7 +32,7 @@ class PostMixin:
         :param on_error: the function to be called when the :class:`Request` object is rejected.
         :param on_always: the function to be called when the :class:`Request` object is  is either resolved or rejected.
         :param parameters: the kwargs that will be sent to the executor
-        :param target_peapod: a regex string represent the certain peas/pods request targeted
+        :param target_peapod: a regex string. Only matching Executors will process the request.
         :param request_size: the number of Documents per request. <=0 means all inputs in one request.
         :param show_progress: if set, client will show a progress bar on receiving every request.
         :param continue_on_error: if set, a Request that causes callback error will be logged only without blocking the further requests.
@@ -102,7 +102,7 @@ class AsyncPostMixin:
         :param on_error: the function to be called when the :class:`Request` object is rejected.
         :param on_always: the function to be called when the :class:`Request` object is  is either resolved or rejected.
         :param parameters: the kwargs that will be sent to the executor
-        :param target_peapod: a regex string represent the certain peas/pods request targeted
+        :param target_peapod: a regex string. Only matching Executors will process the request.
         :param request_size: the number of Documents per request. <=0 means all inputs in one request.
         :param show_progress: if set, client will show a progress bar on receiving every request.
         :param continue_on_error: if set, a Request that causes callback error will be logged only without blocking the further requests.

--- a/jina/clients/request/__init__.py
+++ b/jina/clients/request/__init__.py
@@ -39,7 +39,7 @@ def request_generator(
     :param data_type: if ``data`` is an iterator over self-contained document, i.e. :class:`DocumentSourceType`;
             or an iterator over possible Document content (set to text, blob and buffer).
     :param parameters: a dictionary of parameters to be sent to the executor
-    :param target_peapod: a regex string represent the certain peas/pods request targeted
+    :param target_peapod: a regex string. Only matching Executors will process the request.
     :param kwargs: additional arguments
     :yield: request
     """

--- a/jina/clients/request/asyncio.py
+++ b/jina/clients/request/asyncio.py
@@ -27,7 +27,7 @@ async def request_generator(
     :param data_type: if ``data`` is an iterator over self-contained document, i.e. :class:`DocumentSourceType`;
             or an iterator over possible Document content (set to text, blob and buffer).
     :param parameters: the kwargs that will be sent to the executor
-    :param target_peapod: a regex string represent the certain peas/pods request targeted
+    :param target_peapod: a regex string. Only matching Executors will process the request.
     :param kwargs: additional arguments
     :yield: request
     """

--- a/jina/helloworld/multimodal/flow-search.yml
+++ b/jina/helloworld/multimodal/flow-search.yml
@@ -2,7 +2,6 @@ jtype: Flow
 version: '1'
 with:
   cors: True
-  expose_crud_endpoints: True
 executors:
   - name: craftText
     uses:

--- a/jina/peapods/pods/compound.py
+++ b/jina/peapods/pods/compound.py
@@ -105,7 +105,6 @@ class CompoundPod(BasePod, ExitStack):
             self._enter_pea(self.head_pea)
             for _args in self.replicas_args:
                 _args.noblock_on_start = True
-                _args.polling = PollingType.ALL
                 self._enter_replica(Pod(_args))
             tail_args = self.tail_args
             tail_args.noblock_on_start = True
@@ -119,7 +118,6 @@ class CompoundPod(BasePod, ExitStack):
                 self.head_pea = Pea(head_args)
                 self._enter_pea(self.head_pea)
                 for _args in self.replicas_args:
-                    _args.polling = PollingType.ALL
                     self._enter_replica(Pod(_args))
                 tail_args = self.tail_args
                 self.tail_pea = Pea(tail_args)
@@ -223,6 +221,7 @@ class CompoundPod(BasePod, ExitStack):
             _args.port_ctrl = helper.random_port()
             _args.socket_out = SocketType.PUSH_CONNECT
             _args.socket_in = SocketType.DEALER_CONNECT
+            _args.polling = PollingType.ALL
             _args.dynamic_routing = False
             # ugly trick to avoid Head of Replica to have wrong host in
             tmp_args = copy.deepcopy(_args)

--- a/jina/peapods/runtimes/request_handlers/data_request_handler.py
+++ b/jina/peapods/runtimes/request_handlers/data_request_handler.py
@@ -189,6 +189,11 @@ class DataRequestHandler:
 
     @staticmethod
     def replace_docs(msg, docs):
+        """Replaces the docs in a message with new Documents.
+
+        :param msg: The message object
+        :param docs: the new docs to be used
+        """
         msg.request.docs.clear()
         msg.request.docs.extend(docs)
 

--- a/jina/peapods/runtimes/request_handlers/data_request_handler.py
+++ b/jina/peapods/runtimes/request_handlers/data_request_handler.py
@@ -132,6 +132,15 @@ class DataRequestHandler:
             self.logger.debug(
                 f'skip executor: mismatch request, exec_endpoint: {msg.envelope.header.exec_endpoint}, requests: {self._executor.requests}'
             )
+            if partial_requests:
+                DataRequestHandler.replace_docs(
+                    msg,
+                    docs=_get_docs_from_msg(
+                        msg,
+                        partial_request=partial_requests,
+                        field='docs',
+                    ),
+                )
             return
 
         params = self._parse_params(msg.request.parameters, self._executor.metas.name)
@@ -174,11 +183,14 @@ class DataRequestHandler:
                 )
             elif r_docs != msg.request.docs:
                 # this means the returned DocArray is a completely new one
-                msg.request.docs.clear()
-                msg.request.docs.extend(r_docs)
+                DataRequestHandler.replace_docs(msg, docs)
         elif partial_requests:
-            msg.request.docs.clear()
-            msg.request.docs.extend(docs)
+            DataRequestHandler.replace_docs(msg, docs)
+
+    @staticmethod
+    def replace_docs(msg, docs):
+        msg.request.docs.clear()
+        msg.request.docs.extend(docs)
 
     def close(self):
         """ Close the data request handler, by closing the executor """

--- a/jina/peapods/runtimes/request_handlers/data_request_handler.py
+++ b/jina/peapods/runtimes/request_handlers/data_request_handler.py
@@ -135,15 +135,15 @@ class DataRequestHandler:
             return
 
         params = self._parse_params(msg.request.parameters, self._executor.metas.name)
-
+        docs = _get_docs_from_msg(
+            msg,
+            partial_request=partial_requests,
+            field='docs',
+        )
         # executor logic
         r_docs = self._executor(
             req_endpoint=msg.envelope.header.exec_endpoint,
-            docs=_get_docs_from_msg(
-                msg,
-                partial_request=partial_requests,
-                field='docs',
-            ),
+            docs=docs,
             parameters=params,
             docs_matrix=_get_docs_matrix_from_message(
                 msg,
@@ -176,6 +176,9 @@ class DataRequestHandler:
                 # this means the returned DocArray is a completely new one
                 msg.request.docs.clear()
                 msg.request.docs.extend(r_docs)
+        elif partial_requests:
+            msg.request.docs.clear()
+            msg.request.docs.extend(docs)
 
     def close(self):
         """ Close the data request handler, by closing the executor """

--- a/jina/peapods/runtimes/request_handlers/data_request_handler.py
+++ b/jina/peapods/runtimes/request_handlers/data_request_handler.py
@@ -183,7 +183,7 @@ class DataRequestHandler:
                 )
             elif r_docs != msg.request.docs:
                 # this means the returned DocArray is a completely new one
-                DataRequestHandler.replace_docs(msg, docs)
+                DataRequestHandler.replace_docs(msg, r_docs)
         elif partial_requests:
             DataRequestHandler.replace_docs(msg, docs)
 

--- a/tests/integration/crud/flow.yml
+++ b/tests/integration/crud/flow.yml
@@ -2,7 +2,6 @@ jtype: Flow
 with:
   return_results: True
   protocol: $RESTFUL
-  expose_crud_endpoint: true
 executors:
   - name: indexer
     uses:

--- a/tests/integration/external_pod/test_external_pod.py
+++ b/tests/integration/external_pod/test_external_pod.py
@@ -8,8 +8,8 @@ from jina import Flow, Executor, requests, Document, DocumentArray
 from jina.helper import random_port
 
 
-def validate_response(resp):
-    assert len(resp.data.docs) == 50
+def validate_response(resp, expected_docs=50):
+    assert len(resp.data.docs) == expected_docs
     for doc in resp.data.docs:
         assert 'external_real' in doc.tags['name']
 
@@ -44,6 +44,8 @@ def external_pod_args(num_replicas, num_parallel):
         str(num_parallel),
         '--replicas',
         str(num_replicas),
+        '--polling',
+        'all',
     ]
     return set_pod_parser().parse_args(args)
 
@@ -81,7 +83,7 @@ def test_flow_with_external_pod(
         )
         with flow:
             resp = flow.index(inputs=input_docs, return_results=True)
-        validate_response(resp[0])
+        validate_response(resp[0], 50 * num_parallel)
 
 
 @pytest.fixture(scope='function')
@@ -152,10 +154,10 @@ def test_two_flow_with_shared_external_pod(
         )
         with flow1, flow2:
             results = flow1.index(inputs=input_docs, return_results=True)
-            validate_response(results[0])
+            validate_response(results[0], 50 * num_parallel)
 
             results = flow2.index(inputs=input_docs, return_results=True)
-            validate_response(results[0])
+            validate_response(results[0], 50 * num_parallel * 2)
 
 
 def test_two_flow_with_shared_external_executor(
@@ -187,7 +189,7 @@ def test_two_flow_with_shared_external_executor(
             validate_response(results[0])
 
             results = flow2.index(inputs=input_docs, return_results=True)
-            validate_response(results[0])
+            validate_response(results[0], 50 * 2)
 
 
 @pytest.fixture(scope='function')
@@ -205,6 +207,8 @@ def external_pod_parallel_1_args(num_replicas, num_parallel):
         str(num_parallel),
         '--replicas',
         str(num_replicas),
+        '--polling',
+        'all',
     ]
     return set_pod_parser().parse_args(args)
 
@@ -229,6 +233,8 @@ def external_pod_parallel_2_args(num_replicas, num_parallel):
         str(num_parallel),
         '--replicas',
         str(num_replicas),
+        '--polling',
+        'all',
     ]
     return set_pod_parser().parse_args(args)
 
@@ -280,7 +286,7 @@ def test_flow_with_external_pod_parallel(
 
         with flow:
             resp = flow.index(inputs=input_docs, return_results=True)
-        validate_response(resp[0])
+        validate_response(resp[0], 50 * num_parallel * 2)
 
 
 @pytest.fixture(scope='function')
@@ -298,6 +304,8 @@ def external_pod_pre_parallel_args(num_replicas, num_parallel):
         str(num_parallel),
         '--replicas',
         str(num_replicas),
+        '--polling',
+        'all',
     ]
     return set_pod_parser().parse_args(args)
 
@@ -341,7 +349,7 @@ def test_flow_with_external_pod_pre_parallel(
         )
         with flow:
             resp = flow.index(inputs=input_docs, return_results=True)
-        validate_response(resp[0])
+        validate_response(resp[0], 50 * num_parallel * 2)
 
 
 @pytest.fixture(scope='function')
@@ -361,6 +369,8 @@ def external_pod_join_args(num_replicas, num_parallel):
         str(num_parallel),
         '--replicas',
         str(num_replicas),
+        '--polling',
+        'all',
     ]
     return set_pod_parser().parse_args(args)
 
@@ -407,4 +417,4 @@ def test_flow_with_external_pod_join(
         )
         with flow:
             resp = flow.index(inputs=input_docs, return_results=True)
-        validate_response(resp[0])
+        validate_response(resp[0], 50 * num_parallel * num_parallel * 2)

--- a/tests/integration/v2_api/test_func_routing.py
+++ b/tests/integration/v2_api/test_func_routing.py
@@ -245,7 +245,7 @@ def test_target_peapod_with_two_pathways_one_skip():
             return_results=True,
             target_peapod='my_target',
         )
-        assert len(results[0].data.docs) == 2
+        assert len(results[0].data.docs) == 1
 
 
 def test_target_peapod_with_parallel():

--- a/tests/integration/v2_api/test_func_routing.py
+++ b/tests/integration/v2_api/test_func_routing.py
@@ -210,3 +210,51 @@ def test_target_peapod_with_overlaped_name(mocker):
         mock = mocker.Mock()
         f.post(on='/foo', target_peapod='foo', inputs=Document(), on_error=mock)
         mock.assert_called()
+
+
+def test_target_peapod_with_one_pathways():
+    f = Flow().add().add(name='my_target')
+    with f:
+        results = f.post(
+            on='/search',
+            inputs=Document(),
+            return_results=True,
+            target_peapod='my_target',
+        )
+        assert len(results[0].data.docs) == 1
+
+
+def test_target_peapod_with_two_pathways():
+    f = Flow().add().add(needs=['gateway', 'pod0'], name='my_target')
+    with f:
+        results = f.post(
+            on='/search',
+            inputs=Document(),
+            return_results=True,
+            target_peapod='my_target',
+        )
+        assert len(results[0].data.docs) == 2
+
+
+def test_target_peapod_with_two_pathways_one_skip():
+    f = Flow().add().add(needs=['gateway', 'pod0']).add(name='my_target')
+    with f:
+        results = f.post(
+            on='/search',
+            inputs=Document(),
+            return_results=True,
+            target_peapod='my_target',
+        )
+        assert len(results[0].data.docs) == 2
+
+
+def test_target_peapod_with_parallel():
+    f = Flow().add(shards=2).add(name='my_target')
+    with f:
+        results = f.post(
+            on='/search',
+            inputs=Document(),
+            return_results=True,
+            target_peapod='my_target',
+        )
+        assert len(results[0].data.docs) == 1

--- a/tests/jinahub/flow.yml
+++ b/tests/jinahub/flow.yml
@@ -3,7 +3,6 @@ version: '1'
 with:
   read_only: true
   protocol: http
-  expose_crud_endpoints: true
   port_expose: 45678
 pods:
   - name: pod1


### PR DESCRIPTION
The expected behavior from Executor side should be:

```
if Documents are returned:
    forward them to next Pod
else:
    forward whatever the docs object contains after Executor execution to next Pod
```

Subtasks

- [x] repair all tests (this will test the new behavior sufficiently!)
- [x] adopt cookbooks