### PR TITLE
feat(executor): Executor.from_hub now accepts jinahub scheme 🍾 

### DIFF
--- a/jina/executors/__init__.py
+++ b/jina/executors/__init__.py
@@ -5,7 +5,7 @@ from typing import Dict, TypeVar, Optional, Callable
 
 from .decorators import store_init_kwargs, wrap_func
 from .. import __default_endpoint__, __args_executor_init__
-from ..helper import typename
+from ..helper import typename, ArgNamespace
 from ..jaml import JAMLCompatible, JAML, subvar_regex, internal_var_regex
 
 __all__ = ['BaseExecutor', 'AnyExecutor', 'ExecutorType']
@@ -236,3 +236,32 @@ class BaseExecutor(JAMLCompatible, metaclass=ExecutorType):
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.close()
+
+    @classmethod
+    def from_hub(cls, uri: str, **kwargs) -> 'BaseExecutor':
+        """Construct an Executor from Hub.
+
+        :param uri: a hub Executor scheme starts with `jinahub://`
+        :param kwargs: other kwargs accepted by the CLI ``jina hub pull``
+        :return: the Hub Executor object.
+        """
+        from ..hubble.helper import is_valid_huburi
+
+        _source = None
+        if is_valid_huburi(uri):
+            from ..hubble.hubio import HubIO
+            from ..parsers.hubble import set_hub_pull_parser
+
+            _args = ArgNamespace.kwargs2namespace(
+                {'no_usage': True, **kwargs},
+                set_hub_pull_parser(),
+                positional_args=(uri,),
+            )
+            _source = HubIO(args=_args).pull()
+
+        if not _source or _source.startswith('docker://'):
+            raise ValueError(
+                f'Can not construct a native Executor from {uri}. Looks like you want to use it as a '
+                f'Docker container, you may want to use it in the Flow via `.add(uses={uri})` instead.'
+            )
+        return cls.load_config(_source)

--- a/jina/helper.py
+++ b/jina/helper.py
@@ -721,6 +721,7 @@ class ArgNamespace:
         parser: ArgumentParser,
         warn_unknown: bool = False,
         fallback_parsers: List[ArgumentParser] = None,
+        positional_args: Tuple[str, ...] = None,
     ) -> Namespace:
         """
         Convert dict to a namespace.
@@ -729,9 +730,12 @@ class ArgNamespace:
         :param parser: the parser for building kwargs into a namespace
         :param warn_unknown: True, if unknown arguments should be logged
         :param fallback_parsers: a list of parsers to help resolving the args
+        :param positional_args: some parser requires positional arguments to be presented
         :return: argument list
         """
         args = ArgNamespace.kwargs2list(kwargs)
+        if positional_args:
+            args += positional_args
         p_args, unknown_args = parser.parse_known_args(args)
         if warn_unknown and unknown_args:
             _leftovers = set(unknown_args)

--- a/jina/helper.py
+++ b/jina/helper.py
@@ -720,8 +720,8 @@ class ArgNamespace:
         kwargs: Dict[str, Union[str, int, bool]],
         parser: ArgumentParser,
         warn_unknown: bool = False,
-        fallback_parsers: List[ArgumentParser] = None,
-        positional_args: Tuple[str, ...] = None,
+        fallback_parsers: Optional[List[ArgumentParser]] = None,
+        positional_args: Optional[Tuple[str, ...]] = None,
     ) -> Namespace:
         """
         Convert dict to a namespace.

--- a/jina/jaml/__init__.py
+++ b/jina/jaml/__init__.py
@@ -14,7 +14,7 @@ from .helper import JinaResolver, JinaLoader, parse_config_source, load_py_modul
 __all__ = ['JAML', 'JAMLCompatible']
 
 from ..excepts import BadConfigSource
-from ..helper import expand_env_var
+from ..helper import expand_env_var, ArgNamespace
 
 subvar_regex = re.compile(
     r'\${{\s*([\w\[\].]+)\s*}}'
@@ -531,9 +531,29 @@ class JAMLCompatible(metaclass=JAMLCompatibleType):
         :param override_metas: dictionary of parameters to overwrite from the default config's metas field
         :param override_requests: dictionary of parameters to overwrite from the default config's requests field
         :param extra_search_paths: extra paths used when looking for executor yaml files
-        :param kwargs: kwargs for parse_config_source
+        :param kwargs: kwargs for parse_config_source, it can be also arguments accepted by ``jina hub pull``
         :return: :class:`JAMLCompatible` object
         """
+
+        from ..hubble.helper import is_valid_huburi
+
+        if is_valid_huburi(source):
+            from ..hubble.hubio import HubIO
+            from ..parsers.hubble import set_hub_pull_parser
+
+            _args = ArgNamespace.kwargs2namespace(
+                {'no_usage': True, **kwargs},
+                set_hub_pull_parser(),
+                positional_args=(source,),
+            )
+            _source = HubIO(args=_args).pull()
+            if _source.startswith('docker://'):
+                raise BadConfigSource(
+                    f'Can not construct a native Executor from {source}. Looks like you want to use it as a '
+                    f'Docker container, you may want to use it in the Flow via `.add(uses={source})` instead.'
+                )
+            source = _source
+
         if isinstance(source, str) and os.path.exists(source):
             extra_search_paths = (extra_search_paths or []) + [os.path.dirname(source)]
 

--- a/jina/jaml/__init__.py
+++ b/jina/jaml/__init__.py
@@ -14,7 +14,7 @@ from .helper import JinaResolver, JinaLoader, parse_config_source, load_py_modul
 __all__ = ['JAML', 'JAMLCompatible']
 
 from ..excepts import BadConfigSource
-from ..helper import expand_env_var, ArgNamespace
+from ..helper import expand_env_var
 
 subvar_regex = re.compile(
     r'\${{\s*([\w\[\].]+)\s*}}'
@@ -534,25 +534,6 @@ class JAMLCompatible(metaclass=JAMLCompatibleType):
         :param kwargs: kwargs for parse_config_source, it can be also arguments accepted by ``jina hub pull``
         :return: :class:`JAMLCompatible` object
         """
-
-        from ..hubble.helper import is_valid_huburi
-
-        if is_valid_huburi(source):
-            from ..hubble.hubio import HubIO
-            from ..parsers.hubble import set_hub_pull_parser
-
-            _args = ArgNamespace.kwargs2namespace(
-                {'no_usage': True, **kwargs},
-                set_hub_pull_parser(),
-                positional_args=(source,),
-            )
-            _source = HubIO(args=_args).pull()
-            if _source.startswith('docker://'):
-                raise BadConfigSource(
-                    f'Can not construct a native Executor from {source}. Looks like you want to use it as a '
-                    f'Docker container, you may want to use it in the Flow via `.add(uses={source})` instead.'
-                )
-            source = _source
 
         if isinstance(source, str) and os.path.exists(source):
             extra_search_paths = (extra_search_paths or []) + [os.path.dirname(source)]

--- a/jina/jaml/__init__.py
+++ b/jina/jaml/__init__.py
@@ -531,7 +531,7 @@ class JAMLCompatible(metaclass=JAMLCompatibleType):
         :param override_metas: dictionary of parameters to overwrite from the default config's metas field
         :param override_requests: dictionary of parameters to overwrite from the default config's requests field
         :param extra_search_paths: extra paths used when looking for executor yaml files
-        :param kwargs: kwargs for parse_config_source, it can be also arguments accepted by ``jina hub pull``
+        :param kwargs: kwargs for parse_config_source
         :return: :class:`JAMLCompatible` object
         """
 

--- a/tests/unit/executors/test_executor.py
+++ b/tests/unit/executors/test_executor.py
@@ -2,8 +2,15 @@ import os
 
 import pytest
 
-from jina import Executor, requests
+from jina import Executor, requests, DocumentArray, Document
 from jina.executors.metas import get_default_metas
+
+
+def test_executor_load_from_hub():
+    exec = Executor.load_config('jinahub://DummyHubExecutor')
+    da = DocumentArray([Document()])
+    exec.foo(da)
+    assert da.texts == ['hello']
 
 
 def test_executor_import_with_external_dependencies(capsys):

--- a/tests/unit/executors/test_executor.py
+++ b/tests/unit/executors/test_executor.py
@@ -7,7 +7,7 @@ from jina.executors.metas import get_default_metas
 
 
 def test_executor_load_from_hub():
-    exec = Executor.load_config('jinahub://DummyHubExecutor')
+    exec = Executor.from_hub('jinahub://DummyHubExecutor')
     da = DocumentArray([Document()])
     exec.foo(da)
     assert da.texts == ['hello']


### PR DESCRIPTION
Not going to lie, this is really one of my favorite features recently.

```python
from jina import Executor, DocumentArray, Document

exec = Executor.from_hub('jinahub://DummyHubExecutor')

da = DocumentArray([Document()])
exec.foo(da)
assert da.texts == ['hello']
```