### PR TITLE
feat: star routing - refactor grpc data runtime

### DIFF
--- a/cli/api.py
+++ b/cli/api.py
@@ -39,10 +39,10 @@ def executor_native(args: 'Namespace'):
     :param args: arguments coming from the CLI.
     """
     from jina.peapods.runtimes.zmq.zed import ZEDRuntime
-    from jina.peapods.runtimes.grpc import GRPCDataRuntime
+    from jina.peapods.runtimes.grpc import WorkerRuntime
 
     if args.runtime_cls == 'GRPCDataRuntime' or args.grpc_data_requests:
-        runtime_cls = GRPCDataRuntime
+        runtime_cls = WorkerRuntime
     elif args.runtime_cls == 'ZEDRuntime':
         runtime_cls = ZEDRuntime
     else:
@@ -77,9 +77,9 @@ def grpc_data_runtime(args: 'Namespace'):
 
     :param args: arguments coming from the CLI.
     """
-    from jina.peapods.runtimes.grpc import GRPCDataRuntime
+    from jina.peapods.runtimes.grpc import WorkerRuntime
 
-    with GRPCDataRuntime(args) as runtime:
+    with WorkerRuntime(args) as runtime:
         runtime.logger.success(
             f' Executor {runtime._data_request_handler._executor.metas.name} started'
         )

--- a/jina/peapods/runtimes/__init__.py
+++ b/jina/peapods/runtimes/__init__.py
@@ -11,7 +11,7 @@ def list_all_runtimes():
     from .container import ContainerRuntime
     from .jinad import JinadRuntime
     from .zmq.zed import ZEDRuntime
-    from .grpc import GRPCDataRuntime
+    from .grpc import WorkerRuntime
 
     return [
         k
@@ -33,7 +33,7 @@ def get_runtime(name: str):
     from .container import ContainerRuntime
     from .jinad import JinadRuntime
     from .zmq.zed import ZEDRuntime
-    from .grpc import GRPCDataRuntime
+    from .grpc import WorkerRuntime
 
     s = locals()[name]
     if isinstance(s, type) and issubclass(s, BaseRuntime):

--- a/jina/peapods/runtimes/__init__.py
+++ b/jina/peapods/runtimes/__init__.py
@@ -11,7 +11,7 @@ def list_all_runtimes():
     from .container import ContainerRuntime
     from .jinad import JinadRuntime
     from .zmq.zed import ZEDRuntime
-    from .grpc import WorkerRuntime
+    from .worker import WorkerRuntime
 
     return [
         k

--- a/jina/peapods/runtimes/worker/__init__.py
+++ b/jina/peapods/runtimes/worker/__init__.py
@@ -4,24 +4,23 @@ import multiprocessing
 import threading
 import time
 from abc import ABC
-from collections import defaultdict
-from typing import Dict, List, Optional, Union
+from typing import Optional, Union
 
+import grpc
 from grpc import RpcError
 
 from ..request_handlers.data_request_handler import (
     DataRequestHandler,
 )
 from ..zmq.asyncio import AsyncNewLoopRuntime
-from ....enums import OnErrorStrategy
-from ....excepts import NoExplicitMessage, ChainedPodException, RuntimeTerminated
-from ....helper import random_identity
-from ....proto import jina_pb2
+from ...networking import GrpcConnectionPool
+from ....excepts import RuntimeTerminated
+from ....proto import jina_pb2_grpc
 from ....types.message import Message
-from ....types.routing.table import RoutingTable
+from ....types.message.common import ControlMessage
 
 
-class GRPCDataRuntime(AsyncNewLoopRuntime, ABC):
+class WorkerRuntime(AsyncNewLoopRuntime, ABC):
     """Runtime procedure leveraging :class:`Grpclet` for sending DataRequests"""
 
     def __init__(
@@ -39,57 +38,38 @@ class GRPCDataRuntime(AsyncNewLoopRuntime, ABC):
         """
         super().__init__(args, cancel_event, **kwargs)
 
-        self._id = random_identity()
-        self._last_active_time = time.perf_counter()
-
-        self._pending_msgs = defaultdict(list)  # type: Dict[str, List[Message]]
-        self._partial_requests = None
-        self._static_routing_table = args.static_routing_table
-
         # Keep this initialization order, otherwise readiness check is not valid
         self._data_request_handler = DataRequestHandler(args, self.logger)
-        self._grpclet = Grpclet(
-            args=self.args,
-            message_callback=self._callback,
-            logger=self.logger,
+
+        self._grpc_server = grpc.aio.server(
+            options=[
+                ('grpc.max_send_message_length', -1),
+                ('grpc.max_receive_message_length', -1),
+            ]
         )
 
+        jina_pb2_grpc.add_JinaDataRequestRPCServicer_to_server(self, self._grpc_server)
+        self._grpc_server.add_insecure_port(f'0.0.0.0:{self.args.port_in}')
+
+    async def async_setup(self):
+        """
+        Wait for the GRPC server to start
+        """
+        await self._grpc_server.start()
+
     async def async_run_forever(self):
-        """Start the grpclet """
-        await self._grpclet.start()
-
-    async def async_teardown(self):
-        """Close the data request handler and stop sending messages"""
-        self._data_request_handler.close()
-
-        await self._grpclet.stop_sending()
+        """Block until the GRPC server is terminated """
+        await self._grpc_server.wait_for_termination()
 
     async def async_cancel(self):
-        """The async method to stop server."""
+        """Stop the GRPC server"""
         self.logger.debug('Cancel GRPCDataRuntime')
 
-        # Wait max 1.0 second until partial messages are processed
-        timeout_ns = 1e9
-        now = time.time_ns()
-        while self._pending_msgs and time.time_ns() - now < timeout_ns:
-            await asyncio.sleep(0.1)
+        await self._grpc_server.stop(0)
 
-        if self._pending_msgs:
-            self.logger.warning(
-                f'GrpcDataRuntime is closed while there are still {len(self._pending_msgs)} partial requests pending.'
-            )
-
-        await self._grpclet.stop_receiving()
-
-    @staticmethod
-    def get_control_address(**kwargs):
-        """
-        Does return None, exists for keeping interface compatible with ZEDRuntime
-
-        :param kwargs: extra keyword arguments
-        :returns: None
-        """
-        return None
+    async def async_teardown(self):
+        """Close the data request handler"""
+        self._data_request_handler.close()
 
     @staticmethod
     def is_ready(ctrl_address: str, **kwargs) -> bool:
@@ -103,7 +83,9 @@ class GRPCDataRuntime(AsyncNewLoopRuntime, ABC):
         """
 
         try:
-            _ = Grpclet.send_ctrl_msg(ctrl_address, 'STATUS')
+            _ = GrpcConnectionPool.send_message_sync(
+                ControlMessage('STATUS'), ctrl_address
+            )
         except RpcError:
             return False
 
@@ -112,8 +94,8 @@ class GRPCDataRuntime(AsyncNewLoopRuntime, ABC):
     @staticmethod
     def wait_for_ready_or_shutdown(
         timeout: Optional[float],
-        ctrl_address: str,
         shutdown_event: Union[multiprocessing.Event, threading.Event],
+        ctrl_address: str,
         **kwargs,
     ):
         """
@@ -128,122 +110,54 @@ class GRPCDataRuntime(AsyncNewLoopRuntime, ABC):
         timeout_ns = 1000000000 * timeout if timeout else None
         now = time.time_ns()
         while timeout_ns is None or time.time_ns() - now < timeout_ns:
-            if shutdown_event.is_set() or GRPCDataRuntime.is_ready(ctrl_address):
+            if shutdown_event.is_set() or WorkerRuntime.is_ready(ctrl_address):
                 return True
             time.sleep(0.1)
 
         return False
 
-    async def _callback(self, msg: Message) -> None:
-        try:
-            msg = self._post_hook(self._handle(self._pre_hook(msg)))
-            if msg.is_data_request:
-                asyncio.create_task(self._grpclet.send_message(msg))
-        except RuntimeTerminated:
-            GRPCDataRuntime.cancel(self.is_cancel)
-        except NoExplicitMessage:
-            # silent and do not propagate message anymore
-            # 1. wait partial message to be finished
-            pass
-        except (RuntimeError, Exception, ChainedPodException) as ex:
-            if self.args.on_error_strategy == OnErrorStrategy.THROW_EARLY:
-                raise
-            if isinstance(ex, ChainedPodException):
-                # the error is print from previous pod, no need to show it again
-                # hence just add exception and propagate further
-                # please do NOT add logger.error here!
-                msg.add_exception()
-            else:
-                msg.add_exception(ex, executor=self._data_request_handler._executor)
-                self.logger.error(
-                    f'{ex!r}'
-                    + f'\n add "--quiet-error" to suppress the exception details'
-                    if not self.args.quiet_error
-                    else '',
-                    exc_info=not self.args.quiet_error,
-                )
+    async def Call(self, msg, *args) -> Message:
+        """
+        Process they received message and return the result as a new message
 
-            if msg.is_data_request:
-                asyncio.create_task(self._grpclet.send_message(msg))
-            asyncio.create_task(self._grpclet.send_message(msg))
+        :param msg: the message to process
+        :param args: additional arguments in the grpc call, ignored
+        :returns: the response message
+        """
+        try:
+            return self._handle(msg)
+        except RuntimeTerminated:
+            WorkerRuntime.cancel(self.is_cancel)
+        except (RuntimeError, Exception) as ex:
+            self.logger.error(
+                f'{ex!r}' + f'\n add "--quiet-error" to suppress the exception details'
+                if not self.args.quiet_error
+                else '',
+                exc_info=not self.args.quiet_error,
+            )
+            raise
 
     def _handle(self, msg: Message) -> Message:
-        """Register the current message to this pea, so that all message-related properties are up-to-date, including
-        :attr:`request`, :attr:`prev_requests`, :attr:`message`, :attr:`prev_messages`. And then call the executor to handle
-        this message if its envelope's  status is not ERROR, else skip handling of message.
-        .. note::
-            Handle does not handle explicitly message because it may wait for different messages when different parts are expected
+        """Process the given message, data requests are passed to the DataRequestHandler
+
         :param msg: received message
         :return: the transformed message.
         """
+
+        if self.logger.debug_enabled:
+            self._log_info_msg(msg)
 
         # skip executor for non-DataRequest
         if msg.envelope.request_type != 'DataRequest':
             if msg.request.command == 'TERMINATE':
                 raise RuntimeTerminated()
-            self.logger.debug(f'skip executor: not data request')
             return msg
 
-        req_id = msg.envelope.request_id
-        num_expected_parts = self._get_expected_parts(msg)
-        self._data_request_handler.handle(
-            msg=msg,
-            partial_requests=[m.request for m in self._pending_msgs[req_id]]
-            if num_expected_parts > 1
-            else None,
-            peapod_name=self.name,
-        )
+        self._data_request_handler.handle(msg=msg)
 
         return msg
 
-    def _get_expected_parts(self, msg):
-        if msg.is_data_request:
-            if not self._static_routing_table:
-                graph = RoutingTable(msg.envelope.routing_table)
-                return graph.active_target_pod.expected_parts
-            else:
-                return self.args.num_part
-        else:
-            return 1
-
-    def _pre_hook(self, msg: Message) -> Message:
-        """
-        Pre-hook function, what to do after first receiving the message.
-        :param msg: received message
-        :return: `Message`
-        """
-        msg.add_route(self.name, self._id)
-
-        expected_parts = self._get_expected_parts(msg)
-
-        req_id = msg.envelope.request_id
-        if expected_parts > 1:
-            self._pending_msgs[req_id].append(msg)
-
-        num_partial_requests = len(self._pending_msgs[req_id])
-
-        if self.logger.debug_enabled:
-            self._log_info_msg(
-                msg,
-                f'({num_partial_requests}/{expected_parts} parts)'
-                if expected_parts > 1
-                else '',
-            )
-
-        if expected_parts > 1 and expected_parts > num_partial_requests:
-            # NOTE: reduce priority is higher than chain exception
-            # otherwise a reducer will lose its function when earlier pods raise exception
-            raise NoExplicitMessage
-
-        if (
-            msg.envelope.status.code == jina_pb2.StatusProto.ERROR
-            and self.args.on_error_strategy >= OnErrorStrategy.SKIP_HANDLE
-        ):
-            raise ChainedPodException
-
-        return msg
-
-    def _log_info_msg(self, msg, part_str):
+    def _log_info_msg(self, msg):
         info_msg = f'recv {msg.envelope.request_type} '
         req_type = msg.envelope.request_type
         if req_type == 'DataRequest':
@@ -252,25 +166,4 @@ class GRPCDataRuntime(AsyncNewLoopRuntime, ABC):
             )
         elif req_type == 'ControlRequest':
             info_msg += f'({msg.request.command}) '
-        info_msg += f'{part_str} from {msg.colored_route}'
         self.logger.debug(info_msg)
-
-    def _post_hook(self, msg: Message) -> Message:
-        """
-        Post-hook function, what to do before handing out the message.
-        :param msg: the transformed message
-        :return: `Message`
-        """
-        # do NOT access `msg.request.*` in the _pre_hook, as it will trigger the deserialization
-        # all meta information should be stored and accessed via `msg.envelope`
-
-        self._last_active_time = time.perf_counter()
-
-        if self._get_expected_parts(msg) > 1:
-            msgs = self._pending_msgs.pop(msg.envelope.request_id)
-            msg.merge_envelope_from(msgs)
-        elif msg.envelope.request_id in self._pending_msgs:
-            del self._pending_msgs[msg.envelope.request_id]
-
-        msg.update_timestamp()
-        return msg

--- a/jina/types/message/__init__.py
+++ b/jina/types/message/__init__.py
@@ -410,10 +410,6 @@ class Message:
         envelope.version.proto = __proto_version__
         envelope.version.vcs = os.environ.get('JINA_VCS_VERSION', '')
 
-    def update_timestamp(self):
-        """Update the timestamp of the last route"""
-        self.envelope.routes[-1].end_time.GetCurrentTime()
-
     @property
     def response(self) -> 'Request':
         """Get the response of the message in protobuf.

--- a/tests/unit/peapods/runtimes/worker/test_worker_runtime.py
+++ b/tests/unit/peapods/runtimes/worker/test_worker_runtime.py
@@ -3,22 +3,22 @@ import multiprocessing
 import os
 import time
 from multiprocessing import Process
-from threading import Event, Thread
+from threading import Event
 
 import pytest
 
 from jina import DocumentArray
 from jina.clients.request import request_generator
 from jina.parsers import set_pea_parser
-from jina.peapods.grpc import Grpclet
-from jina.peapods.runtimes.grpc import WorkerRuntime
+from jina.peapods.networking import GrpcConnectionPool
+from jina.peapods.runtimes.worker import WorkerRuntime
 from jina.types.document import Document
 from jina.types.message import Message
 
 
 @pytest.mark.slow
 @pytest.mark.timeout(5)
-def test_grpc_data_runtime(mocker):
+def test_worker_runtime():
     args = set_pea_parser().parse_args([])
     handle_mock = multiprocessing.Event()
 
@@ -42,76 +42,13 @@ def test_grpc_data_runtime(mocker):
         timeout=5.0, ctrl_address=f'{args.host}:{args.port_in}', shutdown_event=Event()
     )
 
-    Grpclet._create_grpc_stub(f'{args.host}:{args.port_in}', is_async=False).Call(
-        _create_test_data_message()
+    assert GrpcConnectionPool.send_message_sync(
+        _create_test_data_message(), f'{args.host}:{args.port_in}'
     )
-    time.sleep(0.1)
     assert handle_mock.is_set()
 
     WorkerRuntime.cancel(cancel_event)
     runtime_thread.join()
-
-    assert not WorkerRuntime.is_ready(f'{args.host}:{args.port_in}')
-
-
-@pytest.mark.slow
-@pytest.mark.timeout(10)
-@pytest.mark.parametrize('close_method', ['TERMINATE', 'CANCEL'])
-def test_grpc_data_runtime_waits_for_pending_messages_shutdown(close_method):
-    args = set_pea_parser().parse_args([])
-
-    cancel_event = multiprocessing.Event()
-    handler_closed_event = multiprocessing.Event()
-    slow_executor_block_time = 1.0
-    pending_requests = 3
-    sent_queue = multiprocessing.Queue()
-
-    def start_runtime(args, cancel_event, sent_queue, handler_closed_event):
-        with WorkerRuntime(args, cancel_event) as runtime:
-            runtime._data_request_handler.handle = lambda *args, **kwargs: time.sleep(
-                slow_executor_block_time
-            )
-            runtime._data_request_handler.close = (
-                lambda *args, **kwargs: handler_closed_event.set()
-            )
-
-            async def mock(msg):
-                sent_queue.put('')
-
-            runtime._grpclet.send_message = mock
-
-            runtime.run_forever()
-
-    runtime_thread = Process(
-        target=start_runtime,
-        args=(args, cancel_event, sent_queue, handler_closed_event),
-        daemon=True,
-    )
-    runtime_thread.start()
-
-    assert WorkerRuntime.wait_for_ready_or_shutdown(
-        timeout=5.0, ctrl_address=f'{args.host}:{args.port_in}', shutdown_event=Event()
-    )
-
-    request_start_time = time.time()
-    for i in range(pending_requests):
-        Grpclet._create_grpc_stub(f'{args.host}:{args.port_in}', is_async=False).Call(
-            _create_test_data_message()
-        )
-    time.sleep(0.1)
-
-    if close_method == 'TERMINATE':
-        runtime_thread.terminate()
-    else:
-        WorkerRuntime.cancel(cancel_event)
-    assert not handler_closed_event.is_set()
-    runtime_thread.join()
-
-    assert (
-        time.time() - request_start_time >= slow_executor_block_time * pending_requests
-    )
-    assert sent_queue.qsize() == pending_requests
-    assert handler_closed_event.is_set()
 
     assert not WorkerRuntime.is_ready(f'{args.host}:{args.port_in}')
 
@@ -125,16 +62,15 @@ def test_grpc_data_runtime_waits_for_pending_messages_shutdown(close_method):
     reason='Graceful shutdown is not working at the moment',
 )
 # TODO: This test should work, it does not
-async def test_grpc_data_runtime_graceful_shutdown(close_method):
+async def test_worker_runtime_graceful_shutdown(close_method):
     args = set_pea_parser().parse_args([])
 
     cancel_event = multiprocessing.Event()
     handler_closed_event = multiprocessing.Event()
     slow_executor_block_time = 1.0
     pending_requests = 5
-    sent_queue = multiprocessing.Queue()
 
-    def start_runtime(args, cancel_event, sent_queue, handler_closed_event):
+    def start_runtime(args, cancel_event, handler_closed_event):
         with WorkerRuntime(args, cancel_event) as runtime:
             runtime._data_request_handler.handle = lambda *args, **kwargs: time.sleep(
                 slow_executor_block_time
@@ -143,17 +79,11 @@ async def test_grpc_data_runtime_graceful_shutdown(close_method):
                 lambda *args, **kwargs: handler_closed_event.set()
             )
 
-            async def mock(msg):
-                sent_queue.put('')
-
-            runtime._grpclet.send_message = mock
-
             runtime.run_forever()
 
     runtime_thread = Process(
         target=start_runtime,
-        args=(args, cancel_event, sent_queue, handler_closed_event),
-        daemon=True,
+        args=(args, cancel_event, handler_closed_event),
     )
     runtime_thread.start()
 
@@ -165,7 +95,7 @@ async def test_grpc_data_runtime_graceful_shutdown(close_method):
 
     async def task_wrapper(adress, messages_received):
         msg = _create_test_data_message(len(messages_received))
-        await Grpclet._create_grpc_stub(adress).Call(msg)
+        await GrpcConnectionPool.create_connection(adress).Call(msg)
         messages_received.append(msg)
 
     sent_requests = 0
@@ -189,9 +119,11 @@ async def test_grpc_data_runtime_graceful_shutdown(close_method):
     assert not handler_closed_event.is_set()
     runtime_thread.join()
 
+    for future in asyncio.as_completed(tasks):
+        _ = await future
+
     assert pending_requests == sent_requests
     assert sent_requests == len(messages_received)
-    assert sent_queue.qsize() == pending_requests
 
     assert (
         time.time() - request_start_time >= slow_executor_block_time * pending_requests

--- a/tests/unit/peapods/test_networking.py
+++ b/tests/unit/peapods/test_networking.py
@@ -1,8 +1,6 @@
 import asyncio
-import multiprocessing
 import time
 from multiprocessing import Process
-from threading import Event
 
 import grpc
 import pytest
@@ -11,9 +9,7 @@ from jina import DocumentArray, Document
 from jina.clients.request import request_generator
 from jina.enums import PollingType
 from jina.helper import random_port
-from jina.parsers import set_pea_parser
 from jina.peapods.networking import ReplicaList, GrpcConnectionPool
-from jina.peapods.runtimes.worker import GRPCDataRuntime
 from jina.proto import jina_pb2_grpc
 from jina.types.message import Message
 from jina.types.message.common import ControlMessage
@@ -52,7 +48,7 @@ def test_connection_pool(mocker):
     create_mock = mocker.Mock()
     send_mock = mocker.Mock()
     pool = GrpcConnectionPool()
-    pool._create_connection = create_mock
+    pool.create_connection = create_mock
     pool._send_message = send_mock
 
     pool.add_connection(pod='encoder', head=False, address='1.1.1.1:53')


### PR DESCRIPTION
With star routing the grpc data runtime becomes very simpel (receive messages and forward to data request handler).
This PR is refactoring the runtime (now WorkerRuntime) and also removes the partial message logic from the data request handler. In the future this is done before it hits this handler.