### PR TITLE
ci(docs): deploy docs from any branch

### DIFF
--- a/.github/workflows/docs-netlify.yml
+++ b/.github/workflows/docs-netlify.yml
@@ -1,0 +1,44 @@
+name: Deploy docs to Netlify
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        required: true
+        description: 'Branch name'
+
+jobs:
+  deploy:
+    name: Deploy to Netlify
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo "BRANCH_NAME=${{ github.event.inputs.branch }}" >> $GITHUB_ENV
+      - uses: actions/checkout@v2
+        with:
+          repository: jina-ai/jina
+          ref: ${{ env.BRANCH_NAME }}
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+      - run: |
+          npm i -g netlify-cli
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          bash makedoc.sh
+          netlify deploy --dir=_build/dirhtml --alias=${{ env.BRANCH_NAME }} --message="Deploying docs to ${{ env.BRANCH_NAME }} branch"
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+        working-directory: docs
+      - name: Status check
+        uses: Sibz/github-status-action@v1.1.1
+        with:
+          authToken: ${{ secrets.GITHUB_TOKEN }}
+          context: Netlify preview
+          state: success
+          target_url: https://${{ env.BRANCH_NAME }}--jina-docs.netlify.app
+          


### PR DESCRIPTION
Used the [same workflow](https://github.com/deepankarm/jina/runs/3664811034?check_suite_focus=true) in my fork to deploy from the [feat-windows-beta](https://github.com/jina-ai/jina/pull/3290) branch - https://feat-windows-beta--jina-docs.netlify.app/

We can probably enable this workflow for all PRs with label `area/docs` 