### PR TITLE
feat(daemon): support envvars

### DIFF
--- a/.github/2.0/cookbooks/Daemon.md
+++ b/.github/2.0/cookbooks/Daemon.md
@@ -10,29 +10,34 @@ the same host.
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 Table of Contents
 
-- [Minimum Working Example](#minimum-working-example)
-- [Setup JinaD Server](#setup-jinad-server)
-  - [Run](#run)
-    - [Points to note](#points-to-note)
-    - [API Docs](#api-docs)
-- [Start JinaD Client](#start-jinad-client)
-    - [Check if remote server is alive](#check-if-remote-server-is-alive)
-    - [Get the status of the remote server](#get-the-status-of-the-remote-server)
-- [Workspace](#workspace)
-  - [Create a workspace (redoc)](#create-a-workspace-redoc)
-  - [Get details of a workspace (redoc)](#get-details-of-a-workspace-redoc)
-  - [List all workspaces (redoc)](#list-all-workspaces-redoc)
-  - [Delete a workspace (redoc)](#delete-a-workspace-redoc)
-- [Create Remote Executors](#create-remote-executors)
-- [Create Remote Flows](#create-remote-flows)
-  - [Create a Flow (<a href="https://api.jina.ai/daemon/#operation/_create_flows_post">redoc</a>)](#create-a-flow-a-hrefhttpsapijinaaidaemonoperation_create_flows_postredoca)
-  - [Get details of a Flow (<a href="https://api.jina.ai/daemon/#operation/_status_flows__id__get">redoc</a>)](#get-details-of-a-flow-a-hrefhttpsapijinaaidaemonoperation_status_flows__id__getredoca)
-  - [Terminate a Flow (<a href="https://api.jina.ai/daemon/#operation/_delete_flows__id__delete">redoc</a>)](#terminate-a-flow-a-hrefhttpsapijinaaidaemonoperation_delete_flows__id__deleteredoca)
-- [Streaming Remote Logs](#streaming-remote-logs)
-- [Development using JinaD](#development-using-jinad)
-    - [Build](#build)
-    - [Run](#run-1)
-    - [Why?](#why)
+- [Cookbook on `JinaD` API](#cookbook-on-jinad-api)
+  - [Minimum Working Example](#minimum-working-example)
+  - [Setup JinaD Server](#setup-jinad-server)
+    - [Run](#run)
+      - [Points to note](#points-to-note)
+      - [API Docs](#api-docs)
+  - [Start JinaD Client](#start-jinad-client)
+      - [Check if remote server is alive](#check-if-remote-server-is-alive)
+      - [Get the status of the remote server](#get-the-status-of-the-remote-server)
+  - [Workspace](#workspace)
+    - [Create a workspace (redoc)](#create-a-workspace-redoc)
+    - [Get details of a workspace (redoc)](#get-details-of-a-workspace-redoc)
+    - [List all workspaces (redoc)](#list-all-workspaces-redoc)
+    - [Delete a workspace (redoc)](#delete-a-workspace-redoc)
+  - [Create Remote Executors](#create-remote-executors)
+        - [Get all accepted arguments](#get-all-accepted-arguments)
+        - [Create a Pea/Pod (<a href="https://api.jina.ai/daemon/#operation/_create_peas_post">redoc</a>)](#create-a-peapod-redoc)
+        - [Get details of a Pea/Pod (<a href="https://api.jina.ai/daemon/#operation/_status_peas__id__get">redoc</a>)](#get-details-of-a-peapod-redoc)
+        - [Terminate a Pea/Pod (<a href="https://api.jina.ai/daemon/#operation/_delete_peas__id__delete">redoc</a>)](#terminate-a-peapod-redoc)
+  - [Create Remote Flows](#create-remote-flows)
+    - [Create a Flow (<a href="https://api.jina.ai/daemon/#operation/_create_flows_post">redoc</a>)](#create-a-flow-redoc)
+    - [Get details of a Flow (<a href="https://api.jina.ai/daemon/#operation/_status_flows__id__get">redoc</a>)](#get-details-of-a-flow-redoc)
+    - [Terminate a Flow (<a href="https://api.jina.ai/daemon/#operation/_delete_flows__id__delete">redoc</a>)](#terminate-a-flow-redoc)
+  - [Streaming Remote Logs](#streaming-remote-logs)
+  - [Development using JinaD](#development-using-jinad)
+      - [Build](#build)
+      - [Run](#run-1)
+      - [Why?](#why)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -461,13 +466,17 @@ JinaD enables management of (remote + containerized) Flows with all your depende
 
 This creates a new container using the base image, connects it to the network defined by `workspace_id` and starts a
 Flow inside the container. Only the ports needed for external communication are mapped to local. Make sure you've added
-all your config files while creating the workspace in the previous step.
+all your config files while creating the workspace in the previous step. You can also pass environment variables to be set while starting a remote Flow using `envs`.
 
 ```python
 from daemon.clients import JinaDClient
 
 client = JinaDClient(host=HOST, port=PORT)
-client.flows.create(workspace_id=workspace_id, filename='my_awesome_flow.yml')
+client.flows.create(
+  workspace_id=workspace_id,
+  filename='my_awesome_flow.yml',
+  envs={'PORT_EXPOSE': 12345}
+)
 # jflow-a71cc28f-a5db-4cc0-bb9e-bb7797172cc9
 ```
 

--- a/daemon/api/endpoints/flows.py
+++ b/daemon/api/endpoints/flows.py
@@ -1,10 +1,10 @@
 from fastapi import APIRouter, Depends
 from fastapi.exceptions import HTTPException
 
-from ..dependencies import FlowDepends
 from ... import Runtime400Exception
-from ...models import DaemonID, ContainerItem, ContainerStoreStatus, FlowModel
+from ..dependencies import FlowDepends
 from ...models.enums import UpdateOperation
+from ...models import DaemonID, ContainerItem, ContainerStoreStatus, FlowModel
 from ...stores import flow_store as store
 
 router = APIRouter(prefix='/flows', tags=['flows'])
@@ -35,6 +35,7 @@ async def _create(flow: FlowDepends = Depends(FlowDepends)):
             workspace_id=flow.workspace_id,
             params=flow.params,
             ports=flow.ports,
+            envs=flow.envs,
             port_expose=flow.port_expose,
         )
     except Exception as ex:

--- a/daemon/api/endpoints/peas.py
+++ b/daemon/api/endpoints/peas.py
@@ -1,7 +1,7 @@
 from fastapi import Depends, APIRouter, HTTPException
 
-from ..dependencies import PeaDepends
 from ... import Runtime400Exception
+from ..dependencies import PeaDepends
 from ...models import DaemonID, ContainerItem, ContainerStoreStatus, PeaModel
 from ...stores import pea_store as store
 
@@ -37,6 +37,7 @@ async def _create(pea: PeaDepends = Depends(PeaDepends)):
             workspace_id=pea.workspace_id,
             params=pea.params,
             ports=pea.ports,
+            envs=pea.envs,
         )
     except Exception as ex:
         raise Runtime400Exception from ex

--- a/daemon/api/endpoints/pods.py
+++ b/daemon/api/endpoints/pods.py
@@ -1,11 +1,10 @@
-import requests
 from fastapi import Depends, APIRouter, HTTPException
 
-from ..dependencies import PodDepends
 from ... import Runtime400Exception
-from ...stores import pod_store as store
+from ..dependencies import PodDepends
 from ...models.enums import UpdateOperation
 from ...models import DaemonID, ContainerItem, ContainerStoreStatus, PodModel
+from ...stores import pod_store as store
 
 router = APIRouter(prefix='/pods', tags=['pods'])
 
@@ -36,6 +35,7 @@ async def _create(pod: PodDepends = Depends(PodDepends)):
             workspace_id=pod.workspace_id,
             params=pod.params,
             ports=pod.ports,
+            envs=pod.envs,
         )
     except Exception as ex:
         raise Runtime400Exception from ex

--- a/daemon/clients/flows.py
+++ b/daemon/clients/flows.py
@@ -33,20 +33,31 @@ class AsyncFlowClient(AsyncBaseClient):
 
     @if_alive
     async def create(
-        self, workspace_id: 'DaemonID', filename: str, *args, **kwargs
+        self,
+        workspace_id: 'DaemonID',
+        filename: str,
+        envs: Dict[str, str] = {},
+        *args,
+        **kwargs,
     ) -> str:
         """Start a Flow on remote JinaD
 
         :param workspace_id: workspace id where flow will be created
         :param filename: name of the flow yaml file in the workspace
+        :param envs: dict of env vars to be passed
         :param args: positional args
         :param kwargs: keyword args
         :return: flow id
         """
+        envs = (
+            [('envs', f'{k}={v}') for k, v in envs.items()]
+            if envs and isinstance(envs, Dict)
+            else []
+        )
         async with aiohttp.request(
             method='POST',
             url=self.store_api,
-            params={'workspace_id': workspace_id, 'filename': filename},
+            params=[('workspace_id', workspace_id), ('filename', filename)] + envs,
             timeout=self.timeout,
         ) as response:
             response_json = await response.json()

--- a/daemon/clients/peas.py
+++ b/daemon/clients/peas.py
@@ -32,19 +32,27 @@ class AsyncPeaClient(AsyncBaseClient):
 
     @if_alive
     async def create(
-        self, workspace_id: Union[str, 'DaemonID'], payload: Dict
+        self,
+        workspace_id: Union[str, 'DaemonID'],
+        payload: Dict,
+        envs: Dict[str, str] = {},
     ) -> Tuple[bool, str]:
         """Create a remote Pea / Pod
 
         :param workspace_id: id of workspace where the Pea would live in
         :param payload: json payload
-        :return: (True if pea creation succeeded) and (the identity of the spawned Pea/Pod or, error message)
+        :param envs: dict of env vars to be passed
+        :return: (True if Pea/Pod creation succeeded) and (the identity of the spawned Pea/Pod or, error message)
         """
-
+        envs = (
+            [('envs', f'{k}={v}') for k, v in envs.items()]
+            if envs and isinstance(envs, Dict)
+            else []
+        )
         async with aiohttp.request(
             method='POST',
             url=self.store_api,
-            params={'workspace_id': daemonize(workspace_id)},
+            params=[('workspace_id', daemonize(workspace_id))] + envs,
             json=payload,
             timeout=self.timeout,
         ) as response:

--- a/daemon/dockerize.py
+++ b/daemon/dockerize.py
@@ -205,6 +205,7 @@ class Dockerizer:
         container_id: DaemonID,
         command: str,
         ports: Dict,
+        envs: Dict = {},
         entrypoint: Optional[str] = None,
     ) -> Tuple['Container', str, Dict]:
         """
@@ -216,6 +217,7 @@ class Dockerizer:
         :param container_id: name of the container
         :param command: command to be appended to default entrypoint
         :param ports: ports to be mapped with local
+        :param envs: dict of env vars to be set in the container
         :param entrypoint: custom entrypoint
         :raises DockerImageException: if image is not found locally
         :raises DockerContainerException: if container creation fails
@@ -240,7 +242,7 @@ class Dockerizer:
                 image=image,
                 name=container_id,
                 volumes=cls.volume(workspace_id),
-                environment=cls.environment(),
+                environment=cls.environment(envs),
                 network=network,
                 ports=ports,
                 detach=True,
@@ -323,9 +325,11 @@ class Dockerizer:
         }
 
     @classmethod
-    def environment(cls) -> Dict[str, str]:
+    def environment(cls, envs: Dict[str, str]) -> Dict[str, str]:
         """
         Environment variables to be set inside the container during `run`
+
+        :param envs: dict of env vars to be set in the container
         :return: dict of env vars
         """
         return {
@@ -337,6 +341,7 @@ class Dockerizer:
             ),
             'JINA_HUB_CACHE_DIR': os.path.join(__partial_workspace__, '.cache', 'jina'),
             'HOME': __partial_workspace__,
+            **envs,
         }
 
     @classmethod

--- a/daemon/helper.py
+++ b/daemon/helper.py
@@ -1,5 +1,6 @@
 import os
 import re
+from contextlib import contextmanager
 from typing import Callable, List, TYPE_CHECKING, Tuple, Dict
 
 import aiohttp
@@ -107,3 +108,38 @@ def error_msg_from(response: Dict) -> str:
         if isinstance(response['body'], List)
         else response['body']
     )
+
+
+@contextmanager
+def change_cwd(path):
+    """
+    Change the current working dir to ``path`` in a context and set it back to the original one when leaves the context.
+    Yields nothing
+    :param path: Target path.
+    :yields: nothing
+    """
+    curdir = os.getcwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(curdir)
+
+
+@contextmanager
+def change_env(key, val):
+    """
+    Change the environment of ``key`` to ``val`` in a context and set it back to the original one when leaves the context.
+    :param key: Old environment variable.
+    :param val: New environment variable.
+    :yields: nothing
+    """
+    old_var = os.environ.get(key, None)
+    os.environ[key] = val
+    try:
+        yield
+    finally:
+        if old_var:
+            os.environ[key] = old_var
+        else:
+            os.environ.pop(key)

--- a/daemon/stores/containers.py
+++ b/daemon/stores/containers.py
@@ -136,6 +136,7 @@ class ContainerStore(BaseStore):
         workspace_id: DaemonID,
         params: 'BaseModel',
         ports: Dict,
+        envs: Dict[str, str] = {},
         **kwargs,
     ) -> DaemonID:
         """Add a container to the store
@@ -144,6 +145,7 @@ class ContainerStore(BaseStore):
         :param workspace_id: workspace id where the container lives
         :param params: pydantic model representing the args for the container
         :param ports: ports to be mapped to local
+        :param envs: dict of env vars to be passed
         :param kwargs: keyword args
         :raises KeyError: if workspace_id doesn't exist in the store
         :raises PartialDaemonConnectionException: if jinad cannot connect to partial
@@ -174,7 +176,11 @@ class ContainerStore(BaseStore):
             )
 
             container, network, ports = Dockerizer.run(
-                workspace_id=workspace_id, container_id=id, command=command, ports=ports
+                workspace_id=workspace_id,
+                container_id=id,
+                command=command,
+                ports=ports,
+                envs=envs,
             )
             if not await self.ready(uri):
                 raise PartialDaemonConnectionException(

--- a/tests/daemon/unit/api/flow1.yml
+++ b/tests/daemon/unit/api/flow1.yml
@@ -1,7 +1,7 @@
 jtype: Flow
-version: '1.0'
+version: 1
 with:
-  restful: true
+  protocol: http
   port_expose: 28956
 executors:
   - name: executor_ex

--- a/tests/daemon/unit/api/test_dependencies.py
+++ b/tests/daemon/unit/api/test_dependencies.py
@@ -1,11 +1,12 @@
 import os
+from contextlib import nullcontext
 
 import pytest
 
 from fastapi import HTTPException
 from daemon.api import dependencies
 from daemon.models.id import DaemonID
-from daemon.api.dependencies import FlowDepends
+from daemon.api.dependencies import FlowDepends, Environment
 
 
 cur_dir = os.path.dirname(os.path.abspath(__file__))
@@ -13,18 +14,37 @@ filename = os.path.join(cur_dir, 'flow1.yml')
 
 
 def test_flow_depends_localpath(monkeypatch):
-    monkeypatch.setattr(dependencies, "get_workspace_path", lambda *args: filename)
-    f = FlowDepends(DaemonID('jworkspace'), filename)
+    monkeypatch.setattr(dependencies, 'change_cwd', nullcontext)
+    monkeypatch.setattr(dependencies, 'get_workspace_path', lambda *args: filename)
+    f = FlowDepends(DaemonID('jworkspace'), filename, Environment(envs=['a=b']))
     assert str(f.localpath()) == filename
 
     with pytest.raises(HTTPException) as e:
         monkeypatch.setattr(dependencies, "get_workspace_path", lambda *args: 'abc')
-        f = FlowDepends(DaemonID('jworkspace'), filename)
+        f = FlowDepends(DaemonID('jworkspace'), filename, Environment(envs=['a=b']))
         f.localpath()
 
 
-def test_flow_depends_ports():
+def test_flow_depends_ports(monkeypatch):
     expected_port = 28956
-    f = FlowDepends(DaemonID('jworkspace'), filename)
+    monkeypatch.setattr(dependencies, 'change_cwd', nullcontext)
+    monkeypatch.setattr(dependencies, 'get_workspace_path', lambda *args: filename)
+    f = FlowDepends(DaemonID('jworkspace'), filename, Environment(envs=['a=b']))
     assert f.port_expose == expected_port
     assert f.ports == {f'{expected_port}/tcp': expected_port}
+
+
+@pytest.mark.parametrize(
+    ('args, expected'),
+    [
+        (['a=b'], {'a': 'b'}),
+        (
+            ['PORT_EXPOSE=12345', 'password=*dU-rTAv3 u'],
+            {'PORT_EXPOSE': '12345', 'password': '*dU-rTAv3 u'},
+        ),
+        (['a=\nbd'], {'a': 'bd'}),
+        (['a:b'], {}),
+    ],
+)
+def test_environment(args, expected):
+    assert Environment(envs=args).vars == expected

--- a/tests/distributed/test_workspaces/envvars_ws/executor.py
+++ b/tests/distributed/test_workspaces/envvars_ws/executor.py
@@ -1,0 +1,15 @@
+import time
+
+from typing import Any
+
+from jina import Executor, requests, DocumentArray
+
+
+class CustomExecutor(Executor):
+    def foo(self, docs: DocumentArray, *args, **kwargs) -> Any:
+        for d in docs.traverse_flat(['r']):
+            d.text += 'foo'
+
+    def bar(self, docs: DocumentArray, *args, **kwargs) -> Any:
+        for d in docs.traverse_flat(['r']):
+            d.text += 'bar'

--- a/tests/distributed/test_workspaces/envvars_ws/executor.yml
+++ b/tests/distributed/test_workspaces/envvars_ws/executor.yml
@@ -1,0 +1,5 @@
+jtype: CustomExecutor
+metas:
+  py_modules: executor.py
+requests:
+  /blah: $FUNC

--- a/tests/distributed/test_workspaces/envvars_ws/flow.yml
+++ b/tests/distributed/test_workspaces/envvars_ws/flow.yml
@@ -1,0 +1,7 @@
+jtype: Flow
+with:
+  protocol: http
+  port_expose: ${{PORT_EXPOSE}}
+executors:
+  - name: custom
+    uses: executor.yml

--- a/tests/distributed/test_workspaces/test_envvars.py
+++ b/tests/distributed/test_workspaces/test_envvars.py
@@ -1,0 +1,38 @@
+import os
+
+from jina import Client, Document
+from daemon.clients import JinaDClient
+
+import pytest
+import requests
+
+cur_dir = os.path.dirname(os.path.abspath(__file__))
+
+
+@pytest.mark.parametrize('port_expose, func', [('12345', 'foo'), (23456, 'bar')])
+def test_port_expose_env_var(port_expose, func):
+    jinad_client = JinaDClient(host='localhost', port=8000)
+    workspace_id = jinad_client.workspaces.create(
+        paths=[os.path.join(cur_dir, 'envvars_ws')]
+    )
+    flow_id = jinad_client.flows.create(
+        workspace_id=workspace_id,
+        filename='flow.yml',
+        envs={'PORT_EXPOSE': port_expose, 'FUNC': func},
+    )
+
+    r = Client(host='localhost', port_expose=port_expose, protocol='http').post(
+        on='/blah',
+        inputs=(Document(text=f'text {i}') for i in range(2)),
+        return_results=True,
+    )
+    for d in r[0].data.docs:
+        assert d.text.endswith(func)
+    r = requests.get(f'http://localhost:{port_expose}/status')
+    assert r.status_code == 200
+    envs = r.json()['envs']
+    assert envs['JINA_LOG_WORKSPACE'] == '/workspace/logs'
+    assert envs['JINA_HUB_CACHE_DIR'] == '/workspace/.cache/jina'
+    assert envs['JINA_HUB_ROOT'] == '/workspace/.jina/hub-packages'
+    assert jinad_client.flows.delete(flow_id)
+    assert jinad_client.workspaces.delete(workspace_id)

--- a/tests/distributed/test_workspaces/test_remote_workspaces.py
+++ b/tests/distributed/test_workspaces/test_remote_workspaces.py
@@ -157,7 +157,7 @@ async def test_custom_project():
     )
     assert DaemonID(workspace_id).type == 'workspace'
     # Sleep to allow the workspace container to start
-    await asyncio.sleep(5)
+    await asyncio.sleep(10)
 
     async def gen_docs():
         import string


### PR DESCRIPTION
## Description
A lot of times, we have Flow/Executor yamls that have env vars that need to be set while starting the Flow. This PR adds the support to do the same. The user journey remains the same.

1. Create a workspace with all your files. These files might use env var syntax like `${{VAR_NAME}}` or `$VAR_NAME`.
2. Create a Flow in the above workspace. The change in this PR comes in this step. 
   - We add a new query param `envs`. It supports passing multiple strings, in `key=value` format.
   - These env vars are parsed & set while starting the containers in JinaD.
   - JAML already supports env var substitution, which gets used inside the container, while starting Flow/Executor.

## Usage

#### JinaDClient
```python
from daemon.clients import JinaDClient

client = JinaDClient(host=HOST, port=PORT)
client.flows.create(workspace_id=workspace_id, filename='flow.yml', envs={'PORT_EXPOSE': 12345, 'VAR_NAME': 'VAR_VALUE'})
```

#### cURL
```bash
curl -X 'POST' \
  'http://localhost:8000/flows?workspace_id=<workspace-id>&filename=flow.yml&envs=PORT_EXPOSE%3D12345&envs=FUNC%3Dfoo'
```


#### Python requests
```python
import requests
requests.post(
    'http://localhost:8000/flows', 
    params=[('workspace_id',  workspace_id), ('filename', filename), ('envs', 'PORT_EXPOSE=23456'), ('envs', 'FUNC=foo')]
)
```