### PR TITLE
feat: sort top_k and return top_k Document from DocumentArray

### DIFF
--- a/jina/types/arrays/document.py
+++ b/jina/types/arrays/document.py
@@ -375,14 +375,19 @@ class DocumentArray(
             hi_idx -= 1
         self._update_id_to_index_map()
 
-    def sort(self, key=None, *args, **kwargs):
+    def sort(self, key=None, top_k: int = None, *args, **kwargs):
         """
         Sort the items of the :class:`DocumentArray` in place.
 
         :param key: key callable to sort based upon
+        :param top_k: sort only upto top_k Document from DocumentArray
         :param args: variable set of arguments to pass to the sorting underlying function
         :param kwargs: keyword arguments to pass to the sorting underlying function
         """
+        # Only for DocumentArray
+        if isinstance(self._pb_body, list):
+            self._pb_body = self._pb_body[:top_k]
+
         if key:
 
             def overriden_key(proto):

--- a/tests/unit/types/arrays/test_documentarray.py
+++ b/tests/unit/types/arrays/test_documentarray.py
@@ -320,6 +320,18 @@ def test_da_sort_by_document_interface_not_in_proto():
     assert da[0].embedding.shape == (1,)
 
 
+def test_da_sort_by_document_interface_not_in_proto_topk():
+    docs = [Document(embedding=np.array([1] * (10 - i))) for i in range(10)]
+    da = DocumentArray(
+        [docs[i] if (i % 2 == 0) else docs[i].proto for i in range(len(docs))]
+    )
+    assert len(da) == 10
+    assert da[0].embedding.shape == (10,)
+
+    da.sort(key=lambda d: d.embedding.shape[0], top_k=2)
+    assert da[0].embedding.shape == (9,)
+
+
 def test_da_sort_by_document_interface_in_proto():
     docs = [Document(embedding=np.array([1] * (10 - i))) for i in range(10)]
     da = DocumentArray(
@@ -330,6 +342,18 @@ def test_da_sort_by_document_interface_in_proto():
 
     da.sort(key=lambda d: d.embedding.dense.shape[0])
     assert da[0].embedding.shape == (1,)
+
+
+def test_da_sort_by_document_interface_in_proto_topk():
+    docs = [Document(embedding=np.array([1] * (10 - i))) for i in range(10)]
+    da = DocumentArray(
+        [docs[i] if (i % 2 == 0) else docs[i].proto for i in range(len(docs))]
+    )
+    assert len(da) == 10
+    assert da[0].embedding.shape == (10,)
+
+    da.sort(key=lambda d: d.embedding.dense.shape[0], top_k=2)
+    assert da[0].embedding.shape == (9,)
 
 
 def test_da_reverse():


### PR DESCRIPTION
This PR resolves #3467

## Resolution:
- Sort top_k and return top_k `Document` from `DocumentArray`
- added unit test