### PR TITLE
feat(helper): add eta on progressbar for known-length inputs

### DIFF
--- a/jina/clients/base/__init__.py
+++ b/jina/clients/base/__init__.py
@@ -91,6 +91,11 @@ class BaseClient(ABC):
         # override by the caller-specific kwargs
         _kwargs.update(kwargs)
 
+        if hasattr(self._inputs, '__len__'):
+            self._inputs_length = max(1, len(self._inputs) / _kwargs['request_size'])
+        else:
+            self._inputs_length = None
+
         if inspect.isasyncgen(self.inputs):
             from ..request.asyncio import request_generator
 

--- a/jina/clients/base/grpc.py
+++ b/jina/clients/base/grpc.py
@@ -43,7 +43,11 @@ class GRPCBaseClient(BaseClient):
                 stub = jina_pb2_grpc.JinaRPCStub(channel)
                 self.logger.debug(f'connected to {self.args.host}:{self.args.port}')
 
-                cm1 = ProgressBar() if self.show_progress else nullcontext()
+                cm1 = (
+                    ProgressBar(total_length=self._inputs_length)
+                    if self.show_progress
+                    else nullcontext()
+                )
 
                 with cm1 as p_bar:
                     async for resp in stub.Call(req_iter):

--- a/jina/clients/base/http.py
+++ b/jina/clients/base/http.py
@@ -39,7 +39,11 @@ class HTTPBaseClient(BaseClient):
 
         async with AsyncExitStack() as stack:
             try:
-                cm1 = ProgressBar() if self.show_progress else nullcontext()
+                cm1 = (
+                    ProgressBar(total_length=self._inputs_length)
+                    if self.show_progress
+                    else nullcontext()
+                )
                 p_bar = stack.enter_context(cm1)
 
                 proto = 'https' if self.args.https else 'http'

--- a/jina/clients/base/websocket.py
+++ b/jina/clients/base/websocket.py
@@ -37,7 +37,11 @@ class WebSocketBaseClient(BaseClient):
 
         async with AsyncExitStack() as stack:
             try:
-                cm1 = ProgressBar() if self.show_progress else nullcontext()
+                cm1 = (
+                    ProgressBar(total_length=self._inputs_length)
+                    if self.show_progress
+                    else nullcontext()
+                )
                 p_bar = stack.enter_context(cm1)
 
                 proto = 'wss' if self.args.https else 'ws'

--- a/jina/logging/profile.py
+++ b/jina/logging/profile.py
@@ -8,10 +8,9 @@ from collections import defaultdict
 from functools import wraps
 from typing import Optional, Union, Callable
 
-from .. import __windows__
 from jina.enums import ProgressBarStatus
-
 from .logger import JinaLogger
+from .. import __windows__
 from ..helper import colored, get_readable_size, get_readable_time
 
 
@@ -214,6 +213,7 @@ class ProgressBar(TimeContext):
         description: str = 'Working...',
         message_on_done: Union[str, Callable[..., str], None] = None,
         final_line_feed: bool = True,
+        total_length: Optional[int] = None,
     ):
         """
         Create the ProgressBar.
@@ -221,6 +221,7 @@ class ProgressBar(TimeContext):
         :param description: The name of the task, will be displayed in front of the bar.
         :param message_on_done: The final message to print when the progress is complete
         :param final_line_feed: if False, the line will not get a Line Feed and thus is easily overwritable.
+        :param total_length: if set, then every :py:meth:`.update` increases the bar by `1/total_length * _bars_on_row`
         """
         super().__init__(description, None)
         self._bars_on_row = 40
@@ -229,6 +230,7 @@ class ProgressBar(TimeContext):
         self._num_update_called = 0
         self._on_done = message_on_done
         self._final_line_feed = final_line_feed
+        self._total_length = total_length
         self._stop_event = threading.Event()
 
     def update(
@@ -248,7 +250,8 @@ class ProgressBar(TimeContext):
         :param status: If set to a value, it will mark the task as complete, can be either "Done" or "Canceled"
         :param first_enter: if this method is called by `__enter__`
         """
-        self._num_update_called += 0 if first_enter else 1
+        if self._total_length:
+            progress = progress / self._total_length * self._bars_on_row
         self._completed_progress += progress
         self._last_rendered_progress = self._completed_progress
         elapsed = time.perf_counter() - self.start
@@ -268,11 +271,15 @@ class ProgressBar(TimeContext):
         else:
             bar_color, unfinished_bar_color = 'green', 'green'
 
-        speed_str = (
-            'estimating...'
-            if first_enter
-            else f'{self._num_update_called / elapsed:4.1f} step/s'
-        )
+        if first_enter:
+            speed_str = 'estimating...'
+        elif self._total_length:
+            _prog = self._num_update_called / self._total_length
+            speed_str = f'{(_prog * 100):.0f}% ETA: {get_readable_time(seconds=self.now() / (_prog + 1e-6) * (1 - _prog + 1e-6))}'
+        else:
+            speed_str = f'{self._num_update_called / elapsed:4.1f} step/s'
+
+        self._num_update_called += 0 if first_enter else 1
 
         description_str = description or self.task_name or ''
         if status != ProgressBarStatus.WORKING:

--- a/tests/unit/test_progress_bar.py
+++ b/tests/unit/test_progress_bar.py
@@ -11,7 +11,9 @@ from jina.logging.profile import ProgressBar
 @pytest.mark.parametrize('details', [None, 'step {}'])
 @pytest.mark.parametrize('msg_on_done', [None, 'done!', lambda: 'done!'])
 def test_progressbar(total_steps, update_tick, task_name, capsys, details, msg_on_done):
-    with ProgressBar(description=task_name, message_on_done=msg_on_done) as pb:
+    with ProgressBar(
+        description=task_name, message_on_done=msg_on_done, total_length=total_steps
+    ) as pb:
         for j in range(total_steps):
             pb.update(update_tick, message=details.format(j) if details else None)
             time.sleep(0.001)


### PR DESCRIPTION
```python
import time

from jina import DocumentArray, Document, Executor, requests, Flow

da = DocumentArray([Document() for _ in range(100)])

class MyExec(Executor):
    @requests
    def foo(self, **kwargs):
        time.sleep(.1)

with Flow().add(uses=MyExec) as f:
    f.post('/', da, show_progress=True, request_size=1)


```

![578e9792be0ff78f001c128be3349dc4](https://user-images.githubusercontent.com/2041322/137539162-6f6b5cc4-0cb1-4d27-8079-44b36496908f.gif)
