### PR TITLE
fix(container): use pid for container name

### DIFF
--- a/jina/peapods/runtimes/container/__init__.py
+++ b/jina/peapods/runtimes/container/__init__.py
@@ -13,7 +13,7 @@ from .... import __docker_host__
 from .helper import get_docker_network, get_gpu_device_requests
 from ....excepts import BadImageNameError, DockerVersionError
 from ...zmq import send_ctrl_message
-from ....helper import ArgNamespace, slugify, random_name
+from ....helper import ArgNamespace, slugify
 from ....enums import SocketType
 
 if TYPE_CHECKING:
@@ -201,13 +201,14 @@ class ContainerRuntime(ZMQRuntime):
             _args.append('--no-dynamic-routing')
 
         docker_kwargs = self.args.docker_kwargs or {}
+        self._container_name = slugify(f'{self.name}/{os.getpid()}')
         self._container = client.containers.run(
             uses_img,
             _args,
             detach=True,
             auto_remove=True,
             ports=ports,
-            name=slugify(f'{self.name}/{random_name()}'),
+            name=self._container_name,
             volumes=_volumes,
             network_mode=self._net_mode,
             entrypoint=self.args.entrypoint,

--- a/tests/unit/peapods/runtimes/container/test_container_runtime.py
+++ b/tests/unit/peapods/runtimes/container/test_container_runtime.py
@@ -9,7 +9,7 @@ from jina.checker import NetworkChecker
 from jina.executors import BaseExecutor
 from jina.executors.decorators import requests
 from jina import Flow, __windows__
-from jina.helper import random_name
+from jina.helper import random_name, slugify
 from jina.parsers import set_pea_parser
 from jina.parsers.ping import set_ping_parser
 from jina.peapods import Pea
@@ -54,8 +54,14 @@ def docker_image_built():
 def test_simple_container(docker_image_built):
     args = set_pea_parser().parse_args(['--uses', f'docker://{img_name}'])
 
-    with Pea(args):
-        pass
+    with Pea(args) as pea:
+        import docker
+
+        client = docker.from_env()
+        assert (
+            client.containers.get(slugify(f'ContainerRuntime/{pea.worker.pid}'))
+            is not None
+        )
 
     time.sleep(2)
     Pea(args).start().close()


### PR DESCRIPTION
We recently randomized the container name generated by the ContainerRuntime. This is needed so we can instantiate multiple Pods with Docker and the same name concurrently.
It is desirable though to have this name somewhat more deterministic and known during runtime so that we can use it later when necessary.

This PR replaces the random part with the PID of the ContainerRuntime. This should still avoid collisions as every container is spawned from a runtime in a separate process (at least when not using Thread, that would be an exception). The name is also stored as a field in the container runtime for convenience. This field might not always be possible to access though (especially from static cancel methods etc).