### PR TITLE
docs: add note to warn users about int data type in doc.tags and parameters

### DIFF
--- a/docs/fundamentals/document/document-api.md
+++ b/docs/fundamentals/document/document-api.md
@@ -102,6 +102,37 @@ da.get_attributes('tags__dimensions__height', 'tags__dimensions__weight')
 [[5.0, 5.0, 5.0, 5.0, 5.0, 5.0, 5.0, 5.0, 5.0, 5.0], [10.0, 10.0, 10.0, 10.0, 10.0, 10.0, 10.0, 10.0, 10.0, 10.0]]
 ```
 
+
+````{admonition} Note
+:class: caution
+
+As `tags` does not have a fixed schema, it is declared with type `google.protobuf.Struct` in the `DocumentProto`
+protobuf declaration. However, `google.protobuf.Struct` follows the JSON specification and does not 
+differentiate `int` from `float`. **So, data of type `int` in `tags` will be casted to `float` when request is
+sent to executor.**
+
+As a result, users need be explicit and cast the data to the expected type as follows.
+
+```{code-block} python
+---
+emphasize-lines: 7
+---
+
+class MyIndexer(Executor):
+    animals = ['cat', 'dog', 'turtle']
+    @request
+    def foo(self, docs, parameters: dict, **kwargs):
+        for doc in docs:
+            # need to cast to int since list indices must be integers not float
+            index = int(doc.tags['index'])
+            assert self.animals[index] == 'dog'
+
+with Flow().add(uses=Selector) as f:
+    f.post(on='/endpoint',
+    inputs=DocumentArray([]), parameters={'index': 1})
+```
+````
+
 ## Construct `Document`
 
 ### Content attributes

--- a/docs/fundamentals/document/document-api.md
+++ b/docs/fundamentals/document/document-api.md
@@ -103,7 +103,7 @@ da.get_attributes('tags__dimensions__height', 'tags__dimensions__weight')
 ```
 
 
-````{admonition} Note
+`````{admonition} Note
 :class: caution
 
 As `tags` does not have a fixed schema, it is declared with type `google.protobuf.Struct` in the `DocumentProto`
@@ -113,9 +113,10 @@ sent to executor.**
 
 As a result, users need be explicit and cast the data to the expected type as follows.
 
+````{tab} ✅ Do
 ```{code-block} python
 ---
-emphasize-lines: 7
+emphasize-lines: 7, 8
 ---
 
 class MyIndexer(Executor):
@@ -127,11 +128,34 @@ class MyIndexer(Executor):
             index = int(doc.tags['index'])
             assert self.animals[index] == 'dog'
 
-with Flow().add(uses=Selector) as f:
+with Flow().add(uses=MyExecutor) as f:
     f.post(on='/endpoint',
     inputs=DocumentArray([]), parameters={'index': 1})
 ```
 ````
+
+````{tab} 😔 Don't
+```{code-block} python
+---
+emphasize-lines: 7, 8
+---
+
+class MyIndexer(Executor):
+    animals = ['cat', 'dog', 'turtle']
+    @request
+    def foo(self, docs, parameters: dict, **kwargs):
+        for doc in docs:
+            # ERROR: list indices must be integer not float
+            index = doc.tags['index']
+            assert self.animals[index] == 'dog'
+
+with Flow().add(uses=MyExecutor) as f:
+    f.post(on='/endpoint',
+    inputs=DocumentArray([]), parameters={'index': 1})
+```
+````
+
+`````
 
 ## Construct `Document`
 

--- a/docs/fundamentals/executor/executor-built-in-features.md
+++ b/docs/fundamentals/executor/executor-built-in-features.md
@@ -235,7 +235,7 @@ with (Flow().
 ```
 
 
-````{admonition}  Note
+`````{admonition}  Note
 :class: caution
 
 As `parameters` does not have a fixed schema, it is declared with type `google.protobuf.Struct` in the `RequestProto`
@@ -245,9 +245,10 @@ sent to executor.**
 
 As a result, users need be explicit and cast the data to the expected type as follows.
 
+````{tab} ✅ Do
 ```{code-block} python
 ---
-emphasize-lines: 6
+emphasize-lines: 6, 7
 ---
 
 class MyExecutor(Executor):
@@ -258,7 +259,29 @@ class MyExecutor(Executor):
         index = int(parameters.get('index', 0))
         assert self.animals[index] == 'dog'
 
-with Flow().add(uses=Selector) as f:
+with Flow().add(uses=MyExecutor) as f:
     f.post(on='/endpoint', inputs=DocumentArray([]), parameters={'index': 1})
 ```
 ````
+
+````{tab} 😔 Don't
+```{code-block} python
+---
+emphasize-lines: 6, 7
+---
+
+class MyIndexer(Executor):
+    animals = ['cat', 'dog', 'turtle']
+    @request
+    def foo(self, docs, parameters: dict, **kwargs):
+          # ERROR: list indices must be integer not float
+          index = parameters.get('index', 0)
+          assert self.animals[index] == 'dog'
+
+with Flow().add(uses=MyExecutor) as f:
+    f.post(on='/endpoint',
+    inputs=DocumentArray([]), parameters={'index': 1})
+```
+````
+
+`````

--- a/docs/fundamentals/executor/executor-built-in-features.md
+++ b/docs/fundamentals/executor/executor-built-in-features.md
@@ -233,3 +233,32 @@ with (Flow().
         add(uses={'jtype': 'MyExecutor', 'metas': {'name': 'my-executor-2'}})) as f:
     f.post(on='/endpoint', inputs=DocumentArray([]), parameters={'param': 5, 'my-executor-1': {'param': 10}})
 ```
+
+
+````{admonition}  Note
+:class: caution
+
+As `parameters` does not have a fixed schema, it is declared with type `google.protobuf.Struct` in the `RequestProto`
+protobuf declaration. However, `google.protobuf.Struct` follows the JSON specification and does not 
+differentiate `int` from `float`. **So, data of type `int` in `parameters` will be casted to `float` when request is
+sent to executor.**
+
+As a result, users need be explicit and cast the data to the expected type as follows.
+
+```{code-block} python
+---
+emphasize-lines: 6
+---
+
+class MyExecutor(Executor):
+    animals = ['cat', 'dog', 'turtle']
+    @request
+    def foo(self, docs, parameters: dict, **kwargs):
+        # need to cast to int since list indices must be integers not float
+        index = int(parameters.get('index', 0))
+        assert self.animals[index] == 'dog'
+
+with Flow().add(uses=Selector) as f:
+    f.post(on='/endpoint', inputs=DocumentArray([]), parameters={'index': 1})
+```
+````


### PR DESCRIPTION
PR for #3343 