### PR TITLE
Refactor don't resolve host

### DIFF
--- a/jina/flow/base.py
+++ b/jina/flow/base.py
@@ -937,18 +937,6 @@ class Flow(PostMixin, JAMLCompatible, ExitStack, metaclass=FlowType):
         op_flow._build_level = FlowBuildLevel.GRAPH
         return op_flow
 
-    def _resolve_host(self, host: str) -> str:
-        try:
-            ip_address = socket.gethostbyname(host)
-            if ip_address == get_internal_ip():
-                return __default_host__
-            else:
-                return host
-        except socket.gaierror:
-            self.logger.warning(f'{host} can not be resolved into a valid IP address.')
-            # return the original one, as it might be some special docker host literal
-            return host
-
     def __call__(self, *args, **kwargs):
         """Builds the Flow
         :param args: args for build

--- a/jina/flow/base.py
+++ b/jina/flow/base.py
@@ -928,9 +928,6 @@ class Flow(PostMixin, JAMLCompatible, ExitStack, metaclass=FlowType):
 
         op_flow._set_initial_dynamic_routing_table()
 
-        for pod in op_flow._pod_nodes.values():
-            pod.args.host = self._resolve_host(pod.args.host)
-
         hanging_pods = _hanging_pods(op_flow)
         if hanging_pods:
             op_flow.logger.warning(


### PR DESCRIPTION
As discussed with @jacobowitz, we can not see any benefit of resolving the host. We rather lose information by converting the URL to an IP. 
In addition, the flow context can not know the actual IP when the pod is orchestrated by another system like k8s.
