### PR TITLE
fix: progress bar overwrite other logs

### DIFF
--- a/jina/logging/profile.py
+++ b/jina/logging/profile.py
@@ -227,6 +227,7 @@ class ProgressBar(TimeContext):
         self._num_update_called = 0
         self._on_done = message_on_done
         self._stop_event = threading.Event()
+        print()
 
     def update(
         self,


### PR DESCRIPTION
The current progress bar overwrites the last log line printed before the bar starts. Old behavior:

```
PASSED                                                                                              
PASSED                                                                                            
PASSED                                                                                              
PASSED                                                                                              
⠴   CANCELED ━╸━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 0:00:00 8.7 step/s FAILED            
```

New behavior:

```
tests/unit/test_bla.py:my_test1
PASSED
tests/unit/test_bla.py:my_test2
PASSED
tests/unit/test_bla.py:my_test3
PASSED
tests/unit/test_bla.py:my_test4
PASSED
tests/unit/test_bla.py:my_test5
⠴   CANCELED ━╸━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 0:00:00 8.7 step/s FAILED            
```
Canceled from me doing ctrl+c