### PR TITLE
fix: read with args in flow.save_config

### DIFF
--- a/jina/jaml/parsers/flow/v1.py
+++ b/jina/jaml/parsers/flow/v1.py
@@ -86,6 +86,9 @@ class V1Parser(VersionedYAMLParser):
         if data._kwargs:
             r['with'] = data._kwargs
 
+        if data._common_kwargs:
+            r['with'] = dict(r.get('with', {}), **data._common_kwargs)
+
         if data._pod_nodes:
             r['executors'] = []
 

--- a/tests/unit/flow/yaml/flow-gateway.yml
+++ b/tests/unit/flow/yaml/flow-gateway.yml
@@ -1,0 +1,14 @@
+jtype: Flow
+version: 1
+with:
+  name: abc
+  port_expose: 12345
+  protocol: http
+  abc: def
+executors:
+  - name: custom1
+    uses: jinahub://CustomExecutor1
+  - name: custom2
+    uses: CustomExecutor2
+    port_in: 23456
+    port_out: 34567


### PR DESCRIPTION
<table>
<tr>
<td align="center">Before</td> <td align="center">After</td>
</tr>
<tr>
<td> 

```python
from jina import Flow
from jina.jaml import JAML

f = Flow.load_config('''
jtype: Flow
version: 1
with:
  port_expose: 9000
  protocol: http
executors:
  - name: executor1
    port_in: 45678
''')

print(JAML.dump(f))
"""
!Flow
version: '1'
executors:
- name: executor1
  workspace: /home/ubuntu//jina/
  zmq_identity: 7309d5e9-b0e3-41ff-93ba-892e2eb1f786
  port_ctrl: 57077
  port_in: 45678
  port_out: 60949
  socket_in: "ROUTER_BIND"
  socket_out: "ROUTER_BIND"
  port_expose: 9000
  upload_files: []
"""
```

</td>
<td>

```python
from jina import Flow
from jina.jaml import JAML

f = Flow.load_config('''
jtype: Flow
version: 1
with:
  name: abc
  port_expose: 9000
  protocol: http
  abc: def
executors:
  - name: executor1
    port_in: 45678
''')

print(JAML.dump(f))
"""
!Flow
version: '1'
with:
  name: abc
  port_expose: 9000
  protocol: http
  abc: def
executors:
- name: executor1
  workspace: /home/ubuntu/jina
  zmq_identity: 289fb04c-dd7b-4b34-baae-f51bf84127f1
  port_ctrl: 46333
  port_in: 45678
  port_out: 44367
  socket_in: "ROUTER_BIND"
  socket_out: "ROUTER_BIND"
  port_expose: 12345
  upload_files: []
"""
```

</td>
</tr>
</table>