### PR TITLE
fix(types): allow da extend with None

### DIFF
--- a/jina/types/arrays/document.py
+++ b/jina/types/arrays/document.py
@@ -306,6 +306,9 @@ class DocumentArray(
 
         :param iterable: the iterable of Documents to extend this array with
         """
+        if not iterable:
+            return
+
         for doc in iterable:
             self.append(doc)
 

--- a/tests/unit/flow-example/test_flow_empty_request.py
+++ b/tests/unit/flow-example/test_flow_empty_request.py
@@ -1,0 +1,18 @@
+from jina import Flow, Executor, requests
+
+
+class MyExecutor(Executor):
+    @requests
+    def foo(self, **kwargs):
+        print('hello world')
+
+
+def test_empty_post_request(mocker):
+    f = Flow().add(uses=MyExecutor, parallel=2, polling='ALL')
+    with f:
+        on_error_mock = mocker.Mock()
+        on_done_mock = mocker.Mock()
+        f.post('', on_error=on_error_mock, on_done=on_done_mock)
+
+        on_error_mock.assert_not_called()
+        on_done_mock.assert_called_once()

--- a/tests/unit/types/arrays/test_documentarray.py
+++ b/tests/unit/types/arrays/test_documentarray.py
@@ -557,3 +557,9 @@ def test_blobs_setter_da():
 
     for x, doc in zip(blobs, da):
         np.testing.assert_almost_equal(x, doc.blob)
+
+
+def test_none_extend():
+    da = DocumentArray([Document() for _ in range(100)])
+    da.extend(None)
+    assert len(da) == 100


### PR DESCRIPTION
Dont fail if DocumentArray.extend() is called with `None`. Just do nothing.