### PR TITLE
feat: add document array embedding filtering and validation logic to match function

### DIFF
--- a/jina/types/arrays/neural_ops.py
+++ b/jina/types/arrays/neural_ops.py
@@ -79,7 +79,7 @@ class DocumentArrayNeuralOpsMixin:
             from .document import DocumentArray
 
             if not isinstance(rhv, DocumentArray):
-                rhv = DocumentArray(lhv)
+                rhv = DocumentArray(rhv)
 
         if not (lhv and rhv):
             return


### PR DESCRIPTION
Further to the discussion in this [PR](https://github.com/jina-ai/executor-simpleindexer/pull/21), we add the filtering/validation logic to the `match` function so that we still get match results even if some docs indexed have invalid embeddings. We think it might be better to do it here rather than at index time because at index time we do not have information about the `traversal_paths`.

Opening this draft PR to collect feedback on general direction the PR should head. More tests to be added.

Related issue:  jina-ai/internal-tasks#212