### PR TITLE
ci: fix cla

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -11,16 +11,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "CLA Assistant"
-        if: (github.event.comment.body == 'recheckcla' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request'
+        on:
+          issue_comment:
+            types: [ created ]
+          pull_request_target:
+            types: [ opened,closed,synchronize ]
+        if: (github.event.comment.body == 'recheckcla' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
         # Alpha Release
-        uses: hanxiao/github-action@master
+        uses: cla-assistant/github-action@v2.1.3-beta
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # the below token should have repo scope and must be manually added by you in the repository's secret
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_TOKEN }}
         with:
           path-to-signatures: '.github/signatures/v1/cla.json'
           path-To-cladocument: 'https://github.com/jina-ai/jina/blob/master/.github/CLA.md'
-          # branch should not be protected
           branch: 'cla'
           whitelist: jina-bot
-          empty-commit-flag: false
-          blockchain-storage-flag: false
+          signed-commit-message: '$contributorName has signed the CLA in #$pullRequestNo'


### PR DESCRIPTION
Instead of using our fork, this pr switches to the latest upstream version at https://github.com/cla-assistant/github-action