### PR TITLE
ci(k8s): skip k8s from success-all-test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -322,7 +322,7 @@ jobs:
   # just for blocking the merge until all parallel core-test are successful
   success-all-test:
     runs-on: ubuntu-latest
-    needs: [core-test, hub-test, k8s-test, docker-image-test, check-docstring, check-black, code-injection]
+    needs: [core-test, hub-test, docker-image-test, check-docstring, check-black, code-injection]
     if: always()
     steps:
       - uses: technote-space/workflow-conclusion-action@v2


### PR DESCRIPTION
@JoanFM This removes `k8s-test` from `success-all-test.needs`. We'll put it back once this test is not flaky.