### PR TITLE
fix(flow): raise error when using grpc data runtime with shards

### DIFF
--- a/jina/flow/base.py
+++ b/jina/flow/base.py
@@ -709,7 +709,7 @@ class Flow(PostMixin, JAMLCompatible, ExitStack, metaclass=FlowType):
         )
 
         # grpc data runtime does not support sharding at the moment
-        if args.grpc_data_requests and kwargs.get('shards') is not None:
+        if args.grpc_data_requests and kwargs.get('shards') > 1:
             raise NotImplementedError("GRPC data runtime does not support sharding")
 
         if args.grpc_data_requests and args.runtime_cls == 'ZEDRuntime':

--- a/jina/flow/base.py
+++ b/jina/flow/base.py
@@ -713,6 +713,7 @@ class Flow(PostMixin, JAMLCompatible, ExitStack, metaclass=FlowType):
             args.grpc_data_requests
             and kwargs.get('shards') is not None
             and kwargs.get('shards', 1) > 1
+            and self.args.infrastructure != InfrastructureType.K8S
         ):
             raise NotImplementedError("GRPC data runtime does not support sharding")
 

--- a/jina/flow/base.py
+++ b/jina/flow/base.py
@@ -711,6 +711,10 @@ class Flow(PostMixin, JAMLCompatible, ExitStack, metaclass=FlowType):
         if args.grpc_data_requests and args.runtime_cls == 'ZEDRuntime':
             args.runtime_cls = 'GRPCDataRuntime'
 
+            # grpc data runtime does not support sharding at the moment
+            if kwargs.get('shards') is not None:
+                raise NotImplementedError("GRPC data runtime does not support sharding")
+
         # pod workspace if not set then derive from flow workspace
         args.workspace = os.path.abspath(args.workspace or self.workspace)
 

--- a/jina/flow/base.py
+++ b/jina/flow/base.py
@@ -708,12 +708,12 @@ class Flow(PostMixin, JAMLCompatible, ExitStack, metaclass=FlowType):
             kwargs, parser, True, fallback_parsers=FALLBACK_PARSERS
         )
 
+        # grpc data runtime does not support sharding at the moment
+        if kwargs.get('shards') is not None:
+            raise NotImplementedError("GRPC data runtime does not support sharding")
+
         if args.grpc_data_requests and args.runtime_cls == 'ZEDRuntime':
             args.runtime_cls = 'GRPCDataRuntime'
-
-            # grpc data runtime does not support sharding at the moment
-            if kwargs.get('shards') is not None:
-                raise NotImplementedError("GRPC data runtime does not support sharding")
 
         # pod workspace if not set then derive from flow workspace
         args.workspace = os.path.abspath(args.workspace or self.workspace)

--- a/jina/flow/base.py
+++ b/jina/flow/base.py
@@ -709,7 +709,7 @@ class Flow(PostMixin, JAMLCompatible, ExitStack, metaclass=FlowType):
         )
 
         # grpc data runtime does not support sharding at the moment
-        if kwargs.get('shards') is not None:
+        if args.grpc_data_requests and kwargs.get('shards') is not None:
             raise NotImplementedError("GRPC data runtime does not support sharding")
 
         if args.grpc_data_requests and args.runtime_cls == 'ZEDRuntime':

--- a/jina/flow/base.py
+++ b/jina/flow/base.py
@@ -709,7 +709,11 @@ class Flow(PostMixin, JAMLCompatible, ExitStack, metaclass=FlowType):
         )
 
         # grpc data runtime does not support sharding at the moment
-        if args.grpc_data_requests and kwargs.get('shards') > 1:
+        if (
+            args.grpc_data_requests
+            and kwargs.get('shards') is not None
+            and kwargs.get('shards', 1) > 1
+        ):
             raise NotImplementedError("GRPC data runtime does not support sharding")
 
         if args.grpc_data_requests and args.runtime_cls == 'ZEDRuntime':

--- a/tests/unit/flow-construct/test_flow.py
+++ b/tests/unit/flow-construct/test_flow.py
@@ -836,4 +836,5 @@ def test_flow_grpc_with_shard():
         Flow(grpc_data_requests=True).add(shards=2)
         Flow(grpc_data_requests=True).add(shards=None)
 
-    Flow(grpc_data_requests=False).add(shards=-1)
+    Flow(grpc_data_requests=False).add(shards=1)
+    Flow(grpc_data_requests=False).add()

--- a/tests/unit/flow-construct/test_flow.py
+++ b/tests/unit/flow-construct/test_flow.py
@@ -838,4 +838,4 @@ def test_flow_grpc_with_shard():
 
     Flow(grpc_data_requests=False).add(shards=1)
     Flow(grpc_data_requests=False).add()
-    Flow(grpc_data_requests=False, infrastructure=InfrastructureType.K8S).add(shards=2)
+    Flow(grpc_data_requests=True, infrastructure=InfrastructureType.K8S).add(shards=2)

--- a/tests/unit/flow-construct/test_flow.py
+++ b/tests/unit/flow-construct/test_flow.py
@@ -830,6 +830,9 @@ def test_connect_to_predecessor():
 
 
 def test_flow_grpc_with_shard():
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(
+        NotImplementedError, match='GRPC data runtime does not support sharding'
+    ):
         Flow(grpc_data_requests=True).add(shards=2)
         Flow(grpc_data_requests=True).add(shards=None)
+        Flow(grpc_data_requests=False).add(shards=1)

--- a/tests/unit/flow-construct/test_flow.py
+++ b/tests/unit/flow-construct/test_flow.py
@@ -835,4 +835,5 @@ def test_flow_grpc_with_shard():
     ):
         Flow(grpc_data_requests=True).add(shards=2)
         Flow(grpc_data_requests=True).add(shards=None)
-        Flow(grpc_data_requests=False).add(shards=1)
+
+    Flow(grpc_data_requests=False).add(shards=-1)

--- a/tests/unit/flow-construct/test_flow.py
+++ b/tests/unit/flow-construct/test_flow.py
@@ -827,3 +827,9 @@ def test_connect_to_predecessor():
     assert len(f._pod_nodes['gateway'].head_args.hosts_in_connect) == 0
     assert len(f._pod_nodes['pod1'].head_args.hosts_in_connect) == 0
     assert len(f._pod_nodes['pod2'].head_args.hosts_in_connect) == 1
+
+
+def test_flow_grpc_with_shard():
+    with pytest.raises(NotImplementedError):
+        Flow(grpc_data_requests=True).add(shards=2)
+        Flow(grpc_data_requests=True).add(shards=None)

--- a/tests/unit/flow-construct/test_flow.py
+++ b/tests/unit/flow-construct/test_flow.py
@@ -7,7 +7,7 @@ import numpy as np
 import pytest
 
 from jina import Flow, Document
-from jina.enums import SocketType, FlowBuildLevel
+from jina.enums import InfrastructureType, SocketType, FlowBuildLevel
 from jina.excepts import RuntimeFailToStart
 from jina.executors import BaseExecutor
 from jina.helper import random_identity
@@ -838,3 +838,4 @@ def test_flow_grpc_with_shard():
 
     Flow(grpc_data_requests=False).add(shards=1)
     Flow(grpc_data_requests=False).add()
+    Flow(grpc_data_requests=False, infrastructure=InfrastructureType.K8S).add(shards=2)


### PR DESCRIPTION
Fixes Issue: #3197

Expected Behavior: `Flow(grpc_data_requests=True).add(shards=2)` should raise an error.

Implemented Behavior:
```python
>>> Flow(grpc_data_requests=True).add(shards=2)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/workspaces/jina/jina/flow/builder.py", line 33, in arg_wrapper
    return func(self, *args, **kwargs)
  File "/workspaces/jina/jina/flow/base.py", line 716, in add
    raise NotImplementedError("GRPC data runtime does not support sharding")
NotImplementedError: GRPC data runtime does not support sharding
>>> Flow(grpc_data_requests=True).add(shards=None)
<jina.flow.base.Flow object at 0x7fb19e5c8b80>
>>> Flow(grpc_data_requests=True).add()
<jina.flow.base.Flow object at 0x7fb19e5c8b80>
```