### PR TITLE
feat: concurrent rolling updates of shards

### DIFF
--- a/jina/flow/base.py
+++ b/jina/flow/base.py
@@ -1792,8 +1792,13 @@ class Flow(PostMixin, JAMLCompatible, ExitStack, metaclass=FlowType):
         :param dump_path: **backwards compatibility** This function was only accepting dump_path as the only potential arg to override
         :param uses_with: a Dictionary of arguments to restart the executor with
         """
-        self._pod_nodes[pod_name].rolling_update(
-            dump_path=dump_path, uses_with=uses_with
+        from ..helper import run_async
+
+        run_async(
+            self._pod_nodes[pod_name].rolling_update,
+            dump_path=dump_path,
+            uses_with=uses_with,
+            any_event_loop=True,
         )
 
     @property

--- a/jina/peapods/peas/__init__.py
+++ b/jina/peapods/peas/__init__.py
@@ -257,6 +257,34 @@ class BasePea:
             shutdown_event=self.is_shutdown,
         )
 
+    def _fail_start_timeout(self, timeout):
+        """
+        Closes the Pea and raises a TimeoutError with the corresponding warning messages
+
+        :param timeout: The time to wait before readiness or failure is determined
+            .. # noqa: DAR201
+        """
+        _timeout = timeout or -1
+        self.logger.warning(
+            f'{self.runtime_cls!r} timeout after waiting for {self.args.timeout_ready}ms, '
+            f'if your executor takes time to load, you may increase --timeout-ready'
+        )
+        self.close()
+        raise TimeoutError(
+            f'{typename(self)}:{self.name} can not be initialized after {_timeout * 1e3}ms'
+        )
+
+    def _check_failed_to_start(self):
+        """
+        Raises a corresponding exception if failed to start
+        """
+        if self.is_shutdown.is_set():
+            # return too early and the shutdown is set, means something fails!!
+            if not self.is_started.is_set():
+                raise RuntimeFailToStart
+            else:
+                raise RuntimeRunForeverEarlyError
+
     def wait_start_success(self):
         """Block until all peas starts successfully.
 
@@ -269,30 +297,36 @@ class BasePea:
             _timeout /= 1e3
 
         if self._wait_for_ready_or_shutdown(_timeout):
-            if self.is_shutdown.is_set():
-                # return too early and the shutdown is set, means something fails!!
-                if not self.is_started.is_set():
-                    raise RuntimeFailToStart
-                else:
-                    raise RuntimeRunForeverEarlyError
-            else:
-                # han: I intentionally change it to debug as the Flow is now polling
-                # the ready status actively. Hence active print ready status is unnecessary.
-                #  Notice that, relying on Pod console print for readiness in general makes
-                # no sense as the Pod can live remote/container whose log can not be observed at all.
-                #
-                # in short, do not change it back to info, you don't need it.
-                self.logger.debug(__ready_msg__)
+            self._check_failed_to_start()
+            self.logger.debug(__ready_msg__)
         else:
-            _timeout = _timeout or -1
-            self.logger.warning(
-                f'{self.runtime_cls!r} timeout after waiting for {self.args.timeout_ready}ms, '
-                f'if your executor takes time to load, you may increase --timeout-ready'
-            )
-            self.close()
-            raise TimeoutError(
-                f'{typename(self)}:{self.name} can not be initialized after {_timeout * 1e3}ms'
-            )
+            self._fail_start_timeout(_timeout)
+
+    async def async_wait_start_success(self):
+        """Block until all peas starts successfully.
+
+        If not success, it will raise an error hoping the outer function to catch it
+        """
+        import asyncio
+
+        _timeout = self.args.timeout_ready
+        if _timeout <= 0:
+            _timeout = None
+        else:
+            _timeout /= 1e3
+
+        timeout_ns = 1e9 * _timeout if _timeout else None
+        now = time.time_ns()
+        while timeout_ns is None or time.time_ns() - now < timeout_ns:
+
+            if self.ready_or_shutdown.event.is_set():
+                self._check_failed_to_start()
+                self.logger.debug(__ready_msg__)
+                return
+            else:
+                await asyncio.sleep(0.1)
+
+        self._fail_start_timeout(_timeout)
 
     @property
     def _is_dealer(self):

--- a/jina/peapods/pods/compound.py
+++ b/jina/peapods/pods/compound.py
@@ -257,15 +257,29 @@ class CompoundPod(BasePod, ExitStack):
             result.append(_args)
         return result
 
-    def rolling_update(
+    async def rolling_update(
         self, dump_path: Optional[str] = None, *, uses_with: Optional[Dict] = None
     ):
         """Reload all Pods of this Compound Pod.
         :param dump_path: **backwards compatibility** This function was only accepting dump_path as the only potential arg to override
         :param uses_with: a Dictionary of arguments to restart the executor with
         """
-        for shard in self.shards:
-            shard.rolling_update(dump_path=dump_path, uses_with=uses_with)
+        tasks = []
+        try:
+            import asyncio
+
+            tasks = [
+                asyncio.create_task(
+                    shard.rolling_update(dump_path=dump_path, uses_with=uses_with)
+                )
+                for shard in self.shards
+            ]
+            for future in asyncio.as_completed(tasks):
+                _ = await future
+        except:
+            for task in tasks:
+                if not task.done():
+                    task.cancel()
 
     @property
     def _mermaid_str(self) -> List[str]:

--- a/jina/peapods/runtimes/zmq/zed.py
+++ b/jina/peapods/runtimes/zmq/zed.py
@@ -389,7 +389,7 @@ class ZEDRuntime(ZMQRuntime):
         :param kwargs: extra keyword arguments
         :return: True if is ready or it needs to be shutdown
         """
-        timeout_ns = 1000000000 * timeout if timeout else None
+        timeout_ns = 1e9 * timeout if timeout else None
         now = time.time_ns()
         while timeout_ns is None or time.time_ns() - now < timeout_ns:
             if shutdown_event.is_set() or ZEDRuntime.is_ready(


### PR DESCRIPTION
**Changes proposed**
We are now updating one `shard` at a time for `CompoundPod`.  This is unefficient because replicas of different shards could be parallelized and easily doable in an async manner.

**DANGEROUS**
I am not sure about the impact in JinaD where an eventloop already exists. Therefore the rolling update would work in a thread. And I am not sure how the `processes` started from `threads` remain when a thread is `stopped`. @deepankarm @jacobowitz any observation here?

**Future**
In the future inside the `Pod` implementation we could have a logic on how many replicas are upgraded at the same time, etc ... similar to K8s