### PR TITLE
feat(daemon): add timeout to client

### DIFF
--- a/daemon/clients/flows.py
+++ b/daemon/clients/flows.py
@@ -26,7 +26,7 @@ class AsyncFlowClient(AsyncBaseClient):
         :return: dict arguments of remote JinaD
         """
         async with aiohttp.request(
-            method='GET', url=f'{self.store_api}/arguments'
+            method='GET', url=f'{self.store_api}/arguments', timeout=self.timeout
         ) as response:
             if response.status == HTTPStatus.OK:
                 return await response.json()
@@ -47,6 +47,7 @@ class AsyncFlowClient(AsyncBaseClient):
             method='POST',
             url=self.store_api,
             params={'workspace_id': workspace_id, 'filename': filename},
+            timeout=self.timeout,
         ) as response:
             response_json = await response.json()
             if response.status != HTTPStatus.CREATED:
@@ -78,6 +79,7 @@ class AsyncFlowClient(AsyncBaseClient):
                 'pod_name': pod_name,
                 'dump_path': dump_path,
             },
+            timeout=self.timeout,
         ) as response:
             response_json = await response.json()
             if response.status != HTTPStatus.OK:
@@ -100,6 +102,7 @@ class AsyncFlowClient(AsyncBaseClient):
         async with aiohttp.request(
             method='DELETE',
             url=f'{self.store_api}/{daemonize(id, self._kind)}',
+            timeout=self.timeout,
         ) as response:
             response_json = await response.json()
             if response.status != HTTPStatus.OK:

--- a/daemon/clients/peas.py
+++ b/daemon/clients/peas.py
@@ -25,7 +25,7 @@ class AsyncPeaClient(AsyncBaseClient):
         :return: dict arguments of remote JinaD
         """
         async with aiohttp.request(
-            method='GET', url=f'{self.store_api}/arguments'
+            method='GET', url=f'{self.store_api}/arguments', timeout=self.timeout
         ) as response:
             if response.status == HTTPStatus.OK:
                 return await response.json()
@@ -46,6 +46,7 @@ class AsyncPeaClient(AsyncBaseClient):
             url=self.store_api,
             params={'workspace_id': daemonize(workspace_id)},
             json=payload,
+            timeout=self.timeout,
         ) as response:
             response_json = await response.json()
             if response.status == HTTPStatus.CREATED:
@@ -74,7 +75,9 @@ class AsyncPeaClient(AsyncBaseClient):
         """
 
         async with aiohttp.request(
-            method='DELETE', url=f'{self.store_api}/{daemonize(id, self._kind)}'
+            method='DELETE',
+            url=f'{self.store_api}/{daemonize(id, self._kind)}',
+            timeout=self.timeout,
         ) as response:
             response_json = await response.json()
             if response.status != HTTPStatus.OK:

--- a/daemon/clients/pods.py
+++ b/daemon/clients/pods.py
@@ -35,6 +35,7 @@ class AsyncPodClient(AsyncPeaClient):
                 'kind': UpdateOperation.ROLLING_UPDATE.value,
                 'dump_path': dump_path,
             },
+            timeout=self.timeout,
         ) as response:
             response_json = await response.json()
             if response.status != HTTPStatus.OK:

--- a/daemon/dockerize.py
+++ b/daemon/dockerize.py
@@ -336,6 +336,7 @@ class Dockerizer:
                 __partial_workspace__, '.jina', 'hub-packages'
             ),
             'JINA_HUB_CACHE_DIR': os.path.join(__partial_workspace__, '.cache', 'jina'),
+            'HOME': __partial_workspace__,
         }
 
     @classmethod

--- a/jina/peapods/runtimes/jinad/__init__.py
+++ b/jina/peapods/runtimes/jinad/__init__.py
@@ -110,8 +110,7 @@ class JinadRuntime(AsyncNewLoopRuntime):
 
         # reset the runtime to ZEDRuntime/GRPCDataRuntime or ContainerRuntime
         if _args.runtime_cls == 'JinadRuntime':
-            # TODO: add jinahub:// and jinahub+docker:// scheme here
-            if _args.uses.startswith('docker://'):
+            if _args.uses.startswith(('docker://', 'jinahub+docker://')):
                 _args.runtime_cls = 'ContainerRuntime'
             else:
                 if _args.grpc_data_requests:
@@ -126,7 +125,7 @@ class JinadRuntime(AsyncNewLoopRuntime):
 
         # NOTE: on remote relative filepaths should be converted to filename only
         def basename(field):
-            if field and not field.startswith('docker://'):
+            if field and not field.startswith(('docker://', 'jinahub')):
                 try:
                     return os.path.basename(complete_path(field))
                 except FileNotFoundError:

--- a/tests/daemon/unit/clients/test_clients.py
+++ b/tests/daemon/unit/clients/test_clients.py
@@ -2,6 +2,7 @@ import pytest
 import aiohttp
 
 from daemon.models.id import DaemonID
+from daemon.clients import JinaDClient
 from daemon.clients.base import BaseClient, AsyncBaseClient
 from daemon.clients.peas import PeaClient, AsyncPeaClient
 from daemon.clients.pods import PodClient, AsyncPodClient
@@ -371,3 +372,11 @@ async def test_peapod_delete_async(monkeypatch, identity, client_cls):
 
     monkeypatch.setattr(aiohttp, 'request', lambda **kwargs: MockAiohttpException())
     assert not await client.delete(identity)
+
+
+def test_timeout():
+    client = JinaDClient(host='1.2.3.4', port=8000)
+    assert client.peas.timeout.total == 10 * 60
+
+    client = JinaDClient(host='1.2.3.4', port=8000, timeout=10)
+    assert client.peas.timeout.total == 10


### PR DESCRIPTION
This PR adds 3 things:
- Adds timeout for JinaDClient
- Sets `/workspace` to `$HOME` in all partial-jinad based containers. 
- Adds `jinahub+docker://Executor` and `jinahub://Executor` schemes to jinadruntime.