### PR TITLE
refactor(async): use nest-asyncio

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
   hooks:
   - id: darglint
     files: jina/
-    exclude: ^(jina/helloworld/|jina/proto/jina_pb2.py|docs/|jina/resources/)
+    exclude: ^(jina/helloworld/|jina/proto/jina_pb2.py|docs/|jina/resources/|jina/nest_asyncio.py)
     args:
     - --message-template={path}:{line} {msg_id} {msg}
     - -s=sphinx
@@ -15,7 +15,7 @@ repos:
   hooks:
   -   id: pydocstyle
       files: jina/
-      exclude: ^(jina/helloworld/|jina/proto/jina_pb2.py|docs/|jina/resources/)
+      exclude: ^(jina/helloworld/|jina/proto/jina_pb2.py|docs/|jina/resources/|jina/nest_asyncio.py)
       args:
       - --select=D101,D102,D103
 - repo: https://github.com/ambv/black

--- a/daemon/clients/base.py
+++ b/daemon/clients/base.py
@@ -8,7 +8,6 @@ from typing import Dict, Optional, Union
 import aiohttp
 
 from jina import __resources_path__
-from jina.helper import run_async
 from jina.logging.logger import JinaLogger
 
 from .mixin import AsyncToSyncMixin

--- a/daemon/clients/mixin.py
+++ b/daemon/clients/mixin.py
@@ -1,6 +1,6 @@
 from functools import partialmethod
 
-from jina.helper import run_async
+from jina.helper import asyncio_run
 
 
 class AsyncToSyncMixin:
@@ -16,7 +16,7 @@ class AsyncToSyncMixin:
         """
         f = getattr(super(), func_name, None)
         if f:
-            return run_async(f, any_event_loop=True, *args, **kwargs)
+            return asyncio_run(f, any_event_loop=True, *args, **kwargs)
 
     alive = partialmethod(func, 'alive')
     status = partialmethod(func, 'status')

--- a/jina/clients/mixin.py
+++ b/jina/clients/mixin.py
@@ -4,7 +4,7 @@ from typing import Optional, Dict, List, AsyncGenerator
 
 from .base import CallbackFnType, InputType
 from ..enums import InfrastructureType
-from ..helper import run_async
+from ..helper import asyncio_run
 from ..peapods.pods.k8slib import kubernetes_tools
 from ..types.request import Response
 
@@ -71,7 +71,7 @@ class PostMixin:
         else:
             context_mgr = nullcontext()
         with context_mgr:
-            return run_async(
+            return asyncio_run(
                 _get_results,
                 inputs=inputs,
                 on_done=on_done,

--- a/jina/flow/base.py
+++ b/jina/flow/base.py
@@ -78,7 +78,7 @@ FALLBACK_PARSERS = [
 
 
 class Flow(PostMixin, JAMLCompatible, ExitStack, metaclass=FlowType):
-    """Flow is how Jina streamlines and distributes Executors. """
+    """Flow is how Jina streamlines and distributes Executors."""
 
     class _FlowK8sInfraResourcesManager:
         def __init__(self, k8s_namespace: str, k8s_custom_resource_dir: Optional[str]):
@@ -1794,9 +1794,9 @@ class Flow(PostMixin, JAMLCompatible, ExitStack, metaclass=FlowType):
         :param dump_path: **backwards compatibility** This function was only accepting dump_path as the only potential arg to override
         :param uses_with: a Dictionary of arguments to restart the executor with
         """
-        from ..helper import run_async
+        from ..helper import asyncio_run
 
-        run_async(
+        asyncio_run(
             self._pod_nodes[pod_name].rolling_update,
             dump_path=dump_path,
             uses_with=uses_with,

--- a/jina/nest_asyncio.py
+++ b/jina/nest_asyncio.py
@@ -1,0 +1,241 @@
+"""
+BSD 2-Clause License
+
+Copyright (c) 2018-2020, Ewald de Wit
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+"""
+
+import asyncio
+import asyncio.events as events
+import os
+import sys
+import threading
+from contextlib import contextmanager
+from heapq import heappop
+
+
+def apply(loop=None):
+    """Patch asyncio to make its event loop reentrant."""
+    loop = loop or asyncio.get_event_loop()
+    if not isinstance(loop, asyncio.BaseEventLoop):
+        raise ValueError('Can\'t patch loop of type %s' % type(loop))
+    if getattr(loop, '_nest_patched', None):
+        # already patched
+        return
+    _patch_asyncio()
+    _patch_loop(loop)
+    _patch_task()
+    _patch_tornado()
+
+
+def _patch_asyncio():
+    """
+    Patch asyncio module to use pure Python tasks and futures,
+    use module level _current_tasks, all_tasks and patch run method.
+    """
+
+    def run(future, *, debug=False):
+        loop = asyncio.get_event_loop()
+        loop.set_debug(debug)
+        return loop.run_until_complete(future)
+
+    if sys.version_info >= (3, 6, 0):
+        asyncio.Task = asyncio.tasks._CTask = asyncio.tasks.Task = asyncio.tasks._PyTask
+        asyncio.Future = (
+            asyncio.futures._CFuture
+        ) = asyncio.futures.Future = asyncio.futures._PyFuture
+    if sys.version_info < (3, 7, 0):
+        asyncio.tasks._current_tasks = asyncio.tasks.Task._current_tasks  # noqa
+        asyncio.all_tasks = asyncio.tasks.Task.all_tasks  # noqa
+    if not hasattr(asyncio, '_run_orig'):
+        asyncio._run_orig = getattr(asyncio, 'run', None)
+        asyncio.run = run
+
+
+def _patch_loop(loop):
+    """Patch loop to make it reentrant."""
+
+    def run_forever(self):
+        with manage_run(self), manage_asyncgens(self):
+            while True:
+                self._run_once()
+                if self._stopping:
+                    break
+        self._stopping = False
+
+    def run_until_complete(self, future):
+        with manage_run(self):
+            f = asyncio.ensure_future(future, loop=self)
+            if f is not future:
+                f._log_destroy_pending = False
+            while not f.done():
+                self._run_once()
+                if self._stopping:
+                    break
+            if not f.done():
+                raise RuntimeError('Event loop stopped before Future completed.')
+            return f.result()
+
+    def _run_once(self):
+        """
+        Simplified re-implementation of asyncio's _run_once that
+        runs handles as they become ready.
+        """
+        now = self.time()
+        ready = self._ready
+        scheduled = self._scheduled
+        while scheduled and scheduled[0]._cancelled:
+            heappop(scheduled)
+
+        timeout = (
+            0
+            if ready or self._stopping
+            else min(max(scheduled[0]._when - now, 0), 86400)
+            if scheduled
+            else None
+        )
+        event_list = self._selector.select(timeout)
+        self._process_events(event_list)
+
+        end_time = self.time() + self._clock_resolution
+        while scheduled and scheduled[0]._when < end_time:
+            handle = heappop(scheduled)
+            ready.append(handle)
+
+        for _ in range(len(ready)):
+            if not ready:
+                break
+            handle = ready.popleft()
+            if not handle._cancelled:
+                handle._run()
+        handle = None
+
+    @contextmanager
+    def manage_run(self):
+        """Set up the loop for running."""
+        self._check_closed()
+        old_thread_id = self._thread_id
+        old_running_loop = events._get_running_loop()
+        try:
+            self._thread_id = threading.get_ident()
+            events._set_running_loop(self)
+            self._num_runs_pending += 1
+            if self._is_proactorloop:
+                if self._self_reading_future is None:
+                    self.call_soon(self._loop_self_reading)
+            yield
+        finally:
+            self._thread_id = old_thread_id
+            events._set_running_loop(old_running_loop)
+            self._num_runs_pending -= 1
+            if self._is_proactorloop:
+                if (
+                    self._num_runs_pending == 0
+                    and self._self_reading_future is not None
+                ):
+                    ov = self._self_reading_future._ov
+                    self._self_reading_future.cancel()
+                    if ov is not None:
+                        self._proactor._unregister(ov)
+                    self._self_reading_future = None
+
+    @contextmanager
+    def manage_asyncgens(self):
+        old_agen_hooks = sys.get_asyncgen_hooks()
+        try:
+            self._set_coroutine_origin_tracking(self._debug)
+            if self._asyncgens is not None:
+                sys.set_asyncgen_hooks(
+                    firstiter=self._asyncgen_firstiter_hook,
+                    finalizer=self._asyncgen_finalizer_hook,
+                )
+            yield
+        finally:
+            self._set_coroutine_origin_tracking(False)
+            if self._asyncgens is not None:
+                sys.set_asyncgen_hooks(*old_agen_hooks)
+
+    def _check_running(self):
+        """Do not throw exception if loop is already running."""
+        pass
+
+    cls = loop.__class__
+    cls.run_forever = run_forever
+    cls.run_until_complete = run_until_complete
+    cls._run_once = _run_once
+    cls._check_running = _check_running
+    cls._check_runnung = _check_running  # typo in Python 3.7 source
+    cls._nest_patched = True
+    cls._num_runs_pending = 0
+    cls._is_proactorloop = os.name == 'nt' and issubclass(
+        cls, asyncio.ProactorEventLoop
+    )
+    if sys.version_info < (3, 7, 0):
+        cls._set_coroutine_origin_tracking = cls._set_coroutine_wrapper
+
+
+def _patch_task():
+    """Patch the Task's step and enter/leave methods to make it reentrant."""
+
+    def step(task, exc=None):
+        curr_task = curr_tasks.get(task._loop)
+        try:
+            step_orig(task, exc)
+        finally:
+            if curr_task is None:
+                curr_tasks.pop(task._loop, None)
+            else:
+                curr_tasks[task._loop] = curr_task
+
+    Task = asyncio.Task
+    if sys.version_info >= (3, 7, 0):
+
+        def enter_task(loop, task):
+            curr_tasks[loop] = task
+
+        def leave_task(loop, task):
+            curr_tasks.pop(loop, None)
+
+        asyncio.tasks._enter_task = enter_task
+        asyncio.tasks._leave_task = leave_task
+        curr_tasks = asyncio.tasks._current_tasks
+        step_orig = Task._Task__step
+        Task._Task__step = step
+    else:
+        curr_tasks = Task._current_tasks
+        step_orig = Task._step
+        Task._step = step
+
+
+def _patch_tornado():
+    """
+    If tornado is imported before nest_asyncio, make tornado aware of
+    the pure-Python asyncio Future.
+    """
+    if 'tornado' in sys.modules:
+        import tornado.concurrent as tc
+
+        tc.Future = asyncio.Future
+        if asyncio.Future not in tc.FUTURES:
+            tc.FUTURES += (asyncio.Future,)


### PR DESCRIPTION
We have a `run_async` logic in core, which does `asyncio.run(func(...))` in a new thread. Jupyter [recommends](https://ipython.readthedocs.io/en/stable/interactive/autoawait.html#using-autoawait-in-a-notebook-ipykernel) using `nest-asyncio` to make the event loop reentrant. 