### PR TITLE
docs: fix reference to fill_embedding

### DIFF
--- a/docs/advanced/experimental/indexers.md
+++ b/docs/advanced/experimental/indexers.md
@@ -52,7 +52,7 @@ The Executors implemented and provided by Jina implement a CRUD interface as fol
 
 The Create, Update, Delete operations are implemented by the Storage Indexers, while the Read operation is implemented in the `/search` endpoints in the Search Indexers. 
 The `/search` endpoints do not correspond perfectly with the Read operation, as it _searches_ for similar results, and does not return a specific Document by id.
-Some Storage Indexers do implement a `/fill_embedding` endpoint, which functions as a Read by id.
+Some Indexers do implement a `/fill_embedding` endpoint, which functions as a Read by id.
 Please refer to the specific documentation or implementation of the Executor for details.
 
 ## Indexing vs Searching Operations


### PR DESCRIPTION
Not true at the moment. Restricting it to just "Indexers" is both correct and safe for any possible deviations for the time being.