### PR TITLE
fix(kubernetes): add kubernetes dep to perf

### DIFF
--- a/extra-requirements.txt
+++ b/extra-requirements.txt
@@ -72,7 +72,7 @@ jsonschema:                 cicd
 dgl:                        cicd
 black==20.8b1:              test
 matplotlib:                 devel
-kubernetes>=18.20.0:        standard, devel
+kubernetes>=18.20.0:        perf, standard, devel
 pykube-ng==21.3.0:          test
 pytest-kind==21.1.3:        test
 pytest-lazy-fixture:        test

--- a/jina/resources/extra-requirements.txt
+++ b/jina/resources/extra-requirements.txt
@@ -72,7 +72,7 @@ jsonschema:                 cicd
 dgl:                        cicd
 black==20.8b1:              test
 matplotlib:                 devel
-kubernetes>=18.20.0:        standard, devel
+kubernetes>=18.20.0:        perf, standard, devel
 pykube-ng==21.3.0:          test
 pytest-kind==21.1.3:        test
 pytest-lazy-fixture:        test


### PR DESCRIPTION
fixes #3536

Perf is needed so that the requirement is actually part of all hubble built docker images.