### PR TITLE
perf: document fast init

### DIFF
--- a/jina/types/arrays/document.py
+++ b/jina/types/arrays/document.py
@@ -263,7 +263,7 @@ class DocumentArray(
 
     def __iter__(self) -> Iterator['Document']:
         for d in self._pb_body:
-            yield Document(d)
+            yield Document(d, pb_only=True)
 
     def __contains__(self, item: str):
         return item in self._id_to_index

--- a/jina/types/arrays/document.py
+++ b/jina/types/arrays/document.py
@@ -270,7 +270,7 @@ class DocumentArray(
 
     def __getitem__(self, item: Union[int, str, slice]):
         if isinstance(item, int):
-            return Document(self._pb_body[item])
+            return Document(self._pb_body[item], pb_only=True)
         elif isinstance(item, str):
             return self[self._id_to_index[item]]
         elif isinstance(item, slice):

--- a/jina/types/arrays/document.py
+++ b/jina/types/arrays/document.py
@@ -263,14 +263,14 @@ class DocumentArray(
 
     def __iter__(self) -> Iterator['Document']:
         for d in self._pb_body:
-            yield Document(d, pb_only=True)
+            yield Document(d)
 
     def __contains__(self, item: str):
         return item in self._id_to_index
 
     def __getitem__(self, item: Union[int, str, slice]):
         if isinstance(item, int):
-            return Document(self._pb_body[item], pb_only=True)
+            return Document(self._pb_body[item])
         elif isinstance(item, str):
             return self[self._id_to_index[item]]
         elif isinstance(item, slice):

--- a/jina/types/document/__init__.py
+++ b/jina/types/document/__init__.py
@@ -229,14 +229,15 @@ class Document(ProtoTypeMixin, VersionedMixin):
         """
         Document.CNT += 1
 
-        self._pb_body = jina_pb2.DocumentProto()
         try:
             if isinstance(document, jina_pb2.DocumentProto):
                 if copy:
+                    self._pb_body = jina_pb2.DocumentProto()
                     self._pb_body.CopyFrom(document)
                 else:
                     self._pb_body = document
             elif isinstance(document, bytes):
+                self._pb_body = jina_pb2.DocumentProto()
                 self._pb_body.ParseFromString(document)
             elif isinstance(document, (dict, str)):
                 if isinstance(document, str):
@@ -270,6 +271,7 @@ class Document(ProtoTypeMixin, VersionedMixin):
                     )
                 )
 
+                self._pb_body = jina_pb2.DocumentProto()
                 if support_fields.issuperset(user_fields):
                     json_format.ParseDict(document, self._pb_body)
                 else:
@@ -297,12 +299,16 @@ class Document(ProtoTypeMixin, VersionedMixin):
                             )
             elif isinstance(document, Document):
                 if copy:
+                    self._pb_body = jina_pb2.DocumentProto()
                     self._pb_body.CopyFrom(document.proto)
                 else:
                     self._pb_body = document.proto
             elif document is not None:
                 # note ``None`` is not considered as a bad type
                 raise ValueError(f'{typename(document)} is not recognizable')
+            else:
+                # create an empty document
+                self._pb_body = jina_pb2.DocumentProto()
         except Exception as ex:
             raise BadDocType(
                 f'fail to construct a document from {document}, '

--- a/jina/types/document/__init__.py
+++ b/jina/types/document/__init__.py
@@ -144,6 +144,7 @@ class Document(ProtoTypeMixin, VersionedMixin):
     """
 
     ON_GETATTR = ['matches', 'chunks']
+    CNT = 0
 
     # overload_inject_start_document
     @overload
@@ -228,12 +229,16 @@ class Document(ProtoTypeMixin, VersionedMixin):
                 assert d.tags['hello'] == 'world'  # true
                 assert d.tags['good'] == 'bye'  # true
         """
+        Document.CNT += 1
         if pb_only:
-            if not isinstance(document, jina_pb2.DocumentProto):
+            if not isinstance(document, jina_pb2.DocumentProto) or document is None:
                 raise ValueError(
                     'you cannot use pb_only with document not instance of DocumentProto'
                 )
             self._pb_body = document
+            if not self._pb_body.id:
+                self.id = random_identity(use_uuid1=True)
+            self._mermaid_id = str(Document.CNT) + self._pb_body.id
         else:
             self._pb_body = jina_pb2.DocumentProto()
             try:
@@ -326,7 +331,7 @@ class Document(ProtoTypeMixin, VersionedMixin):
                 raise ValueError(
                     f'Document content fields are mutually exclusive, please provide only one of {_all_doc_content_keys}'
                 )
-            self._mermaid_id = random_identity()
+            self._mermaid_id = str(Document.CNT) + self._pb_body.id
             self.set_attributes(**kwargs)
 
     def pop(self, *fields) -> None:

--- a/jina/types/document/__init__.py
+++ b/jina/types/document/__init__.py
@@ -195,9 +195,9 @@ class Document(ProtoTypeMixin, VersionedMixin):
     def __init__(
         self,
         document: Optional[DocumentSourceType] = None,
-        pb_only: bool = False,
         field_resolver: Dict[str, str] = None,
         copy: bool = False,
+        pb_only: bool = False,
         **kwargs,
     ):
         """

--- a/jina/types/document/__init__.py
+++ b/jina/types/document/__init__.py
@@ -194,6 +194,7 @@ class Document(ProtoTypeMixin, VersionedMixin):
     def __init__(
         self,
         document: Optional[DocumentSourceType] = None,
+        pb_only: bool = False,
         field_resolver: Dict[str, str] = None,
         copy: bool = False,
         **kwargs,
@@ -210,6 +211,7 @@ class Document(ProtoTypeMixin, VersionedMixin):
         :param field_resolver: a map from field names defined in ``document`` (JSON, dict) to the field
                 names defined in Protobuf. This is only used when the given ``document`` is
                 a JSON string or a Python dict.
+        :param pb_only: light weight Document construction using pb_body only
         :param kwargs: other parameters to be set _after_ the document is constructed
 
         .. note::
@@ -226,96 +228,106 @@ class Document(ProtoTypeMixin, VersionedMixin):
                 assert d.tags['hello'] == 'world'  # true
                 assert d.tags['good'] == 'bye'  # true
         """
-        self._pb_body = jina_pb2.DocumentProto()
-        try:
-            if isinstance(document, jina_pb2.DocumentProto):
-                if copy:
-                    self._pb_body.CopyFrom(document)
-                else:
-                    self._pb_body = document
-            elif isinstance(document, (dict, str)):
-                if isinstance(document, str):
-                    document = json.loads(document)
-
-                def _update_doc(d: Dict):
-                    for key in _all_doc_array_keys:
-                        if key in d:
-                            value = d[key]
-                            if isinstance(value, list):
-                                d[key] = NdArray(np.array(d[key])).dict()
-                        if 'chunks' in d:
-                            for chunk in d['chunks']:
-                                _update_doc(chunk)
-                        if 'matches' in d:
-                            for match in d['matches']:
-                                _update_doc(match)
-
-                _update_doc(document)
-
-                if field_resolver:
-                    document = {
-                        field_resolver.get(k, k): v for k, v in document.items()
-                    }
-
-                user_fields = set(document)
-                support_fields = set(
-                    self.attributes(
-                        include_proto_fields_camelcase=True, include_properties=False
-                    )
+        if pb_only:
+            if not isinstance(document, jina_pb2.DocumentProto):
+                raise ValueError(
+                    'you cannot use pb_only with document not instance of DocumentProto'
                 )
+            self._pb_body = document
+        else:
+            self._pb_body = jina_pb2.DocumentProto()
+            try:
+                if isinstance(document, jina_pb2.DocumentProto):
+                    if copy:
+                        self._pb_body.CopyFrom(document)
+                    else:
+                        self._pb_body = document
+                elif isinstance(document, (dict, str)):
+                    if isinstance(document, str):
+                        document = json.loads(document)
 
-                if support_fields.issuperset(user_fields):
-                    json_format.ParseDict(document, self._pb_body)
-                else:
-                    _intersect = support_fields.intersection(user_fields)
-                    _remainder = user_fields.difference(_intersect)
-                    if _intersect:
-                        json_format.ParseDict(
-                            {k: document[k] for k in _intersect}, self._pb_body
+                    def _update_doc(d: Dict):
+                        for key in _all_doc_array_keys:
+                            if key in d:
+                                value = d[key]
+                                if isinstance(value, list):
+                                    d[key] = NdArray(np.array(d[key])).dict()
+                            if 'chunks' in d:
+                                for chunk in d['chunks']:
+                                    _update_doc(chunk)
+                            if 'matches' in d:
+                                for match in d['matches']:
+                                    _update_doc(match)
+
+                    _update_doc(document)
+
+                    if field_resolver:
+                        document = {
+                            field_resolver.get(k, k): v for k, v in document.items()
+                        }
+
+                    user_fields = set(document)
+                    support_fields = set(
+                        self.attributes(
+                            include_proto_fields_camelcase=True,
+                            include_properties=False,
                         )
-                    if _remainder:
-                        support_prop = set(
-                            self.attributes(
-                                include_proto_fields=False, include_properties=True
+                    )
+
+                    if support_fields.issuperset(user_fields):
+                        json_format.ParseDict(document, self._pb_body)
+                    else:
+                        _intersect = support_fields.intersection(user_fields)
+                        _remainder = user_fields.difference(_intersect)
+                        if _intersect:
+                            json_format.ParseDict(
+                                {k: document[k] for k in _intersect}, self._pb_body
                             )
-                        )
-                        _intersect2 = support_prop.intersection(_remainder)
-                        _remainder2 = _remainder.difference(_intersect2)
-
-                        if _intersect2:
-                            self.set_attributes(**{p: document[p] for p in _intersect2})
-
-                        if _remainder2:
-                            self._pb_body.tags.update(
-                                {k: document[k] for k in _remainder}
+                        if _remainder:
+                            support_prop = set(
+                                self.attributes(
+                                    include_proto_fields=False, include_properties=True
+                                )
                             )
-            elif isinstance(document, bytes):
-                self._pb_body.ParseFromString(document)
-            elif isinstance(document, Document):
-                if copy:
-                    self._pb_body.CopyFrom(document.proto)
-                else:
-                    self._pb_body = document.proto
-            elif document is not None:
-                # note ``None`` is not considered as a bad type
-                raise ValueError(f'{typename(document)} is not recognizable')
-        except Exception as ex:
-            raise BadDocType(
-                f'fail to construct a document from {document}, '
-                f'if you are trying to set the content '
-                f'you may use "Document(content=your_content)"'
-            ) from ex
+                            _intersect2 = support_prop.intersection(_remainder)
+                            _remainder2 = _remainder.difference(_intersect2)
 
-        if self._pb_body.id is None or not self._pb_body.id:
-            self.id = random_identity(use_uuid1=True)
+                            if _intersect2:
+                                self.set_attributes(
+                                    **{p: document[p] for p in _intersect2}
+                                )
 
-        # check if there are mutually exclusive content fields
-        if _contains_conflicting_content(**kwargs):
-            raise ValueError(
-                f'Document content fields are mutually exclusive, please provide only one of {_all_doc_content_keys}'
-            )
-        self._mermaid_id = random_identity()
-        self.set_attributes(**kwargs)
+                            if _remainder2:
+                                self._pb_body.tags.update(
+                                    {k: document[k] for k in _remainder}
+                                )
+                elif isinstance(document, bytes):
+                    self._pb_body.ParseFromString(document)
+                elif isinstance(document, Document):
+                    if copy:
+                        self._pb_body.CopyFrom(document.proto)
+                    else:
+                        self._pb_body = document.proto
+                elif document is not None:
+                    # note ``None`` is not considered as a bad type
+                    raise ValueError(f'{typename(document)} is not recognizable')
+            except Exception as ex:
+                raise BadDocType(
+                    f'fail to construct a document from {document}, '
+                    f'if you are trying to set the content '
+                    f'you may use "Document(content=your_content)"'
+                ) from ex
+
+            if self._pb_body.id is None or not self._pb_body.id:
+                self.id = random_identity(use_uuid1=True)
+
+            # check if there are mutually exclusive content fields
+            if _contains_conflicting_content(**kwargs):
+                raise ValueError(
+                    f'Document content fields are mutually exclusive, please provide only one of {_all_doc_content_keys}'
+                )
+            self._mermaid_id = random_identity()
+            self.set_attributes(**kwargs)
 
     def pop(self, *fields) -> None:
         """Remove the values from the given fields of this Document.


### PR DESCRIPTION
This speeds up DocumentArray.__iter__ heavily since Document constructor becomes much faster
Consequently, all methods that use __iter__ become faster.
When developing this, we had to set mermaid_id efficiently. A similar issue was raised before: https://github.com/jina-ai/jina/issues/2582

To solve it, we used a class attribute counter (to make mermaid_id unique based on document id which is already unique)

results:
|    |      master      |  perf-document-fast-init ( ff87e72 ) | perf-document-fast-init (ec5961d) | perf-document-fast-init (latest) |
|----------|:-------------:|------:|------:|------:|
| document array iter |  1.16 s | 0.32 s | 0.50 s | 0.36 s |
| document array get_attributes('text') |    1.32 s   |   0.42 s | 0.61 s | 0.43 s |
| document array get_attributes('text', 'embedding') | 3.32 s | 2.06 s | 2.21 s | 2.17 s |
| document construct by pb_body | 1.3 s | 0.68 s | 0.6 s | 0.45 s |