### PR TITLE
perf(daemon): reload files across flows/executors

### DIFF
--- a/daemon/api/endpoints/peas.py
+++ b/daemon/api/endpoints/peas.py
@@ -62,7 +62,7 @@ async def _delete(id: DaemonID, workspace: bool = False):
     try:
         await store.delete(id=id, workspace=workspace)
     except KeyError:
-        raise HTTPException(status_code=404, detail=f'{id} not found in {store!r}')
+        raise HTTPException(status_code=404, detail=f'{id} not found in store')
 
 
 @router.get(

--- a/daemon/api/endpoints/pods.py
+++ b/daemon/api/endpoints/pods.py
@@ -70,7 +70,7 @@ async def _delete(id: DaemonID, workspace: bool = False):
     try:
         await store.delete(id=id, workspace=workspace)
     except KeyError:
-        raise HTTPException(status_code=404, detail=f'{id} not found in {store!r}')
+        raise HTTPException(status_code=404, detail=f'{id} not found in store')
 
 
 @router.get(
@@ -80,4 +80,4 @@ async def _status(id: DaemonID):
     try:
         return store[id]
     except KeyError:
-        raise HTTPException(status_code=404, detail=f'{id} not found in {store!r}')
+        raise HTTPException(status_code=404, detail=f'{id} not found in store')

--- a/daemon/api/endpoints/workspaces.py
+++ b/daemon/api/endpoints/workspaces.py
@@ -45,10 +45,10 @@ async def _delete(
             everything=everything,
         )
     except KeyError:
-        raise HTTPException(status_code=404, detail=f'{id} not found in {store!r}')
+        raise HTTPException(status_code=404, detail=f'{id} not found in store')
     except ValueError:
         raise HTTPException(
-            status_code=404, detail=f'There is no container to kill in {store!r}'
+            status_code=404, detail=f'There is no container to kill in store'
         )
 
 

--- a/daemon/clients/workspaces.py
+++ b/daemon/clients/workspaces.py
@@ -309,7 +309,7 @@ class AsyncWorkspaceClient(AsyncBaseClient):
             response_json = await response.json()
             if response.status != HTTPStatus.OK:
                 self._logger.error(
-                    f'deletion of {self._kind.title()} {id} failed: {error_msg_from(response_json)}'
+                    f'deletion of {self._kind.title()} failed as {error_msg_from(response_json)}'
                 )
             return response.status == HTTPStatus.OK
 

--- a/daemon/helper.py
+++ b/daemon/helper.py
@@ -99,15 +99,18 @@ def error_msg_from(response: Dict) -> str:
     :param response: dict response
     :return: prettified response string
     """
-    if 'detail' not in response or 'body' not in response:
+    if 'detail' not in response and 'body' not in response:
         return response
     if response['detail'] == PartialDaemon400Exception.__name__:
         return response['body']
-    return (
-        '\n'.join(j for j in response['body'])
-        if isinstance(response['body'], List)
-        else response['body']
-    )
+    if 'body' in response:
+        return (
+            '\n'.join(j for j in response['body'])
+            if isinstance(response['body'], List)
+            else response['body']
+        )
+    else:
+        return response['detail']
 
 
 @contextmanager

--- a/daemon/stores/partial.py
+++ b/daemon/stores/partial.py
@@ -109,6 +109,9 @@ class PartialFlowStore(PartialStore):
             self.object: Flow = Flow.load_config(yaml_source).build()
             self.object.workspace_id = jinad_args.workspace_id
             self.object.workspace = __partial_workspace__
+            self.object.env = {'HOME': __partial_workspace__}
+            # TODO(Deepankar): pass envs from main daemon process to partial-daemon so that
+            # Pods/Peas/Runtimes/Executors can inherit these env vars
 
             for pod in self.object._pod_nodes.values():
                 runtime_cls = update_runtime_cls(pod.args, copy=True).runtime_cls

--- a/jina/flow/base.py
+++ b/jina/flow/base.py
@@ -1586,6 +1586,10 @@ class Flow(PostMixin, JAMLCompatible, ExitStack, metaclass=FlowType):
 
     @workspace.setter
     def workspace(self, value: str):
+        """set workspace dir for flow & all pods
+
+        :param value: workspace to be set
+        """
         self.args.workspace = value
         for k, p in self:
             p.args.workspace = value
@@ -1626,6 +1630,25 @@ class Flow(PostMixin, JAMLCompatible, ExitStack, metaclass=FlowType):
                     if v and isinstance(v, List):
                         for i in v:
                             i.workspace_id = value
+
+    @property
+    def env(self) -> Optional[Dict]:
+        """Get all envs to be set in the Flow
+
+        :return: envs as dict
+        """
+        return self.args.env
+
+    @env.setter
+    def env(self, value: Dict[str, str]):
+        """set env vars for flow & all pods.
+        This can be used by jinad to set envs for Flow and all child objects
+
+        :param value: value to be set
+        """
+        self.args.env = value
+        for k, v in self:
+            v.args.env = value
 
     @property
     def identity(self) -> Dict[str, str]:

--- a/jina/peapods/runtimes/jinad/__init__.py
+++ b/jina/peapods/runtimes/jinad/__init__.py
@@ -2,7 +2,7 @@ import os
 import copy
 import asyncio
 import argparse
-from typing import Union
+from typing import TYPE_CHECKING, Union
 
 from ....enums import SocketType
 
@@ -17,7 +17,7 @@ from ....excepts import (
     DaemonWorkspaceCreationFailed,
 )
 
-if False:
+if TYPE_CHECKING:
     import multiprocessing
     import threading
     from ....logging.logger import JinaLogger
@@ -98,8 +98,9 @@ class JinadRuntime(AsyncNewLoopRuntime):
         """Cancels the logstream task, removes the remote Pea & Workspace"""
         self.logstream.cancel()
         await self.client.peas.delete(id=self.pea_id)
-        # NOTE: don't fail if workspace deletion fails here
-        await self.client.workspaces.delete(id=self.workspace_id)
+        # Don't delete workspace here, as other Executors might use them.
+        # TODO(Deepankar): probably enable an arg here?
+        # await self.client.workspaces.delete(id=self.workspace_id)
 
     async def _sleep_forever(self):
         """Sleep forever, no prince will come."""

--- a/tests/distributed/test_topologies/test_topologies.py
+++ b/tests/distributed/test_topologies/test_topologies.py
@@ -189,7 +189,7 @@ def test_remote_flow_local_executors(mocker, parallel):
 
 
 def test_remote_workspace_value():
-    HOST = __default_host__  # '3.208.18.63'
+    HOST = __default_host__
     client = JinaDClient(host=HOST, port=8000)
     workspace_id = client.workspaces.create(paths=[os.path.join(cur_dir, 'yamls')])
     flow_id = client.flows.create(

--- a/tests/distributed/test_workspaces/cache_validator.py
+++ b/tests/distributed/test_workspaces/cache_validator.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+import requests as py_req
+from jina import Executor, requests, DocumentArray
+
+
+class CacheValidator(Executor):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.exists = False
+        self.cache_path = Path.home() / '.company' / 'model.blah'
+        if not self.cache_path.exists():
+            self.cache_path.parent.mkdir(parents=True, exist_ok=True)
+            response = py_req.get('https://jina.ai')
+            with open(self.cache_path, 'w') as f:
+                f.write(response.text)
+        else:
+            self.exists = True
+
+    @requests
+    def foo(self, docs: DocumentArray, *args, **kwargs):
+        docs[0].tags['exists'] = self.exists

--- a/tests/distributed/test_workspaces/flow_cache_validator.yml
+++ b/tests/distributed/test_workspaces/flow_cache_validator.yml
@@ -1,0 +1,7 @@
+jtype: Flow
+version: 1
+with:
+  port_expose: 9000
+executors:
+  - uses: CacheValidator
+    py_module: cache_validator.py

--- a/tests/distributed/test_workspaces/test_cache_validate.py
+++ b/tests/distributed/test_workspaces/test_cache_validate.py
@@ -1,0 +1,90 @@
+import os
+from contextlib import contextmanager
+
+from daemon.clients import JinaDClient
+from jina.types.request import Response
+from jina.helper import random_identity
+from jina import Document, Client, __default_host__, Flow
+
+cur_dir = os.path.dirname(os.path.abspath(__file__))
+HOST = __default_host__
+client = JinaDClient(host=HOST, port=8000)
+
+
+@contextmanager
+def RemoteFlow(workspace_id) -> Response:
+    flow_id = client.flows.create(
+        workspace_id=workspace_id, filename='flow_cache_validator.yml'
+    )
+    args = client.flows.get(flow_id)['arguments']['object']['arguments']
+    yield Client(host=HOST, port=args['port_expose'], protocol=args['protocol']).post(
+        on='/', inputs=[Document()], show_progress=True, return_results=True
+    )
+    assert client.flows.delete(flow_id)
+
+
+def test_cache_validate_remote_flow():
+    """
+    This test validates that files (e.g.- pre-trained model) downloaded in an Executor
+    in a remote Flow should be available to be accessed during the 2nd time an
+    Executor/Flow tries accessing it.
+    """
+    workspace_id = client.workspaces.create(
+        paths=[
+            os.path.join(cur_dir, 'cache_validator.py'),
+            os.path.join(cur_dir, 'flow_cache_validator.yml'),
+        ]
+    )
+
+    with RemoteFlow(workspace_id) as response:
+        # 1st Flow in remote workspace should download the file.
+        # hence `exists` should be False
+        assert not response[0].data.docs[0].tags['exists']
+
+    with RemoteFlow(workspace_id) as response:
+        # 2nd Flow in remote workspace should be able to access the file.
+        # hence `exists` should be True.
+        assert response[0].data.docs[0].tags['exists']
+
+    new_workspace_id = client.workspaces.create(
+        paths=[
+            os.path.join(cur_dir, 'cache_validator.py'),
+            os.path.join(cur_dir, 'flow_cache_validator.yml'),
+        ]
+    )
+
+    with RemoteFlow(new_workspace_id) as response:
+        # 1st Flow in a new workspace shouldn't be able to access the file.
+        # hence `exists` should be False
+        assert not response[0].data.docs[0].tags['exists']
+
+
+def test_cache_validate_remote_executor():
+    from .cache_validator import CacheValidator
+
+    workspace_id = random_identity()
+    # 1st Executor in remote workspace should download the file.
+    f = Flow().add(
+        uses=CacheValidator,
+        host='localhost:8000',
+        py_modules=[os.path.join(cur_dir, 'cache_validator.py')],
+        workspace_id=workspace_id,
+    )
+    with f:
+        response = f.post(
+            on='/', inputs=[Document()], show_progress=True, return_results=True
+        )
+        assert not response[0].data.docs[0].tags['exists']
+
+    # 2nd Executor in remote workspace should be able to access the file.
+    f = Flow().add(
+        uses=CacheValidator,
+        host='localhost:8000',
+        py_modules=[os.path.join(cur_dir, 'cache_validator.py')],
+        workspace_id=workspace_id,
+    )
+    with f:
+        response = f.post(
+            on='/', inputs=[Document()], show_progress=True, return_results=True
+        )
+        assert response[0].data.docs[0].tags['exists']


### PR DESCRIPTION
If a remote `Executor` downloads a pre-trained model, we want to make sure, during the next run the Executor can reload from the previously downloaded model (from disk). This can be done by reusing the previous workspace. This PR adds tests to show how it can be used & fixes few bugs related to the same. 