### PR TITLE
cd: try to fix benchmark

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -316,13 +316,15 @@ jobs:
           COMMITS_SINCE_LAST_VER=$(git rev-list $LAST_VER..HEAD --count)
           NEXT_VER=$RELEASE_VER".dev"$COMMITS_SINCE_LAST_VER
           echo "NEXT_VER=$NEXT_VER" >> $GITHUB_ENV
+          TAG=$(echo $GITHUB_REF | cut -d '/' -f 3)
+          echo "TAG=$TAG" >> $GITHUB_ENV
       - uses: benc-uk/workflow-dispatch@v1
         with:
           token: ${{ secrets.JINA_DEV_BOT }}
           workflow: Benchmark Jina
           repo: jina-ai/jina-terraform
           ref: "main"
-          inputs: '{ "pypi_releases": "[\"${{ env.NEXT_VER }}\"]"}'
+          inputs: '{ "pypi_releases": "[\"${{ env.NEXT_VER }}\"]", "git_tags": "[\"${{ env.TAG }}\"]"}'
   # just for blocking the merge until all parallel core-test are successful
   success-all-steps:
     runs-on: ubuntu-latest


### PR DESCRIPTION
What I observed:

`git_tags` and `pypi_releases` are two inputs we send to terraform. We always receive the latest `pypi_releases` in terraform, but always an empty list of `git_tags`, check one of the latest run [here](https://pipelines.actions.githubusercontent.com/mMdSPZiy5oVvo6JcmmBKsNWI6ZpVHg14BH6ltcCDBsGcYwykL8/_apis/pipelines/1/runs/810/signedlogcontent/2?urlExpires=2021-11-22T12%3A58%3A22.5774691Z&urlSigningMethod=HMACV1&urlSignature=TqPNLWshOIp3ll%2F3lc3zMkz854qClhc1Apc5BRPnd4s%3D)

![F0117F90-6292-4FB5-861A-E9E5F8ED66C2](https://user-images.githubusercontent.com/9794489/142869253-9fae56dd-2543-44b8-a4da-1812074e7174.png)

and we failed to concat versions in terraform:

![CF6E1F2A-C2CF-4BBB-AC20-4E977389A663](https://user-images.githubusercontent.com/9794489/142870294-52d80ff3-7afa-49b3-9814-715e39468956.png)


Not 100% sure if it is the case since I can not test.
