### PR TITLE
perf: Document embedding getter

### DIFF
--- a/docs/fundamentals/document/documentarray-api.md
+++ b/docs/fundamentals/document/documentarray-api.md
@@ -337,16 +337,14 @@ default, the cosine similarity is used to evaluate the score between documents.
 ```
 
 More generally, given two `DocumentArray` objects `da_1` and `da_2` the
-function `da_1.match(da_2, metric=some_metric, normalization=(0, 1), limit=N)` finds for each document in `da_1`
-then `N` documents from `da_2` with the lowest metric values according to `some_metric`.
+function `da_1.match(da_2, metric=some_metric, normalization=(0, 1), limit=N)` finds for each document in `da_1` the `N` documents from `da_2` with the lowest metric values according to `some_metric`.
 
 - `metric` can be `'cosine'`, `'euclidean'`,  `'sqeuclidean'` or a callable that takes 2 `ndarray` parameters and
   returns an `ndarray`
 - `normalization` is a tuple [a, b] to be used with min-max normalization. The min distance will be rescaled to `a`, the
   max distance will be rescaled to `b`; all other values will be rescaled into range `[a, b]`.
 
-The following example find the 3 closest documents, according to the euclidean distance, for each element in `da_1` from
-the elements in `da_2`.
+The following example finds for each element in `da_1` the 3 closest documents from the elements in `da_2` )according to the euclidean distance).
 
 ```{code-block} python
 ---

--- a/jina/types/document/__init__.py
+++ b/jina/types/document/__init__.py
@@ -531,7 +531,13 @@ class Document(ProtoTypeMixin, VersionedMixin):
 
         :return: the embedding of this Document
         """
-        return NdArray(self._pb_body.embedding).value
+        if self._pb_body.embedding.HasField('dense'):
+            dense_proto = self._pb_body.embedding.dense
+            return np.frombuffer(dense_proto.buffer, dtype=dense_proto.dtype).reshape(
+                dense_proto.shape
+            )
+        else:
+            return NdArray(self._pb_body.embedding).value
 
     def get_sparse_embedding(
         self, sparse_ndarray_cls_type: Type[BaseSparseNdArray], **kwargs


### PR DESCRIPTION
This PR doubles the performance for retrieving embeddings using `doc.embedding` without any change on the API.

This is achieved removing the instantiation of  a `NdArray`  created only to get it's `.value` (which is a numpy array), essentially doubling performance.

Benchmark

```
d = Document(embedding = np.random.rand((128)))
d.embedding
```

- This PR
      ```
      %timeit aux = d.embedding
      2.4 µs ± 50.6 ns per loop
      ```

- Master
      ```
       %timeit aux = d.embedding
       6.2 µs ± 173 ns per loop 
      ```
 
