### PR TITLE
fix(grpc): enable grpc runtime for http and websocket gateway

### DIFF
--- a/jina/peapods/grpc/__init__.py
+++ b/jina/peapods/grpc/__init__.py
@@ -80,15 +80,16 @@ class Grpclet(jina_pb2_grpc.JinaDataRequestRPCServicer):
             raise ex
 
     @staticmethod
-    def send_ctrl_msg(pod_address: str, command: str):
+    def send_ctrl_msg(pod_address: str, command: str, timeout=1.0):
         """
         Sends a control message via gRPC to pod_address
         :param pod_address: the pod to send the command to
         :param command: the command to send (TERMINATE/ACTIVATE/...)
+        :param timeout: optional timeout for the request in seconds
         :returns: Empty protobuf struct
         """
         stub = Grpclet._create_grpc_stub(pod_address, is_async=False)
-        response = stub.Call(ControlMessage(command))
+        response = stub.Call(ControlMessage(command), timeout=timeout)
         return response
 
     @staticmethod

--- a/jina/peapods/grpc/__init__.py
+++ b/jina/peapods/grpc/__init__.py
@@ -34,7 +34,7 @@ class Grpclet(jina_pb2_grpc.JinaDataRequestRPCServicer):
         self.msg_sent = 0
         self._pending_tasks = []
         self._send_routing_table = args.send_routing_table
-        if hasattr(args, 'routing_table'):
+        if not args.send_routing_table:
             self._routing_table = RoutingTable(args.routing_table)
             self._next_targets = self._routing_table.get_next_target_addresses()
         else:

--- a/jina/peapods/runtimes/gateway/http/app.py
+++ b/jina/peapods/runtimes/gateway/http/app.py
@@ -72,7 +72,10 @@ def get_fastapi_app(args: 'argparse.Namespace', logger: 'JinaLogger'):
     @app.on_event('shutdown')
     async def _shutdown():
         await servicer.close()
-        await iolet.close()
+        if inspect.iscoroutine(iolet.close):
+            await iolet.close()
+        else:
+            iolet.close()
 
     openapi_tags = []
     if not args.no_debug_endpoints:

--- a/jina/peapods/runtimes/gateway/http/app.py
+++ b/jina/peapods/runtimes/gateway/http/app.py
@@ -1,10 +1,12 @@
 import argparse
+import inspect
 import json
 from typing import Dict
 
 from google.protobuf.json_format import MessageToDict
 
 from ..prefetch import PrefetchCaller
+from ....grpc import Grpclet
 from ....zmq import AsyncZmqlet
 from ..... import __version__
 from .....clients.request import request_generator
@@ -57,13 +59,20 @@ def get_fastapi_app(args: 'argparse.Namespace', logger: 'JinaLogger'):
             'CORS is enabled. This service is now accessible from any website!'
         )
 
-    zmqlet = AsyncZmqlet(args, logger)
-    servicer = PrefetchCaller(args, zmqlet)
+    if args.grpc_data_requests:
+        iolet = Grpclet(
+            args=args,
+            message_callback=None,
+            logger=logger,
+        )
+    else:
+        iolet = AsyncZmqlet(args, logger)
+    servicer = PrefetchCaller(args, iolet)
 
     @app.on_event('shutdown')
     async def _shutdown():
         await servicer.close()
-        zmqlet.close()
+        await iolet.close()
 
     openapi_tags = []
     if not args.no_debug_endpoints:

--- a/jina/peapods/runtimes/gateway/websocket/app.py
+++ b/jina/peapods/runtimes/gateway/websocket/app.py
@@ -1,4 +1,5 @@
 import argparse
+import inspect
 from typing import List
 
 from ..prefetch import PrefetchCaller
@@ -49,7 +50,10 @@ def get_fastapi_app(args: 'argparse.Namespace', logger: 'JinaLogger'):
     @app.on_event('shutdown')
     async def _shutdown():
         await servicer.close()
-        await iolet.close()
+        if inspect.iscoroutine(iolet.close):
+            await iolet.close()
+        else:
+            iolet.close()
 
     @app.websocket('/')
     async def websocket_endpoint(websocket: WebSocket):

--- a/jina/peapods/runtimes/gateway/websocket/app.py
+++ b/jina/peapods/runtimes/gateway/websocket/app.py
@@ -2,6 +2,7 @@ import argparse
 from typing import List
 
 from ..prefetch import PrefetchCaller
+from ....grpc import Grpclet
 from ....zmq import AsyncZmqlet
 from .....importer import ImportExtensions
 from .....logging.logger import JinaLogger
@@ -35,13 +36,20 @@ def get_fastapi_app(args: 'argparse.Namespace', logger: 'JinaLogger'):
 
     app = FastAPI()
 
-    zmqlet = AsyncZmqlet(args, logger)
-    servicer = PrefetchCaller(args, zmqlet)
+    if args.grpc_data_requests:
+        iolet = Grpclet(
+            args=args,
+            message_callback=None,
+            logger=logger,
+        )
+    else:
+        iolet = AsyncZmqlet(args, logger)
+    servicer = PrefetchCaller(args, iolet)
 
     @app.on_event('shutdown')
     async def _shutdown():
         await servicer.close()
-        zmqlet.close()
+        await iolet.close()
 
     @app.websocket('/')
     async def websocket_endpoint(websocket: WebSocket):

--- a/jina/peapods/runtimes/grpc/__init__.py
+++ b/jina/peapods/runtimes/grpc/__init__.py
@@ -122,7 +122,11 @@ class GRPCDataRuntime(BaseRuntime, ABC):
         :param control_address: the address where the control message needs to be sent
         :param kwargs: extra keyword arguments
         """
-        Grpclet.send_ctrl_msg(control_address, 'TERMINATE')
+        try:
+            Grpclet.send_ctrl_msg(control_address, 'TERMINATE')
+        except RpcError:
+            # TERMINATE can fail if the the runtime dies before sending the return value
+            pass
 
     @staticmethod
     def wait_for_ready_or_shutdown(

--- a/tests/unit/flow/test_flow_dynamic_routing.py
+++ b/tests/unit/flow/test_flow_dynamic_routing.py
@@ -67,7 +67,6 @@ def test_static_routing_table_parallel():
     f = Flow(static_routing_table=True).add(uses=SimplAddExecutor, parallel=2)
 
     with f:
-        print(f._get_routing_table().json())
         results = f.post(on='/index', inputs=[Document(text='1')], return_results=True)
         assert len(results[0].docs) == 2
 

--- a/tests/unit/peapods/runtimes/gateway/http/test_app.py
+++ b/tests/unit/peapods/runtimes/gateway/http/test_app.py
@@ -27,12 +27,17 @@ class TestExecutor(Executor):
         print(f"# docs {docs}")
 
 
-def test_tag_update():
+@pytest.mark.parametrize(
+    'grpc_data_requests',
+    [True, False],
+)
+def test_tag_update(grpc_data_requests):
     PORT_EXPOSE = 33300
 
     f = Flow(
         port_expose=PORT_EXPOSE,
         protocol='http',
+        grpc_data_requests=grpc_data_requests,
     ).add(uses=TestExecutor)
 
     with f:


### PR DESCRIPTION
This PR enables the GRPCDataRuntime to be run with HTTP and Websocket Flows. Before those were ignoring `grpc_data_requests` and always starting an AsyncZmqlet.

This fixes https://github.com/jina-ai/jina/issues/3243