### PR TITLE
fix(hub): replace docker hub url with jina hub url, and it is clickable

### DIFF
--- a/jina/hubble/hubio.py
+++ b/jina/hubble/hubio.py
@@ -459,7 +459,10 @@ metas:
             ':point_up:️ [bold red]Please keep this token in a safe place!',
         )
         table.add_row(':eyes: Visibility', visibility)
-        table.add_row(':whale: DockerHub', f'https://hub.docker.com/r/jinahub/{uuid8}/')
+        table.add_row(
+            ':link: JinaHub',
+            f'[link=https://hub.jina.ai/executor/{uuid8}/]https://hub.jina.ai/executor/{uuid8}/[/link]',
+        )
         console.print(table)
 
         presented_id = image.get('name', uuid8)


### PR DESCRIPTION
Clickable Jina Hub url in terminal!

<img width="1552" alt="Screen Shot 2021-09-14 at 5 27 23 PM" src="https://user-images.githubusercontent.com/4194287/133232464-cf3bebf2-f72b-43ed-b4a1-1be4dcd2d197.png">
