### PR TITLE
feat(flow): block() now waits for specific threading event

### DIFF
--- a/jina/flow/base.py
+++ b/jina/flow/base.py
@@ -1130,7 +1130,6 @@ class Flow(PostMixin, JAMLCompatible, ExitStack, metaclass=FlowType):
         if GATEWAY_NAME in self._pod_nodes:
             self._pod_nodes.pop(GATEWAY_NAME)
 
-
         self._build_level = FlowBuildLevel.EMPTY
         self.logger.debug('Flow is closed!')
         self.logger.close()


### PR DESCRIPTION
Just a demo, no strong need of merging

```python
import threading

from jina import Flow, Executor, requests


class MyExecutor(Executor):
    f = None

    @requests(on='/kill')
    def foo(self, **kwargs):
        print('overthrow my flow', self.f)
        # to gently kill the flow, you need to make sure the killing
        # happens *after* the message is sent back backed to frontend. so
        # first return the message and better with some delays.
        th = threading.Thread(target=self.f.close)
        th.start()


f = Flow(runtime_backend='thread', protocol='http',
         port_expose=12345).add(uses=MyExecutor)
MyExecutor.f = f

f.expose_endpoint('/kill')
with f:
    f.block()

print('i have overthrown the flow!')

```

```bash
           Flow@6411[I]:🎉 Flow is ready to use!
	🔗 Protocol: 		HTTP
	🏠 Local access:	0.0.0.0:12345
	🔒 Private network:	172.18.1.109:12345
	🌐 Public address:	94.135.231.132:12345
	💬 Swagger UI:		http://localhost:12345/docs
	📚 Redoc:		http://localhost:12345/redoc
killing <jina.flow.base.Flow object at 0x1593c4190>
i have overthrown the flow!

```