### PR TITLE
feat: flow polls ready status from every pod 🍾 

### DIFF
--- a/jina/flow/base.py
+++ b/jina/flow/base.py
@@ -1081,13 +1081,17 @@ class Flow(PostMixin, JAMLCompatible, ExitStack, metaclass=FlowType):
                         pendings.append(_k)
                     else:
                         num_done += 1
+                sys.stdout.write('\r{}\r'.format(' ' * 100))
+                pending_str = colored(' '.join(pendings)[:50], 'yellow')
+                sys.stdout.write(
+                    f'{colored(next(spinner), "green")} {num_done}/{num_all} waiting {pending_str} to be ready...'
+                )
+                sys.stdout.flush()
+
                 if not pendings:
-                    sys.stdout.write('\r{}\r'.format(' ' * 80))
+                    sys.stdout.write('\r{}\r'.format(' ' * 100))
                     break
                 time.sleep(0.1)
-                sys.stdout.write(
-                    f'\r{next(spinner)} {num_done}/{num_all} waiting {pendings} to be ready...'
-                )
 
         # kick off all pods wait-ready threads
         for k, v in self:
@@ -1117,7 +1121,9 @@ class Flow(PostMixin, JAMLCompatible, ExitStack, metaclass=FlowType):
 
         error_pods = [k for k, v in results.items() if v != 'done']
         if error_pods:
-            self.logger.error(f'Flow is aborted due to: {error_pods}')
+            self.logger.error(
+                f'Flow is aborted due to {error_pods} can not be started.'
+            )
             self.close()
             return False
         else:

--- a/jina/flow/base.py
+++ b/jina/flow/base.py
@@ -1,10 +1,13 @@
 import argparse
 import base64
 import copy
+import itertools
 import json
 import os
 import re
+import sys
 import threading
+import time
 import uuid
 import warnings
 from collections import OrderedDict
@@ -1045,25 +1048,90 @@ class Flow(PostMixin, JAMLCompatible, ExitStack, metaclass=FlowType):
             if not getattr(v.args, 'external', False):
                 self.enter_context(v)
 
-        for k, v in self:
-            try:
-                if not getattr(v.args, 'external', False):
-                    v.wait_start_success()
-            except Exception as ex:
-                self.logger.error(
-                    f'{k}:{v!r} can not be started due to {ex!r}, Flow is aborted'
-                )
-                self.close()
-                raise
-
-        self.logger.debug(
-            f'{self.num_pods} Pods (i.e. {self.num_peas} Peas) are running in this Flow'
-        )
-
-        self._build_level = FlowBuildLevel.RUNNING
-        self._show_success_message()
+        if self._wait_until_all_ready():
+            self._build_level = FlowBuildLevel.RUNNING
 
         return self
+
+    def _wait_until_all_ready(self) -> bool:
+        results = {}
+        threads = []
+
+        def _wait_ready(_pod_name, _pod):
+            try:
+                if not getattr(_pod.args, 'external', False):
+                    results[_pod_name] = 'pending'
+                    _pod.wait_start_success()
+                    results[_pod_name] = 'done'
+            except Exception as ex:
+                results[_pod_name] = repr(ex)
+
+        def _polling_status():
+            spinner = itertools.cycle(
+                ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏']
+            )
+
+            while True:
+                num_all = len(results)
+                num_done = 0
+                pendings = []
+                for _k, _v in results.items():
+                    sys.stdout.flush()
+                    if _v == 'pending':
+                        pendings.append(_k)
+                    else:
+                        num_done += 1
+                if not pendings:
+                    sys.stdout.write('\r{}\r'.format(' ' * 80))
+                    break
+                time.sleep(0.1)
+                sys.stdout.write(
+                    f'\r{next(spinner)} {num_done}/{num_all} waiting {pendings} to be ready...'
+                )
+
+        # kick off all pods wait-ready threads
+        for k, v in self:
+            t = threading.Thread(
+                target=_wait_ready,
+                args=(
+                    k,
+                    v,
+                ),
+            )
+            threads.append(t)
+            t.start()
+
+        # kick off spinner thread
+        t_m = threading.Thread(target=_polling_status)
+        t_m.start()
+
+        # kick off ip getter thread
+        addr_table = []
+        t_ip = threading.Thread(target=self._get_address_table, args=(addr_table,))
+        t_ip.start()
+
+        for t in threads:
+            t.join()
+        t_ip.join()
+        t_m.join()
+
+        error_pods = [k for k, v in results.items() if v != 'done']
+        if error_pods:
+            self.logger.error(f'Flow is aborted due to: {error_pods}')
+            self.close()
+            return False
+        else:
+            if self.args.infrastructure == InfrastructureType.K8S:
+                self.logger.info('🎉 Kubernetes Flow is ready to use!')
+            else:
+                self.logger.info('🎉 Flow is ready to use!')
+
+            if addr_table:
+                self.logger.info('\n' + '\n'.join(addr_table))
+            self.logger.debug(
+                f'{self.num_pods} Pods (i.e. {self.num_peas} Peas) are running in this Flow'
+            )
+            return True
 
     @property
     def num_pods(self) -> int:
@@ -1387,12 +1455,9 @@ class Flow(PostMixin, JAMLCompatible, ExitStack, metaclass=FlowType):
     def __iter__(self):
         return self._pod_nodes.items().__iter__()
 
-    def _show_success_message(self):
-
-        if self.args.infrastructure == InfrastructureType.K8S:
-            self.logger.info('🎉 Kubernetes deployment done!')
-        else:
-            address_table = [
+    def _get_address_table(self, address_table):
+        address_table.extend(
+            [
                 f'\t🔗 Protocol: \t\t{colored(self.protocol, attrs="bold")}',
                 f'\t🏠 Local access:\t'
                 + colored(f'{self.host}:{self.port_expose}', 'cyan', attrs='underline'),
@@ -1403,34 +1468,34 @@ class Flow(PostMixin, JAMLCompatible, ExitStack, metaclass=FlowType):
                     attrs='underline',
                 ),
             ]
-            if self.address_public:
-                address_table.append(
-                    f'\t🌐 Public address:\t'
-                    + colored(
-                        f'{self.address_public}:{self.port_expose}',
-                        'cyan',
-                        attrs='underline',
-                    )
+        )
+        if self.address_public:
+            address_table.append(
+                f'\t🌐 Public address:\t'
+                + colored(
+                    f'{self.address_public}:{self.port_expose}',
+                    'cyan',
+                    attrs='underline',
                 )
-            if self.protocol == GatewayProtocolType.HTTP:
-                address_table.append(
-                    f'\t💬 Swagger UI:\t\t'
-                    + colored(
-                        f'http://localhost:{self.port_expose}/docs',
-                        'cyan',
-                        attrs='underline',
-                    )
+            )
+        if self.protocol == GatewayProtocolType.HTTP:
+            address_table.append(
+                f'\t💬 Swagger UI:\t\t'
+                + colored(
+                    f'http://localhost:{self.port_expose}/docs',
+                    'cyan',
+                    attrs='underline',
                 )
-                address_table.append(
-                    f'\t📚 Redoc:\t\t'
-                    + colored(
-                        f'http://localhost:{self.port_expose}/redoc',
-                        'cyan',
-                        attrs='underline',
-                    )
+            )
+            address_table.append(
+                f'\t📚 Redoc:\t\t'
+                + colored(
+                    f'http://localhost:{self.port_expose}/redoc',
+                    'cyan',
+                    attrs='underline',
                 )
-
-            self.logger.info('🎉 Flow is ready to use!\n' + '\n'.join(address_table))
+            )
+        return address_table
 
     def block(self):
         """Block the process until user hits KeyboardInterrupt"""

--- a/jina/peapods/peas/__init__.py
+++ b/jina/peapods/peas/__init__.py
@@ -276,7 +276,13 @@ class BasePea:
                 else:
                     raise RuntimeRunForeverEarlyError
             else:
-                self.logger.success(__ready_msg__)
+                # han: I intentionally change it to debug as the Flow is now polling
+                # the ready status actively. Hence active print ready status is unnecessary.
+                #  Notice that, relying on Pod console print for readiness in general makes
+                # no sense as the Pod can live remote/container whose log can not be observed at all.
+                #
+                # in short, do not change it back to info, you don't need it.
+                self.logger.debug(__ready_msg__)
         else:
             _timeout = _timeout or -1
             self.logger.warning(


### PR DESCRIPTION
An interesting problem. At first, it looks like a simple UI thing, but digging deeper reveals the flaw of the current readiness-check logic. This PR changes the readiness check on Flow start from "blocking-style" to "rotating polling-style", which overall fits better to microservice architecture like Jina.

Let's first see this example:

```python
import time

from jina import Flow, Executor


class SlowExecutor(Executor):
    def __init__(self, wait, **kwargs):
        super().__init__(**kwargs)
        time.sleep(wait)


f = (
    Flow()
    .add(uses=SlowExecutor, uses_with={'wait': 4})
    .add(uses=SlowExecutor, uses_with={'wait': 3})
    .add(uses=SlowExecutor, uses_with={'wait': 2})
    .add(uses=SlowExecutor, uses_with={'wait': 1})
)

with f:
    pass
```

In current master (3ba5ec18586671c3b8fd59a1150883607e77100c), it behaves as follows:

It waits for 4s without printing anything, and then suddenly all "ready to use".

![d4232e60fc97876f9de09e11b340b881](https://user-images.githubusercontent.com/2041322/133319974-39c2f7a5-4397-4062-b497-260d538057e6.gif)

What's wrong with this behavior? From the surface, it is a UI problem: user has to just wait there for not knowing what's to wait for. Go deeper, we will see it is the problem of the health-check logic on Flow start.

The current Flow start healthy check is as follows:
https://github.com/jina-ai/jina/blob/3ba5ec18586671c3b8fd59a1150883607e77100c/jina/flow/base.py#L1048-L1057

Which sequentially checking each Pod's readiness. In our example code, the first pod is a slow-starter, hence the whole for-loop is blocked by the first pod and hence nothing printed on the console.

This can be solved by implementing readiness-check in *a "rotating polling" manner*, which is the essence of this PR.

- a Flow is composed k pods,
- the Flow starts k threads, each checks a pod readiness, 
- another thread to check if all are ready, how many are ready, and to draw spinner on the screen
- when all threads are joined, return to the main thread and print all ready.

The same example now behaves like this under the current PR:

![6aecccc3ee77311726ac59971d152ae0](https://user-images.githubusercontent.com/2041322/133321472-722636ce-de92-480f-be38-b25a65f263f7.gif)

Much better.

As a bonus, I also put `get_public_ip` in a thread so that its time can overlap the time of pod-start. Now the overall Flow start is much smoother and faster! 😄 
