### PR TITLE
fix(k8s): Do not hard code the FQDN

### DIFF
--- a/jina/peapods/pods/k8s.py
+++ b/jina/peapods/pods/k8s.py
@@ -268,7 +268,7 @@ class K8sPod(BasePod):
         dns_name = kubernetes_deployment.to_dns_name(name)
         return {
             'name': name,
-            'head_host': f'{dns_name}.{self.args.k8s_namespace}.svc.cluster.local',
+            'head_host': f'{dns_name}.{self.args.k8s_namespace}.svc',
             'head_port_in': self.fixed_head_port_in,
             'tail_port_out': self.fixed_tail_port_out,
             'head_zmq_identity': self.head_zmq_identity,

--- a/jina/peapods/pods/k8slib/kubernetes_deployment.py
+++ b/jina/peapods/pods/k8slib/kubernetes_deployment.py
@@ -96,7 +96,7 @@ def deploy_service(
         },
         custom_resource_dir=custom_resource_dir,
     )
-    return f'{name}.{namespace}.svc.cluster.local'
+    return f'{name}.{namespace}.svc'
 
 
 def get_cli_params(arguments: Namespace, skip_list: Tuple[str] = ()) -> str:

--- a/tests/unit/peapods/pods/k8slib/test_kubernetes_deployment.py
+++ b/tests/unit/peapods/pods/k8slib/test_kubernetes_deployment.py
@@ -71,7 +71,7 @@ def test_deploy_service(init_container: Dict, custom_resource: str, monkeypatch)
     else:
         assert deployment_call_args[0] == 'deployment'
 
-    assert service_name == 'test-executor.test-ns.svc.cluster.local'
+    assert service_name == 'test-executor.test-ns.svc'
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/peapods/pods/test_k8s_pod.py
+++ b/tests/unit/peapods/pods/test_k8s_pod.py
@@ -106,12 +106,12 @@ def test_parse_args_custom_executor(parallel: int):
         (
             'gateway',
             '1',
-            [{'name': 'gateway', 'head_host': 'gateway.ns.svc.cluster.local'}],
+            [{'name': 'gateway', 'head_host': 'gateway.ns.svc'}],
         ),
         (
             'test-pod',
             '1',
-            [{'name': 'test-pod', 'head_host': 'test-pod.ns.svc.cluster.local'}],
+            [{'name': 'test-pod', 'head_host': 'test-pod.ns.svc'}],
         ),
         (
             'test-pod',
@@ -119,13 +119,13 @@ def test_parse_args_custom_executor(parallel: int):
             [
                 {
                     'name': 'test-pod_head',
-                    'head_host': 'test-pod-head.ns.svc.cluster.local',
+                    'head_host': 'test-pod-head.ns.svc',
                 },
-                {'name': 'test-pod_0', 'head_host': 'test-pod-0.ns.svc.cluster.local'},
-                {'name': 'test-pod_1', 'head_host': 'test-pod-1.ns.svc.cluster.local'},
+                {'name': 'test-pod_0', 'head_host': 'test-pod-0.ns.svc'},
+                {'name': 'test-pod_1', 'head_host': 'test-pod-1.ns.svc'},
                 {
                     'name': 'test-pod_tail',
-                    'head_host': 'test-pod-tail.ns.svc.cluster.local',
+                    'head_host': 'test-pod-tail.ns.svc',
                 },
             ],
         ),


### PR DESCRIPTION
It is not recommended to hard code service FQDN. 

Ref https://github.com/kubernetes/dns/blob/master/docs/specification.md

The cluster domain can be configured by the CoreDNS/KubeDNS, and it can be run without the FQDN.