### PR TITLE
fix(flow): use negative logic for k8s_connection_pooling (#3532)

### DIFF
--- a/jina/flow/base.py
+++ b/jina/flow/base.py
@@ -804,6 +804,8 @@ class Flow(PostMixin, JAMLCompatible, ExitStack, metaclass=FlowType):
         op_flow._pod_nodes[pod_name] = PodFactory.build_pod(
             args, needs, self.args.infrastructure
         )
+        # expose internally used args for testing
+        op_flow._args = args
 
         op_flow.last_pod = pod_name
 

--- a/jina/parsers/peapods/runtimes/zed.py
+++ b/jina/parsers/peapods/runtimes/zed.py
@@ -203,14 +203,6 @@ is wrong in the upstream, it is hard to carry this exception and moving forward 
         else argparse.SUPPRESS,
     )
 
-    gp.add_argument(
-        '--k8s-connection-pool',
-        action='store_true',
-        default=True,
-        help='Defines if connection pooling should be used in K8s'
-        if _SHOW_ALL_ARGS
-        else argparse.SUPPRESS,
-    )
 
     gp.add_argument(
         '--k8s-no-connection-pool',

--- a/tests/unit/flow-construct/test_flow.py
+++ b/tests/unit/flow-construct/test_flow.py
@@ -736,7 +736,7 @@ def test_flow_empty_data_request(mocker):
 
 
 def test_flow_common_kwargs():
-
+    
     with Flow(name='hello', something_random=True).add() as f:
         assert f._common_kwargs == {'something_random': True}
 
@@ -824,6 +824,21 @@ def test_connect_to_predecessor():
     assert len(f._pod_nodes['gateway'].head_args.hosts_in_connect) == 0
     assert len(f._pod_nodes['executor1'].head_args.hosts_in_connect) == 0
     assert len(f._pod_nodes['executor2'].head_args.hosts_in_connect) == 1
+
+
+@pytest.mark.parametrize('k8s_no_connection_pool', [None, False, True])
+def test_flow_k8s_connection_pooling(k8s_no_connection_pool):
+    if k8s_no_connection_pool is None:
+        f = Flow(name='k8s-flow', port_expose=8080, infrastructure='K8S').add()
+    else: 
+        f = Flow(name='k8s-flow', port_expose=8080, infrastructure='K8S', k8s_no_connection_pool=k8s_no_connection_pool).add()
+    if k8s_no_connection_pool and f._args.k8s_connection_pool:
+        # Check if value is properly overridden
+        raise AssertionError(f'Flow got k8s_no_connection_pool={k8s_no_connection_pool} but uses k8s_connection_pool {f._args.k8s_connection_pool}')
+    if k8s_no_connection_pool is None or k8s_no_connection_pool == False:
+        # Check if default value True is used
+        if f._args.k8s_connection_pool == False:
+            raise AssertionError(f'Flow uses k8s_connection_pool={f._args.k8s_connection_pool} but k8s_no_connection_pool was not passed or passed as False.')
 
 
 def test_flow_grpc_with_shard():


### PR DESCRIPTION
This pull request fixes that k8s_connection_pooling is always set True.

We use negative logic with the flag k8s_no_connection_pooling, which sets k8s_connection_pooling False.

Test are provided.