### PR TITLE
docs: use port replace port expose in client

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,7 +1,0 @@
-# .coveragerc to control coverage.py
-[report]
-# regrexes for lines to exclude from consideration
-exclude_lines =
-  NotImplementedError
-omit =
-  jina/resources/*

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -2,7 +2,6 @@ codecov:
   # https://docs.codecov.io/docs/comparing-commits
   allow_coverage_offsets: true
 ignore:
-  - "jina/hub"
   - "jina/resources"
 coverage:
   status:

--- a/docs/fundamentals/flow/flow-as-a-service.md
+++ b/docs/fundamentals/flow/flow-as-a-service.md
@@ -24,7 +24,7 @@ with f:
 ```python
 from jina import Client, Document
 
-c = Client(protocol='grpc', port_expose=12345)
+c = Client(protocol='grpc', port=12345)
 c.post('/', Document())
 ```
 
@@ -97,7 +97,7 @@ While keep this server open, let's create a client on a different machine:
 ```python
 from jina import Client
 
-c = Client(host='192.168.1.15', port_expose=12345)
+c = Client(host='192.168.1.15', port=12345)
 
 c.post('/')
 ```
@@ -132,7 +132,7 @@ This will serve the Flow with WebSocket, so any Client connects to it should fol
 ```python
 from jina import Client
 
-c = Client(protocol='websocket', host='192.168.1.15', port_expose=12345)
+c = Client(protocol='websocket', host='192.168.1.15', port=12345)
 c.post('/')
 ```
 
@@ -265,7 +265,7 @@ One can also use Python Client to send HTTP request, simply:
 ```python
 from jina import Client
 
-c = Client(protocol='http', port_expose=12345)
+c = Client(protocol='http', port=12345)
 c.post('/', ...)
 ```
 

--- a/docs/fundamentals/flow/index.md
+++ b/docs/fundamentals/flow/index.md
@@ -71,7 +71,7 @@ Client:
 ```python
 from jina import Client, Document
 
-c = Client(port_expose=12345)
+c = Client(port=12345)
 c.post(on='/bar', inputs=Document(), on_done=print)
 ```
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    slow: marks tests as slow (deselect with '-m "not slow"')

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,5 @@
 markers =
     slow: marks tests as slow (deselect with '-m "not slow"')
     timeout: marks test timeout duration
+    asyncio: marks that run async tests
+    repeat: marks that test run n times

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 markers =
     slow: marks tests as slow (deselect with '-m "not slow"')
+    timeout: marks test timeout duration

--- a/tests/integration/crud/__init__.py
+++ b/tests/integration/crud/__init__.py
@@ -8,7 +8,7 @@ from jina.logging.logger import JinaLogger
 
 
 class CrudIndexer(Executor):
-    """Simple indexer class """
+    """Simple indexer class"""
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/tests/integration/v2_api/test_returns.py
+++ b/tests/integration/v2_api/test_returns.py
@@ -15,7 +15,6 @@ def test_different_responses(test_docs, mocker):
         assert response.data.docs[0].id == '1'
 
     class MyExecutor(Executor):
-
         @requests(on='/return_docs')
         def return_docs(self, docs, *args, **kwargs):
             return docs

--- a/tests/unit/clients/python/test_client.py
+++ b/tests/unit/clients/python/test_client.py
@@ -167,7 +167,7 @@ def test_client_from_kwargs(protocol):
 def test_independent_client(protocol):
     with Flow(protocol=protocol) as f:
         c = Client(host='localhost', port=f.port_expose, protocol=protocol)
-        assert isinstance(c, f.client)
+        assert type(c) == type(f.client)
         c.post('/')
 
 

--- a/tests/unit/clients/python/test_client.py
+++ b/tests/unit/clients/python/test_client.py
@@ -167,7 +167,7 @@ def test_client_from_kwargs(protocol):
 def test_independent_client(protocol):
     with Flow(protocol=protocol) as f:
         c = Client(host='localhost', port=f.port_expose, protocol=protocol)
-        assert type(c) == type(f.client)
+        assert isinstance(c, f.client)
         c.post('/')
 
 
@@ -188,10 +188,11 @@ def test_all_sync_clients(protocol, mocker):
     m3 = mocker.Mock()
     m4 = mocker.Mock()
     with f:
-        f.post('/', on_done=m1)
-        f.post('/foo', docs, on_done=m2)
-        f.post('/foo', on_done=m3)
-        f.post('/foo', docs, parameters={'hello': 'world'}, on_done=m4)
+        c = Client(host='localhost', port=f.port_expose, protocol=protocol)
+        c.post('/', on_done=m1)
+        c.post('/foo', docs, on_done=m2)
+        c.post('/foo', on_done=m3)
+        c.post('/foo', docs, parameters={'hello': 'world'}, on_done=m4)
 
     m1.assert_called_once()
     m2.assert_called()


### PR DESCRIPTION
1. fixed all clients in docs from `port_expose` to `port`.
2. minor test change, test client `test_independent_client` is not testing client, it's testing flow.
3. remove `coverage.rc` since not used anymore, remove `jina/hub` from test config since hub is not a submodule of jina anymore. Added `pytest.ini` to ignore `pytest.mark.slow` warnings.