### PR TITLE
ci: only run commit lint when only changing docs folder

### DIFF
--- a/.github/workflows/ci-no-code-related.yml
+++ b/.github/workflows/ci-no-code-related.yml
@@ -1,0 +1,53 @@
+name: CI for Code Un-related Changes
+
+on:
+  pull_request:
+    paths:
+      - 'docs/**'
+      - '.github/workflows/**'
+
+jobs:
+  commit-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: find the prev warning if exist
+        if: ${{ !github.event.pull_request.head.repo.fork }}
+        uses: peter-evans/find-comment@v1
+        id: fc
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: 'bad commit message'
+      - name: Delete comment if exist
+        if: ${{ steps.fc.outputs.comment-id != 0 && !github.event.pull_request.head.repo.fork }}
+        uses: actions/github-script@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.issues.deleteComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: ${{ steps.fc.outputs.comment-id }},
+            })
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - run: "echo \"module.exports = {extends: ['@commitlint/config-conventional']}\" > commitlint.config.js"
+      - uses: wagoid/commitlint-github-action@v1
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      - name: if lint failed
+        if: ${{ failure() }}
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            Thanks for your contribution :heart:
+            :broken_heart: Unfortunately, this PR has one ore more **bad commit messages**, it can not be merged. To fix this problem, please refer to:
+            - [Commit Message Guideline for the First Time Contributor](https://github.com/jina-ai/jina/issues/553)
+            - [Contributing Guideline](https://github.com/jina-ai/jina/blob/master/CONTRIBUTING.md)
+
+            Note, other CI tests will *not* *start* until the commit messages get fixed.
+
+            This message will be deleted automatically when the commit messages get fixed.
+          reaction-type: "eyes"

--- a/.github/workflows/ci-no-code-related.yml
+++ b/.github/workflows/ci-no-code-related.yml
@@ -9,41 +9,7 @@ jobs:
   commit-lint:
     runs-on: ubuntu-latest
     steps:
-      - name: find the prev warning if exist
-        if: ${{ !github.event.pull_request.head.repo.fork }}
-        uses: peter-evans/find-comment@v1
-        id: fc
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          comment-author: 'github-actions[bot]'
-          body-includes: 'bad commit message'
-      - name: Delete comment if exist
-        if: ${{ steps.fc.outputs.comment-id != 0 && !github.event.pull_request.head.repo.fork }}
-        uses: actions/github-script@v3
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            github.issues.deleteComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              comment_id: ${{ steps.fc.outputs.comment-id }},
-            })
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
       - uses: wagoid/commitlint-github-action@v4
-      - name: if lint failed
-        if: ${{ failure() }}
-        uses: peter-evans/create-or-update-comment@v1
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            Thanks for your contribution :heart:
-            :broken_heart: Unfortunately, this PR has one ore more **bad commit messages**, it can not be merged. To fix this problem, please refer to:
-            - [Commit Message Guideline for the First Time Contributor](https://github.com/jina-ai/jina/issues/553)
-            - [Contributing Guideline](https://github.com/jina-ai/jina/blob/master/CONTRIBUTING.md)
-
-            Note, other CI tests will *not* *start* until the commit messages get fixed.
-
-            This message will be deleted automatically when the commit messages get fixed.
-          reaction-type: "eyes"

--- a/.github/workflows/ci-no-code-related.yml
+++ b/.github/workflows/ci-no-code-related.yml
@@ -31,10 +31,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - run: "echo \"module.exports = {extends: ['@commitlint/config-conventional']}\" > commitlint.config.js"
-      - uses: wagoid/commitlint-github-action@v1
-        env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      - uses: wagoid/commitlint-github-action@v4
       - name: if lint failed
         if: ${{ failure() }}
         uses: peter-evans/create-or-update-comment@v1

--- a/.github/workflows/ci-no-code-related.yml
+++ b/.github/workflows/ci-no-code-related.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     paths:
       - 'docs/**'
-      - '.github/workflows/**'
 
 jobs:
   commit-lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,10 +35,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - run: "echo \"module.exports = {extends: ['@commitlint/config-conventional']}\" > commitlint.config.js"
-      - uses: wagoid/commitlint-github-action@v1
-        env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      - uses: wagoid/commitlint-github-action@v4
       - name: if lint failed
         if: ${{ failure() }}
         uses: peter-evans/create-or-update-comment@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,44 +13,10 @@ jobs:
   commit-lint:
     runs-on: ubuntu-latest
     steps:
-      - name: find the prev warning if exist
-        if: ${{ !github.event.pull_request.head.repo.fork }}
-        uses: peter-evans/find-comment@v1
-        id: fc
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          comment-author: 'github-actions[bot]'
-          body-includes: 'bad commit message'
-      - name: Delete comment if exist
-        if: ${{ steps.fc.outputs.comment-id != 0 && !github.event.pull_request.head.repo.fork }}
-        uses: actions/github-script@v3
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            github.issues.deleteComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              comment_id: ${{ steps.fc.outputs.comment-id }},
-            })
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
       - uses: wagoid/commitlint-github-action@v4
-      - name: if lint failed
-        if: ${{ failure() }}
-        uses: peter-evans/create-or-update-comment@v1
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            Thanks for your contribution :heart:
-            :broken_heart: Unfortunately, this PR has one ore more **bad commit messages**, it can not be merged. To fix this problem, please refer to:
-            - [Commit Message Guideline for the First Time Contributor](https://github.com/jina-ai/jina/issues/553)
-            - [Contributing Guideline](https://github.com/jina-ai/jina/blob/master/CONTRIBUTING.md)
-
-            Note, other CI tests will *not* *start* until the commit messages get fixed.
-
-            This message will be deleted automatically when the commit messages get fixed.
-          reaction-type: "eyes"
 
   lint-flake-8:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: CI
 
 on:
   pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - '.github/workflows/**'
 
 #on:
 #  push:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     paths-ignore:
       - 'docs/**'
-      - '.github/workflows/**'
 
 #on:
 #  push:


### PR DESCRIPTION
Two main changes in this PR:

1. Don't run `core-test` or any other test when just changing the docs. This will save a lot of time and resources.
2. Remove *adding-comment when commit lint fails* function because it won't work if the PR is raised by external contributors(in other words, the source branch of the PR comes from a forked repo). That means the value is very limited, and considering the complexity it adds, I would say it's a nice move to remove this functionality. So that this change won't increase a lot modulization concerns, because they are so simple. 