### PR TITLE
feat(DocumentArray): sort top_k

### DIFF
--- a/tests/unit/types/arrays/test_documentarray.py
+++ b/tests/unit/types/arrays/test_documentarray.py
@@ -320,6 +320,30 @@ def test_da_sort_by_document_interface_not_in_proto():
     assert da[0].embedding.shape == (1,)
 
 
+@pytest.mark.parametrize('reverse', [True, False])
+def test_da_reverse_sort_topk_by_document_interface_not_in_proto(reverse):
+    docs = [Document(embedding=np.array([1] * (10 - i))) for i in range(10)]
+    da = DocumentArray(
+        [docs[i] if (i % 2 == 0) else docs[i].proto for i in range(len(docs))]
+    )
+    assert len(da) == 10
+    assert da[0].embedding.shape == (10,)
+
+    da.sort(key=lambda d: d.embedding.shape[0], top_k=5, reverse=reverse)
+    if reverse:
+        assert da[0].embedding.shape == (10,)
+        assert da[1].embedding.shape == (9,)
+        assert da[2].embedding.shape == (8,)
+        assert da[3].embedding.shape == (7,)
+        assert da[4].embedding.shape == (6,)
+    else:
+        assert da[0].embedding.shape == (1,)
+        assert da[1].embedding.shape == (2,)
+        assert da[2].embedding.shape == (3,)
+        assert da[3].embedding.shape == (4,)
+        assert da[4].embedding.shape == (5,)
+
+
 def test_da_sort_by_document_interface_in_proto():
     docs = [Document(embedding=np.array([1] * (10 - i))) for i in range(10)]
     da = DocumentArray(
@@ -330,6 +354,30 @@ def test_da_sort_by_document_interface_in_proto():
 
     da.sort(key=lambda d: d.embedding.dense.shape[0])
     assert da[0].embedding.shape == (1,)
+
+
+@pytest.mark.parametrize('reverse', [True, False])
+def test_da_sort_topk_by_document_interface_in_proto(reverse):
+    docs = [Document(embedding=np.array([1] * (10 - i))) for i in range(10)]
+    da = DocumentArray(
+        [docs[i] if (i % 2 == 0) else docs[i].proto for i in range(len(docs))]
+    )
+    assert len(da) == 10
+    assert da[0].embedding.shape == (10,)
+
+    da.sort(key=lambda d: d.embedding.dense.shape[0], top_k=5, reverse=reverse)
+    if reverse:
+        assert da[0].embedding.shape == (10,)
+        assert da[1].embedding.shape == (9,)
+        assert da[2].embedding.shape == (8,)
+        assert da[3].embedding.shape == (7,)
+        assert da[4].embedding.shape == (6,)
+    else:
+        assert da[0].embedding.shape == (1,)
+        assert da[1].embedding.shape == (2,)
+        assert da[2].embedding.shape == (3,)
+        assert da[3].embedding.shape == (4,)
+        assert da[4].embedding.shape == (5,)
 
 
 def test_da_reverse():

--- a/tests/unit/types/arrays/test_matcharray.py
+++ b/tests/unit/types/arrays/test_matcharray.py
@@ -71,6 +71,30 @@ def test_matches_sort_by_document_interface_in_proto():
     assert query.matches[0].weight == 1
 
 
+@pytest.mark.parametrize('reverse', [True, False])
+def test_matches_topk_sort_by_document_interface_in_proto(reverse):
+    docs = [Document(weight=(10 - i)) for i in range(10)]
+    query = Document()
+    query.matches = docs
+    assert len(query.matches) == 10
+    assert query.matches[0].weight == 10
+
+    query.matches.sort(key=lambda m: m.weight, top_k=5, reverse=reverse)
+    if reverse:
+        assert query.matches[0].weight == 10
+        assert query.matches[1].weight == 9
+        assert query.matches[2].weight == 8
+        assert query.matches[3].weight == 7
+        assert query.matches[4].weight == 6
+
+    else:
+        assert query.matches[0].weight == 1
+        assert query.matches[1].weight == 2
+        assert query.matches[2].weight == 3
+        assert query.matches[3].weight == 4
+        assert query.matches[4].weight == 5
+
+
 def test_matches_sort_by_document_interface_not_in_proto():
     docs = [Document(embedding=np.array([1] * (10 - i))) for i in range(10)]
     query = Document()
@@ -80,6 +104,21 @@ def test_matches_sort_by_document_interface_not_in_proto():
 
     query.matches.sort(key=lambda m: m.embedding.shape[0])
     assert query.matches[0].embedding.shape == (1,)
+
+
+@pytest.mark.parametrize('reverse', [True, False])
+def test_matches_topk_sort_by_document_interface_not_in_proto(reverse):
+    docs = [Document(embedding=np.array([1] * (10 - i))) for i in range(10)]
+    query = Document()
+    query.matches = docs
+    assert len(query.matches) == 10
+    assert query.matches[0].embedding.shape == (10,)
+
+    query.matches.sort(key=lambda m: m.embedding.shape[0], top_k=5, reverse=reverse)
+    if reverse:
+        assert query.matches[0].embedding.shape == (10,)
+    else:
+        assert query.matches[0].embedding.shape == (1,)
 
 
 def test_query_match_array_sort_scores():


### PR DESCRIPTION
This PR resolves #3467

- Added `_sort_top_k` method to sort only top_k elements. 
- For `reverse = False`(default), Sorted top_k smallest values them in ascending order and keep it at the top while the rest of the list may not be sorted.
- For `reverse = True`, Sorted top_k biggest values  and keep it at the top while the rest of the list may not be sorted.
- Added unit test case