### PR TITLE
feat(daemon): custom dockerfile

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -142,7 +142,7 @@ jobs:
     needs: prep-testbed
     runs-on: ubuntu-latest
     env:
-      JINA_DAEMON_BUILD: DEVEL
+      JINA_DAEMON_DOCKERFILE: DEVEL
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,7 +240,7 @@ jobs:
     needs: prep-testbed
     runs-on: ubuntu-latest
     env:
-      JINA_DAEMON_BUILD: DEVEL
+      JINA_DAEMON_DOCKERFILE: DEVEL
     strategy:
       fail-fast: false
       matrix:

--- a/daemon/Dockerfiles/default.Dockerfile
+++ b/daemon/Dockerfiles/default.Dockerfile
@@ -8,11 +8,10 @@ FROM jinaai/jina:$JINA_VERSION-$PY_VERSION-daemon
 ARG PIP_REQUIREMENTS
 
 RUN if [ -n "$PIP_REQUIREMENTS" ]; then \
-        echo "Installing ${PIP_REQUIREMENTS}"; \
-        for package in ${PIP_REQUIREMENTS}; do \
-            pip install "${package}"; \
-        done; \
+    echo "Installing ${PIP_REQUIREMENTS}"; \
+    for package in ${PIP_REQUIREMENTS}; do \
+    pip install "${package}"; \
+    done; \
     fi
 
 STOPSIGNAL SIGINT
-WORKDIR /workspace

--- a/daemon/Dockerfiles/devel.Dockerfile
+++ b/daemon/Dockerfiles/devel.Dockerfile
@@ -7,10 +7,8 @@ FROM jinaai/jina:$LOCALTAG-daemon
 ARG PIP_REQUIREMENTS
 
 RUN if [ -n "$PIP_REQUIREMENTS" ]; then \
-        echo "Installing ${PIP_REQUIREMENTS}"; \
-        for package in ${PIP_REQUIREMENTS}; do \
-            pip install "${package}"; \
-        done; \
-    fi
-
-WORKDIR /workspace
+	echo "Installing ${PIP_REQUIREMENTS}"; \
+	for package in ${PIP_REQUIREMENTS}; do \
+	pip install "${package}"; \
+	done; \
+	fi

--- a/daemon/clients/workspaces.py
+++ b/daemon/clients/workspaces.py
@@ -64,13 +64,10 @@ class AsyncWorkspaceClient(AsyncBaseClient):
         for path in paths:
             try:
                 _path = Path(path)
-                if complete:
+                if _path.is_file():
                     add_field_from(_path)
-                else:
-                    if _path.is_file():
-                        add_field_from(_path)
-                    elif _path.is_dir():
-                        [add_field_from(p) for p in _path.rglob('*') if p.is_file()]
+                elif _path.is_dir():
+                    [add_field_from(p) for p in _path.rglob('*') if p.is_file()]
             except TypeError:
                 self._logger.error(f'invalid path {path}')
                 continue

--- a/daemon/dockerize.py
+++ b/daemon/dockerize.py
@@ -247,7 +247,6 @@ class Dockerizer:
                 entrypoint=entrypoint,
                 working_dir=__partial_workspace__,
                 extra_hosts={__docker_host__: 'host-gateway'},
-                device_requests=ContainerRuntime._get_gpu_device_requests('all'),
             )
         except docker.errors.NotFound as e:
             cls.logger.critical(

--- a/daemon/dockerize.py
+++ b/daemon/dockerize.py
@@ -193,7 +193,6 @@ class Dockerizer:
         return cls.run(
             workspace_id=workspace_id,
             container_id=workspace_id,
-            command=None,
             ports={f'{port}/tcp': port for port in daemon_file.ports},
             entrypoint=daemon_file.run,
         )
@@ -203,10 +202,9 @@ class Dockerizer:
         cls,
         workspace_id: DaemonID,
         container_id: DaemonID,
-        command: str,
+        entrypoint: str,
         ports: Dict,
         envs: Dict = {},
-        entrypoint: Optional[str] = None,
     ) -> Tuple['Container', str, Dict]:
         """
         Runs a container using an existing image (tagged with `workspace_id`).
@@ -215,7 +213,6 @@ class Dockerizer:
             This uses the default entrypoint (mini-jinad) & appends `command` for execution.
         :param workspace_id: workspace id
         :param container_id: name of the container
-        :param command: command to be appended to default entrypoint
         :param ports: ports to be mapped with local
         :param envs: dict of env vars to be set in the container
         :param entrypoint: custom entrypoint
@@ -246,8 +243,8 @@ class Dockerizer:
                 network=network,
                 ports=ports,
                 detach=True,
-                command=command,
                 entrypoint=entrypoint,
+                working_dir=__partial_workspace__,
                 extra_hosts={__docker_host__: 'host-gateway'},
             )
         except docker.errors.NotFound as e:

--- a/daemon/dockerize.py
+++ b/daemon/dockerize.py
@@ -9,6 +9,7 @@ import docker
 from jina import __docker_host__
 from jina.helper import colored
 from jina.logging.logger import JinaLogger
+from jina.peapods.runtimes.container import ContainerRuntime
 from . import (
     jinad_args,
     __root_workspace__,
@@ -246,6 +247,7 @@ class Dockerizer:
                 entrypoint=entrypoint,
                 working_dir=__partial_workspace__,
                 extra_hosts={__docker_host__: 'host-gateway'},
+                device_requests=ContainerRuntime._get_gpu_device_requests('all'),
             )
         except docker.errors.NotFound as e:
             cls.logger.critical(

--- a/daemon/files.py
+++ b/daemon/files.py
@@ -86,7 +86,7 @@ class DaemonFile:
     def dockerfile(self, value: Union[DaemonDockerfile, str]):
         """Property setter for dockerfile
 
-        :param dockerfile: allowed values in DaemonDockerfile
+        :param value: allowed values in DaemonDockerfile
         """
         try:
             self._dockerfile = os.path.join(

--- a/daemon/files.py
+++ b/daemon/files.py
@@ -1,21 +1,21 @@
-import glob
 import os
+import re
 from itertools import chain
 from pathlib import Path
-from typing import Dict, List
+from typing import Dict, List, Union
 
 from fastapi import UploadFile
 
-from jina.helper import cached_property
 from jina.logging.logger import JinaLogger
+from jina.excepts import DaemonInvalidDockerfile
 from . import __rootdir__, __dockerfiles__, jinad_args
 from .helper import get_workspace_path
 from .models import DaemonID
-from .models.enums import DaemonBuild, PythonVersion
+from .models.enums import DaemonDockerfile, PythonVersion
 
 
-def workspace_files(
-    workspace_id: DaemonID, files: List[UploadFile], logger: 'JinaLogger'
+def store_files_in_workspace(
+    workspace_id: DaemonID, files: List[UploadFile], logger: "JinaLogger"
 ) -> None:
     """Store the uploaded files in local disk
 
@@ -31,9 +31,6 @@ def workspace_files(
     for f in files:
         dest = os.path.join(workdir, f.filename)
         if os.path.isfile(dest):
-            if f.filename == 'requirements.txt':
-                _merge_requirement_file(dest, f)
-                continue
             logger.warning(
                 f'file {f.filename} already exists in workspace {workspace_id}, will be replaced'
             )
@@ -43,33 +40,13 @@ def workspace_files(
         logger.debug(f'saved uploads to {dest}')
 
 
-def _merge_requirement_file(dest: str, f: UploadFile) -> None:
-    """Merge requirement files
+def is_requirements_txt(filename) -> bool:
+    """Check if filename is of requirements.txt format
 
-    :param dest: existing requirements file location
-    :param f: file obj for the new requirements file
+    :param filename: filename
+    :return: True if filename is in requirements.txt format
     """
-    # Open existing requirements in binary mode
-    # UploadFile is also in binary mode
-    with open(dest, "rb") as existing_requirements_file:
-        old_requirements = _read_requirements_file(existing_requirements_file)
-    old_requirements.update(_read_requirements_file(f.file))
-    # Store merged requirements
-    with open(dest, "w") as req_file:
-        req_file.write("\n".join(list(old_requirements.values())))
-
-
-def _read_requirements_file(f) -> Dict:
-    """Read requirement.txt file
-
-    :param f: req file object
-    :return: dict representing pip requirements
-    """
-    requirements = {}
-    for line in f.readlines():
-        line = line.decode()
-        requirements[line.split('=')[0]] = line.replace("\n", "")
-    return requirements
+    return True if re.match(r'.*requirements.*\.txt$', filename) else False
 
 
 class DaemonFile:
@@ -87,7 +64,10 @@ class DaemonFile:
         self._logger.debug(
             f'analysing {self.extension} files in workdir: {self._workdir}'
         )
-        self._build = DaemonBuild.default
+        self._build = DaemonDockerfile.default
+        self._dockerfile = os.path.join(
+            __dockerfiles__, f'{DaemonDockerfile.default}.Dockerfile'
+        )
         self._python = PythonVersion.default
         self._jina = 'master'
         self._run = ''
@@ -95,26 +75,36 @@ class DaemonFile:
         self.process_file()
 
     @property
-    def build(self) -> str:
-        """Property representing build value
+    def dockerfile(self) -> str:
+        """Property representing dockerfile value
 
-        :return: daemon build in the daemonfile
+        :return: daemon dockerfile in the daemonfile
         """
-        return self._build
+        return self._dockerfile
 
-    @build.setter
-    def build(self, build: DaemonBuild):
-        """Property setter for build
+    @dockerfile.setter
+    def dockerfile(self, value: Union[DaemonDockerfile, str]):
+        """Property setter for dockerfile
 
-        :param build: allowed values in DaemonBuild
+        :param dockerfile: allowed values in DaemonDockerfile
         """
         try:
-            self._build = DaemonBuild(build)
-        except ValueError:
-            self._logger.warning(
-                f'invalid value `{build}` passed for \'build\'. allowed values: {DaemonBuild.values}. '
-                f'picking default build: {self._build}'
+            self._dockerfile = os.path.join(
+                __dockerfiles__, f'{DaemonDockerfile(value).value}.Dockerfile'
             )
+            self._build = DaemonDockerfile(value)
+        except ValueError:
+            self._logger.debug(
+                f'value passed for `dockerfile` not in default list of values: {DaemonDockerfile.values}.'
+            )
+            if os.path.isfile(os.path.join(self._workdir, value)):
+                self._dockerfile = os.path.join(self._workdir, value)
+                self._build = DaemonDockerfile.OTHERS
+            else:
+                self._logger.critical(
+                    f'unable to find dockerfile passed at {value}, cannot proceed with the build'
+                )
+                raise DaemonInvalidDockerfile()
 
     @property
     def python(self):
@@ -188,38 +178,33 @@ class DaemonFile:
         except ValueError:
             self._logger.warning(f'invalid value `{ports}` passed for \'ports\'')
 
-    @cached_property
+    @property
     def requirements(self) -> str:
         """pip packages mentioned in requirements.txt
 
         :return: space separated values
         """
-        # TODO: merge this with _read_requirements_file()
-        _req = f'{self._workdir}/requirements.txt'
-        if not Path(_req).is_file():
+        requirements = ''
+        for filename in os.listdir(self._workdir):
+            if is_requirements_txt(filename):
+                with open(os.path.join(self._workdir, filename)) as f:
+                    requirements += ' '.join(f.read().splitlines())
+        if not requirements:
             self._logger.warning(
                 'please add a requirements.txt file to manage python dependencies in the workspace'
             )
             return ''
-        with open(_req) as f:
-            return ' '.join(f.read().splitlines())
+        else:
+            return requirements
 
-    @cached_property
+    @property
     def dockercontext(self) -> str:
         """directory for docker context during docker build
 
         :return: docker context directory"""
-        return __rootdir__ if self.build == DaemonBuild.DEVEL else self._workdir
+        return __rootdir__ if self._build == DaemonDockerfile.DEVEL else self._workdir
 
-    @cached_property
-    def dockerfile(self) -> str:
-        """location of dockerfile
-
-        :return: location of dockerfile in local directory
-        """
-        return f'{__dockerfiles__}/{self.build.value}.Dockerfile'
-
-    @cached_property
+    @property
     def dockerargs(self) -> Dict:
         """dict of args to be passed during docker build
 
@@ -233,7 +218,7 @@ class DaemonFile:
         """
         return (
             {'PIP_REQUIREMENTS': self.requirements}
-            if self.build == DaemonBuild.DEVEL
+            if self._build == DaemonDockerfile.DEVEL
             else {
                 'PIP_REQUIREMENTS': self.requirements,
                 'PY_VERSION': self.python.name.lower(),
@@ -264,14 +249,14 @@ class DaemonFile:
         with open(file) as fp:
             config.read_file(chain([f'[{DEFAULTSECT}]'], fp))
             params = dict(config.items(DEFAULTSECT))
-        self.build = params.get('build')
+        self.dockerfile = params.get('dockerfile', DaemonDockerfile.default)
         self.python = params.get('python')
         self.run = params.get('run', '').strip()
         self.ports = params.get('ports', '')
 
     def __repr__(self) -> str:
         return (
-            f'DaemonFile(build={self.build}, python={self.python}, jina={self.jinav}, '
+            f'DaemonFile(dockerfile={self.dockerfile}, python={self.python}, jina={self.jinav}, '
             f'run={self.run}, context={self.dockercontext}, args={self.dockerargs}), '
             f'ports={self.ports})'
         )

--- a/daemon/models/containers.py
+++ b/daemon/models/containers.py
@@ -10,7 +10,7 @@ class ContainerArguments(BaseModel):
     """Pydantic model for ContainerArguments"""
 
     object: Dict
-    command: str
+    entrypoint: str
 
 
 class ContainerMetadata(BaseModel):

--- a/daemon/models/enums.py
+++ b/daemon/models/enums.py
@@ -1,4 +1,5 @@
 import os
+import warnings
 from enum import Enum
 from typing import List
 
@@ -27,23 +28,32 @@ class IDLiterals(DaemonEnum):
     JWORKSPACE = 'jworkspace'
 
 
-class DaemonBuild(DaemonEnum):
+class DaemonDockerfile(DaemonEnum):
     """Enum representing build value passed in .jinad file"""
 
     DEVEL = 'devel'
     DEFAULT = 'default'
     CPU = 'default'
     GPU = 'gpu'
+    OTHERS = 'others'
 
     @classproperty
     def default(cls) -> str:
-        """Get default value for DaemonBuild
+        """Get default value for DaemonDockerfile
 
         .. note::
             set env var `JINA_DAEMON_BUILD` to `DEVEL` if you're working on dev mode
 
-        :return: default value for DaemonBuild"""
-        return cls.DEVEL if os.getenv('JINA_DAEMON_BUILD') == 'DEVEL' else cls.DEFAULT
+        :return: default value for DaemonDockerfile"""
+        if os.getenv('JINA_DAEMON_DOCKERFILE') == 'DEVEL':
+            return cls.DEVEL
+        elif os.getenv('JINA_DAEMON_BUILD') == 'DEVEL':
+            warnings.warn(
+                'env var `JINA_DAEMON_BUILD` is deprecated now. Please use `JINA_DAEMON_DOCKERFILE`'
+            )
+            return cls.DEVEL
+        else:
+            return cls.DEFAULT
 
 
 class PythonVersion(DaemonEnum):

--- a/daemon/tasks.py
+++ b/daemon/tasks.py
@@ -10,7 +10,7 @@ from jina.logging.logger import JinaLogger
 from . import __task_queue__, daemon_logger, jinad_args
 from .dockerize import Dockerizer
 from .excepts import DockerImageException, DockerNetworkException
-from .files import DaemonFile, workspace_files
+from .files import DaemonFile, store_files_in_workspace
 from .helper import id_cleaner, get_workspace_path
 from .models.id import DaemonID
 from .models.workspaces import WorkspaceArguments, WorkspaceItem, WorkspaceMetadata
@@ -42,7 +42,6 @@ class DaemonWorker(Thread):
             _args.files.extend([f.filename for f in self.files] if self.files else [])
             _args.jinad.update(
                 {
-                    'build': self.daemon_file.build,
                     'dockerfile': self.daemon_file.dockerfile,
                 }
             )
@@ -51,7 +50,6 @@ class DaemonWorker(Thread):
             _args = WorkspaceArguments(
                 files=[f.filename for f in self.files] if self.files else [],
                 jinad={
-                    'build': self.daemon_file.build,
                     'dockerfile': self.daemon_file.dockerfile,
                 },
                 requirements=self.daemon_file.requirements,
@@ -152,7 +150,9 @@ class DaemonWorker(Thread):
                 if store[self.id].arguments
                 else RemoteWorkspaceState.CREATING,
             )
-            workspace_files(workspace_id=self.id, files=self.files, logger=self._logger)
+            store_files_in_workspace(
+                workspace_id=self.id, files=self.files, logger=self._logger
+            )
             store.update(
                 id=self.id,
                 value=WorkspaceItem(

--- a/docs/advanced/daemon/development-using-jinad.md
+++ b/docs/advanced/daemon/development-using-jinad.md
@@ -1,6 +1,5 @@
 # JinaD Development Guides
 
-
 ## Build
 
 ```bash
@@ -12,7 +11,7 @@ docker build -f Dockerfiles/debianx.Dockerfile --build-arg PIP_TAG=daemon -t jin
 ```bash
 docker run --add-host host.docker.internal:host-gateway \
            --name jinad \
-           -e JINA_DAEMON_BUILD=DEVEL \
+           -e JINA_DAEMON_DOCKERFILE=DEVEL \
            -e JINA_LOG_LEVEL=DEBUG \
            -v /var/run/docker.sock:/var/run/docker.sock \
            -v /tmp/jinad:/tmp/jinad \
@@ -26,7 +25,7 @@ docker run --add-host host.docker.internal:host-gateway \
 
   All images created by JinaD during local tests use image with this name (hard-coded).
 
-- `--env JINA_DAEMON_BUILD=DEVEL` ?
+- `--env JINA_DAEMON_DOCKERFILE=DEVEL` ?
 
   This makes sure default build for JinaD is `DEVEL`. This should be passed only during development, CICD etc and must not be used when using the official image.
 
@@ -46,4 +45,3 @@ docker run --add-host host.docker.internal:host-gateway \
   This is the default root workspace for JinaD. This gets mounted internally to all child containers. If we don't mount
   this while starting, `/tmp/jinad` local to JinaD would get mounted to child containers, which is not accessible by
   DOCKERHOST.
-

--- a/jina/excepts.py
+++ b/jina/excepts.py
@@ -134,3 +134,7 @@ class RuntimeRunForeverEarlyError(Exception):
 
 class DockerVersionError(SystemError):
     """Raised when the docker version is incompatible"""
+
+
+class DaemonInvalidDockerfile(FileNotFoundError):
+    """Raised when invalid dockerfile is passed to JinaD"""

--- a/tests/daemon/unit/api/endpoints/test_logs.py
+++ b/tests/daemon/unit/api/endpoints/test_logs.py
@@ -51,7 +51,7 @@ def _create_flow():
             rest_api_uri='',
             uri="",
         ),
-        arguments=ContainerArguments(command='command', object=Flow()),
+        arguments=ContainerArguments(entrypoint='entrypoint', object=Flow()),
         workspace_id=workspace_id,
     )
 

--- a/tests/daemon/unit/models/bad_ws_wrong_dockerfile/.jinad
+++ b/tests/daemon/unit/models/bad_ws_wrong_dockerfile/.jinad
@@ -1,0 +1,2 @@
+dockerfile = abc
+python = 3.6

--- a/tests/daemon/unit/models/good_ws/.jinad
+++ b/tests/daemon/unit/models/good_ws/.jinad
@@ -1,4 +1,4 @@
-build = default
+dockerfile = default
 jina = 2.0.0.rc2
 python = 3.7
 ports = 12345,12344

--- a/tests/daemon/unit/models/good_ws_custom_dockerfile/.jinad
+++ b/tests/daemon/unit/models/good_ws_custom_dockerfile/.jinad
@@ -1,0 +1,1 @@
+dockerfile = custom.Dockerfile

--- a/tests/daemon/unit/models/good_ws_custom_dockerfile/custom-requirements.txt
+++ b/tests/daemon/unit/models/good_ws_custom_dockerfile/custom-requirements.txt
@@ -1,0 +1,2 @@
+sklearn
+redis

--- a/tests/daemon/unit/models/good_ws_custom_dockerfile/custom.Dockerfile
+++ b/tests/daemon/unit/models/good_ws_custom_dockerfile/custom.Dockerfile
@@ -1,0 +1,8 @@
+# custom dockerfile has to use jina:*-daemon image to have parital-daemon
+FROM jinaai/jina:test-daemon
+
+COPY custom-requirements.txt custom-requirements.txt
+RUN pip install --no-cache-dir -r custom-requirements.txt
+
+# run additional custom commands
+RUN apt update && apt install -y redis-server

--- a/tests/daemon/unit/models/good_ws_multiple_files/.jinad
+++ b/tests/daemon/unit/models/good_ws_multiple_files/.jinad
@@ -1,4 +1,4 @@
-build = devel
+dockerfile = devel
 python = 3.7
 run = "echo Hello"
 ports = 12345,123456

--- a/tests/daemon/unit/models/good_ws_multiple_files/sample.jinad
+++ b/tests/daemon/unit/models/good_ws_multiple_files/sample.jinad
@@ -1,4 +1,4 @@
-build = gpu
+dockerfile = gpu
 python = 3.9
 invalid_key = invalid_value
 ports = 12345,123456

--- a/tests/daemon/unit/models/good_ws_wrong_ports/.jinad
+++ b/tests/daemon/unit/models/good_ws_wrong_ports/.jinad
@@ -1,0 +1,1 @@
+ports = thats_wrong

--- a/tests/daemon/unit/models/good_ws_wrong_values/.jinad
+++ b/tests/daemon/unit/models/good_ws_wrong_values/.jinad
@@ -1,3 +1,0 @@
-build = abc
-python = 3.6
-ports = thats_wrong

--- a/tests/daemon/unit/test_files.py
+++ b/tests/daemon/unit/test_files.py
@@ -1,11 +1,8 @@
 import os
-import tempfile
-from fastapi import UploadFile
 
+from jina.excepts import DaemonInvalidDockerfile
 from daemon import daemon_logger
-from daemon.models import DaemonID
-from daemon.files import DaemonFile
-from daemon.files import workspace_files
+from daemon.files import DaemonFile, is_requirements_txt
 
 import pytest
 
@@ -16,30 +13,76 @@ cur_filename = os.path.basename(__file__)
 @pytest.mark.parametrize(
     'workdir, expected_response',
     [
-        ('good_ws', ('default', '3.7', 'echo Hello', [12345, 12344])),
-        ('good_ws_no_file', ('devel', '3.8', '', [])),
-        ('good_ws_emptyfile', ('devel', '3.8', '', [])),
-        ('good_ws_multiple_files', ('devel', '3.7', 'echo Hello', [12345, 123456])),
-        ('good_ws_wrong_values', ('devel', '3.8', '', [])),
+        (
+            'good_ws',
+            (
+                os.path.join('daemon', 'Dockerfiles', 'default.Dockerfile'),
+                '3.7',
+                'echo Hello',
+                [12345, 12344],
+            ),
+        ),
+        (
+            'good_ws_no_file',
+            (
+                os.path.join('daemon', 'Dockerfiles', 'devel.Dockerfile'),
+                '3.8',
+                '',
+                [],
+            ),
+        ),
+        (
+            'good_ws_emptyfile',
+            (os.path.join('daemon', 'Dockerfiles', 'devel.Dockerfile'), '3.8', '', []),
+        ),
+        (
+            'good_ws_multiple_files',
+            (
+                os.path.join('daemon', 'Dockerfiles', 'devel.Dockerfile'),
+                '3.7',
+                'echo Hello',
+                [12345, 123456],
+            ),
+        ),
+        (
+            'good_ws_wrong_ports',
+            (
+                os.path.join('daemon', 'Dockerfiles', 'devel.Dockerfile'),
+                '3.8',
+                '',
+                [],
+            ),
+        ),
+        (
+            'good_ws_custom_dockerfile',
+            (
+                os.path.join(
+                    'models', 'good_ws_custom_dockerfile', 'custom.Dockerfile'
+                ),
+                '3.8',
+                '',
+                [],
+            ),
+        ),
     ],
 )
-def test_jinad_file_workspace(workdir, expected_response):
+def test_jinad_file_good(workdir, expected_response):
     d = DaemonFile(workdir=f'{cur_dir}/models/{workdir}')
-    assert d.build == expected_response[0]
+    assert d.dockerfile.endswith(expected_response[0])
     assert d.python == expected_response[1]
     assert d.run == expected_response[2]
     assert d.ports == expected_response[3]
 
 
-def _test_workspace_files():
-    with tempfile.NamedTemporaryFile() as fp1, tempfile.NamedTemporaryFile() as fp2:
-        fp1.write(b'Hello world1!')
-        fp2.write(b'Hello world2!')
-        fp1.flush()
-        fp2.flush()
-        fp1.seek(0, 0)
-        fp2.seek(0, 0)
-        id = DaemonID('jworkspace')
-        print(fp1.read())
-        files = [UploadFile(filename='a.txt'), UploadFile(filename='b.txt', file=fp2)]
-        workspace_files(id, files, daemon_logger)
+@pytest.mark.parametrize('workdir', ['bad_ws_wrong_dockerfile'])
+def test_jinad_file_bad(workdir):
+    with pytest.raises(DaemonInvalidDockerfile):
+        DaemonFile(workdir=f'{cur_dir}/models/{workdir}')
+
+
+def test_is_requirements_txt():
+    for name in ['requirements.txt', 'custom-requirements.txt', 'requirements-gpu.txt']:
+        assert is_requirements_txt(name)
+
+    for name in ['blah.txt', 'a.py']:
+        assert not is_requirements_txt(name)

--- a/tests/distributed/test_remote_flow_dump_rolling_update/docker-compose.yml
+++ b/tests/distributed/test_remote_flow_dump_rolling_update/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   jinad:
     image: jinaai/jina:test-daemon
     environment:
-      JINA_DAEMON_BUILD: DEVEL
+      JINA_DAEMON_DOCKERFILE: DEVEL # # only used in devel mode
       JINA_LOG_LEVEL: DEBUG
     container_name: test_remote_flow_dump_reload
     ports:

--- a/tests/distributed/test_rolling_update_container_runtime/docker-compose.yml
+++ b/tests/distributed/test_rolling_update_container_runtime/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   jinad:
     image: jinaai/jina:test-daemon
     environment:
-      JINA_DAEMON_BUILD: DEVEL
+      JINA_DAEMON_DOCKERFILE: DEVEL # # only used in devel mode
       JINA_LOG_LEVEL: DEBUG
     container_name: test_remote_flow_dump_reload
     ports:

--- a/tests/distributed/test_workspaces/custom_workspace_blocking/.jinad
+++ b/tests/distributed/test_workspaces/custom_workspace_blocking/.jinad
@@ -1,3 +1,3 @@
-build = devel
+dockerfile = devel
 python = 3.7
 run = "sleep infinity"

--- a/tests/distributed/test_workspaces/custom_workspace_no_run/.jinad
+++ b/tests/distributed/test_workspaces/custom_workspace_no_run/.jinad
@@ -1,3 +1,3 @@
-build = devel
+dockerfile = devel
 python = 3.7
 ports = 12345,12344

--- a/tests/distributed/test_workspaces/docker-compose.yml
+++ b/tests/distributed/test_workspaces/docker-compose.yml
@@ -11,4 +11,4 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
-      - JINA_DAEMON_BUILD=DEVEL
+      - JINA_DAEMON_DOCKERFILE=DEVEL # only used in devel mode

--- a/tests/distributed/test_workspaces/flow_app_ws/.jinad
+++ b/tests/distributed/test_workspaces/flow_app_ws/.jinad
@@ -1,4 +1,4 @@
-build = devel
+dockerfile = devel
 python = 3.7
 ports = 42860
 run = "python app.py 42860"

--- a/tests/distributed/test_workspaces/redis_executor.py
+++ b/tests/distributed/test_workspaces/redis_executor.py
@@ -1,0 +1,31 @@
+import time
+import redis
+import subprocess
+
+from jina import Executor, requests, DocumentArray, Document
+
+
+class DummyRedisIndexer(Executor):
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.redis_server = subprocess.Popen(
+            ['redis-server', '--daemonize', 'yes', '--port', '2374']
+        )
+        print('sleeping for 2secs to allow redis server to start')
+        time.sleep(2)
+        self.handler = redis.Redis(host='localhost', port=2374, db=0)
+        assert self.handler.ping()
+
+    @requests(on='/index')
+    def index(self, docs: DocumentArray, *args, **kwargs):
+        self.handler.mset({doc.text: doc.SerializeToString() for doc in docs})
+
+    @requests(on='/search')
+    def search(self, docs: DocumentArray, *args, **kwargs):
+        for doc in docs:
+            result = self.handler.get(doc.text)
+            if result:
+                doc.matches = [Document(result)]
+
+    def close(self) -> None:
+        self.redis_server.kill()

--- a/tests/distributed/test_workspaces/sklearn_encoder_ws/.jinad
+++ b/tests/distributed/test_workspaces/sklearn_encoder_ws/.jinad
@@ -1,3 +1,3 @@
-build = devel
+dockerfile = devel
 python = 3.8
 ports = 23088

--- a/tests/distributed/test_workspaces/tdb_indexer_ws/.jinad
+++ b/tests/distributed/test_workspaces/tdb_indexer_ws/.jinad
@@ -1,4 +1,4 @@
-build = devel
+dockerfile = devel
 python = 3.7
 ports = 23087
 ; run = "python -m http.server 23087"

--- a/tests/distributed/test_workspaces/test_custom_container.py
+++ b/tests/distributed/test_workspaces/test_custom_container.py
@@ -70,7 +70,6 @@ def test_update_custom_container():
     new_image_id = workspace_details.metadata.image_id
     assert new_image_id
     assert new_image_id != image_id
-    assert len(workspace_details.arguments.requirements.split()) == 3
 
 
 def test_delete_custom_container():

--- a/tests/distributed/test_workspaces/test_custom_dockerfile.py
+++ b/tests/distributed/test_workspaces/test_custom_dockerfile.py
@@ -1,0 +1,26 @@
+import os
+import numpy as np
+
+from jina import Flow, __default_host__, Document
+
+cur_dir = os.path.dirname(os.path.abspath(__file__))
+
+
+def test_custom_dockerfile():
+    f = Flow().add(
+        uses='DummyRedisIndexer',
+        py_modules=[os.path.join(cur_dir, 'redis_executor.py')],
+        upload_files=[
+            os.path.join(cur_dir, '../../daemon/unit/models/good_ws_custom_dockerfile'),
+        ],
+        host='localhost:8000',
+    )
+    with f:
+        f.index(
+            inputs=(
+                Document(text=f'{i}', embedding=np.random.rand(2, 3)) for i in range(5)
+            ),
+        )
+        resp = f.search(inputs=[Document(text='3')], return_results=True)
+        assert resp[0].docs[0].matches[0].text == '3'
+        assert resp[0].docs[0].matches[0].embedding.shape == (2, 3)

--- a/tests/distributed/test_workspaces/test_remote_workspaces.py
+++ b/tests/distributed/test_workspaces/test_remote_workspaces.py
@@ -59,7 +59,7 @@ def test_upload_via_yaml(parallels, mocker):
         Flow()
         .add()
         .add(
-            uses='mwu_encoder.yml',
+            uses=[os.path.join(cur_dir, 'mwu_encoder.yml')],
             host=CLOUD_HOST,
             parallel=parallels,
             upload_files=[os.path.join(cur_dir, 'mwu_encoder.py')],
@@ -224,7 +224,7 @@ def test_upload_simple_non_standard_rootworkspace(docker_compose, mocker):
         Flow()
         .add()
         .add(
-            uses='mwu_encoder.yml',
+            uses=[os.path.join(cur_dir, 'mwu_encoder.yml')],
             host='localhost:9000',
             upload_files=[os.path.join(cur_dir, 'mwu_encoder.py')],
         )

--- a/tests/distributed/test_workspaces/test_remote_workspaces.py
+++ b/tests/distributed/test_workspaces/test_remote_workspaces.py
@@ -40,7 +40,7 @@ def test_upload_via_pymodule(parallels, mocker):
             uses_with={'greetings': 'hi'},
             host=CLOUD_HOST,
             parallel=parallels,
-            py_modules=['mwu_encoder.py'],
+            py_modules=[os.path.join(cur_dir, 'mwu_encoder.py')],
         )
         .add()
     )
@@ -62,7 +62,7 @@ def test_upload_via_yaml(parallels, mocker):
             uses='mwu_encoder.yml',
             host=CLOUD_HOST,
             parallel=parallels,
-            upload_files=['mwu_encoder.py'],
+            upload_files=[os.path.join(cur_dir, 'mwu_encoder.py')],
         )
         .add()
     )
@@ -226,7 +226,7 @@ def test_upload_simple_non_standard_rootworkspace(docker_compose, mocker):
         .add(
             uses='mwu_encoder.yml',
             host='localhost:9000',
-            upload_files=['mwu_encoder.py'],
+            upload_files=[os.path.join(cur_dir, 'mwu_encoder.py')],
         )
         .add()
     )


### PR DESCRIPTION
A hacky implementation to support custom dockerfiles in JinaD workspaces. Since JinaD relies on `partial-daemon` inside the child containers, in the custom dockerfile, the user must have a `daemon` base image mentioned, e.g.
1. `FROM jinaai/jina:<version/master/test>-daemon` must be included inside the dockerfile.  
2. Add an entry `dockerfile = custom.dockerfile` in `.jinad` file.

As a test, I have added a `DummyRedisIndexer` that relies on the `redis-server` cli to start the server during Executor init and that gets used during index & query. Installing of redis-server from `apt` is done inside the custom dockerfile. The same can be extended to enable using GPUs from the host machine for both Flows & Executors. (Note: Enabling `--gpus all` is still not added)

https://github.com/jina-ai/jina/blob/e838fe3cd9546998260c09393f7045a11b65af74/tests/distributed/test_workspaces/redis_executor.py#L8-L17