### PR TITLE
feat: k8s hubble no cache

### DIFF
--- a/jina/peapods/pods/k8slib/kubernetes_deployment.py
+++ b/jina/peapods/pods/k8slib/kubernetes_deployment.py
@@ -198,7 +198,7 @@ def get_image_name(uses: str) -> str:
     """
     try:
         scheme, name, tag, secret = parse_hub_uri(uses)
-        meta_data = HubIO.fetch_meta(name, tag, secret=secret)
+        meta_data = HubIO.fetch_meta(name, tag, secret=secret, force=True)
         image_name = meta_data.image_name
         return image_name
     except Exception:


### PR DESCRIPTION
- currently, it can happen that you have an old cache file from the hubble api on your machine. Means k8s won't pull the latest image.
This codechange forces to send a request to the api.