### PR TITLE
feat(types): add scipy sparse to ravel/unravel

### DIFF
--- a/jina/types/arrays/memmap/__init__.py
+++ b/jina/types/arrays/memmap/__init__.py
@@ -21,6 +21,7 @@ PAGE_SIZE = mmap.ALLOCATIONGRANULARITY
 if TYPE_CHECKING:
     from ...document import Document
     from ..document import DocumentArray
+    from ...ndarray import ArrayType
 
 __all__ = ['DocumentArrayMemmap']
 
@@ -496,7 +497,7 @@ class DocumentArrayMemmap(
             del fp
 
     @ContentPropertyMixin.embeddings.getter
-    def embeddings(self) -> np.ndarray:
+    def embeddings(self) -> 'ArrayType':
         """Return a `np.ndarray` stacking all the `embedding` attributes as rows.
 
         :return: embeddings stacked per row as `np.ndarray`.

--- a/jina/types/arrays/mixins/content.py
+++ b/jina/types/arrays/mixins/content.py
@@ -42,7 +42,7 @@ class ContentPropertyMixin:
         else:
             emb_shape0 = value.shape[0]
             self._check_length(emb_shape0)
-            NdArray.ravel(self, value, 'embedding')
+            NdArray.ravel(value, self, 'embedding')
 
     @property
     def blobs(self) -> 'ArrayType':
@@ -73,7 +73,7 @@ class ContentPropertyMixin:
             blobs_shape0 = value.shape[0]
             self._check_length(blobs_shape0)
 
-            NdArray.ravel(self, value, 'blob')
+            NdArray.ravel(value, self, 'blob')
 
     @property
     def texts(self) -> List[str]:

--- a/jina/types/arrays/mixins/content.py
+++ b/jina/types/arrays/mixins/content.py
@@ -1,7 +1,5 @@
 from typing import List, Sequence, TYPE_CHECKING
 
-import numpy as np
-
 from ...ndarray import NdArray
 
 if TYPE_CHECKING:
@@ -18,10 +16,10 @@ class ContentPropertyMixin:
             )
 
     @property
-    def embeddings(self) -> np.ndarray:
-        """Return a `np.ndarray` stacking all the `embedding` attributes as rows.
+    def embeddings(self) -> 'ArrayType':
+        """Return a :class:`ArrayType` stacking all the `embedding` attributes as rows.
 
-        :return: a ndarray of embedding
+        :return: a :class:`ArrayType` of embedding
         """
         return NdArray.unravel([d.embedding for d in self._pb_body])
 
@@ -44,14 +42,11 @@ class ContentPropertyMixin:
         else:
             emb_shape0 = value.shape[0]
             self._check_length(emb_shape0)
-
-            # the best-effort & universal way to index ArrayType on torch, tf, numpy, scipy.sparse
-            for d, j in zip(self, range(emb_shape0)):
-                d.embedding = value[j, ...]
+            NdArray.ravel(self, value, 'embedding')
 
     @property
-    def blobs(self) -> np.ndarray:
-        """Return a `np.ndarray` stacking all :attr:`.blob`.
+    def blobs(self) -> 'ArrayType':
+        """Return a :class:`ArrayType` stacking all :attr:`.blob`.
 
         The `blob` attributes are stacked together along a newly created first
         dimension (as if you would stack using ``np.stack(X, axis=0)``).
@@ -60,7 +55,7 @@ class ContentPropertyMixin:
                  All dtype and shape values are assumed to be equal to the values of the
                  first element in the DocumentArray / DocumentArrayMemmap
 
-        :return: a ndarray of blobs
+        :return: a :class:`ArrayType` of blobs
         """
         return NdArray.unravel([d.blob for d in self._pb_body])
 
@@ -78,9 +73,7 @@ class ContentPropertyMixin:
             blobs_shape0 = value.shape[0]
             self._check_length(blobs_shape0)
 
-            # the best-effort & universal way to index ArrayType on torch, tf, numpy, scipy.sparse
-            for d, j in zip(self, range(blobs_shape0)):
-                d.blob = value[j, ...]
+            NdArray.ravel(self, value, 'blob')
 
     @property
     def texts(self) -> List[str]:

--- a/jina/types/ndarray/__init__.py
+++ b/jina/types/ndarray/__init__.py
@@ -21,6 +21,8 @@ if TYPE_CHECKING:
         jina_pb2.NdArrayProto,
     )
 
+    from ... import Document
+
 __all__ = ['NdArray']
 
 
@@ -74,6 +76,35 @@ class NdArray(ProtoTypeMixin):
                 return _to_framework_array(x, framework)
 
     @staticmethod
+    def ravel(value: 'ArrayType', docs: Iterator['Document'], field: str) -> None:
+        """Ravel :attr:`value` into ``doc.field`` of each documents
+
+        :param docs: the docs to set
+        :param field: the field of the doc to set
+        :param value: the value to be set on ``doc.field``
+        """
+        emb_shape0 = value.shape[0]
+
+        use_get_row = False
+        if hasattr(value, 'getformat'):
+            # for scipy only
+            sp_format = value.getformat()
+            if sp_format in {'bsr', 'coo'}:
+                # for BSR and COO, they dont implement [j, ...] in scipy
+                # but they offer get_row() API which implicitly translate the
+                # sparse row into CSR format, hence needs to convert back
+                # not very efficient, but this is the best we can do.
+                use_get_row = True
+
+        if use_get_row:
+            for d, j in zip(docs, range(emb_shape0)):
+                row = getattr(value.getrow(j), f'to{sp_format}')()
+                setattr(d, field, row)
+        else:
+            for d, j in zip(docs, range(emb_shape0)):
+                setattr(d, field, value[j, ...])
+
+    @staticmethod
     def unravel(protos: Sequence[jina_pb2.NdArrayProto]) -> 'ArrayType':
         """Unravel many ndarray-like proto in one-shot, by following the shape
         and dtype of the first proto.
@@ -81,24 +112,14 @@ class NdArray(ProtoTypeMixin):
         :param protos: a list of ndarray protos
         :return: a framework ndarray
         """
-        first = NdArray(next(iter(protos)))
+        first = NdArray(protos[0])
         framework, is_sparse = first._pb_body.cls_name, first.is_sparse
 
         if is_sparse:
-            if framework in {'tensorflow', 'scipy'}:
+            if framework in {'tensorflow'}:
                 raise NotImplementedError(
                     f'fast ravel on sparse {framework} is not supported yet.'
                 )
-
-            all_ds = []
-            for j, p in enumerate(protos):
-                _d = _get_dense_array(p.sparse.indices)
-
-                _idx = np.array([j] * _d.shape[-1], dtype=np.int32)
-                if framework == 'torch':
-                    _idx = _idx.reshape([1, -1])
-                    _d = np.vstack([_idx, _d])
-                all_ds.append(_d)
 
             val = _unravel_dense_array(
                 (d.sparse.values.buffer for d in protos),
@@ -106,11 +127,50 @@ class NdArray(ProtoTypeMixin):
                 dtype=first.sparse.values.dtype,
             )
 
-            idx = np.concatenate(all_ds, axis=-1)
             shape = [len(protos)] + list(first.sparse.shape)
-            from torch import sparse_coo_tensor
 
-            return sparse_coo_tensor(idx, val, shape)
+            all_ds = []
+            for j, p in enumerate(protos):
+                _d = _get_dense_array(p.sparse.indices)
+
+                if _d.size > 0:
+                    if framework == 'torch':
+                        _idx = np.array([j] * _d.shape[-1], dtype=np.int32).reshape(
+                            [1, -1]
+                        )
+                        _d = np.vstack([_idx, _d])
+                    if framework == 'scipy':
+                        _idx = np.array([j] * _d.shape[0], dtype=np.int32)
+                        _d = np.stack([_idx, _d[:, 1]], axis=-1)
+                    all_ds.append(_d)
+
+            if framework == 'torch':
+                idx = np.concatenate(all_ds, axis=-1)
+                from torch import sparse_coo_tensor
+
+                return sparse_coo_tensor(idx, val, shape)
+            if framework == 'scipy':
+                # scipy sparse is limited to ndim=2
+                idx = np.concatenate(all_ds, axis=0)
+                sp_format = first._pb_body.parameters['sparse_format']
+                shape = [len(protos), first.sparse.shape[-1]]
+                if sp_format == 'csc':
+                    from scipy.sparse import csc_matrix
+
+                    return csc_matrix((val, idx.T), shape=shape)
+                if sp_format == 'csr':
+                    from scipy.sparse import csr_matrix
+
+                    return csr_matrix((val, idx.T), shape=shape)
+                if sp_format == 'coo':
+                    from scipy.sparse import coo_matrix
+
+                    return coo_matrix((val, idx.T), shape=shape)
+                if sp_format == 'bsr':
+                    from scipy.sparse import bsr_matrix
+
+                    return bsr_matrix((val, idx.T), shape=shape)
+
         else:
             if framework in {'numpy', 'torch', 'paddle', 'tensorflow'}:
                 x = _unravel_dense_array(

--- a/tests/unit/types/ndarray/test_ndarray.py
+++ b/tests/unit/types/ndarray/test_ndarray.py
@@ -106,9 +106,6 @@ def test_ravel_embeddings_blobs(ndarray_val, attr, is_sparse):
 
 @pytest.mark.parametrize('sparse_cls', [csr_matrix, csc_matrix, bsr_matrix, coo_matrix])
 def test_bsr_coo_unravel(sparse_cls):
-    # it's hard to implement unravel setter for BSR and COO sparse
-    # matrix, but for unravel getter, they should work just fine.
-
     a = np.random.random([10, 72])
     a[a > 0.5] = 0
 


### PR DESCRIPTION
add full scipy support to ravel/unravel, now ravel setter/getter supports scipy sparse matrix perfectly.

```python

import numpy as np
import scipy.sparse
import torch
import tensorflow
tensorflow.enable_eager_execution()

from jina import DocumentArray

sp_embed = np.random.random([10, 7])
sp_embed[sp_embed > 0.5] = 0

da = DocumentArray.empty(10)
da.embeddings = sp_embed
print(type(da.embeddings), type(da[0].embedding))
# <class 'numpy.ndarray'> <class 'numpy.ndarray'>

# to torch
da.embeddings = torch.from_numpy(sp_embed)
print(type(da.embeddings), type(da[0].embedding))
# <class 'torch.Tensor'> <class 'torch.Tensor'>

# to tf
da.embeddings = tensorflow.constant(sp_embed)
print(type(da.embeddings), type(da[0].embedding))
# <class 'tensorflow.python.framework.ops.EagerTensor'> <class 'tensorflow.python.framework.ops.EagerTensor'>

# now convert it to real sparse matrix
# torch sparse
da.embeddings = torch.tensor(sp_embed).to_sparse()
print(type(da.embeddings), type(da[0].embedding))
# <class 'torch.Tensor'> <class 'torch.Tensor'>

# scipy sparse
da.embeddings = scipy.sparse.coo_matrix(sp_embed)
print(type(da.embeddings), type(da[0].embedding))
# <class 'scipy.sparse.coo.coo_matrix'> <class 'scipy.sparse.coo.coo_matrix'>

```