### PR TITLE
chore(pods): Print logs with JinaLogger and add logs for k8s namespace creation

### DIFF
--- a/jina/peapods/pods/k8s.py
+++ b/jina/peapods/pods/k8s.py
@@ -149,7 +149,7 @@ class K8sPod(BasePod):
         kubernetes_tools.create(
             'namespace',
             {'name': self.args.k8s_namespace},
-            logger,
+            logger=logger,
             custom_resource_dir=getattr(self.args, 'k8s_custom_resource_dir', None),
         )
         if self.name == 'gateway':

--- a/jina/peapods/pods/k8s.py
+++ b/jina/peapods/pods/k8s.py
@@ -92,7 +92,8 @@ class K8sPod(BasePod):
             else ('-' + str(deployment_id))
         )
         dns_name = kubernetes_deployment.to_dns_name(name_suffix)
-        init_container_args = kubernetes_deployment.get_init_container_args(self)
+        init_container_args = kubernetes_deployment.get_init_container_args(
+            self)
         uses_metas = kubernetes_deployment.dictionary_to_cli_param(
             {'pea_id': deployment_id}
         )
@@ -119,7 +120,8 @@ class K8sPod(BasePod):
             replicas=replicas,
             pull_policy='IfNotPresent',
             init_container=init_container_args,
-            custom_resource_dir=getattr(self.args, 'k8s_custom_resource_dir', None),
+            custom_resource_dir=getattr(
+                self.args, 'k8s_custom_resource_dir', None),
         )
 
     @staticmethod
@@ -146,25 +148,27 @@ class K8sPod(BasePod):
         logger.info(
             f'🔑\tCreate Namespace {self.args.k8s_namespace} for {self.name} '
         )
-
         kubernetes_tools.create(
             'namespace',
             {'name': self.args.k8s_namespace},
             logger,
-            custom_resource_dir=getattr(self.args, 'k8s_custom_resource_dir', None),
+            custom_resource_dir=getattr(
+                self.args, 'k8s_custom_resource_dir', None),
         )
         if self.name == 'gateway':
             self._deploy_gateway()
         else:
             if self.deployment_args['head_deployment'] is not None:
-                self._deploy_runtime(self.deployment_args['head_deployment'], 1, 'head')
+                self._deploy_runtime(
+                    self.deployment_args['head_deployment'], 1, 'head')
 
             for i in range(self.args.parallel):
                 deployment_args = self.deployment_args['deployments'][i]
                 self._deploy_runtime(deployment_args, self.args.replicas, i)
 
             if self.deployment_args['tail_deployment'] is not None:
-                self._deploy_runtime(self.deployment_args['tail_deployment'], 1, 'tail')
+                self._deploy_runtime(
+                    self.deployment_args['tail_deployment'], 1, 'tail')
         return self
 
     def wait_start_success(self):

--- a/jina/peapods/pods/k8s.py
+++ b/jina/peapods/pods/k8s.py
@@ -142,9 +142,15 @@ class K8sPod(BasePod):
 
         :return: self
         """
+        logger = JinaLogger(f'start_{self.name}')
+        logger.info(
+            f'🔑\tCreate Namespace {self.args.k8s_namespace} for {self.name} '
+        )
+
         kubernetes_tools.create(
             'namespace',
             {'name': self.args.k8s_namespace},
+            logger,
             custom_resource_dir=getattr(self.args, 'k8s_custom_resource_dir', None),
         )
         if self.name == 'gateway':

--- a/jina/peapods/pods/k8s.py
+++ b/jina/peapods/pods/k8s.py
@@ -92,8 +92,7 @@ class K8sPod(BasePod):
             else ('-' + str(deployment_id))
         )
         dns_name = kubernetes_deployment.to_dns_name(name_suffix)
-        init_container_args = kubernetes_deployment.get_init_container_args(
-            self)
+        init_container_args = kubernetes_deployment.get_init_container_args(self)
         uses_metas = kubernetes_deployment.dictionary_to_cli_param(
             {'pea_id': deployment_id}
         )
@@ -120,8 +119,7 @@ class K8sPod(BasePod):
             replicas=replicas,
             pull_policy='IfNotPresent',
             init_container=init_container_args,
-            custom_resource_dir=getattr(
-                self.args, 'k8s_custom_resource_dir', None),
+            custom_resource_dir=getattr(self.args, 'k8s_custom_resource_dir', None),
         )
 
     @staticmethod
@@ -146,29 +144,26 @@ class K8sPod(BasePod):
         """
         logger = JinaLogger(f'start_{self.name}')
         logger.info(
-            f'🔑\tCreate Namespace {self.args.k8s_namespace} for {self.name} '
+            f'🏝️\tCreate Namespace "{self.args.k8s_namespace}" for "{self.name}"'
         )
         kubernetes_tools.create(
             'namespace',
             {'name': self.args.k8s_namespace},
             logger,
-            custom_resource_dir=getattr(
-                self.args, 'k8s_custom_resource_dir', None),
+            custom_resource_dir=getattr(self.args, 'k8s_custom_resource_dir', None),
         )
         if self.name == 'gateway':
             self._deploy_gateway()
         else:
             if self.deployment_args['head_deployment'] is not None:
-                self._deploy_runtime(
-                    self.deployment_args['head_deployment'], 1, 'head')
+                self._deploy_runtime(self.deployment_args['head_deployment'], 1, 'head')
 
             for i in range(self.args.parallel):
                 deployment_args = self.deployment_args['deployments'][i]
                 self._deploy_runtime(deployment_args, self.args.replicas, i)
 
             if self.deployment_args['tail_deployment'] is not None:
-                self._deploy_runtime(
-                    self.deployment_args['tail_deployment'], 1, 'tail')
+                self._deploy_runtime(self.deployment_args['tail_deployment'], 1, 'tail')
         return self
 
     def wait_start_success(self):

--- a/jina/peapods/pods/k8slib/kubernetes_deployment.py
+++ b/jina/peapods/pods/k8slib/kubernetes_deployment.py
@@ -66,6 +66,7 @@ def deploy_service(
             'port_ctrl': port_ctrl,
             'type': 'ClusterIP',
         },
+        logger=logger,
         custom_resource_dir=custom_resource_dir,
     )
 
@@ -94,6 +95,7 @@ def deploy_service(
             'pull_policy': pull_policy,
             **init_container,
         },
+        logger=logger,
         custom_resource_dir=custom_resource_dir,
     )
     return f'{name}.{namespace}.svc.cluster.local'

--- a/jina/peapods/pods/k8slib/kubernetes_tools.py
+++ b/jina/peapods/pods/k8slib/kubernetes_tools.py
@@ -119,7 +119,7 @@ def create(
                     # Kubernetes apiserver, it looks like:
                     # {..."message": "<resource> <name> already exists"...}
                     resp = json.loads(api_exception.body)
-                    logger.warning(f'🔁\t{resp["message"]}')
+                    logger.info(f'🔁\t{resp["message"]}')
                 else:
                     raise e
         except Exception as e2:

--- a/jina/peapods/pods/k8slib/kubernetes_tools.py
+++ b/jina/peapods/pods/k8slib/kubernetes_tools.py
@@ -119,7 +119,7 @@ def create(
                     # Kubernetes apiserver, it looks like:
                     # {..."message": "<resource> <name> already exists"...}
                     resp = json.loads(api_exception.body)
-                    logger.info(f'🔁\t{resp["message"]}')
+                    logger.warning(f'🔁\t{resp["message"]}')
                 else:
                     raise e
         except Exception as e2:

--- a/jina/peapods/pods/k8slib/kubernetes_tools.py
+++ b/jina/peapods/pods/k8slib/kubernetes_tools.py
@@ -2,6 +2,8 @@ import os
 import tempfile
 from typing import Dict, Optional
 
+from jina.logging.logger import JinaLogger
+
 cur_dir = os.path.dirname(__file__)
 DEFAULT_RESOURCE_DIR = os.path.join(
     cur_dir, '..', '..', '..', 'resources', 'k8s', 'template'
@@ -83,7 +85,10 @@ class K8SClients:
 __k8s_clients = K8SClients()
 
 
-def create(template: str, params: Dict, custom_resource_dir: Optional[str] = None):
+def create(template: str, 
+    params: Dict,
+    logger: JinaLogger,
+    custom_resource_dir: Optional[str] = None):
     """Create a resource on Kubernetes based on the `template`. It fills the `template` using the `params`.
 
     :param template: path to the template file.
@@ -104,7 +109,9 @@ def create(template: str, params: Dict, custom_resource_dir: Optional[str] = Non
             utils.create_from_yaml(__k8s_clients.k8s_client, path)
         except FailToCreateError as e:
             if e.api_exceptions[0].status == 409:
-                print('exists already')
+                    logger.info(
+        f'🔁\tThe resource already exists in the kubernetes cluster'
+    )
             else:
                 raise e
         except Exception as e2:

--- a/jina/peapods/pods/k8slib/kubernetes_tools.py
+++ b/jina/peapods/pods/k8slib/kubernetes_tools.py
@@ -1,8 +1,10 @@
 import os
 import tempfile
+import json
 from typing import Dict, Optional
 
 from jina.logging.logger import JinaLogger
+from jina.logging.predefined import default_logger
 
 cur_dir = os.path.dirname(__file__)
 DEFAULT_RESOURCE_DIR = os.path.join(
@@ -85,15 +87,18 @@ class K8SClients:
 __k8s_clients = K8SClients()
 
 
-def create(template: str, 
+def create(
+    template: str,
     params: Dict,
-    logger: JinaLogger,
-    custom_resource_dir: Optional[str] = None):
+    logger: JinaLogger = default_logger,
+    custom_resource_dir: Optional[str] = None,
+):
     """Create a resource on Kubernetes based on the `template`. It fills the `template` using the `params`.
 
     :param template: path to the template file.
     :param custom_resource_dir: Path to a folder containing the kubernetes yml template files.
         Defaults to the standard location jina.resources if not specified.
+    :param logger: logger to use. Defaults to the default logger.
     :param params: dictionary for replacing the placeholders (keys) with the actual values.
     """
 
@@ -108,12 +113,15 @@ def create(template: str,
         try:
             utils.create_from_yaml(__k8s_clients.k8s_client, path)
         except FailToCreateError as e:
-            if e.api_exceptions[0].status == 409:
-                    logger.info(
-        f'🔁\tThe resource already exists in the kubernetes cluster'
-    )
-            else:
-                raise e
+            for api_exception in e.api_exceptions:
+                if api_exception.status == 409:
+                    # The exception's body is the error response from the
+                    # Kubernetes apiserver, it looks like:
+                    # {..."message": "<resource> <name> already exists"...}
+                    resp = json.loads(api_exception.body)
+                    logger.info(f'🔁\t{resp["message"]}')
+                else:
+                    raise e
         except Exception as e2:
             raise e2
     finally:


### PR DESCRIPTION
Before the PR:

```
exists already
    deploy_pod0@95791[I]:🔋     Create Service for "pod0" with image "pod0" pulling from "jinahub/0hnlmu3q:v33-2.1.0"
exists already
    deploy_pod0@95791[I]:🐳     Create Deployment for "jinahub/0hnlmu3q:v33-2.1.0" with replicas 1 and init_container False
exists already
exists already
 deploy_gateway@95791[I]:🔋     Create Service for "gateway" with image "gateway" pulling from "jinaai/jina:master-py38-standard"
exists already
 deploy_gateway@95791[I]:🐳     Create Deployment for "jinaai/jina:master-py38-standard" with replicas 1 and init_container False
exists already
      test-flow@95791[I]:🎉 Kubernetes Flow is ready to use!
      test-flow@95791[I]:
        🔗 Protocol:            HTTP
        🔒 Private network:     10.73.114.107:8080
        💬 Swagger UI:          http://localhost:8080/docs
        📚 Redoc:               http://localhost:8080/redoc
```

The log `exists already` is printed directly to STDOUT. We should use Jinalogger for it.

After the PR:

```
     start_pod0@99324[I]:🔑     Create Namespace test-flow for pod0
     start_pod0@99324[I]:🔁     The resource already exists in the kubernetes cluster
    deploy_pod0@99324[I]:🔋     Create Service for "pod0" with image "pod0" pulling from "jinahub/0hnlmu3q:v33-2.1.0"
    deploy_pod0@99324[I]:🔁     The resource already exists in the kubernetes cluster
    deploy_pod0@99324[I]:🐳     Create Deployment for "jinahub/0hnlmu3q:v33-2.1.0" with replicas 1 and init_container False
    deploy_pod0@99324[I]:🔁     The resource already exists in the kubernetes cluster
  start_gateway@99324[I]:🔑     Create Namespace test-flow for gateway
  start_gateway@99324[I]:🔁     The resource already exists in the kubernetes cluster
 deploy_gateway@99324[I]:🔋     Create Service for "gateway" with image "gateway" pulling from "jinaai/jina:master-py38-standard"
 deploy_gateway@99324[I]:🔁     The resource already exists in the kubernetes cluster
 deploy_gateway@99324[I]:🐳     Create Deployment for "jinaai/jina:master-py38-standard" with replicas 1 and init_container False
 deploy_gateway@99324[I]:🔁     The resource already exists in the kubernetes cluster
      test-flow@99324[I]:🎉 Kubernetes Flow is ready to use!
      test-flow@99324[I]:
        🔗 Protocol:            HTTP
        🔒 Private network:     10.73.114.107:8080
        💬 Swagger UI:          http://localhost:8080/docs
        📚 Redoc:               http://localhost:8080/redoc
```