### PR TITLE
feat(daemon): allow gpus arg for remote Executors

### DIFF
--- a/daemon/api/dependencies.py
+++ b/daemon/api/dependencies.py
@@ -12,6 +12,7 @@ from jina import Flow, __docker_host__
 from jina.helper import cached_property
 from jina.peapods import CompoundPod
 from jina.peapods.peas.helper import update_runtime_cls
+from jina.peapods.runtimes.container.helper import get_gpu_device_requests
 from jina.enums import (
     PeaRoleType,
     SocketType,
@@ -68,6 +69,9 @@ class FlowDepends:
         self.envs = envs.vars
         self._ports = {}
         self.load_and_dump()
+        # Unlike `PeaModel` / `PodModel`, `gpus` arg doesn't exist in FlowModel
+        # We try assigning `all` gpus to the Flow container by default.
+        self.device_requests = get_gpu_device_requests('all')
 
     def localpath(self) -> Path:
         """Validates local filepath in workspace from filename.
@@ -329,6 +333,9 @@ class PeaDepends:
         self.params.identity = self.id
         self.params.workspace_id = self.workspace_id
         self.params.runs_in_docker = True
+        self.device_requests = (
+            get_gpu_device_requests(self.params.gpus) if self.params.gpus else None
+        )
 
 
 class PodDepends(PeaDepends):

--- a/daemon/api/endpoints/flows.py
+++ b/daemon/api/endpoints/flows.py
@@ -36,6 +36,7 @@ async def _create(flow: FlowDepends = Depends(FlowDepends)):
             params=flow.params,
             ports=flow.ports,
             envs=flow.envs,
+            device_requests=flow.device_requests,
         )
     except Exception as ex:
         raise Runtime400Exception from ex

--- a/daemon/api/endpoints/peas.py
+++ b/daemon/api/endpoints/peas.py
@@ -38,6 +38,7 @@ async def _create(pea: PeaDepends = Depends(PeaDepends)):
             params=pea.params,
             ports=pea.ports,
             envs=pea.envs,
+            device_requests=pea.device_requests,
         )
     except Exception as ex:
         raise Runtime400Exception from ex

--- a/daemon/api/endpoints/pods.py
+++ b/daemon/api/endpoints/pods.py
@@ -36,6 +36,7 @@ async def _create(pod: PodDepends = Depends(PodDepends)):
             params=pod.params,
             ports=pod.ports,
             envs=pod.envs,
+            device_requests=pod.device_requests,
         )
     except Exception as ex:
         raise Runtime400Exception from ex

--- a/daemon/dockerize.py
+++ b/daemon/dockerize.py
@@ -9,7 +9,7 @@ import docker
 from jina import __docker_host__
 from jina.helper import colored
 from jina.logging.logger import JinaLogger
-from jina.peapods.runtimes.container import ContainerRuntime
+from jina.peapods.runtimes.container.helper import get_gpu_device_requests
 from . import (
     jinad_args,
     __root_workspace__,
@@ -205,7 +205,8 @@ class Dockerizer:
         container_id: DaemonID,
         entrypoint: str,
         ports: Dict,
-        envs: Dict = {},
+        envs: Optional[Dict] = {},
+        device_requests: Optional[List] = None,
     ) -> Tuple['Container', str, Dict]:
         """
         Runs a container using an existing image (tagged with `workspace_id`).
@@ -214,13 +215,25 @@ class Dockerizer:
             This uses the default entrypoint (mini-jinad) & appends `command` for execution.
         :param workspace_id: workspace id
         :param container_id: name of the container
+        :param entrypoint: entrypoint for the container
         :param ports: ports to be mapped with local
         :param envs: dict of env vars to be set in the container
-        :param entrypoint: custom entrypoint
+        :param device_requests: docker device requests
         :raises DockerImageException: if image is not found locally
         :raises DockerContainerException: if container creation fails
         :return: tuple of container object, network id & ports
         """
+
+        def _validate_port_conflict(error: str) -> str:
+            msg = ""
+            if 'port is already allocated' in error:
+                match = re.findall(PORT_REGEX, error)
+                if match and len(match) > 0:
+                    msg = f'port conflict: {match[0]}'
+            return msg
+
+        def _validate_device_request(error: str) -> bool:
+            return True if 'could not select device driver' in error else False
 
         from .stores import workspace_store
 
@@ -236,7 +249,7 @@ class Dockerizer:
             f'{colored(network, "cyan")} and ports {colored(ports, "cyan")}'
         )
         try:
-            container: 'Container' = cls.client.containers.run(
+            run_kwargs = dict(
                 image=image,
                 name=container_id,
                 volumes=cls.volume(workspace_id),
@@ -245,9 +258,11 @@ class Dockerizer:
                 ports=ports,
                 detach=True,
                 entrypoint=entrypoint,
+                device_requests=device_requests or [],
                 working_dir=__partial_workspace__,
                 extra_hosts={__docker_host__: 'host-gateway'},
             )
+            container: 'Container' = cls.client.containers.run(**run_kwargs)
         except docker.errors.NotFound as e:
             cls.logger.critical(
                 f'Image {image} or Network {network} not found locally {e!r}'
@@ -258,11 +273,27 @@ class Dockerizer:
             )
         except docker.errors.APIError as e:
             msg = f'API Error while starting the docker container{e}'
-            if 'port is already allocated' in str(e):
-                match = re.findall(PORT_REGEX, str(e))
-                if match and len(match) > 0:
-                    msg = f'port conflict: {match[0]}'
-            cls.logger.critical(msg)
+            if _validate_device_request(str(e)):
+                # It might not be possible for local to know remote machine's gpu status.
+                # For few cases (Flow creation), we always set `gpus='all'`, which might fail
+                # if dockerd cannot find the device. In that case, run again without device requests
+                cls.logger.debug(
+                    f'couldn\'t start the container with following device request. '
+                    f'restarting after resetting device: {run_kwargs["device_requests"]}'
+                )
+                try:
+                    # This leaves the old container in a "created" state and conflicts the name.
+                    cls.rm_container(container_id)
+                except:
+                    pass
+                run_kwargs.pop('device_requests')
+                container: 'Container' = cls.client.containers.run(**run_kwargs)
+            else:
+                msg += _validate_port_conflict(str(e))
+                raise DockerContainerException(msg)
+        except docker.errors.APIError as e:
+            msg = f'API Error while starting the docker container{e}'
+            msg += _validate_port_conflict(str(e))
             raise DockerContainerException(msg)
         # TODO: network & ports return can be avoided?
         return container, network, ports

--- a/daemon/stores/containers.py
+++ b/daemon/stores/containers.py
@@ -4,7 +4,7 @@ import asyncio
 from copy import deepcopy
 from platform import uname
 from http import HTTPStatus
-from typing import Dict, TYPE_CHECKING, Union
+from typing import Dict, TYPE_CHECKING, List, Optional, Union
 
 import aiohttp
 
@@ -140,7 +140,8 @@ class ContainerStore(BaseStore):
         workspace_id: DaemonID,
         params: 'BaseModel',
         ports: Union[Dict, PortMappings],
-        envs: Dict[str, str] = {},
+        envs: Optional[Dict[str, str]] = {},
+        device_requests: Optional[List] = None,
         **kwargs,
     ) -> DaemonID:
         """Add a container to the store
@@ -150,6 +151,7 @@ class ContainerStore(BaseStore):
         :param params: pydantic model representing the args for the container
         :param ports: ports to be mapped to local
         :param envs: dict of env vars to be passed
+        :param device_requests: docker device requests
         :param kwargs: keyword args
         :raises KeyError: if workspace_id doesn't exist in the store or not ACTIVE
         :raises PartialDaemonConnectionException: if jinad cannot connect to partial
@@ -192,6 +194,7 @@ class ContainerStore(BaseStore):
                 entrypoint=entrypoint,
                 ports=dockerports,
                 envs=envs,
+                device_requests=device_requests,
             )
             if not await self.ready(uri):
                 raise PartialDaemonConnectionException(

--- a/jina/peapods/runtimes/container/helper.py
+++ b/jina/peapods/runtimes/container/helper.py
@@ -38,3 +38,40 @@ def get_docker_network(client) -> Optional[str]:
             return None
     except Exception:
         return None
+
+
+def get_gpu_device_requests(gpu_args):
+    """Get docker device requests from gpu args
+
+    :param gpu_args: gpu args fr
+    :return: docker device requests
+    """
+    import docker
+
+    _gpus = {
+        'count': 0,
+        'capabilities': ['gpu'],
+        'device': [],
+        'driver': '',
+    }
+    for gpu_arg in gpu_args.split(','):
+        if gpu_arg == 'all':
+            _gpus['count'] = -1
+        if gpu_arg.isdigit():
+            _gpus['count'] = int(gpu_arg)
+        if '=' in gpu_arg:
+            gpu_arg_key, gpu_arg_value = gpu_arg.split('=')
+            if gpu_arg_key in _gpus.keys():
+                if isinstance(_gpus[gpu_arg_key], list):
+                    _gpus[gpu_arg_key].append(gpu_arg_value)
+                else:
+                    _gpus[gpu_arg_key] = gpu_arg_value
+    device_requests = [
+        docker.types.DeviceRequest(
+            count=_gpus['count'],
+            driver=_gpus['driver'],
+            device_ids=_gpus['device'],
+            capabilities=[_gpus['capabilities']],
+        )
+    ]
+    return device_requests

--- a/jina/peapods/runtimes/jinad/__init__.py
+++ b/jina/peapods/runtimes/jinad/__init__.py
@@ -81,7 +81,6 @@ class JinadRuntime(AsyncNewLoopRuntime):
         while not self.is_cancel.is_set():
             await asyncio.sleep(0.1)
 
-        await self.async_cancel()
         send_ctrl_message(self.ctrl_addr, 'TERMINATE', self.timeout_ctrl)
 
     async def async_run_forever(self):
@@ -95,12 +94,12 @@ class JinadRuntime(AsyncNewLoopRuntime):
         )
 
     async def async_cancel(self):
-        """Cancels the logstream task, removes the remote Pea & Workspace"""
+        """Cancels the logstream task, removes the remote Pea"""
         self.logstream.cancel()
-        await self.client.peas.delete(id=self.pea_id)
+        if await self.client.peas.delete(id=self.pea_id):
+            self.logger.success(f'Successfully terminated remote Pea {self.pea_id}')
         # Don't delete workspace here, as other Executors might use them.
         # TODO(Deepankar): probably enable an arg here?
-        # await self.client.workspaces.delete(id=self.workspace_id)
 
     async def _sleep_forever(self):
         """Sleep forever, no prince will come."""

--- a/tests/distributed/test_topologies/test_topologies.py
+++ b/tests/distributed/test_topologies/test_topologies.py
@@ -189,6 +189,10 @@ def test_remote_flow_local_executors(mocker, parallel):
 
 
 def test_remote_workspace_value():
+    """
+    This tests the value set in `self.workspace` in a remote Flow.
+    It should always be `/workspace/ExecutorName/...
+    """
     HOST = __default_host__
     client = JinaDClient(host=HOST, port=8000)
     workspace_id = client.workspaces.create(paths=[os.path.join(cur_dir, 'yamls')])
@@ -206,3 +210,17 @@ def test_remote_workspace_value():
     )
     assert client.flows.delete(flow_id)
     assert client.workspaces.delete(workspace_id)
+
+
+@pytest.mark.parametrize('gpus', ['all', '2'])
+def test_remote_executor_gpu(mocker, gpus):
+    # This test wouldn't be able to use gpus on remote, as they're not available on CI.
+    # But it shouldn't fail the Pea creation.
+    response_mock = mocker.Mock()
+    f = Flow().add(host=CLOUD_HOST, gpus=gpus)
+    with f:
+        f.index(
+            inputs=(Document(text='hello') for _ in range(NUM_DOCS)),
+            on_done=response_mock,
+        )
+    response_mock.assert_called()

--- a/tests/unit/peapods/runtimes/container/test_container_runtime.py
+++ b/tests/unit/peapods/runtimes/container/test_container_runtime.py
@@ -14,6 +14,7 @@ from jina.parsers import set_pea_parser
 from jina.parsers.ping import set_ping_parser
 from jina.peapods import Pea
 from jina.peapods.runtimes.container import ContainerRuntime
+from jina.peapods.runtimes.container.helper import get_gpu_device_requests
 from tests import random_docs, validate_callback
 
 if __windows__:
@@ -387,7 +388,7 @@ def test_gpu_container(
         ['--uses', f'docker://{img_name}', '--gpus', gpus_value]
     )
 
-    device_requests = ContainerRuntime._get_gpu_device_requests(args.gpus)
+    device_requests = get_gpu_device_requests(args.gpus)
     assert device_requests[0]['Count'] == expected_count
     assert device_requests[0]['DeviceIDs'] == expected_device
     assert device_requests[0]['Driver'] == expected_driver


### PR DESCRIPTION
This PR
1. Enables any remote Executors to set `gpus` argument with `Flow` syntax. This argument was only valid for local + dockerized Executors. Since all remote Executors are dockerized, this enables setting up `docker devices` on any remote containers.
2. All remote Flows are by default started with `gpus: all` devices set, as we don't have `gpus` arg for Flows. If needed and used, we can enable it later.

Note: If on remote, docker cannot access the device passed, we reset the device & start the container again. 

Usage with remote Executor
----

```python
f = Flow().add(
    uses='CustomExecutor',
    host=CLOUDHOST,
    port_jinad=8000,
    py_modules=['/path/to/pymodule.py'],
    upload_files=['/path/to/requirements.txt'],
    gpus='all'
)
```