### PR TITLE
fix: gateway uvicorn needed

### DIFF
--- a/docs/advanced/experimental/kubernetes.md
+++ b/docs/advanced/experimental/kubernetes.md
@@ -270,7 +270,7 @@ Console output:
 ```txt
 start_test_searcher@81116[I]:🏝️	Create Namespace "search-flow" for "test_searcher"
 deploy_test_searcher@81116[I]:🔋	Create Service for "test-searcher-head" with exposed port "8080"
-deploy_test_searcher@81116[I]:🐳	Create Deployment for "test-searcher-head" with image "jinaai/jina:x.x.x-py38-standard", replicas 1 and init_container False
+deploy_test_searcher@81116[I]:🐳	Create Deployment for "test-searcher-head" with image "jinaai/jina:x.x.x-py38-perf", replicas 1 and init_container False
 deploy_test_searcher@81116[I]:🔋	Create Service for "test-searcher-0" with exposed port "8080"
 deploy_test_searcher@81116[I]:🐳	Create Deployment for "test-searcher-0" with image "jinahub/nflcyqe2:v10-2.1.0", replicas 2 and init_container False
 deploy_test_searcher@81116[I]:🔋	Create Service for "test-searcher-1" with exposed port "8080"

--- a/jina/peapods/pods/k8s.py
+++ b/jina/peapods/pods/k8s.py
@@ -93,7 +93,7 @@ class K8sPod(BasePod, ExitFIFO):
                 image_name = (
                     'jinaai/jina:test-pip'
                     if test_pip
-                    else f'jinaai/jina:{self.version}-py38-standard'
+                    else f'jinaai/jina:{self.version}-py38-perf'
                 )
                 uses = 'BaseExecutor'
             else:

--- a/tests/unit/peapods/pods/test_k8s_pod.py
+++ b/tests/unit/peapods/pods/test_k8s_pod.py
@@ -240,7 +240,7 @@ def test_start_deploys_runtime():
 
     assert dns_name == pod_name
     assert kwargs['namespace'] == namespace
-    assert kwargs['image_name'] == f'jinaai/jina:{pod.version}-py38-standard'
+    assert kwargs['image_name'] == f'jinaai/jina:{pod.version}-py38-perf'
     assert kwargs['replicas'] == 1
     assert kwargs['init_container'] is None
     assert kwargs['custom_resource_dir'] is None


### PR DESCRIPTION
Thank's @winstonww  for reporting this issue.

Currently, Kubernetes is not usable. The Gateway is deployed using perf which does not contain uvicorn.

```
To enable this feature, use pip install jina[TAG], where [TAG] is one of [uvicorn[standard]>=0.14.0] [standard] [daemon] [devel] [demo].
 (raised from /usr/local/lib/python3.8/site-packages/jina/peapods/runtimes/gateway/http/__init__.py:23)

Traceback (most recent call last):
  File "/usr/local/bin/jina", line 8, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.8/site-packages/cli/__init__.py", line 116, in main
    getattr(api, args.cli.replace('-', '_'))(args)
  File "/usr/local/lib/python3.8/site-packages/cli/api.py", line 109, in gateway
    with runtime_cls(args) as runtime:
  File "/usr/local/lib/python3.8/site-packages/jina/peapods/runtimes/zmq/asyncio.py", line 88, in __init__
    self._loop.run_until_complete(self.async_setup())
  File "/usr/local/lib/python3.8/asyncio/base_events.py", line 616, in run_until_complete
    return future.result()
  File "/usr/local/lib/python3.8/site-packages/jina/peapods/runtimes/gateway/http/__init__.py", line 23, in async_setup
    from uvicorn import Config, Server
  File "/usr/local/lib/python3.8/site-packages/jina/importer.py", line 86, in __exit__
    raise exc_val
  File "/usr/local/lib/python3.8/site-packages/jina/peapods/runtimes/gateway/http/__init__.py", line 23, in async_setup
    from uvicorn import Config, Server
ModuleNotFoundError: No module named 'uvicorn'
```