### PR TITLE
fix: name can be None in args

### DIFF
--- a/jina/jaml/parsers/executor/legacy.py
+++ b/jina/jaml/parsers/executor/legacy.py
@@ -106,8 +106,11 @@ class LegacyParser(VersionedYAMLParser):
         :param data: the data for the parser
         :return: True if it is tail/head, False otherwise
         """
-        name = data.get('runtime_args', {}).get('name', '')
-        return 'head' in name or 'tail' in name
+        try:
+            name = data.get('runtime_args', {}).get('name', '')
+            return 'head' in name or 'tail' in name
+        except Exception as _:
+            pass  # name can be None in tests since it's not passed
 
     def dump(self, data: 'BaseExecutor') -> Dict:
         """


### PR DESCRIPTION
`runtime_args.name` can be `None` in some tests, and we don't want to make tests require more scaffolding

Ex https://github.com/jina-ai/executors/runs/3534309301#step:4:781