### PR TITLE
ci: remove hack to ci-no-code-related workflow (#3914)

### DIFF
--- a/.github/workflows/ci-no-code-related.yml
+++ b/.github/workflows/ci-no-code-related.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - 'docs/**'
+      - 'README.md'
 
 jobs:
   commit-lint:

--- a/.github/workflows/ci-no-code-related.yml
+++ b/.github/workflows/ci-no-code-related.yml
@@ -13,17 +13,3 @@ jobs:
         with:
           fetch-depth: 0
       - uses: wagoid/commitlint-github-action@v4
-
-  # Because we enable GitHub status check for these two jobs:
-  # lint-flake-8 and success-all-test
-  # So that, we need to fake these two jobs.
-  # Otherwise the PR will infinitely wait for success of these two nonexistent jobs
-  lint-flake-8:
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo 'fake success'
-
-  success-all-test:
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo 'fake success'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths-ignore:
       - 'docs/**'
+      - 'README.md'
 
 #on:
 #  push:


### PR DESCRIPTION
This reverts commit db10582899a11a09a25f45f15c2a9ef70b5428a9.

**Since we already made some changes about GitHub Actions' configuration, this hack is no longer needed.**