### PR TITLE
perf: remove environment variable reading from init

### DIFF
--- a/jina/types/ndarray/dense/numpy.py
+++ b/jina/types/ndarray/dense/numpy.py
@@ -8,6 +8,8 @@ from ....proto import jina_pb2
 
 __all__ = ['BaseDenseNdArray']
 
+QUANTIZE = os.environ.get('JINA_ARRAY_QUANT')
+
 
 class DenseNdArray(BaseDenseNdArray):
     """
@@ -41,7 +43,7 @@ class DenseNdArray(BaseDenseNdArray):
         **kwargs
     ):
         super().__init__(proto, *args, **kwargs)
-        self.quantize = os.environ.get('JINA_ARRAY_QUANT', quantize)
+        self.quantize = quantize or QUANTIZE
 
     @property
     def value(self) -> 'np.ndarray':


### PR DESCRIPTION
This PR removes runtime environment variable read for DenseNDarray creation

- Before this PR
            ```
            %timeit aux = jina.types.ndarray.dense.numpy.DenseNdArray()
            2.81 µs ± 177 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
            ```
            
- After this PR
            ```
            %timeit aux = jina.types.ndarray.dense.numpy.DenseNdArray()
            1.48 µs ± 11.8 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
            ```