### PR TITLE
feat: add support for gce https ingress

### DIFF
--- a/cli/autocomplete.py
+++ b/cli/autocomplete.py
@@ -182,6 +182,7 @@ ac_table = {
             '--default-swagger-ui',
             '--no-debug-endpoints',
             '--no-crud-endpoints',
+            '--no-health-check-endpoint',
             '--expose-endpoints',
             '--uvicorn-kwargs',
             '--compress',

--- a/docs/fundamentals/flow/flow-as-a-service.md
+++ b/docs/fundamentals/flow/flow-as-a-service.md
@@ -282,13 +282,14 @@ By default the following endpoints are exposed to the public:
 
 #### Hide CRUD and debug endpoints from HTTP interface
 
-User can decide to hide CRUD and debug endpoints in production, or when the context is not applicable. For example, in the code snippet below, we didn't implement any CRUD endpoints for the executor, hence it does not make sense to expose them to public.
+User can decide to hide CRUD, debug or health check endpoints in production, or when the context is not applicable. For example, in the code snippet below, we didn't implement any CRUD endpoints for the executor, hence it does not make sense to expose them to public.
 
 ```python
 from jina import Flow
 f = Flow(protocol='http',
          no_debug_endpoints=True,
-         no_crud_endpoints=True)
+         no_crud_endpoints=True,
+         no_health_check_endpoint=True)
 ```
 
 ```{figure} ../../../.github/2.0/hide-crud-debug-endpoints.png

--- a/jina/flow/base.py
+++ b/jina/flow/base.py
@@ -166,6 +166,7 @@ class Flow(PostMixin, JAMLCompatible, ExitStack, metaclass=FlowType):
         native: Optional[bool] = False,
         no_crud_endpoints: Optional[bool] = False,
         no_debug_endpoints: Optional[bool] = False,
+        no_health_check_endpoint: Optional[bool] = False,
         on_error_strategy: Optional[str] = 'IGNORE',
         port_ctrl: Optional[int] = None,
         port_expose: Optional[int] = None,
@@ -236,6 +237,7 @@ class Flow(PostMixin, JAMLCompatible, ExitStack, metaclass=FlowType):
 
                   Any executor that has `@requests(on=...)` bind with those values will receive data requests.
         :param no_debug_endpoints: If set, /status /post endpoints are removed from HTTP interface.
+        :param no_health_check_endpoint: If set, / endpoint is removed from HTTP interface.
         :param on_error_strategy: The skip strategy on exceptions.
 
           - IGNORE: Ignore it, keep running all Executors in the sequel flow

--- a/jina/flow/base.py
+++ b/jina/flow/base.py
@@ -237,7 +237,7 @@ class Flow(PostMixin, JAMLCompatible, ExitStack, metaclass=FlowType):
 
                   Any executor that has `@requests(on=...)` bind with those values will receive data requests.
         :param no_debug_endpoints: If set, /status /post endpoints are removed from HTTP interface.
-        :param no_health_check_endpoint: If set, / endpoint is removed from HTTP interface.
+        :param no_health_check_endpoint: If set, root / endpoint is removed from HTTP interface.
         :param on_error_strategy: The skip strategy on exceptions.
 
           - IGNORE: Ignore it, keep running all Executors in the sequel flow

--- a/jina/parsers/peapods/runtimes/remote.py
+++ b/jina/parsers/peapods/runtimes/remote.py
@@ -134,6 +134,13 @@ def mixin_http_gateway_parser(parser=None):
     )
 
     gp.add_argument(
+        '--no-health-check-endpoint',
+        action='store_true',
+        default=False,
+        help='If set, root / endpoint is removed from HTTP interface. ',
+    )
+
+    gp.add_argument(
         '--expose-endpoints',
         type=str,
         help='''

--- a/jina/peapods/pods/k8s.py
+++ b/jina/peapods/pods/k8s.py
@@ -41,11 +41,7 @@ class K8sPod(BasePod):
 
         def _deploy_gateway(self):
             test_pip = os.getenv('JINA_K8S_USE_TEST_PIP') is not None
-            image_name = (
-                'jinaai/jina:test-pip'
-                if test_pip
-                else f'jinaai/jina:{self.version}-py38-standard'
-            )
+            image_name = 'winstonww/jina:add-root-path'
             kubernetes_deployment.deploy_service(
                 self.dns_name,
                 namespace=self.k8s_namespace,

--- a/jina/peapods/pods/k8s.py
+++ b/jina/peapods/pods/k8s.py
@@ -41,7 +41,11 @@ class K8sPod(BasePod):
 
         def _deploy_gateway(self):
             test_pip = os.getenv('JINA_K8S_USE_TEST_PIP') is not None
-            image_name = 'winstonww/jina:add-root-path'
+            image_name = (
+                'jinaai/jina:test-pip'
+                if test_pip
+                else f'jinaai/jina:{self.version}-py38-standard'
+            )
             kubernetes_deployment.deploy_service(
                 self.dns_name,
                 namespace=self.k8s_namespace,

--- a/jina/peapods/pods/k8slib/kubernetes_deployment.py
+++ b/jina/peapods/pods/k8slib/kubernetes_deployment.py
@@ -129,7 +129,7 @@ def deploy_service(
             'port_in': port_in,
             'port_out': port_out,
             'port_ctrl': port_ctrl,
-            'type': 'ClusterIP',
+            'type': 'NodePort',
         },
         logger=logger,
         custom_resource_dir=custom_resource_dir,

--- a/jina/peapods/runtimes/gateway/http/app.py
+++ b/jina/peapods/runtimes/gateway/http/app.py
@@ -112,6 +112,20 @@ def get_fastapi_app(args: 'argparse.Namespace', logger: 'JinaLogger'):
                 'used_memory': used_memory_readable(),
             }
 
+        @app.get(
+            path='/',
+            summary='Root Health Check',
+            response_model=JinaStatusModel,
+            tags=['Debug'],
+        )
+        async def _root():
+            _info = get_full_version()
+            return {
+                'jina': _info[0],
+                'envs': _info[1],
+                'used_memory': used_memory_readable(),
+            }
+
         @app.post(
             path='/post',
             summary='Post a data request to some endpoint',

--- a/jina/peapods/runtimes/gateway/http/models.py
+++ b/jina/peapods/runtimes/gateway/http/models.py
@@ -260,6 +260,16 @@ class JinaStatusModel(BaseModel):
         allow_population_by_field_name = True
 
 
+class JinaHealthCheckModel(BaseModel):
+    """Pydantic BaseModel for Jina health check, used as the response model in REST app."""
+
+    success: bool
+
+    class Config:
+        alias_generator = _to_camel_case
+        allow_population_by_field_name = True
+
+
 def _get_example_data():
     _example = jina_pb2.DocumentArrayProto()
     d0 = Document(id='🐲', tags={'guardian': 'Azure Dragon', 'position': 'East'})


### PR DESCRIPTION
This PR aims to address the following:

1. Convert K8s `Service` type to `NodePort` because `gce` `Ingress` requires it
2. Add health check endpoint at `/`, also needed by `gce` `Ingress`

Opening this draft PR for some preliminary feedback. Will also add some tests going forward. Thanks.

Related Issue: https://github.com/jina-ai/showcase/issues/6