### PR TITLE
docs(k8s): fix the wrong namespace in the kubernetes example

### DIFF
--- a/docs/advanced/experimental/kubernetes.md
+++ b/docs/advanced/experimental/kubernetes.md
@@ -39,7 +39,7 @@ The following code deploys a simple `Flow` with just a single `Executor`.
 ```python
 from jina import Flow
 
-f = Flow(name='test-flow', port_expose=8080, infrastructure='K8S', protocol='http').add(
+f = Flow(name='index-flow', port_expose=8080, infrastructure='K8S', protocol='http').add(
     uses='jinahub+docker://CLIPImageEncoder'
 )
 


### PR DESCRIPTION
https://github.com/jina-ai/jina/compare/master...gaocegege:typo?expand=1#diff-2b5818fa7aa948f44308441b2bc44d8c208025cdffbdbb2cc1058bf6febb9669R53

We are using index-flow namespace below, thus here is a typo. This PR is to fix it.