### PR TITLE
docs: first indexer cheat sheet version

### DIFF
--- a/docs/advanced/experimental/index.md
+++ b/docs/advanced/experimental/index.md
@@ -19,4 +19,6 @@ kubernetes
 indexers
 compound-executor
 graph-document
+scaling
+indexers-cheat-sheet
 ```

--- a/docs/advanced/experimental/indexers-cheat-sheet.md
+++ b/docs/advanced/experimental/indexers-cheat-sheet.md
@@ -4,18 +4,18 @@ The [Jina Hub](http://hub.jina.ai) offers multiple Indexers for different use-ca
 In a lot of production use-cases Indexers heavily use {ref}`shards <shards>` and {ref}`replicas <replicas>`.
 There are four major questions that should be answered, when deciding for an Indexer and its configuration.
 
-## Does my data fit into memory?
+### Does my data fit into memory?
 
 Estimated the total number `N` of Documents that you want to index.
 Understand the average size `x` of a Document.
 Does `N * x` fit into memory?
 
-## How many requests per second (RPS) does the system need to handle?
+### How many requests per second (RPS) does the system need to handle?
 
 RPS is typically used for knowing how big to scale distributed systems.
 Depending on your use-case you might have completely different RPS expectations.
 
-## What latency do your users expect?
+### What latency do your users expect?
 
 Latency is typically measured via the p95 or p99 [percentile](https://en.wikipedia.org/wiki/Percentile).
 Meaning, how fast are 95% or 99% percent of the requests answered.
@@ -27,7 +27,7 @@ A webshop might want a really low latency in order to increase user experience.
 A high-quality Q&A chatbot might be OK with having answers only after one or even several seconds.
 ```
 
-## Do you need instant failure recovery?
+### Do you need instant failure recovery?
 
 When running any service in the cloud, an underlying machine could die at any time.
 Usually, a new machine will spawn and take over.

--- a/docs/advanced/experimental/indexers-cheat-sheet.md
+++ b/docs/advanced/experimental/indexers-cheat-sheet.md
@@ -4,6 +4,8 @@ The [Jina Hub](http://hub.jina.ai) offers multiple Indexers for different use-ca
 In a lot of production use-cases Indexers heavily use {ref}`shards <shards>` and {ref}`replicas <replicas>`.
 There are four major questions that should be answered, when deciding for an Indexer and its configuration.
 
+## Questions
+
 ### Does my data fit into memory?
 
 Estimated the total number `N` of Documents that you want to index.

--- a/docs/advanced/experimental/indexers-cheat-sheet.md
+++ b/docs/advanced/experimental/indexers-cheat-sheet.md
@@ -1,0 +1,43 @@
+# Indexers on Jina Hub
+
+The [Jina Hub](hub.jina.ai) offers multiple Indexers for different use-cases.
+There are four major questions that should be answered, when deciding for an Indexer and its configuration.
+In a lot of production use-cases Indexers heavily use {ref}`shards <./scaling/shards>` and {ref}`replicas <./scaling/replicas>`
+
+## Does my data fit into memory?
+
+What is your estimated total number `N` of Documents, that you want to index?
+What is the average size `x` of a Document?
+Does `N * x` fit into memory?
+
+## How many requests per second (RPS) does the system need to handle?
+
+RPS is typically used for knowing how big to scale distributed systems.
+Depending on your use-case you might have completely different RPS expectations.
+
+## What latency do your users expect?
+
+Latency is typically measured via the p95 or p99 [percentile](https://en.wikipedia.org/wiki/Percentile).
+
+```{admonition}
+:class: tip
+
+A webshop might want a really low latency in order to increase user experience.
+A high-quality Q&A chatbot might be OK with having answers only after one or even several seconds.
+```
+
+## Do you need instant failure recovery?
+
+When running any service in the cloud, it might always happen that the underlying machine gets killed.
+Usually, a new machine will spawn and take over.
+Anyhow, this might take some minutes.
+If you need instant failure recovery, you need to use replicas.
+Jina provides this via the [FaissPostgresSearcher](https://hub.jina.ai/executor/nflcyqe2) in combination with {ref}`replicas <./scaling/replicas>` inside {ref}`kubernetes (k8s) <./kubernetes>`.
+
+| Index Size | RPS | Latency p95 | Best Indexer | configuration |
+| --- | --- | --- | --- | --- |
+| fit into memory | < 20 | any | [SimpleIndexer](https://hub.jina.ai/executor/zb38xlt4) | use default |
+| any | > 20 | any | [FaissPostgresSearcher](https://hub.jina.ai/executor/nflcyqe2) | use k8s & [replicas] |
+| not fit into memory | any | any | [FaissPostgresSearcher](https://hub.jina.ai/executor/nflcyqe2) | use shards |
+| not fit into memory | > 20 | any | [FaissPostgresSearcher](https://hub.jina.ai/executor/nflcyqe2) | use k8s & shards & replicas|
+| any | any | small | [FaissPostgresSearcher](https://hub.jina.ai/executor/nflcyqe2) | use k8s & shards & replicas|

--- a/docs/advanced/experimental/indexers-cheat-sheet.md
+++ b/docs/advanced/experimental/indexers-cheat-sheet.md
@@ -1,13 +1,13 @@
-# Indexers on Jina Hub
+# Indexer Cheat Sheet
 
-The [Jina Hub](hub.jina.ai) offers multiple Indexers for different use-cases.
+The [Jina Hub](http://hub.jina.ai) offers multiple Indexers for different use-cases.
+In a lot of production use-cases Indexers heavily use {ref}`shards <shards>` and {ref}`replicas <replicas>`.
 There are four major questions that should be answered, when deciding for an Indexer and its configuration.
-In a lot of production use-cases Indexers heavily use {ref}`shards <./scaling/shards>` and {ref}`replicas <./scaling/replicas>`
 
 ## Does my data fit into memory?
 
-What is your estimated total number `N` of Documents, that you want to index?
-What is the average size `x` of a Document?
+Estimated the total number `N` of Documents that you want to index.
+Understand the average size `x` of a Document.
 Does `N * x` fit into memory?
 
 ## How many requests per second (RPS) does the system need to handle?
@@ -18,8 +18,9 @@ Depending on your use-case you might have completely different RPS expectations.
 ## What latency do your users expect?
 
 Latency is typically measured via the p95 or p99 [percentile](https://en.wikipedia.org/wiki/Percentile).
+Meaning, how fast are 95% or 99% percent of the requests answered.
 
-```{admonition}
+```{admonition} Tip
 :class: tip
 
 A webshop might want a really low latency in order to increase user experience.
@@ -28,16 +29,18 @@ A high-quality Q&A chatbot might be OK with having answers only after one or eve
 
 ## Do you need instant failure recovery?
 
-When running any service in the cloud, it might always happen that the underlying machine gets killed.
+When running any service in the cloud, an underlying machine could die at any time.
 Usually, a new machine will spawn and take over.
 Anyhow, this might take some minutes.
 If you need instant failure recovery, you need to use replicas.
-Jina provides this via the [FaissPostgresSearcher](https://hub.jina.ai/executor/nflcyqe2) in combination with {ref}`replicas <./scaling/replicas>` inside {ref}`kubernetes (k8s) <./kubernetes>`.
+Jina provides this via the [FaissPostgresSearcher](https://hub.jina.ai/executor/nflcyqe2) in combination with {ref}`replicas <replicas>` inside {ref}`kubernetes (k8s) <kubernetes>`.
 
-| Index Size | RPS | Latency p95 | Best Indexer | configuration |
-| --- | --- | --- | --- | --- |
-| fit into memory | < 20 | any | [SimpleIndexer](https://hub.jina.ai/executor/zb38xlt4) | use default |
-| any | > 20 | any | [FaissPostgresSearcher](https://hub.jina.ai/executor/nflcyqe2) | use k8s & [replicas] |
-| not fit into memory | any | any | [FaissPostgresSearcher](https://hub.jina.ai/executor/nflcyqe2) | use shards |
-| not fit into memory | > 20 | any | [FaissPostgresSearcher](https://hub.jina.ai/executor/nflcyqe2) | use k8s & shards & replicas|
-| any | any | small | [FaissPostgresSearcher](https://hub.jina.ai/executor/nflcyqe2) | use k8s & shards & replicas|
+## Cheat Sheet
+
+| Index Size | RPS | Latency p95 | Best Indexer + configuration |
+| --- | --- | --- | --- |
+| fit into memory | < 20 | any | [SimpleIndexer](https://hub.jina.ai/executor/zb38xlt4) + use default |
+| any | > 20 | any | [FaissPostgresSearcher](https://hub.jina.ai/executor/nflcyqe2) + use k8s & replicas |
+| not fit into memory | any | any | [FaissPostgresSearcher](https://hub.jina.ai/executor/nflcyqe2) + use shards |
+| not fit into memory | > 20 | any | [FaissPostgresSearcher](https://hub.jina.ai/executor/nflcyqe2) + use k8s & shards & replicas|
+| any | any | small | [FaissPostgresSearcher](https://hub.jina.ai/executor/nflcyqe2) + use k8s & shards & replicas|

--- a/docs/advanced/experimental/indexers.md
+++ b/docs/advanced/experimental/indexers.md
@@ -60,6 +60,7 @@ For a showcase code, check our [integration tests](https://github.com/jina-ai/ex
 
 The split between indexing and search Flows allows you to continuously serve requests in your application (in the search Flow), while still being able to write or modify the underlying data. Then when you want to update the state of the searchable data for your users, you perform a dump and rolling update.
 
+(dump-rolling-update)=
 ## Dump and rolling update
 
 The communication between index and search Flows is done via this pair of actions.

--- a/docs/advanced/experimental/indexers.md
+++ b/docs/advanced/experimental/indexers.md
@@ -39,7 +39,7 @@ Besides, there are two types of special indexer,
 
 ```
 
-## Indexing vs searching operations
+## Indexing vs Searching Operations
 
 The recommended usage of these Executors is to split them into Indexing vs Search Flows.
 In the Indexing Flow, you perform write, update, and delete. 
@@ -61,7 +61,7 @@ For a showcase code, check our [integration tests](https://github.com/jina-ai/ex
 The split between indexing and search Flows allows you to continuously serve requests in your application (in the search Flow), while still being able to write or modify the underlying data. Then when you want to update the state of the searchable data for your users, you perform a dump and rolling update.
 
 (dump-rolling-restart)=
-## Dump and rolling update
+## Dump and Rolling Update
 
 The communication between index and search Flows is done via this pair of actions.
 The **dump** action tells the indexer to export its internal data (from whatever format it stores it in) to a disk location, optimized to be read by the shards in your search Flow.

--- a/docs/advanced/experimental/indexers.md
+++ b/docs/advanced/experimental/indexers.md
@@ -60,7 +60,7 @@ For a showcase code, check our [integration tests](https://github.com/jina-ai/ex
 
 The split between indexing and search Flows allows you to continuously serve requests in your application (in the search Flow), while still being able to write or modify the underlying data. Then when you want to update the state of the searchable data for your users, you perform a dump and rolling update.
 
-(dump-rolling-update)=
+(dump-rolling-restart)=
 ## Dump and rolling update
 
 The communication between index and search Flows is done via this pair of actions.

--- a/docs/advanced/experimental/kubernetes.md
+++ b/docs/advanced/experimental/kubernetes.md
@@ -1,3 +1,4 @@
+(kubernetes)=
 # Jina on Kubernetes
 
 Jina natively supports Kubernetes and you can use it via Flow API.

--- a/docs/advanced/experimental/scaling.md
+++ b/docs/advanced/experimental/scaling.md
@@ -1,0 +1,60 @@
+# Scaling Executors in kubernetes
+
+In Jina we support to ways of scaling:
+- *Replicas* can be used with any Executor type.
+- *Shards* should only be used with Indexers, since they store a state.
+
+```{admonition} Important
+:class: important
+This page describes Jinas behavior with kubernetes deployment for now.
+When using `shards` and `replicas` without kubernetes, Jina will behave slightly different.
+It is discouraged to use the `parallel` argument, when deploying to kubernetes.
+```
+
+(replicas)=
+## Replicas
+
+Replication (or horizontal scaling) means duplicating an Executor and its state.
+It allows more requests to be served in parallel.
+A single request to Jina is only send to one of the replicas.
+Furthermore, it increases the failure tolerance.
+When one replica dies, another will immediately take over.
+In a cloud environment any machine might die at any point in time.
+Thus, using replicas is important for reliable services.
+Replicas are currently only supported, when deploying Jina with kubernetes.
+
+```python Usage
+from jina import Flow
+
+f = Flow().add(name='ExecutorWithReplicas', replicas=3)
+```
+
+(shards)=
+## Shards
+
+Sharding means splitting the content of an Indexer into several parts.
+These parts are then put on different machines.
+This is helpful, in two situations:
+
+- When the full data does not fit onto one machine.
+- When the latency of a single request becomes to slow.
+  Then two machines can compute the result faster.
+
+When you shard your index, the request handling usually differes for index and search requests:
+
+- Index (and update, delete) will just be handled by a single shard.
+- Search requests are handled by all shards.
+
+```python Usage
+from jina import Flow
+
+f = Flow().add(name='ExecutorWithShards', shards=3)
+```
+
+## Combining Replicas & Shards
+
+Combining both gives all above mentioned advantages.
+When deploying to kubernetes, Jina replicates is applied on each single shard.
+Thus, shards can scale independently.
+The data syncronisation across replicas must be handled by the respective Indexer.
+For more detailed see {doc}`Dump and rolling update <./indexers/dump-rolling-update>`.

--- a/docs/advanced/experimental/scaling.md
+++ b/docs/advanced/experimental/scaling.md
@@ -1,4 +1,4 @@
-# Scaling Executors in kubernetes
+# Scaling Executors in Kubernetes
 
 In Jina we support two ways of scaling:
 - **Replicas** can be used with any Executor type.
@@ -52,7 +52,7 @@ index_flow = Flow().add(name='ExecutorWithShards', shards=3, polling='any')
 search_flow = Flow().add(name='ExecutorWithShards', shards=3, polling='all', uses_after='MatchMerger')
 ```
 
-### Merging search results via `uses_after`
+### Merging Search Results Via `uses_after`
 
 Each shard of a search Flow returns one set of results for each query Document.
 A merger Executor combines them afterwards.


### PR DESCRIPTION
First draft for indexer cheat sheet. 

- I have not included graphics for shards & replicas, since the graphics we generate via `.plot()` are not in sync with what is actually deployed in k8s.
- links might be broken. have to play around to see how to make them work. Will fix this.

picture of the table itself, since we don't pre-build the docs:

![image](https://user-images.githubusercontent.com/4920275/134122209-82b3185b-dcd6-4434-be06-5fb8c80be864.png)
