### PR TITLE
fix: Remove unused class MyConverter

### DIFF
--- a/jina/helloworld/fashion/app.py
+++ b/jina/helloworld/fashion/app.py
@@ -12,7 +12,7 @@ if __name__ == '__main__':
         index_generator,
         query_generator,
     )
-    from my_executors import MyEncoder, MyIndexer, MyEvaluator, MyConverter
+    from my_executors import MyEncoder, MyIndexer, MyEvaluator
 else:
     from .helper import (
         print_result,
@@ -21,7 +21,7 @@ else:
         index_generator,
         query_generator,
     )
-    from .my_executors import MyEncoder, MyIndexer, MyEvaluator, MyConverter
+    from .my_executors import MyEncoder, MyIndexer, MyEvaluator
 
 cur_dir = os.path.dirname(os.path.abspath(__file__))
 


### PR DESCRIPTION
We already implement the conversion logic in [MyEncoder](https://github.com/jina-ai/jina/blob/4c4f69b150bc1f7103f31aea8ceade1f36081a7e/jina/helloworld/fashion/my_executors.py#L69). Thus there is no need to import it.

BTW, should we remove the definition of `MyConverter` from my_executors.py?