### PR TITLE
docs: clearer windows install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ fragmented, multi-vendor, generic legacy tools.
 - via Docker: `docker run jinaai/jina:latest`
 - [More install options](https://docs.jina.ai/get-started/install/)
 
+If you are using Windows, be sure to install Jina on [WSL2](https://docs.microsoft.com/en-us/windows/wsl/install).
+
 ## [Documentation](https://docs.jina.ai)
 
 ## Run Quick Demo


### PR DESCRIPTION
So many of the support requests we get on community Slack are about Windows issues which wouldn't occur if folks actually used WSL2 as recommended. Hence this PR makes it more noticeable and should reduce our support burden.
