### PR TITLE
feat(worker): merge docs in worker runtime

### DIFF
--- a/jina/peapods/networking.py
+++ b/jina/peapods/networking.py
@@ -348,7 +348,23 @@ class GrpcConnectionPool:
         :returns: the response message
         """
         return GrpcConnectionPool.create_connection(target, is_async=False).Call(
-            msg, timeout=timeout
+            [msg], timeout=timeout
+        )
+
+    @staticmethod
+    def send_messages_sync(
+        messages: List[Message], target: str, timeout=1.0
+    ) -> Message:
+        """
+        Sends messages synchronizly to the target via grpc
+
+        :param messages: the list of messages to send
+        :param target: where to send the message to, like 127.0.0.1:8080
+        :param timeout: timeout for the send
+        :returns: the response message
+        """
+        return GrpcConnectionPool.create_connection(target, is_async=False).Call(
+            messages, timeout=timeout
         )
 
     @staticmethod

--- a/jina/peapods/runtimes/request_handlers/data_request_handler.py
+++ b/jina/peapods/runtimes/request_handlers/data_request_handler.py
@@ -16,23 +16,48 @@ if TYPE_CHECKING:
 
 
 def _get_docs_matrix_from_message(
-    msg: 'Message',
+    messages: List['Message'],
     field: str,
 ) -> List['DocumentArray']:
-    result = [getattr(msg.request, field)]
+    if len(messages) > 1:
+        result = [
+            getattr(r, field)
+            for r in reversed([message.request for message in messages])
+        ]
+    else:
+        result = [getattr(messages[0].request, field)]
 
-    # to unify all length=0 DocumentArray (or any other results) will simply considered as None
-    # otherwise, the executor has to handle [None, None, None] or [DocArray(0), DocArray(0), DocArray(0)]
+        # to unify all length=0 DocumentArray (or any other results) will simply considered as None
+        # otherwise, the executor has to handle [None, None, None] or [DocArray(0), DocArray(0), DocArray(0)]
     len_r = sum(len(r) for r in result)
     if len_r:
         return result
 
 
-def _get_docs_from_msg(
-    msg: 'Message',
+def get_docs_from_messages(
+    messages: List['Message'],
     field: str,
 ) -> 'DocumentArray':
-    return getattr(msg.request, field)
+    """
+    Gets a field from the message
+
+    :param messages: messages to get the field from
+    :param field: field name to access
+
+    :returns: DocumentArray extraced from the field from all messages
+    """
+    if len(messages) > 1:
+        result = DocumentArray(
+            [
+                d
+                for r in reversed([message.request for message in messages])
+                for d in getattr(r, field)
+            ]
+        )
+    else:
+        result = getattr(messages[0].request, field)
+
+    return result
 
 
 class DataRequestHandler:
@@ -85,47 +110,52 @@ class DataRequestHandler:
             parsed_params.update(**specific_parameters)
         return parsed_params
 
-    def handle(self, msg: 'Message'):
+    def handle(self, messages: 'List[Message]') -> Message:
         """Initialize private parameters and execute private loading functions.
 
-        :param msg: The message to handle containing a DataRequest
+        :param messages: The messages to handle containing a DataRequest
+        :returns: the processed message
         """
         # skip executor if endpoints mismatch
         if (
-            msg.envelope.header.exec_endpoint not in self._executor.requests
+            messages[0].envelope.header.exec_endpoint not in self._executor.requests
             and __default_endpoint__ not in self._executor.requests
         ):
             self.logger.debug(
-                f'skip executor: mismatch request, exec_endpoint: {msg.envelope.header.exec_endpoint}, requests: {self._executor.requests}'
+                f'skip executor: mismatch request, exec_endpoint: {messages[0].envelope.header.exec_endpoint}, requests: {self._executor.requests}'
             )
-            return
+            if len(messages) > 1:
+                DataRequestHandler.replace_docs(
+                    messages[0],
+                    docs=get_docs_from_messages(messages, field='docs'),
+                )
+            return messages[0]
 
         params = self._parse_params(
-            msg.request.parameters.dict(), self._executor.metas.name
+            messages[0].request.parameters.dict(), self._executor.metas.name
         )
-        docs = _get_docs_from_msg(
-            msg,
+        docs = get_docs_from_messages(
+            messages,
             field='docs',
         )
         # executor logic
         r_docs = self._executor(
-            req_endpoint=msg.envelope.header.exec_endpoint,
+            req_endpoint=messages[0].envelope.header.exec_endpoint,
             docs=docs,
             parameters=params,
             docs_matrix=_get_docs_matrix_from_message(
-                msg,
+                messages,
                 field='docs',
             ),
-            groundtruths=_get_docs_from_msg(
-                msg,
+            groundtruths=get_docs_from_messages(
+                messages,
                 field='groundtruths',
             ),
             groundtruths_matrix=_get_docs_matrix_from_message(
-                msg,
+                messages,
                 field='groundtruths',
             ),
         )
-
         # assigning result back to request
         # 1. Return none: do nothing
         # 2. Return nonempty and non-DocumentArray: raise error
@@ -133,15 +163,19 @@ class DataRequestHandler:
         # 4. Return DocArray and its not a shallow copy of self.docs: assign self.request.docs
         if r_docs is not None:
             if isinstance(r_docs, AbstractDocumentArray):
-                if r_docs != msg.request.docs:
+                if r_docs != messages[0].request.docs:
                     # this means the returned DocArray is a completely new one
-                    DataRequestHandler.replace_docs(msg, r_docs)
+                    DataRequestHandler.replace_docs(messages[0], r_docs)
             elif isinstance(r_docs, dict):
-                msg.request.parameters.update(r_docs)
+                messages[0].request.parameters.update(r_docs)
             else:
                 raise TypeError(
                     f'return type must be {DocumentArray!r}, `None` or Dict, but getting {r_docs!r}'
                 )
+        elif len(messages) > 1:
+            DataRequestHandler.replace_docs(messages[0], docs)
+
+        return messages[0]
 
     @staticmethod
     def replace_docs(msg, docs):

--- a/tests/unit/peapods/runtimes/request_handlers/test_data_request_handlers.py
+++ b/tests/unit/peapods/runtimes/request_handlers/test_data_request_handlers.py
@@ -46,11 +46,7 @@ def test_data_request_handler_new_docs(logger):
     )[0]
     msg = Message(None, req, 'test', '123')
     assert len(msg.request.docs) == 10
-    handler.handle(
-        msg=msg,
-        partial_requests=None,
-        peapod_name='name',
-    )
+    msg = handler.handle(messages=[msg])
 
     assert len(msg.request.docs) == 1
     assert msg.request.docs[0].text == 'new document'
@@ -67,11 +63,7 @@ def test_data_request_handler_change_docs(logger):
     )[0]
     msg = Message(None, req, 'test', '123')
     assert len(msg.request.docs) == 10
-    handler.handle(
-        msg=msg,
-        partial_requests=None,
-        peapod_name='name',
-    )
+    msg = handler.handle(messages=[msg])
 
     assert len(msg.request.docs) == 10
     for doc in msg.request.docs:
@@ -96,11 +88,7 @@ def test_data_request_handler_change_docs_dam(logger, tmpdir):
     )[0]
     msg = Message(None, req, 'test', '123')
     assert len(msg.request.docs) == 10
-    handler.handle(
-        msg=msg,
-        partial_requests=None,
-        peapod_name='name',
-    )
+    msg = handler.handle(messages=[msg])
 
     assert len(msg.request.docs) == 10
     for doc in msg.request.docs:
@@ -119,13 +107,12 @@ def test_data_request_handler_change_docs_from_partial_requests(logger):
             )
         )[0]
     ] * NUM_PARTIAL_REQUESTS
-    msg = Message(None, partial_reqs[-1], 'test', '123')
-    assert len(msg.request.docs) == 10
-    handler.handle(
-        msg=msg,
-        partial_requests=partial_reqs,
-        peapod_name='name',
-    )
+    messages = []
+    for request in partial_reqs:
+        messages.append(Message(None, request, 'test', '123'))
+    assert len(messages) == 5
+    assert len(messages[0].request.docs) == 10
+    msg = handler.handle(messages=messages)
 
     assert len(msg.request.docs) == 10 * NUM_PARTIAL_REQUESTS
     for doc in msg.request.docs:

--- a/tests/unit/peapods/runtimes/worker/test_worker_runtime.py
+++ b/tests/unit/peapods/runtimes/worker/test_worker_runtime.py
@@ -3,7 +3,7 @@ import multiprocessing
 import os
 import time
 from multiprocessing import Process
-from threading import Event, Thread
+from threading import Event
 
 import pytest
 
@@ -38,13 +38,15 @@ def test_worker_runtime():
         timeout=5.0, ctrl_address=f'{args.host}:{args.port_in}', shutdown_event=Event()
     )
 
-    assert GrpcConnectionPool.send_message_sync(
+    response = GrpcConnectionPool.send_message_sync(
         _create_test_data_message(),
         f'{args.host}:{args.port_in}',
     )
 
     WorkerRuntime.cancel(cancel_event)
     runtime_thread.join()
+
+    assert response
 
     assert not WorkerRuntime.is_ready(f'{args.host}:{args.port_in}')
 
@@ -75,12 +77,13 @@ def test_worker_runtime_docs_merging():
         [_create_test_data_message(), _create_test_data_message()],
         f'{args.host}:{args.port_in}',
     )
-    assert response
-    # we send two messages, its documents should be merged by concatinating
-    assert len(response.response.docs) == 2
 
     WorkerRuntime.cancel(cancel_event)
     runtime_thread.join()
+
+    assert response
+    # we send two messages, its documents should be merged by concatinating
+    assert len(response.response.docs) == 2
 
     assert not WorkerRuntime.is_ready(f'{args.host}:{args.port_in}')
 


### PR DESCRIPTION
This closes https://github.com/jina-ai/internal-tasks/issues/264

One can see the disadvantage of the multi message approach here. The DataRequestHandler gets multiple messages and we arbitrarily manipulate the first message and return it.
Ideally this should be multiple requests and we always return the only existing message (to preserve meta information)