### PR TITLE
perf: small improve on uuid generation in doc

### DIFF
--- a/daemon/models/id.py
+++ b/daemon/models/id.py
@@ -1,7 +1,6 @@
 import uuid
 from typing import Dict, Union
 
-from jina.helper import random_identity
 from .enums import IDLiterals
 
 
@@ -74,7 +73,7 @@ class DaemonID(str):
             )
 
         if not jid:
-            jid = random_identity()
+            jid = str(uuid.uuid4())
         else:
             try:
                 jid = uuid.UUID(*jid)

--- a/jina/helper.py
+++ b/jina/helper.py
@@ -453,7 +453,7 @@ def random_identity(use_uuid1: bool = False) -> str:
     :return: A random UUID.
 
     """
-    return str(random_uuid(use_uuid1))
+    return random_uuid(use_uuid1).hex
 
 
 def random_uuid(use_uuid1: bool = False) -> uuid.UUID:

--- a/jina/types/document/__init__.py
+++ b/jina/types/document/__init__.py
@@ -1,4 +1,5 @@
 import json
+import uuid
 import mimetypes
 from typing import (
     Dict,
@@ -23,7 +24,7 @@ from ..score import NamedScore
 from ..score.map import NamedScoreMapping
 from ..struct import StructView
 from ...excepts import BadDocType
-from ...helper import random_identity, typename
+from ...helper import typename
 from ...proto import jina_pb2
 
 if TYPE_CHECKING:
@@ -265,7 +266,7 @@ class Document(AllMixins, ProtoTypeMixin):
             ) from ex
 
         if self._pb_body.id is None or not self._pb_body.id:
-            self.id = random_identity(use_uuid1=True)
+            self.id = uuid.uuid1().hex
 
         if kwargs:
             # check if there are mutually exclusive content fields


### PR DESCRIPTION
test settings: 1 million documents generation:

```python
from jina import Document

[Document() for _ in range(1000000)]
```

feature branch: 21239777 function calls (21233402 primitive calls) in 16.524 seconds

master branch: 23239839 function calls (23233463 primitive calls) in 19.815 seconds

we saved 2million function calls and roughly 17% time saving.

old & new uuid looks a bit different: 

![D0364F55-4D62-490A-AB1D-9749A233AC7A](https://user-images.githubusercontent.com/9794489/142441649-49c7fc7c-827f-4f58-98b3-c9158465cdf7.png)
