### PR TITLE
docs(fundamentals): remove useless `:class:` literal in documentarray docs

### DIFF
--- a/docs/fundamentals/document/documentarray-api.md
+++ b/docs/fundamentals/document/documentarray-api.md
@@ -217,8 +217,8 @@ shuffled_da_with_seed = da.shuffle(seed=1)  # shuffle the DocumentArray with see
 
 ### Split elements by tags
 
-`DocumentArray` provides function `.split` that split the `DocumentArray` into multiple :class:`DocumentArray` according to the tag value (stored in `tags`) of each :class:`Document`.
-It returns a python `dict` where `Documents` with the same value on `tag` are grouped together, their orders are preserved from the original :class:`DocumentArray`.
+`DocumentArray` provides function `.split` that split the `DocumentArray` into multiple `DocumentArray` according to the tag value (stored in `tags`) of each `Document`.
+It returns a python `dict` where `Documents` with the same value on `tag` are grouped together, their orders are preserved from the original `DocumentArray`.
 
 To make use of the function:
 


### PR DESCRIPTION
Wrong document: https://docs.jina.ai//fundamentals/document/documentarray-api/?highlight=traverse#split-elements-by-tags

I believe it's kind of legacy from `.rst` file? 

<img width="867" alt="Screen Shot 2021-11-04 at 6 25 21 PM" src="https://user-images.githubusercontent.com/4194287/140297982-94bd0e1e-ae2b-441e-8fbd-ab1d30d7db7e.png">