### PR TITLE
docs: replace UUID with NAME

### DIFF
--- a/docs/advanced/hub/push-executor.md
+++ b/docs/advanced/hub/push-executor.md
@@ -36,7 +36,7 @@ Anyone can use any public Executor, but to use a private Executor one must know 
 
 ## Update published Executors
 
-To override or update a published Executor, you must have both `Name` and `SECRET`.
+To override or update a published Executor, you must have both `NAME` and `SECRET`.
 
 ```bash
 jina hub push [--public/--private] --force <NAME> --secret <SECRET> <path_to_executor_folder>

--- a/docs/advanced/hub/push-executor.md
+++ b/docs/advanced/hub/push-executor.md
@@ -19,7 +19,7 @@ jina hub push [--public/--private] <path_to_executor_folder>
 ```
 
 
-It will return `UUID` & `SECRET`, which you will need when using (if private) or update the Executor later. **Please keep them carefully.**
+It will return `NAME` & `SECRET`, which you will need when using (if private) or update the Executor later. **Please keep them carefully.**
 
 You can then visit [the Hub portal](https://hub.jina.ai), click on the "Recent" tab and see your published Executor.
 
@@ -36,10 +36,10 @@ Anyone can use any public Executor, but to use a private Executor one must know 
 
 ## Update published Executors
 
-To override or update a published Executor, you must have both `UUID` and `SECRET`.
+To override or update a published Executor, you must have both `Name` and `SECRET`.
 
 ```bash
-jina hub push [--public/--private] --force <UUID> --secret <SECRET> <path_to_executor_folder>
+jina hub push [--public/--private] --force <NAME> --secret <SECRET> <path_to_executor_folder>
 ```
 
 (hub_tags)=
@@ -64,5 +64,5 @@ jina hub push . -t v1.0.0 -t latest # Result in two tags: v1.0.0, latest
 If you want to create a new tag for an existing Executor, you can also add the `-t` option here:
 
 ```bash
-jina hub push [--public/--private] --force <UUID> --secret <SECRET> -t TAG <path_to_executor_folder>
+jina hub push [--public/--private] --force <NAME> --secret <SECRET> -t TAG <path_to_executor_folder>
 ```

--- a/jina/parsers/hubble/pull.py
+++ b/jina/parsers/hubble/pull.py
@@ -36,6 +36,6 @@ def mixin_hub_pull_parser(parser):
     parser.add_argument(
         'uri',
         type=hub_uri,
-        help='The URI of the executor to pull (e.g., jinahub[+docker]://UUID8)',
+        help='The URI of the executor to pull (e.g., jinahub[+docker]://NAME)',
     )
     mixin_hub_pull_options_parser(parser)

--- a/jina/parsers/hubble/push.py
+++ b/jina/parsers/hubble/push.py
@@ -45,7 +45,7 @@ One can later fetch a tagged Executor via `jinahub[+docker]://MyExecutor/gpu`
     gp.add_argument(
         '--force',
         type=str,
-        help='If set, push will overwrite the Executor on the Hub that shares the same UUID8 identifier',
+        help='If set, push will overwrite the Executor on the Hub that shares the same NAME or UUID8 identifier',
     )
     gp.add_argument(
         '--secret',


### PR DESCRIPTION
As `UUID` is hidden from the user, it should be replaced with `NAME`

![image](https://user-images.githubusercontent.com/4329072/134922775-e64e9ef6-649d-4207-b3aa-01125597bb35.png)
