### PR TITLE
docs: expand executor yaml to be more usable

### DIFF
--- a/docs/fundamentals/executor/executor-built-in-features.md
+++ b/docs/fundamentals/executor/executor-built-in-features.md
@@ -134,11 +134,11 @@ metas:
   description: "MyExecutor does a thing to the stuff in your Documents"
   workspace: workspace
   py_modules:
-  - executor.py
+    - executor.py
 requests:
-  index: class_index_method
-  search: class_search_method
-  random: class_other_method
+  index: MyExecutor_index_method
+  search: MyExecutor_search_method
+  random: MyExecutor_other_method
 ```
 
 - `jtype` is a string. Defines the class name, interchangeable with bang mark `!`;


### PR DESCRIPTION
It took me ages to get my [remove_dead_urls](https://github.com/alexcg1/executor_remove_dead_urls) Executor to work since I didn't have a *real* example `config.yml` to look at, just the skeleton.

This PR puts flesh on the bones and will prevent others getting confused like I did.
