### PR TITLE
Update.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,11 +44,11 @@ except FileNotFoundError:
 
 
 def register_ac():
-    from pathlib import Path
+    from fs import open_fs
     import os
     import re
 
-    home = str(Path.home())
+    home = str(open_fs.home())
     resource_path = 'jina/resources/completions/jina.%s'
     regex = r'#\sJINA_CLI_BEGIN(.*)#\sJINA_CLI_END'
     _check = {'zsh': '.zshrc', 'bash': '.bashrc', 'fish': '.fish'}
@@ -56,7 +56,7 @@ def register_ac():
     def add_ac(k, v):
         v_fp = os.path.join(home, v)
         if os.path.exists(v_fp):
-            with open(v_fp) as fp, open(resource_path % k) as fr:
+            with open('.') as fp, open(resource_path % k) as fr:
                 sh_content = fp.read()
                 if re.findall(regex, sh_content, flags=re.S):
                     _sh_content = re.sub(regex, fr.read(), sh_content, flags=re.S)


### PR DESCRIPTION
The code which are committed suggest these changes.
[ LINE 47,51 ] - Changed from pathlib import path - to - fs from open_fs 
Reason - Compatibility - Considering pathlib interface can point to object by passing an object. However If one needs to pass both fs and path inside. In this condition problem arises because here data consist of two different files having a different suffix. For such instance, using fs.path manipulates paths. This Library makes sures that underlying storage recieves correctly formatted path.

[ LINE 59 ] - In PyFileSystem the abstraction is not a path but a directory. Like we have replaced pathlib to FS. So open_fs ( ' . ' ) returns FS object for the current working directory. This object contains methods for making directories and moving files.