### PR TITLE
ci: fix cd

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -264,6 +264,7 @@ jobs:
           JINAHUB_PASSWORD: ${{ secrets.JINAHUB_PASSWORD }}
 
   k8s-test:
+    needs: update-schema
     runs-on: ubuntu-latest
     needs: update-schema
     steps:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -117,15 +117,14 @@ jobs:
   prep-testbed:
     runs-on: ubuntu-latest
     needs: update-schema
-    with:
-      inputs: '{ "release_token": "${{ env.release_token }}", "triggered_by": "CD"}'
-      token: ${{ secrets.JINA_DEV_BOT }}
+    env:
+      release_token: ${{ secrets.JINA_CORE_RELEASE_TOKEN }}
     steps:
       - uses: actions/checkout@v2
       - id: set-matrix
         run: |
           sudo apt-get install jq
-          echo "::set-output name=matrix::$(bash scripts/get-all-test-paths.sh tests)"
+          echo "::set-output name=matrix::$(bash scripts/get-all-test-paths.sh)"
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -117,6 +117,9 @@ jobs:
   prep-testbed:
     runs-on: ubuntu-latest
     needs: update-schema
+    with:
+      inputs: '{ "release_token": "${{ env.release_token }}", "triggered_by": "CD"}'
+      token: ${{ secrets.JINA_DEV_BOT }}
     steps:
       - uses: actions/checkout@v2
       - id: set-matrix

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -266,7 +266,6 @@ jobs:
   k8s-test:
     needs: update-schema
     runs-on: ubuntu-latest
-    needs: update-schema
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python 3.7


### PR DESCRIPTION
> Error when evaluating 'strategy' for job 'core-test'. (Line: 137, Col: 20): Error reading JToken from JsonReader. Path '',

the error pop up after [this pr](https://github.com/jina-ai/jina/commit/4769b336bb0ff55cb65eb15466d4bacdd0bfc70f).
Hypothesis:
`pre-testbed` failed to generate outputs, thus produce empty output matrix (`core-test` needs `pre-testbed`). And in `core-test`:
```yaml
    strategy:
      fail-fast: false
      matrix:
        python-version: [3.7]
        test-path: ${{fromJson(needs.prep-testbed.outputs.matrix)}}
```
`fromJson` get an empty string.

Previously, `pre-testbed` has 2 needs: `update-schema` and `update-doc`. `update-doc` has been removed in #3526. 

this should be related to env settings. so I added env back to this PR. also some minor clean up such as remove unused `tests` in the bash script.