### PR TITLE
refactor: go lang warning

### DIFF
--- a/jina/peapods/pods/k8slib/kubernetes_tools.py
+++ b/jina/peapods/pods/k8slib/kubernetes_tools.py
@@ -194,7 +194,7 @@ def get_port_forward_contextmanager(
         required=True,
         help_text='Sending requests to the Kubernetes cluster requires to install the portforward package. '
         'Please do `pip install "jina[portforward]"`'
-        'Also make sure golang is installed by running `go version`',
+        'Also make sure golang is installed `https://golang.org/`',
     ):
         import portforward
 


### PR DESCRIPTION
- warning needs to be added if the portforward package is not there and has to be installed since it requires golang