### PR TITLE
feat(document): add support for Hugging Face datasets

### DIFF
--- a/extra-requirements.txt
+++ b/extra-requirements.txt
@@ -76,3 +76,4 @@ kubernetes>=18.20.0:        perf, standard, devel
 pytest-kind==21.1.3:        test
 pytest-lazy-fixture:        test
 portforward>=0.2.4:         test
+datasets:                   devel

--- a/jina/resources/extra-requirements.txt
+++ b/jina/resources/extra-requirements.txt
@@ -76,3 +76,4 @@ kubernetes>=18.20.0:        perf, standard, devel
 pytest-kind==21.1.3:        test
 pytest-lazy-fixture:        test
 portforward>=0.2.4:         test
+datasets:                   devel

--- a/tests/unit/clients/python/test_io.py
+++ b/tests/unit/clients/python/test_io.py
@@ -11,6 +11,7 @@ from jina.types.document.generators import (
     from_ndarray,
     from_lines,
     from_csv,
+    from_huggingface_datasets,
 )
 
 cur_dir = os.path.dirname(os.path.abspath(__file__))
@@ -27,6 +28,23 @@ def filepath(tmpdir):
     with open(input_filepath, 'w') as input_file:
         input_file.writelines(["1\n", "2\n", "3\n"])
     return input_filepath
+
+
+@pytest.fixture(scope='function')
+def dataset_configs():
+    config = {
+        'adversarial': {
+            'dataset_path': 'adversarial_qa',
+            'name': 'adversarialQA',
+            'split': 'test',
+        },
+        'tweet_eval': {
+            'dataset_path': 'tweet_eval',
+            'name': 'emoji',
+            'split': 'train+test',
+        },
+    }
+    return config
 
 
 def test_input_lines_with_filepath(filepath):
@@ -141,6 +159,105 @@ def test_input_lines_with_jsonlines_docs_groundtruth():
     assert result[0][1].text == "b"
     assert result[1][0].text == "c"
     assert result[1][1].text == "d"
+
+
+@pytest.mark.parametrize(
+    'size, sampling_rate',
+    [
+        (None, None),
+        (1, None),
+        (None, 0.5),
+    ],
+)
+def test_input_huggingface_datasets_from_path(dataset_configs, size, sampling_rate):
+    result = list(
+        from_huggingface_datasets(
+            dataset_configs['adversarial']['dataset_path'],
+            size=size,
+            name=dataset_configs['adversarial']['name'],
+            sampling_rate=sampling_rate,
+            split=dataset_configs['adversarial']['split'],
+        )
+    )
+
+    if size is not None:
+        assert len(result) == size
+
+    assert isinstance(result[0], Document)
+
+
+def test_input_huggingface_datasets_with_tweet_dataset(dataset_configs):
+    result = list(
+        from_huggingface_datasets(
+            dataset_configs['tweet_eval']['dataset_path'],
+            name=dataset_configs['tweet_eval']['name'],
+            split=dataset_configs['tweet_eval']['split'],
+        )
+    )
+    assert isinstance(result[0], Document)
+    assert result[0].text
+
+
+def test_input_huggingface_datasets_with_field_resolver(dataset_configs):
+    field_resolver = {'question': 'text'}
+    result = list(
+        from_huggingface_datasets(
+            dataset_configs['adversarial']['dataset_path'],
+            field_resolver=field_resolver,
+            name=dataset_configs['adversarial']['name'],
+            split=dataset_configs['adversarial']['split'],
+        )
+    )
+    assert isinstance(result[0], Document)
+    assert result[0].text
+    assert 'title' in result[0].tags
+
+
+def test_input_huggingface_datasets_with_filter_fields(dataset_configs):
+    field_resolver = {'question': 'text'}
+    result = list(
+        from_huggingface_datasets(
+            dataset_configs['adversarial']['dataset_path'],
+            field_resolver=field_resolver,
+            filter_fields=True,
+            name=dataset_configs['adversarial']['name'],
+            split=dataset_configs['adversarial']['split'],
+        )
+    )
+    assert isinstance(result[0], Document)
+    assert result[0].text
+    assert not 'title' in result[0].tags
+
+
+def test_input_huggingface_datasets_with_no_dataset_name(dataset_configs):
+    with pytest.raises(ValueError):
+        result = from_huggingface_datasets(
+            dataset_configs['adversarial']['dataset_path'],
+            split=dataset_configs['adversarial']['split'],
+        )
+        for _ in result:
+            pass
+
+
+def test_input_huggingface_datasets_with_no_split(dataset_configs):
+    with pytest.raises(ValueError):
+        result = from_huggingface_datasets(
+            dataset_configs['adversarial']['dataset_path'],
+            name=dataset_configs['adversarial']['name'],
+        )
+        for _ in result:
+            pass
+
+
+def test_input_huggingface_datasets_with_filter_fields_and_no_resolver(dataset_configs):
+    with pytest.raises(ValueError):
+        result = from_huggingface_datasets(
+            dataset_configs['adversarial']['dataset_path'],
+            name=dataset_configs['adversarial']['name'],
+            filter_fields=True,
+        )
+        for _ in result:
+            pass
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
**Motivation**
Hugging Face Datasets has a large repository of datasets (https://huggingface.co/datasets). It will be easy for the users to experiment and create downstream applications with Jina using these datasets. This feature aims to provide an interface for the users to easily load such datasets.

**Additions**
This PR adds ``from_huggingface_datasets`` generator to load datasets using Hugging Face Datasets. It supports passing additional arguments to the `datasets` library and yields Jina Documents.