### PR TITLE
fix(spawn): reregister all jaml classes

### DIFF
--- a/jina/flow/base.py
+++ b/jina/flow/base.py
@@ -4,7 +4,6 @@ import copy
 import json
 import os
 import re
-import socket
 import threading
 import uuid
 import warnings
@@ -715,18 +714,6 @@ class Flow(PostMixin, JAMLCompatible, ExitStack, metaclass=FlowType):
         args = ArgNamespace.kwargs2namespace(
             kwargs, parser, True, fallback_parsers=FALLBACK_PARSERS
         )
-
-        # Temporary workaround to re-import executor module when using mp spawn start
-        # method, so that the executor is re-registered with pyyaml. The re-import
-        # occurs because the class will be in the arguments passed to mp.Process.start
-        # method. A better solution probably involves deeper refactoring
-        if isinstance(kwargs.get('uses'), type(JAMLCompatible)):
-            args._exec_cls = kwargs['uses']
-
-        if isinstance(kwargs.get('uses'), str):
-            cls = JAML.cls_from_tag(kwargs['uses'])
-            if cls:
-                args._exec_cls = cls
 
         if args.grpc_data_requests and args.runtime_cls == 'ZEDRuntime':
             args.runtime_cls = 'GRPCDataRuntime'

--- a/jina/jaml/__init__.py
+++ b/jina/jaml/__init__.py
@@ -146,6 +146,19 @@ class JAML:
         )
 
     @staticmethod
+    def registered_classes() -> Dict:
+        """
+        Return a dict of tags and :class:`JAMLCompatible` classes that have been registered.
+
+        :return: tags and classes
+        """
+        return {
+            k[1:]: v
+            for k, v in JinaLoader.yaml_constructors.items()
+            if k and k.startswith('!')
+        }
+
+    @staticmethod
     def cls_from_tag(tag: str) -> Optional['JAMLCompatible']:
         """Fetch class from yaml tag
 

--- a/tests/integration/multiprocessing_spawn/modules/main_jaml.py
+++ b/tests/integration/multiprocessing_spawn/modules/main_jaml.py
@@ -6,7 +6,7 @@ import jina
 def run():
     from exec import Exec
 
-    with jina.Flow().add(uses='Exec') as f:
+    with jina.Flow().add(uses='jtype: Exec') as f:
         pass
 
 

--- a/tests/integration/multiprocessing_spawn/test_spawn.py
+++ b/tests/integration/multiprocessing_spawn/test_spawn.py
@@ -32,3 +32,12 @@ def test_launch_spawn_name():
         env={'JINA_MP_START_METHOD': 'spawn', 'PATH': os.environ['PATH']},
         cwd=Path(__file__).parent / 'modules',
     )
+
+
+def test_launch_spawn_jaml():
+    subprocess.run(
+        [sys.executable, 'main_jaml.py'],
+        check=True,
+        env={'JINA_MP_START_METHOD': 'spawn', 'PATH': os.environ['PATH']},
+        cwd=Path(__file__).parent / 'modules',
+    )


### PR DESCRIPTION
This reverts the hacks added in #3380 and #3404 and passes all `JAMLCompatible` classes registered in main process to the `run` method in Peas. 