### PR TITLE
refactor: separate k8s namespace from flow name

### DIFF
--- a/docs/advanced/experimental/kubernetes.md
+++ b/docs/advanced/experimental/kubernetes.md
@@ -65,7 +65,7 @@ embedding size:  512
 
 You might have noticed that the above `Flow` has been deployed to the Namespace `example-clip`.
 By default, we use the `Flow` name as the `Kubernetes` namespace.
-However, you can deploy `Flow` to a given `Namespace` you want, such as:
+However, you can deploy `Flow` to any given `Namespace`, like this:
 
 ```{code-block} python
 ---

--- a/docs/advanced/experimental/kubernetes.md
+++ b/docs/advanced/experimental/kubernetes.md
@@ -30,11 +30,6 @@ The context manager makes sure to deploy the `Flow` when entering the context an
 All Executors in the Flow should be used with `jinahub+docker://...` or `docker://...`.
 ```
 
-```{admonition} Caution
-:class: caution
-We heavily recommend you to deploy `Flow` in a separate K8s namespace by passing `k8s_namespace` into the `Flow` arguments.
-```
-
 ## Examples
 
 ### CLIP image encoder
@@ -85,6 +80,12 @@ f = Flow(
     protocol='http',
     k8s_namespace='custom-namespace',
 ).add(uses='jinahub+docker://CLIPImageEncoder')
+```
+
+```{admonition} Caution
+:class: caution
+We heavily recommend you to deploy different `Flow` into separated namespaces. To be more concrete,
+if `custom-namespace` has been used by another `Flow`, please set a different `k8s_namespace` name.
 ```
 
 ### Postgres indexer

--- a/docs/advanced/experimental/kubernetes.md
+++ b/docs/advanced/experimental/kubernetes.md
@@ -65,7 +65,7 @@ embedding size:  512
 
 You might have noticed that the above `Flow` has been deployed to the Namespace `example-clip`.
 By default, we use the `Flow` name as the `Kubernetes` namespace.
-However, you can deploy `Flow` to a given `Namspace` you wanted, such as:
+However, you can deploy `Flow` to a given `Namespace` you want, such as:
 
 ```{code-block} python
 ---

--- a/docs/advanced/experimental/kubernetes.md
+++ b/docs/advanced/experimental/kubernetes.md
@@ -30,6 +30,11 @@ The context manager makes sure to deploy the `Flow` when entering the context an
 All Executors in the Flow should be used with `jinahub+docker://...` or `docker://...`.
 ```
 
+```{admonition} Caution
+:class: caution
+We heavily recommend you to deploy `Flow` in a separate K8s namespace by passing `k8s_namespace` into the `Flow` arguments.
+```
+
 ## Examples
 
 ### CLIP image encoder

--- a/docs/advanced/experimental/kubernetes.md
+++ b/docs/advanced/experimental/kubernetes.md
@@ -84,7 +84,7 @@ f = Flow(
 
 ```{admonition} Caution
 :class: caution
-We heavily recommend you to deploy different `Flow` into separated namespaces. To be more concrete,
+We heavily recommend you to deploy each `Flow` into a separate namespace. In particular it should not be deployed into namespaces, where other essential non Jina services are running. 
 if `custom-namespace` has been used by another `Flow`, please set a different `k8s_namespace` name.
 ```
 

--- a/docs/advanced/experimental/kubernetes.md
+++ b/docs/advanced/experimental/kubernetes.md
@@ -63,6 +63,24 @@ Forwarding from [::1]:8080 -> 8080
 embedding size:  512                                                                                       
 ```
 
+You might have noticed that the above `Flow` has been deployed to the Namespace `example-clip`.
+By default, we use the `Flow` name as the `Kubernetes` namespace.
+However, you can deploy `Flow` to a given `Namspace` you wanted, such as:
+
+```{code-block} python
+---
+emphasize-lines: 8
+---
+from jina import Flow
+
+f = Flow(
+    name='example-clip',
+    port_expose=8080,
+    infrastructure='K8S',
+    protocol='http',
+    k8s_namespace='custom-namespace',
+).add(uses='jinahub+docker://CLIPImageEncoder')
+```
 
 ### Postgres indexer
 

--- a/jina/clients/mixin.py
+++ b/jina/clients/mixin.py
@@ -66,7 +66,7 @@ class PostMixin:
             and self.args.infrastructure == InfrastructureType.K8S
         ):
             context_mgr = kubernetes_tools.get_port_forward_contextmanager(
-                self.args.name, self.port_expose
+                self.args.k8s_namespace, self.port_expose
             )
         else:
             context_mgr = nullcontext()

--- a/jina/clients/mixin.py
+++ b/jina/clients/mixin.py
@@ -66,7 +66,7 @@ class PostMixin:
             and self.args.infrastructure == InfrastructureType.K8S
         ):
             context_mgr = kubernetes_tools.get_port_forward_contextmanager(
-                self.args.k8s_namespace, self.port_expose
+                self.args.k8s_namespace or self.args.name, self.port_expose
             )
         else:
             context_mgr = nullcontext()

--- a/jina/flow/base.py
+++ b/jina/flow/base.py
@@ -468,13 +468,13 @@ class Flow(PostMixin, JAMLCompatible, ExitStack, metaclass=FlowType):
                 port_expose=self.port_expose,
                 pod_role=PodRoleType.GATEWAY,
                 expose_endpoints=json.dumps(self._endpoints_mapping),
-                k8s_namespace=self.args.name,
+                k8s_namespace=self.args.k8s_namespace,
             )
         )
 
         kwargs.update(self._common_kwargs)
         args = ArgNamespace.kwargs2namespace(kwargs, set_gateway_parser())
-        args.k8s_namespace = self.args.name
+        args.k8s_namespace = self.args.k8s_namespace
         args.connect_to_predecessor = False
         args.noblock_on_start = True
         self._pod_nodes[GATEWAY_NAME] = PodFactory.build_pod(
@@ -791,7 +791,7 @@ class Flow(PostMixin, JAMLCompatible, ExitStack, metaclass=FlowType):
         # pod workspace if not set then derive from flow workspace
         args.workspace = os.path.abspath(args.workspace or self.workspace)
 
-        args.k8s_namespace = self.args.name
+        args.k8s_namespace = self.args.k8s_namespace
         args.noblock_on_start = True
         args.extra_search_paths = self.args.extra_search_paths
         args.zmq_identity = None

--- a/jina/flow/base.py
+++ b/jina/flow/base.py
@@ -363,7 +363,7 @@ class Flow(PostMixin, JAMLCompatible, ExitStack, metaclass=FlowType):
         self.k8s_infrastructure_manager = None
         if self.args.infrastructure == InfrastructureType.K8S:
             self.k8s_infrastructure_manager = self._FlowK8sInfraResourcesManager(
-                k8s_namespace=self.args.k8s_namespace,
+                k8s_namespace=self.args.k8s_namespace or self.args.name,
                 k8s_custom_resource_dir=getattr(
                     self.args, 'k8s_custom_resource_dir', None
                 ),
@@ -468,13 +468,13 @@ class Flow(PostMixin, JAMLCompatible, ExitStack, metaclass=FlowType):
                 port_expose=self.port_expose,
                 pod_role=PodRoleType.GATEWAY,
                 expose_endpoints=json.dumps(self._endpoints_mapping),
-                k8s_namespace=self.args.k8s_namespace,
+                k8s_namespace=self.args.k8s_namespace or self.args.name,
             )
         )
 
         kwargs.update(self._common_kwargs)
         args = ArgNamespace.kwargs2namespace(kwargs, set_gateway_parser())
-        args.k8s_namespace = self.args.k8s_namespace
+        args.k8s_namespace = self.args.k8s_namespace or self.args.name
         args.connect_to_predecessor = False
         args.noblock_on_start = True
         self._pod_nodes[GATEWAY_NAME] = PodFactory.build_pod(
@@ -791,7 +791,7 @@ class Flow(PostMixin, JAMLCompatible, ExitStack, metaclass=FlowType):
         # pod workspace if not set then derive from flow workspace
         args.workspace = os.path.abspath(args.workspace or self.workspace)
 
-        args.k8s_namespace = self.args.k8s_namespace
+        args.k8s_namespace = self.args.k8s_namespace or self.args.name
         args.noblock_on_start = True
         args.extra_search_paths = self.args.extra_search_paths
         args.zmq_identity = None

--- a/jina/flow/base.py
+++ b/jina/flow/base.py
@@ -10,7 +10,6 @@ import sys
 import threading
 import time
 import uuid
-import warnings
 from collections import OrderedDict
 from contextlib import ExitStack
 from typing import Optional, Union, Tuple, List, Set, Dict, overload, Type
@@ -364,7 +363,7 @@ class Flow(PostMixin, JAMLCompatible, ExitStack, metaclass=FlowType):
         self.k8s_infrastructure_manager = None
         if self.args.infrastructure == InfrastructureType.K8S:
             self.k8s_infrastructure_manager = self._FlowK8sInfraResourcesManager(
-                k8s_namespace=self.args.name,
+                k8s_namespace=self.args.k8s_namespace,
                 k8s_custom_resource_dir=getattr(
                     self.args, 'k8s_custom_resource_dir', None
                 ),

--- a/tests/k8s/conftest.py
+++ b/tests/k8s/conftest.py
@@ -3,7 +3,6 @@ import os
 import docker
 import pytest
 from pytest_kind import KindCluster
-from typing import Optional
 
 from jina.logging.logger import JinaLogger
 

--- a/tests/k8s/test_connection_pool.py
+++ b/tests/k8s/test_connection_pool.py
@@ -20,7 +20,6 @@ async def test_wait_for_ready(
         name='test-flow-slow-executor',
         infrastructure='K8S',
         timeout_ready=120000,
-        k8s_namespace='test-flow-slow-executor-ns',
     ).add(
         name='slow_init_executor',
         uses=slow_init_executor_image,

--- a/tests/k8s/test_connection_pool.py
+++ b/tests/k8s/test_connection_pool.py
@@ -20,6 +20,7 @@ async def test_wait_for_ready(
         name='test-flow-slow-executor',
         infrastructure='K8S',
         timeout_ready=120000,
+        k8s_namespace='test-flow-slow-executor-ns',
     ).add(
         name='slow_init_executor',
         uses=slow_init_executor_image,

--- a/tests/k8s/test_custom_resource_dir.py
+++ b/tests/k8s/test_custom_resource_dir.py
@@ -9,7 +9,11 @@ def test_custom_resource_dir():
     custom_resource_dir = '/test'
 
     flow = Flow(
-        name='test-flow', port_expose=8080, infrastructure='K8S', protocol='http'
+        name='test-flow',
+        port_expose=8080,
+        infrastructure='K8S',
+        protocol='http',
+        k8s_namespace='test-flow-ns',
     ).add(name='test_executor', k8s_custom_resource_dir=custom_resource_dir)
     assert (
         flow._pod_nodes['test_executor'].args.k8s_custom_resource_dir
@@ -19,15 +23,22 @@ def test_custom_resource_dir():
 
 def test_no_resource_dir_specified():
     flow = Flow(
-        name='test-flow', port_expose=8080, infrastructure='K8S', protocol='http'
+        name='test-flow',
+        port_expose=8080,
+        infrastructure='K8S',
+        protocol='http',
+        k8s_namespace='test-flow-ns',
     ).add(name='test_executor')
     assert flow._pod_nodes['test_executor'].args.k8s_custom_resource_dir is None
 
 
 def test_default_k8s_connection_pooling():
-    flow = Flow(name='test-flow', port_expose=8080, infrastructure='K8S').add(
-        name='test_executor'
-    )
+    flow = Flow(
+        name='test-flow',
+        port_expose=8080,
+        infrastructure='K8S',
+        k8s_namespace='test-flow-ns',
+    ).add(name='test_executor')
     assert flow._pod_nodes['test_executor'].args.k8s_connection_pool
 
 
@@ -39,6 +50,7 @@ def test_disable_k8s_connection_pooling(k8s_connection_pool):
             port_expose=8080,
             infrastructure='K8S',
             k8s_disable_connection_pool=not k8s_connection_pool,
+            k8s_namespace='test-flow-ns',
         )
         .add(name='test_executor1', replicas=3)
         .add(name='test_executor2')

--- a/tests/k8s/test_graceful_request_handling.py
+++ b/tests/k8s/test_graceful_request_handling.py
@@ -80,6 +80,7 @@ async def test_no_message_lost_during_scaling(
         name='test-flow-slow-process-executor',
         infrastructure='K8S',
         timeout_ready=120000,
+        k8s_namespace='test-flow-slow-process-executor-ns',
     ).add(
         name='slow_process_executor',
         uses=slow_process_executor_image,
@@ -175,6 +176,7 @@ async def test_no_message_lost_during_kill(
         name='test-flow-slow-process-executor',
         infrastructure='K8S',
         timeout_ready=120000,
+        k8s_namespace='test-flow-slow-process-executor-ns',
     ).add(
         name='slow_process_executor',
         uses=slow_process_executor_image,
@@ -274,6 +276,7 @@ def test_linear_processing_time_scaling(
         name='test-flow-slow-process-executor',
         infrastructure='K8S',
         timeout_ready=120000,
+        k8s_namespace='test-flow-slow-process-executor-ns',
     ).add(
         name='slow_process_executor',
         uses=slow_process_executor_image,

--- a/tests/k8s/test_graceful_request_handling.py
+++ b/tests/k8s/test_graceful_request_handling.py
@@ -287,7 +287,7 @@ def test_linear_processing_time_scaling(
 
     with flow:
         with kubernetes_tools.get_port_forward_contextmanager(
-            'test-flow-slow-process-executor', flow.port_expose
+            'test-flow-slow-process-executor-ns', flow.port_expose
         ):
             # sleep as the port forward setup can take some time
             time.sleep(0.1)

--- a/tests/k8s/test_k8s.py
+++ b/tests/k8s/test_k8s.py
@@ -69,6 +69,7 @@ def k8s_flow_configmap(test_executor_image: str) -> Flow:
         infrastructure='K8S',
         protocol='http',
         timeout_ready=120000,
+        k8s_namespace='k8s-flow-configmap-ns',
     ).add(
         name='test_executor',
         uses=test_executor_image,

--- a/tests/k8s/test_k8s.py
+++ b/tests/k8s/test_k8s.py
@@ -309,7 +309,7 @@ def test_flow_with_k8s_namespace(
     with k8s_flow_with_namespace as f:
         client = K8sClients().core_v1
         namespaces = client.list_namespace().items
-        namespaces = [item['metadata']['name'] for item in namespaces]
+        namespaces = [item.metadata.name for item in namespaces]
         assert 'my-custom-namespace' in namespaces
 
 

--- a/tests/k8s/test_k8s.py
+++ b/tests/k8s/test_k8s.py
@@ -242,26 +242,6 @@ def test_flow_with_configmap(
 
 
 @pytest.mark.timeout(3600)
-def test_flow_with_namespace(
-    k8s_cluster,
-    k8s_flow_with_namespace,
-    load_images_in_kind,
-    set_test_pip_version,
-    logger,
-):
-    resp = run_test(
-        k8s_flow_with_namespace,
-        endpoint='/namespace',
-        port_expose=9090,
-    )
-
-    docs = resp[0].docs
-    assert len(docs) == 10
-    for doc in docs:
-        assert doc.tags.get('namespace') == 'k8s-flow-with-namespace-ns'
-
-
-@pytest.mark.timeout(3600)
 @pytest.mark.skip('Need to config gpu host.')
 def test_flow_with_gpu(
     k8s_cluster,


### PR DESCRIPTION
When deploying with `K8S`, we expect `k8s_namespace` sent to `Flow`, as namespace. Otherwise use default `Flow` name as namespace.