### PR TITLE
docs: improved code snippet readibility

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -34,9 +34,7 @@ The term "final release" is relative to "developmental release" as described bel
 
 `pip install -U jina` only installs the core dependencies of Jina.
 
-The recommended way of installing Jina is `pip install -U jina`
-
-`"standard"` include extra dependencies that enables:
+The recommended way of installing Jina is `pip install -U jina "standard"` include extra dependencies that enables:
 - Jina Hub + Docker support
 - FastAPI + Websocket support (required when using `Flow(protocol='http')` or `Flow(protocol='websocket')`)
 - the best compression via LZ4 algorithm


### PR DESCRIPTION
This PR resolves #3763
In <code>[RELEASE.md](https://github.com/jina-ai/jina/blob/master/RELEASE.md) L-37-L-40</code>, there is readability issue as <code>"standard"</code> gets printed in separate line. SO having that in same line will be better for readibility.