### PR TITLE
feat(proto): adjust proto for star routing

### DIFF
--- a/jina/proto/jina.proto
+++ b/jina/proto/jina.proto
@@ -157,28 +157,6 @@ message RouteProto {
     StatusProto status = 5; // the status of the execution
 }
 
-message TargetPodProto{
-    string host = 1; // the host HeadPea of the BasePod
-    uint32 port = 2; // the port HeadPea of the BasePod
-    uint32 port_out = 6; // the port TailPea of the BasePod
-    uint32 expected_parts = 3; // the number of parts the pod should expect
-    repeated RoutingEdgeProto out_edges = 4; // pod_name of Pods, the TailPea should send traffic to
-    string target_identity = 5;
-}
-
-message RoutingEdgeProto {
-    string pod = 1;
-    bool send_as_bind = 2;
-}
-
-message RoutingTableProto {
-    // Pods that get visited during a Flow. Gateway should be both the first and the last entry.
-    map<string, TargetPodProto>  pods = 1;
-
-    // The currently active Pod. Needed for ZMQ.
-    string active_pod = 2;
-}
-
 /**
  * Represents a Envelope, a part of the ``Message``.
  */
@@ -204,11 +182,11 @@ message EnvelopeProto {
         string vcs = 3; // vcs's version
     }
 
-    VersionProto version = 6; // version info
+    VersionProto version = 5; // version info
 
-    string request_type = 7; // type of the request: DataRequest, ControlRequest
+    string request_type = 6; // type of the request: DataRequest, ControlRequest
 
-    bool check_version = 8; // check local Protobuf version on every Pod that this message flows to
+    bool check_version = 7; // check local Protobuf version on every Pod that this message flows to
 
     /**
      * Represents a config for the compression algorithm
@@ -224,16 +202,11 @@ message EnvelopeProto {
     }
 
 
-    CompressConfigProto compression = 9; // compress configuration used for request
+    CompressConfigProto compression = 8; // compress configuration used for request
 
-    repeated RouteProto routes = 10; // status info on every routes
+    StatusProto status = 9; // status info
 
-    RoutingTableProto routing_table = 13;  // the routing table contains information to the next pods
-
-    StatusProto status = 11; // status info
-
-    HeaderProto header = 12; // header contains meta info defined by the user, copied from Request, for lazy serialization
-
+    HeaderProto header = 10; // header contains meta info defined by the user, copied from Request, for lazy serialization
 }
 
 /**
@@ -333,13 +306,22 @@ message RequestProto {
         enum Command {
             TERMINATE = 0; // shutdown the BasePod
             STATUS = 1; // check the status of the BasePod
-            IDLE = 2; // used in ROUTER-DEALER pattern, tells the router that the dealer is idle
-            CANCEL = 3; // used in ROUTER-DEALER pattern, tells the router that the dealer is busy (or closed)
-            SCALE = 4; // scale up/down a Pod
-            ACTIVATE = 5; // used in ROUTER-DEALER pattern, Indicate a Pea that it can activate itself and send the IDLE command to their router
-            DEACTIVATE = 6; // used in ROUTER-DEALER pattern, Indicate a Pea that it can deactivate itself and send the CANCEL command to their router
+            SCALE = 2; // scale up/down a Pod
+            ACTIVATE = 3; // used to add Peas to a Pod
+            DEACTIVATE = 4; // used to remove Peas from a Pod
         }
         Command command = 1; // the control command
+
+        /**
+         * Represents an entity (like a Pea)
+         */
+        message RelatedEntity {
+            string id = 1; // unique id of the entity, like the name of a pea
+            optional string address = 2; // address of the entity, could be an IP address
+            optional uint32 port = 3; // port this entity is listening on
+        }
+
+        repeated RelatedEntity relatedEntities = 2; // list of entities this ControlMessage is related to
     }
 
     HeaderProto header = 4; // header contains meta info defined by the user
@@ -368,7 +350,7 @@ service JinaRPC {
  */
 service JinaDataRequestRPC {
     // Pass in a Message, wrapping a DataRequest
-    rpc Call (MessageProto) returns (google.protobuf.Empty) {
+    rpc Call (MessageProto) returns (MessageProto) {
     }
 }
 

--- a/jina/proto/jina.proto
+++ b/jina/proto/jina.proto
@@ -1,7 +1,6 @@
 syntax = "proto3";
 import "google/protobuf/timestamp.proto";
 import "google/protobuf/struct.proto";
-import "google/protobuf/empty.proto";
 
 package jina;
 
@@ -317,8 +316,8 @@ message RequestProto {
          */
         message RelatedEntity {
             string id = 1; // unique id of the entity, like the name of a pea
-            optional string address = 2; // address of the entity, could be an IP address
-            optional uint32 port = 3; // port this entity is listening on
+            string address = 2; // address of the entity, could be an IP address
+            uint32 port = 3; // port this entity is listening on
         }
 
         repeated RelatedEntity relatedEntities = 2; // list of entities this ControlMessage is related to

--- a/jina/proto/jina_pb2.py
+++ b/jina/proto/jina_pb2.py
@@ -13,7 +13,6 @@ _sym_db = _symbol_database.Default()
 
 from google.protobuf import timestamp_pb2 as google_dot_protobuf_dot_timestamp__pb2
 from google.protobuf import struct_pb2 as google_dot_protobuf_dot_struct__pb2
-from google.protobuf import empty_pb2 as google_dot_protobuf_dot_empty__pb2
 
 
 DESCRIPTOR = _descriptor.FileDescriptor(
@@ -22,9 +21,9 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   syntax='proto3',
   serialized_options=None,
   create_key=_descriptor._internal_create_key,
-  serialized_pb=b'\n\njina.proto\x12\x04jina\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1cgoogle/protobuf/struct.proto\x1a\x1bgoogle/protobuf/empty.proto\"\x87\x02\n\x11\x44\x65nseNdArrayProto\x12\x0e\n\x06\x62uffer\x18\x01 \x01(\x0c\x12\r\n\x05shape\x18\x02 \x03(\r\x12\r\n\x05\x64type\x18\x03 \x01(\t\x12>\n\x0cquantization\x18\x04 \x01(\x0e\x32(.jina.DenseNdArrayProto.QuantizationMode\x12\x0f\n\x07max_val\x18\x05 \x01(\x02\x12\x0f\n\x07min_val\x18\x06 \x01(\x02\x12\r\n\x05scale\x18\x07 \x01(\x02\x12\x16\n\x0eoriginal_dtype\x18\x08 \x01(\t\";\n\x10QuantizationMode\x12\x08\n\x04NONE\x10\x00\x12\x08\n\x04\x46P16\x10\x01\x12\t\n\x05UINT8\x10\x02\x12\x08\n\x04\x46P32\x10\x03\"o\n\x0cNdArrayProto\x12(\n\x05\x64\x65nse\x18\x01 \x01(\x0b\x32\x17.jina.DenseNdArrayProtoH\x00\x12*\n\x06sparse\x18\x02 \x01(\x0b\x32\x18.jina.SparseNdArrayProtoH\x00\x42\t\n\x07\x63ontent\"v\n\x12SparseNdArrayProto\x12(\n\x07indices\x18\x01 \x01(\x0b\x32\x17.jina.DenseNdArrayProto\x12\'\n\x06values\x18\x02 \x01(\x0b\x32\x17.jina.DenseNdArrayProto\x12\r\n\x05shape\x18\x03 \x03(\r\"\x7f\n\x0fNamedScoreProto\x12\r\n\x05value\x18\x01 \x01(\x02\x12\x0f\n\x07op_name\x18\x02 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x03 \x01(\t\x12\'\n\x08operands\x18\x04 \x03(\x0b\x32\x15.jina.NamedScoreProto\x12\x0e\n\x06ref_id\x18\x05 \x01(\t\"}\n\nGraphProto\x12+\n\tadjacency\x18\x01 \x01(\x0b\x32\x18.jina.SparseNdArrayProto\x12.\n\redge_features\x18\x02 \x01(\x0b\x32\x17.google.protobuf.Struct\x12\x12\n\nundirected\x18\x03 \x01(\x08\"\xc4\x05\n\rDocumentProto\x12\n\n\x02id\x18\x01 \x01(\t\x12\x13\n\x0bgranularity\x18\x0e \x01(\r\x12\x11\n\tadjacency\x18\x16 \x01(\r\x12\x11\n\tparent_id\x18\x10 \x01(\t\x12\x10\n\x06\x62uffer\x18\x03 \x01(\x0cH\x00\x12\"\n\x04\x62lob\x18\x0c \x01(\x0b\x32\x12.jina.NdArrayProtoH\x00\x12\x0e\n\x04text\x18\r \x01(\tH\x00\x12!\n\x05graph\x18\x1b \x01(\x0b\x32\x10.jina.GraphProtoH\x00\x12#\n\x06\x63hunks\x18\x04 \x03(\x0b\x32\x13.jina.DocumentProto\x12\x0e\n\x06weight\x18\x05 \x01(\x02\x12$\n\x07matches\x18\x08 \x03(\x0b\x32\x13.jina.DocumentProto\x12\x0b\n\x03uri\x18\t \x01(\t\x12\x11\n\tmime_type\x18\n \x01(\t\x12%\n\x04tags\x18\x0b \x01(\x0b\x32\x17.google.protobuf.Struct\x12\x10\n\x08location\x18\x11 \x03(\r\x12\x0e\n\x06offset\x18\x12 \x01(\r\x12%\n\tembedding\x18\x13 \x01(\x0b\x32\x12.jina.NdArrayProto\x12/\n\x06scores\x18\x1c \x03(\x0b\x32\x1f.jina.DocumentProto.ScoresEntry\x12\x10\n\x08modality\x18\x15 \x01(\t\x12\x39\n\x0b\x65valuations\x18\x1d \x03(\x0b\x32$.jina.DocumentProto.EvaluationsEntry\x1a\x44\n\x0bScoresEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12$\n\x05value\x18\x02 \x01(\x0b\x32\x15.jina.NamedScoreProto:\x02\x38\x01\x1aI\n\x10\x45valuationsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12$\n\x05value\x18\x02 \x01(\x0b\x32\x15.jina.NamedScoreProto:\x02\x38\x01\x42\t\n\x07\x63ontent\"\xaa\x01\n\nRouteProto\x12\x0b\n\x03pod\x18\x01 \x01(\t\x12\x0e\n\x06pod_id\x18\x02 \x01(\t\x12.\n\nstart_time\x18\x03 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12,\n\x08\x65nd_time\x18\x04 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12!\n\x06status\x18\x05 \x01(\x0b\x32\x11.jina.StatusProto\"\x9a\x01\n\x0eTargetPodProto\x12\x0c\n\x04host\x18\x01 \x01(\t\x12\x0c\n\x04port\x18\x02 \x01(\r\x12\x10\n\x08port_out\x18\x06 \x01(\r\x12\x16\n\x0e\x65xpected_parts\x18\x03 \x01(\r\x12)\n\tout_edges\x18\x04 \x03(\x0b\x32\x16.jina.RoutingEdgeProto\x12\x17\n\x0ftarget_identity\x18\x05 \x01(\t\"5\n\x10RoutingEdgeProto\x12\x0b\n\x03pod\x18\x01 \x01(\t\x12\x14\n\x0csend_as_bind\x18\x02 \x01(\x08\"\x9b\x01\n\x11RoutingTableProto\x12/\n\x04pods\x18\x01 \x03(\x0b\x32!.jina.RoutingTableProto.PodsEntry\x12\x12\n\nactive_pod\x18\x02 \x01(\t\x1a\x41\n\tPodsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12#\n\x05value\x18\x02 \x01(\x0b\x32\x14.jina.TargetPodProto:\x02\x38\x01\"\xc9\x04\n\rEnvelopeProto\x12\x11\n\tsender_id\x18\x01 \x01(\t\x12\x13\n\x0breceiver_id\x18\x02 \x01(\t\x12\x12\n\nrequest_id\x18\x03 \x01(\t\x12\x0f\n\x07timeout\x18\x04 \x01(\r\x12\x31\n\x07version\x18\x06 \x01(\x0b\x32 .jina.EnvelopeProto.VersionProto\x12\x14\n\x0crequest_type\x18\x07 \x01(\t\x12\x15\n\rcheck_version\x18\x08 \x01(\x08\x12<\n\x0b\x63ompression\x18\t \x01(\x0b\x32\'.jina.EnvelopeProto.CompressConfigProto\x12 \n\x06routes\x18\n \x03(\x0b\x32\x10.jina.RouteProto\x12.\n\rrouting_table\x18\r \x01(\x0b\x32\x17.jina.RoutingTableProto\x12!\n\x06status\x18\x0b \x01(\x0b\x32\x11.jina.StatusProto\x12!\n\x06header\x18\x0c \x01(\x0b\x32\x11.jina.HeaderProto\x1a\x38\n\x0cVersionProto\x12\x0c\n\x04jina\x18\x01 \x01(\t\x12\r\n\x05proto\x18\x02 \x01(\t\x12\x0b\n\x03vcs\x18\x03 \x01(\t\x1a{\n\x13\x43ompressConfigProto\x12\x11\n\talgorithm\x18\x01 \x01(\t\x12\x11\n\tmin_bytes\x18\x02 \x01(\x04\x12\x11\n\tmin_ratio\x18\x03 \x01(\x02\x12+\n\nparameters\x18\x04 \x01(\x0b\x32\x17.google.protobuf.Struct\"Q\n\x0bHeaderProto\x12\x15\n\rexec_endpoint\x18\x01 \x01(\t\x12\x15\n\rtarget_peapod\x18\x02 \x01(\t\x12\x14\n\x0cno_propagate\x18\x03 \x01(\x08\"\xcf\x02\n\x0bStatusProto\x12*\n\x04\x63ode\x18\x01 \x01(\x0e\x32\x1c.jina.StatusProto.StatusCode\x12\x13\n\x0b\x64\x65scription\x18\x02 \x01(\t\x12\x33\n\texception\x18\x03 \x01(\x0b\x32 .jina.StatusProto.ExceptionProto\x1aN\n\x0e\x45xceptionProto\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0c\n\x04\x61rgs\x18\x02 \x03(\t\x12\x0e\n\x06stacks\x18\x03 \x03(\t\x12\x10\n\x08\x65xecutor\x18\x04 \x01(\t\"z\n\nStatusCode\x12\x0b\n\x07SUCCESS\x10\x00\x12\x0b\n\x07PENDING\x10\x01\x12\t\n\x05READY\x10\x02\x12\t\n\x05\x45RROR\x10\x03\x12\x13\n\x0f\x45RROR_DUPLICATE\x10\x04\x12\x14\n\x10\x45RROR_NOTALLOWED\x10\x05\x12\x11\n\rERROR_CHAINED\x10\x06\"Z\n\x0cMessageProto\x12%\n\x08\x65nvelope\x18\x01 \x01(\x0b\x32\x13.jina.EnvelopeProto\x12#\n\x07request\x18\x02 \x01(\x0b\x32\x12.jina.RequestProto\"7\n\x12\x44ocumentArrayProto\x12!\n\x04\x64ocs\x18\x01 \x03(\x0b\x32\x13.jina.DocumentProto\"\xcf\x04\n\x0cRequestProto\x12\x12\n\nrequest_id\x18\x01 \x01(\t\x12\x39\n\x07\x63ontrol\x18\x02 \x01(\x0b\x32&.jina.RequestProto.ControlRequestProtoH\x00\x12\x33\n\x04\x64\x61ta\x18\x03 \x01(\x0b\x32#.jina.RequestProto.DataRequestProtoH\x00\x12!\n\x06header\x18\x04 \x01(\x0b\x32\x11.jina.HeaderProto\x12+\n\nparameters\x18\x05 \x01(\x0b\x32\x17.google.protobuf.Struct\x12 \n\x06routes\x18\x06 \x03(\x0b\x32\x10.jina.RouteProto\x12!\n\x06status\x18\x07 \x01(\x0b\x32\x11.jina.StatusProto\x1a`\n\x10\x44\x61taRequestProto\x12!\n\x04\x64ocs\x18\x01 \x03(\x0b\x32\x13.jina.DocumentProto\x12)\n\x0cgroundtruths\x18\x02 \x03(\x0b\x32\x13.jina.DocumentProto\x1a\xbb\x01\n\x13\x43ontrolRequestProto\x12?\n\x07\x63ommand\x18\x01 \x01(\x0e\x32..jina.RequestProto.ControlRequestProto.Command\"c\n\x07\x43ommand\x12\r\n\tTERMINATE\x10\x00\x12\n\n\x06STATUS\x10\x01\x12\x08\n\x04IDLE\x10\x02\x12\n\n\x06\x43\x41NCEL\x10\x03\x12\t\n\x05SCALE\x10\x04\x12\x0c\n\x08\x41\x43TIVATE\x10\x05\x12\x0e\n\nDEACTIVATE\x10\x06\x42\x06\n\x04\x62ody2?\n\x07JinaRPC\x12\x34\n\x04\x43\x61ll\x12\x12.jina.RequestProto\x1a\x12.jina.RequestProto\"\x00(\x01\x30\x01\x32J\n\x12JinaDataRequestRPC\x12\x34\n\x04\x43\x61ll\x12\x12.jina.MessageProto\x1a\x16.google.protobuf.Empty\"\x00\x62\x06proto3'
+  serialized_pb=b'\n\njina.proto\x12\x04jina\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1cgoogle/protobuf/struct.proto\"\x87\x02\n\x11\x44\x65nseNdArrayProto\x12\x0e\n\x06\x62uffer\x18\x01 \x01(\x0c\x12\r\n\x05shape\x18\x02 \x03(\r\x12\r\n\x05\x64type\x18\x03 \x01(\t\x12>\n\x0cquantization\x18\x04 \x01(\x0e\x32(.jina.DenseNdArrayProto.QuantizationMode\x12\x0f\n\x07max_val\x18\x05 \x01(\x02\x12\x0f\n\x07min_val\x18\x06 \x01(\x02\x12\r\n\x05scale\x18\x07 \x01(\x02\x12\x16\n\x0eoriginal_dtype\x18\x08 \x01(\t\";\n\x10QuantizationMode\x12\x08\n\x04NONE\x10\x00\x12\x08\n\x04\x46P16\x10\x01\x12\t\n\x05UINT8\x10\x02\x12\x08\n\x04\x46P32\x10\x03\"o\n\x0cNdArrayProto\x12(\n\x05\x64\x65nse\x18\x01 \x01(\x0b\x32\x17.jina.DenseNdArrayProtoH\x00\x12*\n\x06sparse\x18\x02 \x01(\x0b\x32\x18.jina.SparseNdArrayProtoH\x00\x42\t\n\x07\x63ontent\"v\n\x12SparseNdArrayProto\x12(\n\x07indices\x18\x01 \x01(\x0b\x32\x17.jina.DenseNdArrayProto\x12\'\n\x06values\x18\x02 \x01(\x0b\x32\x17.jina.DenseNdArrayProto\x12\r\n\x05shape\x18\x03 \x03(\r\"\x7f\n\x0fNamedScoreProto\x12\r\n\x05value\x18\x01 \x01(\x02\x12\x0f\n\x07op_name\x18\x02 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x03 \x01(\t\x12\'\n\x08operands\x18\x04 \x03(\x0b\x32\x15.jina.NamedScoreProto\x12\x0e\n\x06ref_id\x18\x05 \x01(\t\"}\n\nGraphProto\x12+\n\tadjacency\x18\x01 \x01(\x0b\x32\x18.jina.SparseNdArrayProto\x12.\n\redge_features\x18\x02 \x01(\x0b\x32\x17.google.protobuf.Struct\x12\x12\n\nundirected\x18\x03 \x01(\x08\"\xc4\x05\n\rDocumentProto\x12\n\n\x02id\x18\x01 \x01(\t\x12\x13\n\x0bgranularity\x18\x0e \x01(\r\x12\x11\n\tadjacency\x18\x16 \x01(\r\x12\x11\n\tparent_id\x18\x10 \x01(\t\x12\x10\n\x06\x62uffer\x18\x03 \x01(\x0cH\x00\x12\"\n\x04\x62lob\x18\x0c \x01(\x0b\x32\x12.jina.NdArrayProtoH\x00\x12\x0e\n\x04text\x18\r \x01(\tH\x00\x12!\n\x05graph\x18\x1b \x01(\x0b\x32\x10.jina.GraphProtoH\x00\x12#\n\x06\x63hunks\x18\x04 \x03(\x0b\x32\x13.jina.DocumentProto\x12\x0e\n\x06weight\x18\x05 \x01(\x02\x12$\n\x07matches\x18\x08 \x03(\x0b\x32\x13.jina.DocumentProto\x12\x0b\n\x03uri\x18\t \x01(\t\x12\x11\n\tmime_type\x18\n \x01(\t\x12%\n\x04tags\x18\x0b \x01(\x0b\x32\x17.google.protobuf.Struct\x12\x10\n\x08location\x18\x11 \x03(\r\x12\x0e\n\x06offset\x18\x12 \x01(\r\x12%\n\tembedding\x18\x13 \x01(\x0b\x32\x12.jina.NdArrayProto\x12/\n\x06scores\x18\x1c \x03(\x0b\x32\x1f.jina.DocumentProto.ScoresEntry\x12\x10\n\x08modality\x18\x15 \x01(\t\x12\x39\n\x0b\x65valuations\x18\x1d \x03(\x0b\x32$.jina.DocumentProto.EvaluationsEntry\x1a\x44\n\x0bScoresEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12$\n\x05value\x18\x02 \x01(\x0b\x32\x15.jina.NamedScoreProto:\x02\x38\x01\x1aI\n\x10\x45valuationsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12$\n\x05value\x18\x02 \x01(\x0b\x32\x15.jina.NamedScoreProto:\x02\x38\x01\x42\t\n\x07\x63ontent\"\xaa\x01\n\nRouteProto\x12\x0b\n\x03pod\x18\x01 \x01(\t\x12\x0e\n\x06pod_id\x18\x02 \x01(\t\x12.\n\nstart_time\x18\x03 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12,\n\x08\x65nd_time\x18\x04 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12!\n\x06status\x18\x05 \x01(\x0b\x32\x11.jina.StatusProto\"\xf7\x03\n\rEnvelopeProto\x12\x11\n\tsender_id\x18\x01 \x01(\t\x12\x13\n\x0breceiver_id\x18\x02 \x01(\t\x12\x12\n\nrequest_id\x18\x03 \x01(\t\x12\x0f\n\x07timeout\x18\x04 \x01(\r\x12\x31\n\x07version\x18\x05 \x01(\x0b\x32 .jina.EnvelopeProto.VersionProto\x12\x14\n\x0crequest_type\x18\x06 \x01(\t\x12\x15\n\rcheck_version\x18\x07 \x01(\x08\x12<\n\x0b\x63ompression\x18\x08 \x01(\x0b\x32\'.jina.EnvelopeProto.CompressConfigProto\x12!\n\x06status\x18\t \x01(\x0b\x32\x11.jina.StatusProto\x12!\n\x06header\x18\n \x01(\x0b\x32\x11.jina.HeaderProto\x1a\x38\n\x0cVersionProto\x12\x0c\n\x04jina\x18\x01 \x01(\t\x12\r\n\x05proto\x18\x02 \x01(\t\x12\x0b\n\x03vcs\x18\x03 \x01(\t\x1a{\n\x13\x43ompressConfigProto\x12\x11\n\talgorithm\x18\x01 \x01(\t\x12\x11\n\tmin_bytes\x18\x02 \x01(\x04\x12\x11\n\tmin_ratio\x18\x03 \x01(\x02\x12+\n\nparameters\x18\x04 \x01(\x0b\x32\x17.google.protobuf.Struct\"Q\n\x0bHeaderProto\x12\x15\n\rexec_endpoint\x18\x01 \x01(\t\x12\x15\n\rtarget_peapod\x18\x02 \x01(\t\x12\x14\n\x0cno_propagate\x18\x03 \x01(\x08\"\xcf\x02\n\x0bStatusProto\x12*\n\x04\x63ode\x18\x01 \x01(\x0e\x32\x1c.jina.StatusProto.StatusCode\x12\x13\n\x0b\x64\x65scription\x18\x02 \x01(\t\x12\x33\n\texception\x18\x03 \x01(\x0b\x32 .jina.StatusProto.ExceptionProto\x1aN\n\x0e\x45xceptionProto\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0c\n\x04\x61rgs\x18\x02 \x03(\t\x12\x0e\n\x06stacks\x18\x03 \x03(\t\x12\x10\n\x08\x65xecutor\x18\x04 \x01(\t\"z\n\nStatusCode\x12\x0b\n\x07SUCCESS\x10\x00\x12\x0b\n\x07PENDING\x10\x01\x12\t\n\x05READY\x10\x02\x12\t\n\x05\x45RROR\x10\x03\x12\x13\n\x0f\x45RROR_DUPLICATE\x10\x04\x12\x14\n\x10\x45RROR_NOTALLOWED\x10\x05\x12\x11\n\rERROR_CHAINED\x10\x06\"Z\n\x0cMessageProto\x12%\n\x08\x65nvelope\x18\x01 \x01(\x0b\x32\x13.jina.EnvelopeProto\x12#\n\x07request\x18\x02 \x01(\x0b\x32\x12.jina.RequestProto\"7\n\x12\x44ocumentArrayProto\x12!\n\x04\x64ocs\x18\x01 \x03(\x0b\x32\x13.jina.DocumentProto\"\xc4\x05\n\x0cRequestProto\x12\x12\n\nrequest_id\x18\x01 \x01(\t\x12\x39\n\x07\x63ontrol\x18\x02 \x01(\x0b\x32&.jina.RequestProto.ControlRequestProtoH\x00\x12\x33\n\x04\x64\x61ta\x18\x03 \x01(\x0b\x32#.jina.RequestProto.DataRequestProtoH\x00\x12!\n\x06header\x18\x04 \x01(\x0b\x32\x11.jina.HeaderProto\x12+\n\nparameters\x18\x05 \x01(\x0b\x32\x17.google.protobuf.Struct\x12 \n\x06routes\x18\x06 \x03(\x0b\x32\x10.jina.RouteProto\x12!\n\x06status\x18\x07 \x01(\x0b\x32\x11.jina.StatusProto\x1a`\n\x10\x44\x61taRequestProto\x12!\n\x04\x64ocs\x18\x01 \x03(\x0b\x32\x13.jina.DocumentProto\x12)\n\x0cgroundtruths\x18\x02 \x03(\x0b\x32\x13.jina.DocumentProto\x1a\xb0\x02\n\x13\x43ontrolRequestProto\x12?\n\x07\x63ommand\x18\x01 \x01(\x0e\x32..jina.RequestProto.ControlRequestProto.Command\x12M\n\x0frelatedEntities\x18\x02 \x03(\x0b\x32\x34.jina.RequestProto.ControlRequestProto.RelatedEntity\x1a:\n\rRelatedEntity\x12\n\n\x02id\x18\x01 \x01(\t\x12\x0f\n\x07\x61\x64\x64ress\x18\x02 \x01(\t\x12\x0c\n\x04port\x18\x03 \x01(\r\"M\n\x07\x43ommand\x12\r\n\tTERMINATE\x10\x00\x12\n\n\x06STATUS\x10\x01\x12\t\n\x05SCALE\x10\x02\x12\x0c\n\x08\x41\x43TIVATE\x10\x03\x12\x0e\n\nDEACTIVATE\x10\x04\x42\x06\n\x04\x62ody2?\n\x07JinaRPC\x12\x34\n\x04\x43\x61ll\x12\x12.jina.RequestProto\x1a\x12.jina.RequestProto\"\x00(\x01\x30\x01\x32\x46\n\x12JinaDataRequestRPC\x12\x30\n\x04\x43\x61ll\x12\x12.jina.MessageProto\x1a\x12.jina.MessageProto\"\x00\x62\x06proto3'
   ,
-  dependencies=[google_dot_protobuf_dot_timestamp__pb2.DESCRIPTOR,google_dot_protobuf_dot_struct__pb2.DESCRIPTOR,google_dot_protobuf_dot_empty__pb2.DESCRIPTOR,])
+  dependencies=[google_dot_protobuf_dot_timestamp__pb2.DESCRIPTOR,google_dot_protobuf_dot_struct__pb2.DESCRIPTOR,])
 
 
 
@@ -58,8 +57,8 @@ _DENSENDARRAYPROTO_QUANTIZATIONMODE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=317,
-  serialized_end=376,
+  serialized_start=288,
+  serialized_end=347,
 )
 _sym_db.RegisterEnumDescriptor(_DENSENDARRAYPROTO_QUANTIZATIONMODE)
 
@@ -108,8 +107,8 @@ _STATUSPROTO_STATUSCODE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=3006,
-  serialized_end=3128,
+  serialized_start=2525,
+  serialized_end=2647,
 )
 _sym_db.RegisterEnumDescriptor(_STATUSPROTO_STATUSCODE)
 
@@ -131,35 +130,25 @@ _REQUESTPROTO_CONTROLREQUESTPROTO_COMMAND = _descriptor.EnumDescriptor(
       type=None,
       create_key=_descriptor._internal_create_key),
     _descriptor.EnumValueDescriptor(
-      name='IDLE', index=2, number=2,
+      name='SCALE', index=2, number=2,
       serialized_options=None,
       type=None,
       create_key=_descriptor._internal_create_key),
     _descriptor.EnumValueDescriptor(
-      name='CANCEL', index=3, number=3,
+      name='ACTIVATE', index=3, number=3,
       serialized_options=None,
       type=None,
       create_key=_descriptor._internal_create_key),
     _descriptor.EnumValueDescriptor(
-      name='SCALE', index=4, number=4,
-      serialized_options=None,
-      type=None,
-      create_key=_descriptor._internal_create_key),
-    _descriptor.EnumValueDescriptor(
-      name='ACTIVATE', index=5, number=5,
-      serialized_options=None,
-      type=None,
-      create_key=_descriptor._internal_create_key),
-    _descriptor.EnumValueDescriptor(
-      name='DEACTIVATE', index=6, number=6,
+      name='DEACTIVATE', index=4, number=4,
       serialized_options=None,
       type=None,
       create_key=_descriptor._internal_create_key),
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=3764,
-  serialized_end=3863,
+  serialized_start=3422,
+  serialized_end=3499,
 )
 _sym_db.RegisterEnumDescriptor(_REQUESTPROTO_CONTROLREQUESTPROTO_COMMAND)
 
@@ -241,8 +230,8 @@ _DENSENDARRAYPROTO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=113,
-  serialized_end=376,
+  serialized_start=84,
+  serialized_end=347,
 )
 
 
@@ -285,8 +274,8 @@ _NDARRAYPROTO = _descriptor.Descriptor(
       create_key=_descriptor._internal_create_key,
     fields=[]),
   ],
-  serialized_start=378,
-  serialized_end=489,
+  serialized_start=349,
+  serialized_end=460,
 )
 
 
@@ -331,8 +320,8 @@ _SPARSENDARRAYPROTO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=491,
-  serialized_end=609,
+  serialized_start=462,
+  serialized_end=580,
 )
 
 
@@ -391,8 +380,8 @@ _NAMEDSCOREPROTO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=611,
-  serialized_end=738,
+  serialized_start=582,
+  serialized_end=709,
 )
 
 
@@ -437,8 +426,8 @@ _GRAPHPROTO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=740,
-  serialized_end=865,
+  serialized_start=711,
+  serialized_end=836,
 )
 
 
@@ -476,8 +465,8 @@ _DOCUMENTPROTO_SCORESENTRY = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1422,
-  serialized_end=1490,
+  serialized_start=1393,
+  serialized_end=1461,
 )
 
 _DOCUMENTPROTO_EVALUATIONSENTRY = _descriptor.Descriptor(
@@ -514,8 +503,8 @@ _DOCUMENTPROTO_EVALUATIONSENTRY = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1492,
-  serialized_end=1565,
+  serialized_start=1463,
+  serialized_end=1536,
 )
 
 _DOCUMENTPROTO = _descriptor.Descriptor(
@@ -683,8 +672,8 @@ _DOCUMENTPROTO = _descriptor.Descriptor(
       create_key=_descriptor._internal_create_key,
     fields=[]),
   ],
-  serialized_start=868,
-  serialized_end=1576,
+  serialized_start=839,
+  serialized_end=1547,
 )
 
 
@@ -743,191 +732,8 @@ _ROUTEPROTO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1579,
-  serialized_end=1749,
-)
-
-
-_TARGETPODPROTO = _descriptor.Descriptor(
-  name='TargetPodProto',
-  full_name='jina.TargetPodProto',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  create_key=_descriptor._internal_create_key,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='host', full_name='jina.TargetPodProto.host', index=0,
-      number=1, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=b"".decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    _descriptor.FieldDescriptor(
-      name='port', full_name='jina.TargetPodProto.port', index=1,
-      number=2, type=13, cpp_type=3, label=1,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    _descriptor.FieldDescriptor(
-      name='port_out', full_name='jina.TargetPodProto.port_out', index=2,
-      number=6, type=13, cpp_type=3, label=1,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    _descriptor.FieldDescriptor(
-      name='expected_parts', full_name='jina.TargetPodProto.expected_parts', index=3,
-      number=3, type=13, cpp_type=3, label=1,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    _descriptor.FieldDescriptor(
-      name='out_edges', full_name='jina.TargetPodProto.out_edges', index=4,
-      number=4, type=11, cpp_type=10, label=3,
-      has_default_value=False, default_value=[],
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    _descriptor.FieldDescriptor(
-      name='target_identity', full_name='jina.TargetPodProto.target_identity', index=5,
-      number=5, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=b"".decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  serialized_options=None,
-  is_extendable=False,
-  syntax='proto3',
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=1752,
-  serialized_end=1906,
-)
-
-
-_ROUTINGEDGEPROTO = _descriptor.Descriptor(
-  name='RoutingEdgeProto',
-  full_name='jina.RoutingEdgeProto',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  create_key=_descriptor._internal_create_key,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='pod', full_name='jina.RoutingEdgeProto.pod', index=0,
-      number=1, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=b"".decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    _descriptor.FieldDescriptor(
-      name='send_as_bind', full_name='jina.RoutingEdgeProto.send_as_bind', index=1,
-      number=2, type=8, cpp_type=7, label=1,
-      has_default_value=False, default_value=False,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  serialized_options=None,
-  is_extendable=False,
-  syntax='proto3',
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=1908,
-  serialized_end=1961,
-)
-
-
-_ROUTINGTABLEPROTO_PODSENTRY = _descriptor.Descriptor(
-  name='PodsEntry',
-  full_name='jina.RoutingTableProto.PodsEntry',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  create_key=_descriptor._internal_create_key,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='key', full_name='jina.RoutingTableProto.PodsEntry.key', index=0,
-      number=1, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=b"".decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    _descriptor.FieldDescriptor(
-      name='value', full_name='jina.RoutingTableProto.PodsEntry.value', index=1,
-      number=2, type=11, cpp_type=10, label=1,
-      has_default_value=False, default_value=None,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  serialized_options=b'8\001',
-  is_extendable=False,
-  syntax='proto3',
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=2054,
-  serialized_end=2119,
-)
-
-_ROUTINGTABLEPROTO = _descriptor.Descriptor(
-  name='RoutingTableProto',
-  full_name='jina.RoutingTableProto',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  create_key=_descriptor._internal_create_key,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='pods', full_name='jina.RoutingTableProto.pods', index=0,
-      number=1, type=11, cpp_type=10, label=3,
-      has_default_value=False, default_value=[],
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    _descriptor.FieldDescriptor(
-      name='active_pod', full_name='jina.RoutingTableProto.active_pod', index=1,
-      number=2, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=b"".decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-  ],
-  extensions=[
-  ],
-  nested_types=[_ROUTINGTABLEPROTO_PODSENTRY, ],
-  enum_types=[
-  ],
-  serialized_options=None,
-  is_extendable=False,
-  syntax='proto3',
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=1964,
-  serialized_end=2119,
+  serialized_start=1550,
+  serialized_end=1720,
 )
 
 
@@ -972,8 +778,8 @@ _ENVELOPEPROTO_VERSIONPROTO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2526,
-  serialized_end=2582,
+  serialized_start=2045,
+  serialized_end=2101,
 )
 
 _ENVELOPEPROTO_COMPRESSCONFIGPROTO = _descriptor.Descriptor(
@@ -1024,8 +830,8 @@ _ENVELOPEPROTO_COMPRESSCONFIGPROTO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2584,
-  serialized_end=2707,
+  serialized_start=2103,
+  serialized_end=2226,
 )
 
 _ENVELOPEPROTO = _descriptor.Descriptor(
@@ -1066,56 +872,42 @@ _ENVELOPEPROTO = _descriptor.Descriptor(
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
     _descriptor.FieldDescriptor(
       name='version', full_name='jina.EnvelopeProto.version', index=4,
-      number=6, type=11, cpp_type=10, label=1,
+      number=5, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
     _descriptor.FieldDescriptor(
       name='request_type', full_name='jina.EnvelopeProto.request_type', index=5,
-      number=7, type=9, cpp_type=9, label=1,
+      number=6, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=b"".decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
     _descriptor.FieldDescriptor(
       name='check_version', full_name='jina.EnvelopeProto.check_version', index=6,
-      number=8, type=8, cpp_type=7, label=1,
+      number=7, type=8, cpp_type=7, label=1,
       has_default_value=False, default_value=False,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
     _descriptor.FieldDescriptor(
       name='compression', full_name='jina.EnvelopeProto.compression', index=7,
+      number=8, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='status', full_name='jina.EnvelopeProto.status', index=8,
       number=9, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
     _descriptor.FieldDescriptor(
-      name='routes', full_name='jina.EnvelopeProto.routes', index=8,
-      number=10, type=11, cpp_type=10, label=3,
-      has_default_value=False, default_value=[],
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    _descriptor.FieldDescriptor(
-      name='routing_table', full_name='jina.EnvelopeProto.routing_table', index=9,
-      number=13, type=11, cpp_type=10, label=1,
-      has_default_value=False, default_value=None,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    _descriptor.FieldDescriptor(
-      name='status', full_name='jina.EnvelopeProto.status', index=10,
-      number=11, type=11, cpp_type=10, label=1,
-      has_default_value=False, default_value=None,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    _descriptor.FieldDescriptor(
-      name='header', full_name='jina.EnvelopeProto.header', index=11,
-      number=12, type=11, cpp_type=10, label=1,
+      name='header', full_name='jina.EnvelopeProto.header', index=9,
+      number=10, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
@@ -1132,8 +924,8 @@ _ENVELOPEPROTO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2122,
-  serialized_end=2707,
+  serialized_start=1723,
+  serialized_end=2226,
 )
 
 
@@ -1178,8 +970,8 @@ _HEADERPROTO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2709,
-  serialized_end=2790,
+  serialized_start=2228,
+  serialized_end=2309,
 )
 
 
@@ -1231,8 +1023,8 @@ _STATUSPROTO_EXCEPTIONPROTO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2926,
-  serialized_end=3004,
+  serialized_start=2445,
+  serialized_end=2523,
 )
 
 _STATUSPROTO = _descriptor.Descriptor(
@@ -1277,8 +1069,8 @@ _STATUSPROTO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2793,
-  serialized_end=3128,
+  serialized_start=2312,
+  serialized_end=2647,
 )
 
 
@@ -1316,8 +1108,8 @@ _MESSAGEPROTO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3130,
-  serialized_end=3220,
+  serialized_start=2649,
+  serialized_end=2739,
 )
 
 
@@ -1348,8 +1140,8 @@ _DOCUMENTARRAYPROTO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3222,
-  serialized_end=3277,
+  serialized_start=2741,
+  serialized_end=2796,
 )
 
 
@@ -1387,8 +1179,53 @@ _REQUESTPROTO_DATAREQUESTPROTO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3577,
-  serialized_end=3673,
+  serialized_start=3096,
+  serialized_end=3192,
+)
+
+_REQUESTPROTO_CONTROLREQUESTPROTO_RELATEDENTITY = _descriptor.Descriptor(
+  name='RelatedEntity',
+  full_name='jina.RequestProto.ControlRequestProto.RelatedEntity',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='id', full_name='jina.RequestProto.ControlRequestProto.RelatedEntity.id', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='address', full_name='jina.RequestProto.ControlRequestProto.RelatedEntity.address', index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='port', full_name='jina.RequestProto.ControlRequestProto.RelatedEntity.port', index=2,
+      number=3, type=13, cpp_type=3, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=3362,
+  serialized_end=3420,
 )
 
 _REQUESTPROTO_CONTROLREQUESTPROTO = _descriptor.Descriptor(
@@ -1406,10 +1243,17 @@ _REQUESTPROTO_CONTROLREQUESTPROTO = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='relatedEntities', full_name='jina.RequestProto.ControlRequestProto.relatedEntities', index=1,
+      number=2, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
   ],
   extensions=[
   ],
-  nested_types=[],
+  nested_types=[_REQUESTPROTO_CONTROLREQUESTPROTO_RELATEDENTITY, ],
   enum_types=[
     _REQUESTPROTO_CONTROLREQUESTPROTO_COMMAND,
   ],
@@ -1419,8 +1263,8 @@ _REQUESTPROTO_CONTROLREQUESTPROTO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3676,
-  serialized_end=3863,
+  serialized_start=3195,
+  serialized_end=3499,
 )
 
 _REQUESTPROTO = _descriptor.Descriptor(
@@ -1497,8 +1341,8 @@ _REQUESTPROTO = _descriptor.Descriptor(
       create_key=_descriptor._internal_create_key,
     fields=[]),
   ],
-  serialized_start=3280,
-  serialized_end=3871,
+  serialized_start=2799,
+  serialized_end=3507,
 )
 
 _DENSENDARRAYPROTO.fields_by_name['quantization'].enum_type = _DENSENDARRAYPROTO_QUANTIZATIONMODE
@@ -1543,17 +1387,11 @@ _DOCUMENTPROTO.fields_by_name['graph'].containing_oneof = _DOCUMENTPROTO.oneofs_
 _ROUTEPROTO.fields_by_name['start_time'].message_type = google_dot_protobuf_dot_timestamp__pb2._TIMESTAMP
 _ROUTEPROTO.fields_by_name['end_time'].message_type = google_dot_protobuf_dot_timestamp__pb2._TIMESTAMP
 _ROUTEPROTO.fields_by_name['status'].message_type = _STATUSPROTO
-_TARGETPODPROTO.fields_by_name['out_edges'].message_type = _ROUTINGEDGEPROTO
-_ROUTINGTABLEPROTO_PODSENTRY.fields_by_name['value'].message_type = _TARGETPODPROTO
-_ROUTINGTABLEPROTO_PODSENTRY.containing_type = _ROUTINGTABLEPROTO
-_ROUTINGTABLEPROTO.fields_by_name['pods'].message_type = _ROUTINGTABLEPROTO_PODSENTRY
 _ENVELOPEPROTO_VERSIONPROTO.containing_type = _ENVELOPEPROTO
 _ENVELOPEPROTO_COMPRESSCONFIGPROTO.fields_by_name['parameters'].message_type = google_dot_protobuf_dot_struct__pb2._STRUCT
 _ENVELOPEPROTO_COMPRESSCONFIGPROTO.containing_type = _ENVELOPEPROTO
 _ENVELOPEPROTO.fields_by_name['version'].message_type = _ENVELOPEPROTO_VERSIONPROTO
 _ENVELOPEPROTO.fields_by_name['compression'].message_type = _ENVELOPEPROTO_COMPRESSCONFIGPROTO
-_ENVELOPEPROTO.fields_by_name['routes'].message_type = _ROUTEPROTO
-_ENVELOPEPROTO.fields_by_name['routing_table'].message_type = _ROUTINGTABLEPROTO
 _ENVELOPEPROTO.fields_by_name['status'].message_type = _STATUSPROTO
 _ENVELOPEPROTO.fields_by_name['header'].message_type = _HEADERPROTO
 _STATUSPROTO_EXCEPTIONPROTO.containing_type = _STATUSPROTO
@@ -1566,7 +1404,9 @@ _DOCUMENTARRAYPROTO.fields_by_name['docs'].message_type = _DOCUMENTPROTO
 _REQUESTPROTO_DATAREQUESTPROTO.fields_by_name['docs'].message_type = _DOCUMENTPROTO
 _REQUESTPROTO_DATAREQUESTPROTO.fields_by_name['groundtruths'].message_type = _DOCUMENTPROTO
 _REQUESTPROTO_DATAREQUESTPROTO.containing_type = _REQUESTPROTO
+_REQUESTPROTO_CONTROLREQUESTPROTO_RELATEDENTITY.containing_type = _REQUESTPROTO_CONTROLREQUESTPROTO
 _REQUESTPROTO_CONTROLREQUESTPROTO.fields_by_name['command'].enum_type = _REQUESTPROTO_CONTROLREQUESTPROTO_COMMAND
+_REQUESTPROTO_CONTROLREQUESTPROTO.fields_by_name['relatedEntities'].message_type = _REQUESTPROTO_CONTROLREQUESTPROTO_RELATEDENTITY
 _REQUESTPROTO_CONTROLREQUESTPROTO.containing_type = _REQUESTPROTO
 _REQUESTPROTO_CONTROLREQUESTPROTO_COMMAND.containing_type = _REQUESTPROTO_CONTROLREQUESTPROTO
 _REQUESTPROTO.fields_by_name['control'].message_type = _REQUESTPROTO_CONTROLREQUESTPROTO
@@ -1588,9 +1428,6 @@ DESCRIPTOR.message_types_by_name['NamedScoreProto'] = _NAMEDSCOREPROTO
 DESCRIPTOR.message_types_by_name['GraphProto'] = _GRAPHPROTO
 DESCRIPTOR.message_types_by_name['DocumentProto'] = _DOCUMENTPROTO
 DESCRIPTOR.message_types_by_name['RouteProto'] = _ROUTEPROTO
-DESCRIPTOR.message_types_by_name['TargetPodProto'] = _TARGETPODPROTO
-DESCRIPTOR.message_types_by_name['RoutingEdgeProto'] = _ROUTINGEDGEPROTO
-DESCRIPTOR.message_types_by_name['RoutingTableProto'] = _ROUTINGTABLEPROTO
 DESCRIPTOR.message_types_by_name['EnvelopeProto'] = _ENVELOPEPROTO
 DESCRIPTOR.message_types_by_name['HeaderProto'] = _HEADERPROTO
 DESCRIPTOR.message_types_by_name['StatusProto'] = _STATUSPROTO
@@ -1664,35 +1501,6 @@ RouteProto = _reflection.GeneratedProtocolMessageType('RouteProto', (_message.Me
   })
 _sym_db.RegisterMessage(RouteProto)
 
-TargetPodProto = _reflection.GeneratedProtocolMessageType('TargetPodProto', (_message.Message,), {
-  'DESCRIPTOR' : _TARGETPODPROTO,
-  '__module__' : 'jina_pb2'
-  # @@protoc_insertion_point(class_scope:jina.TargetPodProto)
-  })
-_sym_db.RegisterMessage(TargetPodProto)
-
-RoutingEdgeProto = _reflection.GeneratedProtocolMessageType('RoutingEdgeProto', (_message.Message,), {
-  'DESCRIPTOR' : _ROUTINGEDGEPROTO,
-  '__module__' : 'jina_pb2'
-  # @@protoc_insertion_point(class_scope:jina.RoutingEdgeProto)
-  })
-_sym_db.RegisterMessage(RoutingEdgeProto)
-
-RoutingTableProto = _reflection.GeneratedProtocolMessageType('RoutingTableProto', (_message.Message,), {
-
-  'PodsEntry' : _reflection.GeneratedProtocolMessageType('PodsEntry', (_message.Message,), {
-    'DESCRIPTOR' : _ROUTINGTABLEPROTO_PODSENTRY,
-    '__module__' : 'jina_pb2'
-    # @@protoc_insertion_point(class_scope:jina.RoutingTableProto.PodsEntry)
-    })
-  ,
-  'DESCRIPTOR' : _ROUTINGTABLEPROTO,
-  '__module__' : 'jina_pb2'
-  # @@protoc_insertion_point(class_scope:jina.RoutingTableProto)
-  })
-_sym_db.RegisterMessage(RoutingTableProto)
-_sym_db.RegisterMessage(RoutingTableProto.PodsEntry)
-
 EnvelopeProto = _reflection.GeneratedProtocolMessageType('EnvelopeProto', (_message.Message,), {
 
   'VersionProto' : _reflection.GeneratedProtocolMessageType('VersionProto', (_message.Message,), {
@@ -1762,6 +1570,13 @@ RequestProto = _reflection.GeneratedProtocolMessageType('RequestProto', (_messag
   ,
 
   'ControlRequestProto' : _reflection.GeneratedProtocolMessageType('ControlRequestProto', (_message.Message,), {
+
+    'RelatedEntity' : _reflection.GeneratedProtocolMessageType('RelatedEntity', (_message.Message,), {
+      'DESCRIPTOR' : _REQUESTPROTO_CONTROLREQUESTPROTO_RELATEDENTITY,
+      '__module__' : 'jina_pb2'
+      # @@protoc_insertion_point(class_scope:jina.RequestProto.ControlRequestProto.RelatedEntity)
+      })
+    ,
     'DESCRIPTOR' : _REQUESTPROTO_CONTROLREQUESTPROTO,
     '__module__' : 'jina_pb2'
     # @@protoc_insertion_point(class_scope:jina.RequestProto.ControlRequestProto)
@@ -1774,11 +1589,11 @@ RequestProto = _reflection.GeneratedProtocolMessageType('RequestProto', (_messag
 _sym_db.RegisterMessage(RequestProto)
 _sym_db.RegisterMessage(RequestProto.DataRequestProto)
 _sym_db.RegisterMessage(RequestProto.ControlRequestProto)
+_sym_db.RegisterMessage(RequestProto.ControlRequestProto.RelatedEntity)
 
 
 _DOCUMENTPROTO_SCORESENTRY._options = None
 _DOCUMENTPROTO_EVALUATIONSENTRY._options = None
-_ROUTINGTABLEPROTO_PODSENTRY._options = None
 
 _JINARPC = _descriptor.ServiceDescriptor(
   name='JinaRPC',
@@ -1787,8 +1602,8 @@ _JINARPC = _descriptor.ServiceDescriptor(
   index=0,
   serialized_options=None,
   create_key=_descriptor._internal_create_key,
-  serialized_start=3873,
-  serialized_end=3936,
+  serialized_start=3509,
+  serialized_end=3572,
   methods=[
   _descriptor.MethodDescriptor(
     name='Call',
@@ -1813,8 +1628,8 @@ _JINADATAREQUESTRPC = _descriptor.ServiceDescriptor(
   index=1,
   serialized_options=None,
   create_key=_descriptor._internal_create_key,
-  serialized_start=3938,
-  serialized_end=4012,
+  serialized_start=3574,
+  serialized_end=3644,
   methods=[
   _descriptor.MethodDescriptor(
     name='Call',
@@ -1822,7 +1637,7 @@ _JINADATAREQUESTRPC = _descriptor.ServiceDescriptor(
     index=0,
     containing_service=None,
     input_type=_MESSAGEPROTO,
-    output_type=google_dot_protobuf_dot_empty__pb2._EMPTY,
+    output_type=_MESSAGEPROTO,
     serialized_options=None,
     create_key=_descriptor._internal_create_key,
   ),

--- a/jina/proto/jina_pb2_grpc.py
+++ b/jina/proto/jina_pb2_grpc.py
@@ -2,7 +2,6 @@
 """Client and server classes corresponding to protobuf-defined services."""
 import grpc
 
-from google.protobuf import empty_pb2 as google_dot_protobuf_dot_empty__pb2
 from . import serializer as jina__pb2
 
 
@@ -18,10 +17,10 @@ class JinaRPCStub(object):
             channel: A grpc.Channel.
         """
         self.Call = channel.stream_stream(
-            '/jina.JinaRPC/Call',
-            request_serializer=jina__pb2.RequestProto.SerializeToString,
-            response_deserializer=jina__pb2.RequestProto.FromString,
-        )
+                '/jina.JinaRPC/Call',
+                request_serializer=jina__pb2.RequestProto.SerializeToString,
+                response_deserializer=jina__pb2.RequestProto.FromString,
+                )
 
 
 class JinaRPCServicer(object):
@@ -30,7 +29,8 @@ class JinaRPCServicer(object):
     """
 
     def Call(self, request_iterator, context):
-        """Pass in a Request and a filled Request with matches will be returned."""
+        """Pass in a Request and a filled Request with matches will be returned.
+        """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details('Method not implemented!')
         raise NotImplementedError('Method not implemented!')
@@ -38,52 +38,39 @@ class JinaRPCServicer(object):
 
 def add_JinaRPCServicer_to_server(servicer, server):
     rpc_method_handlers = {
-        'Call': grpc.stream_stream_rpc_method_handler(
-            servicer.Call,
-            request_deserializer=jina__pb2.RequestProto.FromString,
-            response_serializer=jina__pb2.RequestProto.SerializeToString,
-        ),
+            'Call': grpc.stream_stream_rpc_method_handler(
+                    servicer.Call,
+                    request_deserializer=jina__pb2.RequestProto.FromString,
+                    response_serializer=jina__pb2.RequestProto.SerializeToString,
+            ),
     }
     generic_handler = grpc.method_handlers_generic_handler(
-        'jina.JinaRPC', rpc_method_handlers
-    )
+            'jina.JinaRPC', rpc_method_handlers)
     server.add_generic_rpc_handlers((generic_handler,))
 
 
-# This class is part of an EXPERIMENTAL API.
+ # This class is part of an EXPERIMENTAL API.
 class JinaRPC(object):
     """*
     jina gRPC service.
     """
 
     @staticmethod
-    def Call(
-        request_iterator,
-        target,
-        options=(),
-        channel_credentials=None,
-        call_credentials=None,
-        insecure=False,
-        compression=None,
-        wait_for_ready=None,
-        timeout=None,
-        metadata=None,
-    ):
-        return grpc.experimental.stream_stream(
-            request_iterator,
+    def Call(request_iterator,
             target,
-            '/jina.JinaRPC/Call',
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
+        return grpc.experimental.stream_stream(request_iterator, target, '/jina.JinaRPC/Call',
             jina__pb2.RequestProto.SerializeToString,
             jina__pb2.RequestProto.FromString,
-            options,
-            channel_credentials,
-            insecure,
-            call_credentials,
-            compression,
-            wait_for_ready,
-            timeout,
-            metadata,
-        )
+            options, channel_credentials,
+            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
 
 class JinaDataRequestRPCStub(object):
@@ -98,10 +85,10 @@ class JinaDataRequestRPCStub(object):
             channel: A grpc.Channel.
         """
         self.Call = channel.unary_unary(
-            '/jina.JinaDataRequestRPC/Call',
-            request_serializer=jina__pb2.MessageProto.SerializeToString,
-            response_deserializer=google_dot_protobuf_dot_empty__pb2.Empty.FromString,
-        )
+                '/jina.JinaDataRequestRPC/Call',
+                request_serializer=jina__pb2.MessageProto.SerializeToString,
+                response_deserializer=jina__pb2.MessageProto.FromString,
+                )
 
 
 class JinaDataRequestRPCServicer(object):
@@ -110,7 +97,8 @@ class JinaDataRequestRPCServicer(object):
     """
 
     def Call(self, request, context):
-        """Pass in a Message, wrapping a DataRequest"""
+        """Pass in a Message, wrapping a DataRequest
+        """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details('Method not implemented!')
         raise NotImplementedError('Method not implemented!')
@@ -118,49 +106,36 @@ class JinaDataRequestRPCServicer(object):
 
 def add_JinaDataRequestRPCServicer_to_server(servicer, server):
     rpc_method_handlers = {
-        'Call': grpc.unary_unary_rpc_method_handler(
-            servicer.Call,
-            request_deserializer=jina__pb2.MessageProto.FromString,
-            response_serializer=google_dot_protobuf_dot_empty__pb2.Empty.SerializeToString,
-        ),
+            'Call': grpc.unary_unary_rpc_method_handler(
+                    servicer.Call,
+                    request_deserializer=jina__pb2.MessageProto.FromString,
+                    response_serializer=jina__pb2.MessageProto.SerializeToString,
+            ),
     }
     generic_handler = grpc.method_handlers_generic_handler(
-        'jina.JinaDataRequestRPC', rpc_method_handlers
-    )
+            'jina.JinaDataRequestRPC', rpc_method_handlers)
     server.add_generic_rpc_handlers((generic_handler,))
 
 
-# This class is part of an EXPERIMENTAL API.
+ # This class is part of an EXPERIMENTAL API.
 class JinaDataRequestRPC(object):
     """*
     jina gRPC service for DataRequests.
     """
 
     @staticmethod
-    def Call(
-        request,
-        target,
-        options=(),
-        channel_credentials=None,
-        call_credentials=None,
-        insecure=False,
-        compression=None,
-        wait_for_ready=None,
-        timeout=None,
-        metadata=None,
-    ):
-        return grpc.experimental.unary_unary(
-            request,
+    def Call(request,
             target,
-            '/jina.JinaDataRequestRPC/Call',
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
+        return grpc.experimental.unary_unary(request, target, '/jina.JinaDataRequestRPC/Call',
             jina__pb2.MessageProto.SerializeToString,
-            google_dot_protobuf_dot_empty__pb2.Empty.FromString,
-            options,
-            channel_credentials,
-            insecure,
-            call_credentials,
-            compression,
-            wait_for_ready,
-            timeout,
-            metadata,
-        )
+            jina__pb2.MessageProto.FromString,
+            options, channel_credentials,
+            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)


### PR DESCRIPTION
This PR makes the necessary changes to our protobuf models for star routing:

1. Remove the RoutingTable completely from the message. This will be an object kept at the gateway locally in the Future.
2. Remove the routes object from the Envelope. Thats not needed anymore as the Gateway can keep track of this locally and add the routes only in the end to the response to the Client.
3. Adjust the CommandMessage: A lot of them are not needed anymore, but ACTIVATE/DEACTIVATE will be used in the future to add/remove peas from a head. Thus we need the networking information to send alongside.
4. Change the gRPC service model to return a Message as the response, instead of the empty workaround

closes https://github.com/jina-ai/internal-tasks/issues/238