### PR TITLE
fix(daemon): workaround failing jinad ci

### DIFF
--- a/daemon/stores/containers.py
+++ b/daemon/stores/containers.py
@@ -78,7 +78,7 @@ class ContainerStore(BaseStore):
         :param uri: uri of partial-daemon
         :return: True if partial-daemon is ready"""
         async with aiohttp.ClientSession() as session:
-            for _ in range(20):
+            for _ in range(60):
                 try:
                     async with session.get(uri) as response:
                         if response.status == HTTPStatus.OK:
@@ -94,7 +94,7 @@ class ContainerStore(BaseStore):
                         f'error while checking if partial-daemon is ready: {e}'
                     )
         self._logger.error(
-            f'couldn\'t reach {self._kind.title()} container at {uri} after 10secs'
+            f'couldn\'t reach {self._kind.title()} container at {uri} after 30secs'
         )
         return False
 
@@ -198,7 +198,7 @@ class ContainerStore(BaseStore):
             )
             if not await self.ready(uri):
                 raise PartialDaemonConnectionException(
-                    f'{id.type.title()} creation failed, couldn\'t reach the container at {uri} after 10secs'
+                    f'{id.type.title()} creation failed, couldn\'t reach the container at {uri} after 30secs'
                 )
             kwargs.update(
                 {'ports': ports.dict()} if isinstance(ports, PortMappings) else {}


### PR DESCRIPTION
This is a workaround for the failing jinad tests in CI.
In [this debug pr](https://github.com/jina-ai/jina/pull/3622/checks?check_run_id=3847052055) I noticed that it takes longer than 10 seconds to start the docker containers with the peas. I dont know why this is and it seems too long to me. We should probably investigate what is happening there, but might just be CI not having powerful enough machines for all the docker image build and container handling.

As a workaround this PR increases the container run timeout from 10 seconds to 30 seconds. I hope that makes CI more stable.
This mitigates #3610