### PR TITLE
fix(docs): performance and a11y

### DIFF
--- a/docs/_templates/page.html
+++ b/docs/_templates/page.html
@@ -156,11 +156,11 @@
                     {%- endtrans %}
                     {%- endif %}
                     <div class="social-btns">
-                    <a class='social-btn' href="https://github.com/jina-ai/jina/" target="_blank"> <i class="fab fa-github"></i></a>
-                    <a class='social-btn' href="https://slack.jina.ai" target="_blank"> <i class="fab fa-slack"></i></a>
-                    <a class='social-btn' href="https://youtube.com/c/jina-ai" target="_blank"> <i class="fab fa-youtube"></i></a>
-                    <a class='social-btn' href="https://twitter.com/JinaAI_" target="_blank"> <i class="fab fa-twitter"></i></a>
-                    <a class='social-btn' href="https://www.linkedin.com/company/jinaai/" target="_blank"> <i class="fab fa-linkedin"></i></a>
+                    <a class='social-btn' href="https://github.com/jina-ai/jina/" aria-label="GitHub" target="_blank"> <i class="fab fa-github"></i></a>
+                    <a class='social-btn' href="https://slack.jina.ai" aria-label="Slack" target="_blank"> <i class="fab fa-slack"></i></a>
+                    <a class='social-btn' href="https://youtube.com/c/jina-ai" aria-label="YouTube" target="_blank"> <i class="fab fa-youtube"></i></a>
+                    <a class='social-btn' href="https://twitter.com/JinaAI_" aria-label="Twitter" target="_blank"> <i class="fab fa-twitter"></i></a>
+                    <a class='social-btn' href="https://www.linkedin.com/company/jinaai/" aria-label="LinkedIn" target="_blank"> <i class="fab fa-linkedin"></i></a>
                     </div>
                 </div>
                 {% endblock footer %}

--- a/docs/_templates/page.html
+++ b/docs/_templates/page.html
@@ -156,11 +156,11 @@
                     {%- endtrans %}
                     {%- endif %}
                     <div class="social-btns">
-                    <a class='social-btn' href="https://github.com/jina-ai/jina/" aria-label="GitHub" target="_blank"> <i class="fab fa-github"></i></a>
-                    <a class='social-btn' href="https://slack.jina.ai" aria-label="Slack" target="_blank"> <i class="fab fa-slack"></i></a>
-                    <a class='social-btn' href="https://youtube.com/c/jina-ai" aria-label="YouTube" target="_blank"> <i class="fab fa-youtube"></i></a>
-                    <a class='social-btn' href="https://twitter.com/JinaAI_" aria-label="Twitter" target="_blank"> <i class="fab fa-twitter"></i></a>
-                    <a class='social-btn' href="https://www.linkedin.com/company/jinaai/" aria-label="LinkedIn" target="_blank"> <i class="fab fa-linkedin"></i></a>
+                    <a class='social-btn' href="https://github.com/jina-ai/jina/" aria-label="GitHub" target="_blank" rel="noreferrer"> <i class="fab fa-github"></i></a>
+                    <a class='social-btn' href="https://slack.jina.ai" aria-label="Slack" target="_blank" rel="noreferrer"> <i class="fab fa-slack"></i></a>
+                    <a class='social-btn' href="https://youtube.com/c/jina-ai" aria-label="YouTube" target="_blank" rel="noreferrer"> <i class="fab fa-youtube"></i></a>
+                    <a class='social-btn' href="https://twitter.com/JinaAI_" aria-label="Twitter" target="_blank" rel="noreferrer"> <i class="fab fa-twitter"></i></a>
+                    <a class='social-btn' href="https://www.linkedin.com/company/jinaai/" aria-label="LinkedIn" target="_blank" rel="noreferrer"> <i class="fab fa-linkedin"></i></a>
                     </div>
                 </div>
                 {% endblock footer %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -72,7 +72,7 @@ html_css_files = [
     'docbot.css',
     'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta2/css/all.min.css',
 ]
-html_js_files = ['https://cdn.jsdelivr.net/npm/vue@2/dist/vue.js', 'docbot.js']
+html_js_files = ['https://cdn.jsdelivr.net/npm/vue@2/dist/vue.min.js', 'docbot.js']
 htmlhelp_basename = slug
 html_show_sourcelink = False
 html_favicon = '_static/favicon.ico'


### PR DESCRIPTION
This PR includes three fixes:
- Use prod Vue (size drops to 1/3 of the dev version, [read more](https://vuejs.org/v2/guide/installation.html#Development-vs-Production-Mode))
- Add `aria-label` to social button anchors since their content is an icon and can't be read by screen readers
- Add `noreferrer` to social button anchors, [read more](https://web.dev/external-anchors-use-rel-noopener/)