### PR TITLE
feat(util): add get_docs_batch_generator for documentarray

### DIFF
--- a/jina/types/arrays/traversable.py
+++ b/jina/types/arrays/traversable.py
@@ -2,6 +2,8 @@ import itertools
 from abc import abstractmethod
 from typing import Iterable
 
+from ...util import get_docs_batch_generator
+
 
 def _check_traversal_path_type(traversal_paths):
     if isinstance(traversal_paths, str):
@@ -95,3 +97,22 @@ class TraversableSequence:
     @abstractmethod
     def _flatten(sequence):
         ...
+
+    @staticmethod
+    def batch(docs, traversal_path, batch_size, needs_attr):
+        """
+        Calls `get_docs_batch_generator` and returns the `Generator` created.
+
+        Example Usage:
+
+        >>> for batch in batch(docs, ['r'], 10, needs_attr='blob'):
+        >>>     ...
+
+        :param docs: A document array.
+        :param traversal_path: Specifies along which "axis" the document shall be traversed. (defaults to ['r'])
+        :param batch_size: Size of each generated batch (except the last one, which might be smaller, default: 32)
+        :param needs_attr: Optionally, you can filter out docs which don't have this attribute
+
+        :return: Generator
+        """
+        return get_docs_batch_generator(docs, traversal_path, batch_size, needs_attr)

--- a/jina/util/__init__.py
+++ b/jina/util/__init__.py
@@ -1,0 +1,55 @@
+"""Module for Jina helper functions for batching documents in executors."""
+
+from typing import List, Generator, Optional
+
+from jina import DocumentArray
+
+
+def _batch_generator(
+    data: DocumentArray, batch_size: int
+) -> Generator[DocumentArray, None, None]:
+    for i in range(0, len(data), batch_size):
+        yield data[i : i + batch_size]
+
+
+def get_docs_batch_generator(
+    docs: Optional[DocumentArray] = None,
+    traversal_path: List[str] = None,
+    batch_size: int = 32,
+    needs_attr: Optional[str] = None,
+) -> Generator[DocumentArray, None, None]:
+    """
+    Creates a `Generator` that yields `DocumentArray` of size `batch_size` until `docs` is fully traversed along
+    the `traversal_path`. The None `docs` are filtered out and optionally the `docs` can be filtered by checking for
+    the existence of a `Document` attribute.
+    Note, that the last batch might be smaller than `batch_size`.
+
+    Example Usage:
+
+    >>> for batch in get_docs_batch_generator(docs, ['r'], 10, needs_attr='blob'):
+    >>>     ...
+
+    :param docs: A document array.
+    :param traversal_path: Specifies along which "axis" the document shall be traversed. (defaults to ['r'])
+    :param batch_size: Size of each generated batch (except the last one, which might be smaller, default: 32)
+    :param needs_attr: Optionally, you can filter out docs which don't have this attribute
+
+    :return: Generator
+    """
+    traversal_path = traversal_path or ['r']
+    assert batch_size > 0, 'Batch size must be greater zero.'
+    if docs is None:
+        docs = DocumentArray()
+    flat_docs = docs.traverse_flat(traversal_path)
+    if needs_attr:
+        # Text is equal to empty string (not None) by default
+        if needs_attr in ['text', 'uri', 'buffer']:
+            flat_docs = [doc for doc in flat_docs if getattr(doc, needs_attr)]
+        else:
+            flat_docs = [
+                doc for doc in flat_docs if getattr(doc, needs_attr) is not None
+            ]
+
+    filtered_docs = DocumentArray([doc for doc in flat_docs if doc is not None])
+
+    return _batch_generator(filtered_docs, batch_size)


### PR DESCRIPTION
Closes #3333 

This PR aims to add `get_docs_batch_generator` for DocumentArray. This change would enable us to eliminate jina commons requirement from a lot of executors. 

The existing import statement `from jina_commons.batching import get_docs_batch_generator` in executors can be updated to `from jina.util import get_docs_batch_generator`. Another way could be to add `from jina.util import get_docs_batch_generator` to `jina/__init__.py` file and update the existing import statement in executors to `from jina import get_docs_batch_generator`. 