### PR TITLE
ci: fake two required jobs for ci-no-code-related workflow

### DIFF
--- a/.github/workflows/ci-no-code-related.yml
+++ b/.github/workflows/ci-no-code-related.yml
@@ -13,3 +13,17 @@ jobs:
         with:
           fetch-depth: 0
       - uses: wagoid/commitlint-github-action@v4
+
+  # Because we enable GitHub status check for these two jobs:
+  # lint-flake-8 and success-all-test
+  # So that, we need to fake these two jobs.
+  # Otherwise the PR will infinitely wait for success of these two nonexistent jobs
+  lint-flake-8:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo 'fake success'
+
+  success-all-test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo 'fake success'


### PR DESCRIPTION
We enable GitHub status check for these two jobs: lint-flake-8 and success-all-test. So we need to fake these two jobs, otherwise the PR will infinitely wait for success of these two nonexistent jobs. e.g. https://github.com/jina-ai/jina/pull/3886