### PR TITLE
feat(tests): add pod integration tests

### DIFF
--- a/jina/peapods/networking.py
+++ b/jina/peapods/networking.py
@@ -471,8 +471,12 @@ class GrpcConnectionPool:
             options=GrpcConnectionPool.get_default_grpc_options(),
         ) as channel:
             stub = jina_pb2_grpc.JinaDataRequestRPCStub(channel)
-            response = stub.Call([msg], timeout=timeout)
-            return response
+            for i in range(3):
+                try:
+                    return stub.Call([msg], timeout=timeout)
+                except grpc.RpcError as e:
+                    if e.code() != grpc.StatusCode.UNAVAILABLE:
+                        raise
 
     @staticmethod
     def get_default_grpc_options():

--- a/jina/peapods/networking.py
+++ b/jina/peapods/networking.py
@@ -725,11 +725,13 @@ def is_remote_local_connection(first: str, second: str):
 def create_connection_pool(
     k8s_connection_pool: bool = False,
     k8s_namespace: Optional[str] = None,
+    logger: Optional[JinaLogger] = None,
 ) -> GrpcConnectionPool:
     """
     Creates the appropriate connection pool based on parameters
     :param k8s_namespace: k8s namespace the pool will live in, None if outside K8s
     :param k8s_connection_pool: flag to indicate if K8sGrpcConnectionPool should be used, defaults to true in K8s
+    :param logger: the logger to use
     :return: A connection pool object
     """
     if k8s_connection_pool and k8s_namespace:
@@ -737,8 +739,7 @@ def create_connection_pool(
 
         k8s_clients = K8sClients()
         return K8sGrpcConnectionPool(
-            namespace=k8s_namespace,
-            client=k8s_clients.core_v1,
+            namespace=k8s_namespace, client=k8s_clients.core_v1, logger=logger
         )
     else:
-        return GrpcConnectionPool()
+        return GrpcConnectionPool(logger=logger)

--- a/jina/peapods/pods/__init__.py
+++ b/jina/peapods/pods/__init__.py
@@ -134,7 +134,10 @@ class BasePod(ExitStack):
 
         _head_args = copy.deepcopy(args)
         _head_args.polling = args.polling
-        _head_args.port_in = helper.random_port()
+        if not hasattr(args, 'port_in') or not args.port_in:
+            _head_args.port_in = helper.random_port()
+        else:
+            _head_args.port_in = args.port_in
         _head_args.uses = None
         _head_args.pea_role = PeaRoleType.HEAD
 

--- a/jina/peapods/runtimes/gateway/__init__.py
+++ b/jina/peapods/runtimes/gateway/__init__.py
@@ -24,6 +24,7 @@ class GatewayRuntime(AsyncNewLoopRuntime, ABC):
         pods_addresses = json.loads(self.args.pods_addresses)
         # add the connections needed
         self._connection_pool = create_connection_pool(
+            logger=self.logger,
             k8s_connection_pool=self.args.k8s_connection_pool,
             k8s_namespace=self.args.k8s_namespace,
         )

--- a/jina/peapods/runtimes/head/__init__.py
+++ b/jina/peapods/runtimes/head/__init__.py
@@ -39,6 +39,7 @@ class HeadRuntime(AsyncNewLoopRuntime, ABC):
 
         self.name = args.name
         self.connection_pool = create_connection_pool(
+            logger=self.logger,
             k8s_connection_pool=args.k8s_connection_pool,
             k8s_namespace=args.k8s_namespace,
         )

--- a/scripts/get-all-test-paths.sh
+++ b/scripts/get-all-test-paths.sh
@@ -22,7 +22,7 @@ else
     declare -a distributed_tests=("tests/distributed/test_remote_peas/")
     
     # will be executed in one runner
-    declare -a comma_separated_tests=("tests/unit/peapods/runtimes/worker","tests/unit/peapods/runtimes/head","tests/unit/peapods/runtimes/request_handlers/","tests/unit/peapods/runtimes/gateway/grpc/test_grpc_gateway_runtime.py","tests/unit/peapods/runtimes/gateway/graph/test_topology_graph.py","tests/unit/peapods/test_networking.py","tests/unit/peapods/pods/test_pods.py","tests/unit/peapods/pods/test_scale.py","tests/unit/peapods/pods/test_pod_factory.py","tests/integration/runtimes/test_runtimes.py","tests/integration/peas/test_pea.py","tests/integration/peas/container/test_pea.py","tests/unit/peapods/peas/container/test_container_pea.py","tests/unit/peapods/peas/test_pea.py")
+    declare -a comma_separated_tests=("tests/unit/peapods/runtimes/worker","tests/unit/peapods/runtimes/head","tests/unit/peapods/runtimes/request_handlers/","tests/unit/peapods/runtimes/gateway/grpc/test_grpc_gateway_runtime.py","tests/unit/peapods/runtimes/gateway/graph/test_topology_graph.py","tests/unit/peapods/test_networking.py","tests/unit/peapods/pods/test_pods.py","tests/unit/peapods/pods/test_scale.py","tests/unit/peapods/pods/test_pod_factory.py","tests/integration/runtimes/test_runtimes.py","tests/integration/peas/test_pea.py","tests/integration/peas/container/test_pea.py","tests/integration/pods/test_pod.py","tests/unit/peapods/peas/container/test_container_pea.py","tests/unit/peapods/peas/test_pea.py")
 
     dest=( "${distributed_tests[@]}" "${comma_separated_tests[@]}" )
 

--- a/tests/integration/peas/test_pea.py
+++ b/tests/integration/peas/test_pea.py
@@ -171,9 +171,7 @@ async def test_peas_shards(polling):
         # this would be done by the Pod, its adding the worker to the head
         activate_msg = ControlMessage(command='ACTIVATE')
         activate_msg.add_related_entity('worker', '127.0.0.1', worker_port, shard_id=i)
-        assert GrpcConnectionPool.send_message_sync(
-            activate_msg, f'127.0.0.1:{head_port}'
-        )
+        GrpcConnectionPool.send_message_sync(activate_msg, f'127.0.0.1:{head_port}')
 
     # create a single gateway pea
     gateway_pea = _create_gateway_pea(graph_description, pod_addresses, port_expose)
@@ -224,9 +222,7 @@ async def test_peas_replicas():
         # this would be done by the Pod, its adding the worker to the head
         activate_msg = ControlMessage(command='ACTIVATE')
         activate_msg.add_related_entity('worker', '127.0.0.1', worker_port)
-        assert GrpcConnectionPool.send_message_sync(
-            activate_msg, f'127.0.0.1:{head_port}'
-        )
+        GrpcConnectionPool.send_message_sync(activate_msg, f'127.0.0.1:{head_port}')
 
     # create a single gateway pea
     gateway_pea = _create_gateway_pea(graph_description, pod_addresses, port_expose)
@@ -381,9 +377,7 @@ async def test_peas_with_replicas_advance_faster():
         # this would be done by the Pod, its adding the worker to the head
         activate_msg = ControlMessage(command='ACTIVATE')
         activate_msg.add_related_entity('worker', '127.0.0.1', worker_port)
-        assert GrpcConnectionPool.send_message_sync(
-            activate_msg, f'127.0.0.1:{head_port}'
-        )
+        GrpcConnectionPool.send_message_sync(activate_msg, f'127.0.0.1:{head_port}')
 
     # create a single gateway pea
     gateway_pea = _create_gateway_pea(graph_description, pod_addresses, port_expose)
@@ -438,7 +432,7 @@ async def _activate_worker(head_port, worker_port, shard_id=None):
     activate_msg.add_related_entity(
         'worker', '127.0.0.1', worker_port, shard_id=shard_id
     )
-    assert GrpcConnectionPool.send_message_sync(activate_msg, f'127.0.0.1:{head_port}')
+    GrpcConnectionPool.send_message_sync(activate_msg, f'127.0.0.1:{head_port}')
 
 
 async def _start_create_pea(pod, type='worker', executor=None):

--- a/tests/integration/pods/test_pod.py
+++ b/tests/integration/pods/test_pod.py
@@ -1,0 +1,324 @@
+import asyncio
+import json
+import time
+
+import pytest
+
+from jina import Document, Executor, Client, requests
+from jina.enums import PollingType
+from jina.helper import random_port
+from jina.parsers import set_gateway_parser, set_pod_parser
+from jina.peapods import Pod
+
+
+@pytest.mark.asyncio
+# test gateway, head and worker pea by creating them manually in the most simple configuration
+async def test_pods_trivial_topology():
+    pod_port = random_port()
+    port_expose = random_port()
+    graph_description = '{"start-gateway": ["pod0"], "pod0": ["end-gateway"]}'
+    pod_addresses = f'{{"pod0": ["0.0.0.0:{pod_port}"]}}'
+
+    # create a single worker pea
+    worker_pod = _create_regular_pod(pod_port)
+
+    # create a single gateway pea
+    gateway_pod = _create_gateway_pod(graph_description, pod_addresses, port_expose)
+
+    with gateway_pod, worker_pod:
+
+        # send requests to the gateway
+        c = Client(host='localhost', port=port_expose, asyncio=True)
+        responses = c.post(
+            '/', inputs=async_inputs, request_size=1, return_results=True
+        )
+
+        response_list = []
+        async for response in responses:
+            response_list.append(response)
+
+    assert len(response_list) == 20
+    assert len(response_list[0].docs) == 1
+
+
+@pytest.fixture
+def complete_graph_dict():
+    return {
+        'start-gateway': ['pod0', 'pod4', 'pod6'],
+        'pod0': ['pod1', 'pod2'],
+        'pod1': ['end-gateway'],
+        'pod2': ['pod3'],
+        'pod4': ['pod5'],
+        'merger': ['pod_last'],
+        'pod5': ['merger'],
+        'pod3': ['merger'],
+        'pod6': [],  # hanging_pod
+        'pod_last': ['end-gateway'],
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('uses_before', [True, False])
+@pytest.mark.parametrize('uses_after', [True, False])
+# test gateway, head and worker pea by creating them manually in a more Flow like topology with branching/merging
+async def test_pods_flow_topology(complete_graph_dict, uses_before, uses_after):
+    pods = [
+        pod_name for pod_name in complete_graph_dict.keys() if 'gateway' not in pod_name
+    ]
+    started_pods = []
+    pod_addresses = '{'
+    for pod in pods:
+        head_port = random_port()
+        pod_addresses += f'"{pod}": ["0.0.0.0:{head_port}"],'
+        regular_pod = _create_regular_pod(
+            port=head_port,
+            name=f'{pod}',
+            uses_before=uses_before,
+            uses_after=uses_after,
+        )
+
+        started_pods.append(regular_pod)
+        regular_pod.start()
+
+    # remove last comma
+    pod_addresses = pod_addresses[:-1]
+    pod_addresses += '}'
+    port_expose = random_port()
+
+    # create a single gateway pea
+
+    gateway_pod = _create_gateway_pod(
+        json.dumps(complete_graph_dict), pod_addresses, port_expose
+    )
+    gateway_pod.start()
+
+    await asyncio.sleep(0.1)
+
+    # send requests to the gateway
+    c = Client(host='localhost', port=port_expose, asyncio=True)
+    responses = c.post('/', inputs=async_inputs, request_size=1, return_results=True)
+    response_list = []
+    async for response in responses:
+        response_list.append(response)
+
+    # clean up pods
+    gateway_pod.close()
+    for pod in started_pods:
+        pod.close()
+
+    assert len(response_list) == 20
+    expected_docs = 3
+    if uses_before and uses_after:
+        expected_docs = 21
+    elif uses_before or uses_after:
+        expected_docs = 12
+    assert len(response_list[0].docs) == expected_docs
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('polling', [PollingType.ALL, PollingType.ANY])
+# test simple topology with shards
+async def test_pods_shards(polling):
+    head_port = random_port()
+    port_expose = random_port()
+    graph_description = '{"start-gateway": ["pod0"], "pod0": ["end-gateway"]}'
+    pod_addresses = f'{{"pod0": ["0.0.0.0:{head_port}"]}}'
+
+    pod = _create_regular_pod(port=head_port, name='pod', polling=polling, shards=10)
+    pod.start()
+
+    gateway_pod = _create_gateway_pod(graph_description, pod_addresses, port_expose)
+    gateway_pod.start()
+
+    await asyncio.sleep(1.0)
+
+    c = Client(host='localhost', port=port_expose, asyncio=True)
+    responses = c.post('/', inputs=async_inputs, request_size=1, return_results=True)
+    response_list = []
+    async for response in responses:
+        response_list.append(response)
+
+    gateway_pod.close()
+    pod.close()
+
+    assert len(response_list) == 20
+    assert len(response_list[0].docs) == 1 if polling == PollingType.ANY else 10
+
+
+@pytest.mark.asyncio
+# test simple topology with replicas
+async def test_pods_replicas():
+    head_port = random_port()
+    port_expose = random_port()
+    graph_description = '{"start-gateway": ["pod0"], "pod0": ["end-gateway"]}'
+    pod_addresses = f'{{"pod0": ["0.0.0.0:{head_port}"]}}'
+
+    pod = _create_regular_pod(port=head_port, name='pod', replicas=10)
+    pod.start()
+
+    gateway_pod = _create_gateway_pod(graph_description, pod_addresses, port_expose)
+    gateway_pod.start()
+
+    await asyncio.sleep(1.0)
+
+    c = Client(host='localhost', port=port_expose, asyncio=True)
+    responses = c.post('/', inputs=async_inputs, request_size=1, return_results=True)
+    response_list = []
+    async for response in responses:
+        response_list.append(response)
+
+    gateway_pod.close()
+    pod.close()
+
+    assert len(response_list) == 20
+    assert len(response_list[0].docs) == 1
+
+
+@pytest.mark.asyncio
+async def test_pods_with_executor():
+    graph_description = '{"start-gateway": ["pod0"], "pod0": ["end-gateway"]}'
+
+    head_port = random_port()
+    pod_addresses = f'{{"pod0": ["0.0.0.0:{head_port}"]}}'
+
+    regular_pod = _create_regular_pod(
+        port=head_port,
+        name='pod',
+        executor='NameChangeExecutor',
+        uses_before=True,
+        uses_after=True,
+        polling=PollingType.ALL,
+    )
+    regular_pod.start()
+
+    port_expose = random_port()
+    gateway_pod = _create_gateway_pod(graph_description, pod_addresses, port_expose)
+    gateway_pod.start()
+
+    await asyncio.sleep(1.0)
+
+    c = Client(host='localhost', port=port_expose, asyncio=True)
+    responses = c.post('/', inputs=async_inputs, request_size=1, return_results=True)
+    response_list = []
+    async for response in responses:
+        response_list.append(response.docs)
+
+    gateway_pod.close()
+    regular_pod.close()
+
+    assert len(response_list) == 20
+    assert len(response_list[0]) == 4
+
+    doc_texts = [doc.text for doc in response_list[0]]
+    assert doc_texts.count('client0-Request') == 1
+    assert doc_texts.count('pod/uses_before-0') == 1
+    assert doc_texts.count('pod/uses_after-0') == 1
+
+
+@pytest.mark.asyncio
+async def test_pods_with_replicas_advance_faster():
+    head_port = random_port()
+    port_expose = random_port()
+    graph_description = '{"start-gateway": ["pod0"], "pod0": ["end-gateway"]}'
+    pod_addresses = f'{{"pod0": ["0.0.0.0:{head_port}"]}}'
+
+    pod = _create_regular_pod(
+        port=head_port, name='pod', executor='FastSlowExecutor', replicas=10
+    )
+    pod.start()
+
+    gateway_pod = _create_gateway_pod(graph_description, pod_addresses, port_expose)
+    gateway_pod.start()
+
+    await asyncio.sleep(1.0)
+
+    c = Client(host='localhost', port=port_expose, asyncio=True)
+    input_docs = [Document(text='slow'), Document(text='fast')]
+    responses = c.post('/', inputs=input_docs, request_size=1, return_results=True)
+    response_list = []
+    async for response in responses:
+        response_list.append(response)
+
+    gateway_pod.close()
+    pod.close()
+
+    assert len(response_list) == 2
+    for response in response_list:
+        assert len(response.docs) == 1
+
+    assert response_list[0].docs[0].text == 'fast'
+    assert response_list[1].docs[0].text == 'slow'
+
+
+class NameChangeExecutor(Executor):
+    def __init__(self, runtime_args, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.name = runtime_args['name']
+
+    @requests
+    def foo(self, docs, **kwargs):
+        docs.append(Document(text=self.name))
+        return docs
+
+
+class FastSlowExecutor(Executor):
+    @requests
+    def foo(self, docs, **kwargs):
+        for doc in docs:
+            if doc.text == 'slow':
+                time.sleep(1.0)
+
+
+async def _start_create_pod(pod, executor=None):
+    port = random_port()
+    pod = _create_regular_pod(port, f'{pod}', executor)
+
+    pod.start()
+    return port, pod
+
+
+def _create_regular_pod(
+    port,
+    name='',
+    executor=None,
+    uses_before=False,
+    uses_after=False,
+    polling=PollingType.ANY,
+    shards=None,
+    replicas=None,
+):
+    args = set_pod_parser().parse_args([])
+    args.port_in = port
+    args.name = name
+    if shards:
+        args.shards = shards
+    if replicas:
+        args.replicas = replicas
+    args.polling = polling
+    if executor:
+        args.uses = executor if executor else 'NameChangeExecutor'
+    if uses_after:
+        args.uses_after = executor if executor else 'NameChangeExecutor'
+    if uses_before:
+        args.uses_before = executor if executor else 'NameChangeExecutor'
+    return Pod(args)
+
+
+def _create_gateway_pod(graph_description, pod_addresses, port_expose):
+    return Pod(
+        set_gateway_parser().parse_args(
+            [
+                '--graph-description',
+                graph_description,
+                '--pods-addresses',
+                pod_addresses,
+                '--port-expose',
+                str(port_expose),
+            ]
+        )
+    )
+
+
+async def async_inputs():
+    for _ in range(20):
+        yield Document(text='client0-Request')

--- a/tests/unit/peapods/runtimes/worker/test_worker_runtime.py
+++ b/tests/unit/peapods/runtimes/worker/test_worker_runtime.py
@@ -51,7 +51,7 @@ def test_worker_runtime():
 
     assert response
 
-    assert not WorkerRuntime.is_ready(f'{args.host}:{args.port_in}')
+    assert not AsyncNewLoopRuntime.is_ready(f'{args.host}:{args.port_in}')
 
 
 @pytest.mark.slow


### PR DESCRIPTION
This closes https://github.com/jina-ai/internal-tasks/issues/266

This changes:

- Some small improvement with the logger for the connection pool (use same logger as pea to have more readable log config)
- use injected port_in in Pods for the head and dont generate random ones. (this needs to be extended for scaling the heads)
- add integration tests for pods
- make tests less flaky by retrying grpc calls 3 times and avoiding throwing with assertions before we clean up ressources (otherwise retries might get messed up)