### PR TITLE
docs(types): add parallel map to documentarray-like objects

### DIFF
--- a/docs/fundamentals/document/fluent-interface.md
+++ b/docs/fundamentals/document/fluent-interface.md
@@ -41,6 +41,41 @@ d = Document(uri='apple.png')
 ```
 ````
 
+## Parallelization
+
+Fluent interface is super useful when processing a large {class}`~jina.DocumentArray` or {class}`~jina.DocumentArrayMemmap`. One can leverage {meth}`~jina.types.arrays.mixins.parallel.ParallelMixin.map` to speed up things quite a lot. 
+
+The following example shows the time difference on preprocessing ~6000 image Documents.
+
+```python
+from jina import DocumentArray
+from jina.logging.profile import TimeContext
+
+docs = DocumentArray.from_files('*.jpg')
+
+def foo(d):
+    return (d.load_uri_to_image_blob()
+            .set_image_blob_normalization()
+            .set_image_blob_channel_axis(-1, 0))
+
+with TimeContext('map-process'):
+    for d in docs.map(foo, backend='process'):
+        pass
+
+with TimeContext('map-thread'):
+    for d in docs.map(foo, backend='thread'):
+        pass
+
+with TimeContext('for-loop'):
+    for d in docs:
+        foo(d)
+```
+
+```text
+map-process ...	map-process takes 5 seconds (5.55s)
+map-thread ...	map-thread takes 10 seconds (10.28s)
+for-loop ...	for-loop takes 18 seconds (18.52s)
+```
 
 ## Methods
 

--- a/docs/fundamentals/document/fluent-interface.md
+++ b/docs/fundamentals/document/fluent-interface.md
@@ -102,6 +102,7 @@ Provide helper functions for {class}`Document` to support text data.
 ### ImageData
 Provide helper functions for {class}`Document` to support image data.
 - {meth}`~jina.types.document.mixins.image.ImageDataMixin.convert_buffer_to_image_blob`
+- {meth}`~jina.types.document.mixins.image.ImageDataMixin.convert_image_blob_to_buffer`
 - {meth}`~jina.types.document.mixins.image.ImageDataMixin.convert_image_blob_to_sliding_windows`
 - {meth}`~jina.types.document.mixins.image.ImageDataMixin.convert_image_blob_to_uri`
 - {meth}`~jina.types.document.mixins.image.ImageDataMixin.dump_image_blob_to_file`

--- a/jina/types/arrays/mixins/__init__.py
+++ b/jina/types/arrays/mixins/__init__.py
@@ -17,6 +17,7 @@ from .sample import SampleMixin
 from .text import TextToolsMixin
 from .traverse import TraverseMixin
 from .embed import EmbedMixin
+from .parallel import ParallelMixin
 
 
 class AllMixins(
@@ -37,6 +38,7 @@ class AllMixins(
     SampleMixin,
     TextToolsMixin,
     EvaluationMixin,
+    ParallelMixin,
     ABC,
 ):
     """All plugins that can be used in :class:`DocumentArray` or :class:`DocumentArrayMemmap`. """

--- a/jina/types/arrays/mixins/parallel.py
+++ b/jina/types/arrays/mixins/parallel.py
@@ -1,0 +1,44 @@
+from typing import Callable, TYPE_CHECKING, Generator, Optional
+
+if TYPE_CHECKING:
+    from ....helper import T
+    from ...document import Document
+
+
+class ParallelMixin:
+    """Helper functions that provide parallel map to :class:`DocumentArray` or :class:`DocumentArrayMemmap`."""
+
+    def map(
+        self,
+        func: Callable[['Document'], 'T'],
+        backend: str = 'process',
+        num_worker: Optional[int] = None,
+    ) -> Generator['T', None, None]:
+        """Return an iterator that applies function to every item of iterable in parallel, yielding the results.
+
+        :param func: a function that takes :class:`Document` as input and outputs anything. You can either modify elements
+            in-place (only with `thread` backend) or work later on return elements.
+        :param backend: if to use multi-`process` or multi-`thread` as the parallelization backend. In general, if your
+            ``func`` is IO-bound then perhaps `thread` is good enough. If your ``func`` is CPU-bound then you may use `process`.
+            In practice, you should try yourselves to figure out the best value. However, if you wish to modify the elements
+            in-place, regardless of IO/CPU-bound, you should always use `thread` backend.
+
+            .. warning::
+                When using `process` backend, you should not expect ``func`` modify elements in-place. This is because
+                the multiprocessing backing pass the variable via pickle and work in another process. The passed object
+                and the original object do **not** share the same memory.
+
+        :param num_worker: the number of parallel workers. If not given, then the number of CPUs in the system will be used.
+        :yield: anything return from ``func``
+        """
+        if backend == 'thread':
+            from multiprocessing.pool import ThreadPool as Pool
+        elif backend == 'process':
+            from multiprocessing.pool import Pool
+        else:
+            raise ValueError(
+                f'`backend` must be either `process` or `thread`, receiving {backend}'
+            )
+        with Pool(processes=num_worker) as p:
+            for x in p.imap(func, self):
+                yield x

--- a/jina/types/document/__init__.py
+++ b/jina/types/document/__init__.py
@@ -95,8 +95,6 @@ class Document(AllMixins, ProtoTypeMixin):
 
     """
 
-    _ON_GETATTR = ['matches', 'chunks']
-
     # overload_inject_start_document
     @overload
     def __init__(

--- a/jina/types/document/mixins/attribute.py
+++ b/jina/types/document/mixins/attribute.py
@@ -9,12 +9,9 @@ from ....proto import jina_pb2
 class GetSetAttributeMixin:
     """Provide helper functions for :class:`Document` to allow advanced set and get attributes """
 
-    _ON_GETATTR = ['matches', 'chunks']
     _special_mapped_keys = ('scores', 'evaluations')
 
     def __getattr__(self, item):
-        if item in self._ON_GETATTR:
-            self._increaseVersion()
         if hasattr(self._pb_body, item):
             value = getattr(self._pb_body, item)
         elif '__' in item:

--- a/jina/types/document/mixins/image.py
+++ b/jina/types/document/mixins/image.py
@@ -46,13 +46,25 @@ class ImageDataMixin:
         self.blob = blob
         return self
 
-    def convert_image_blob_to_uri(self: T) -> T:
+    def convert_image_blob_to_uri(self: T, channel_axis: int = -1) -> T:
         """Assuming :attr:`.blob` is a _valid_ image, set :attr:`uri` accordingly
 
+        :param channel_axis: the axis id of the color channel, ``-1`` indicates the color channel info at the last axis
         :return: itself after processed
         """
-        png_bytes = _to_png_buffer(self.blob)
+        blob = _move_channel_axis(self.blob, original_channel_axis=channel_axis)
+        png_bytes = _to_png_buffer(blob)
         self.uri = 'data:image/png;base64,' + base64.b64encode(png_bytes).decode()
+        return self
+
+    def convert_image_blob_to_buffer(self: T, channel_axis: int = -1) -> T:
+        """Assuming :attr:`.blob` is a _valid_ image, set :attr:`buffer` accordingly
+
+        :param channel_axis: the axis id of the color channel, ``-1`` indicates the color channel info at the last axis
+        :return: itself after processed
+        """
+        blob = _move_channel_axis(self.blob, original_channel_axis=channel_axis)
+        self.buffer = _to_png_buffer(blob)
         return self
 
     def set_image_blob_shape(

--- a/jina/types/document/mixins/image.py
+++ b/jina/types/document/mixins/image.py
@@ -69,7 +69,7 @@ class ImageDataMixin:
 
         :return: itself after processed
         """
-        blob = _move_channel_axis(self.blob, original_channel_axis=channel_axis)
+        blob = _move_channel_axis(self.blob, channel_axis, -1)
         out_rows, out_cols = shape
         in_rows, in_cols, n_in = blob.shape
 
@@ -79,7 +79,8 @@ class ImageDataMixin:
 
         # resample each image
         r = _nn_interpolate_2D(blob, x, y)
-        self.blob = r.reshape(out_rows, out_cols, n_in)
+        blob = r.reshape(out_rows, out_cols, n_in)
+        self.blob = _move_channel_axis(blob, -1, channel_axis)
 
         return self
 

--- a/jina/types/list.py
+++ b/jina/types/list.py
@@ -1,5 +1,5 @@
 from collections.abc import MutableSequence
-from typing import Union, List, Any
+from typing import Union, List, Any, Optional
 
 from google.protobuf import struct_pb2
 
@@ -14,12 +14,12 @@ class ListView(ProtoTypeMixin, MutableSequence):
     Used inside `StructView` when the inner element is a `ListValue`
     """
 
-    def __init__(self, list: struct_pb2.ListValue):
+    def __init__(self, list: Optional[struct_pb2.ListValue] = None):
         """Create a Python list view of Protobuf ListValue.
 
         :param list: the protobuf ListValue object
         """
-        self._pb_body = list
+        self._pb_body = list or struct_pb2.ListValue()
 
     def insert(self, index: int, object: Any) -> None:
         """

--- a/jina/types/list.py
+++ b/jina/types/list.py
@@ -19,7 +19,7 @@ class ListView(ProtoTypeMixin, MutableSequence):
 
         :param list: the protobuf ListValue object
         """
-        self._pb_body = list or struct_pb2.ListValue()
+        self._pb_body = list if list is not None else struct_pb2.ListValue()
 
     def insert(self, index: int, object: Any) -> None:
         """

--- a/jina/types/mixin.py
+++ b/jina/types/mixin.py
@@ -7,7 +7,22 @@ from ..proto import jina_pb2
 
 
 class ProtoTypeMixin:
-    """Mixin class of `ProtoType`."""
+    """The base mixin class of all Jina types.
+
+    .. note::
+        - All Jina types should inherit from this class.
+        - All subclass should have ``self._pb_body``
+        - All subclass should implement ``__init__`` with the possibility of initializing from ``None``, e.g.:
+
+            .. highlight:: python
+            .. code-block:: python
+
+                class MyJinaType(ProtoTypeMixin):
+
+                    def __init__(self, proto: Optional[jina_pb2.SomePbMsg] = None):
+                        self._pb_body = proto or jina_pb2.SomePbMsg()
+
+    """
 
     def json(self) -> str:
         """Return the object in JSON string
@@ -45,6 +60,13 @@ class ProtoTypeMixin:
         :return: binary string representation of the object
         """
         return self._pb_body.SerializePartialToString()
+
+    def __getstate__(self):
+        return dict(serialized=self.binary_str())
+
+    def __setstate__(self, state):
+        self.__init__()
+        self._pb_body.ParseFromString(state['serialized'])
 
     @property
     def nbytes(self) -> int:

--- a/jina/types/ndarray/__init__.py
+++ b/jina/types/ndarray/__init__.py
@@ -35,7 +35,7 @@ class NdArray(ProtoTypeMixin):
     """
 
     def __init__(self, proto: Optional[jina_pb2.NdArrayProto] = None):
-        self._pb_body = proto or jina_pb2.NdArrayProto()
+        self._pb_body = proto if proto is not None else jina_pb2.NdArrayProto()
 
     @property
     def value(self) -> 'ArrayType':

--- a/jina/types/ndarray/__init__.py
+++ b/jina/types/ndarray/__init__.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, TypeVar, Tuple, Sequence, Iterator
+from typing import TYPE_CHECKING, TypeVar, Tuple, Sequence, Iterator, Optional
 
 import numpy as np
 
@@ -18,7 +18,6 @@ if TYPE_CHECKING:
         tensorflow.SparseTensor,
         tensorflow.Tensor,
         torch.Tensor,
-        jina_pb2.NdArrayProto,
     )
 
     from ... import Document
@@ -35,8 +34,8 @@ class NdArray(ProtoTypeMixin):
     :param proto: the protobuf message, when not given then create a new one via :meth:`get_null_proto`
     """
 
-    def __init__(self, proto: jina_pb2.NdArrayProto):
-        self._pb_body = proto
+    def __init__(self, proto: Optional[jina_pb2.NdArrayProto] = None):
+        self._pb_body = proto or jina_pb2.NdArrayProto()
 
     @property
     def value(self) -> 'ArrayType':

--- a/jina/types/request/__init__.py
+++ b/jina/types/request/__init__.py
@@ -58,23 +58,26 @@ class Request(ProtoTypeMixin, DocsPropertyMixin, GroundtruthPropertyMixin):
         copy: bool = False,
     ):
         self._buffer = None
-        self._pb_body = jina_pb2.RequestProto()  # type: 'jina_pb2.RequestProto'
         self._compression_algorithm = compression_algorithm
         try:
             if isinstance(request, jina_pb2.RequestProto):
                 if copy:
+                    self._pb_body = jina_pb2.RequestProto()
                     self._pb_body.CopyFrom(request)
                 else:
                     self._pb_body = request
             elif isinstance(request, dict):
+                self._pb_body = jina_pb2.RequestProto()
                 json_format.ParseDict(request, self._pb_body)
             elif isinstance(request, str):
+                self._pb_body = jina_pb2.RequestProto()
                 json_format.Parse(request, self._pb_body)
             elif isinstance(request, bytes):
                 self._buffer = request
                 self._pb_body = None
             elif request is None:
                 # make sure every new request has a request id
+                self._pb_body = jina_pb2.RequestProto()
                 self._pb_body.request_id = random_identity()
             elif request is not None:
                 # note ``None`` is not considered as a bad type

--- a/jina/types/routing/table.py
+++ b/jina/types/routing/table.py
@@ -19,8 +19,8 @@ class TargetPod(ProtoTypeMixin):
     :param target: the protobuf object of the TargetPod
     """
 
-    def __init__(self, target: 'jina_pb2.TargetPodProto') -> None:
-        self._pb_body = target
+    def __init__(self, target: Optional['jina_pb2.TargetPodProto'] = None) -> None:
+        self._pb_body = target or jina_pb2.TargetPodProto()
 
     @property
     def port(self) -> int:
@@ -113,27 +113,33 @@ class RoutingTable(ProtoTypeMixin):
         ] = None,
         copy: bool = False,
     ) -> None:
-        self._pb_body = jina_pb2.RoutingTableProto()
         try:
             if isinstance(graph, RoutingTable):
                 if copy:
+                    self._pb_body = jina_pb2.RoutingTableProto()
                     self._pb_body.CopyFrom(graph._pb_body)
                 else:
                     self._pb_body = graph._pb_body
             elif isinstance(graph, jina_pb2.RoutingTableProto):
                 if copy:
+                    self._pb_body = jina_pb2.RoutingTableProto()
                     self._pb_body.CopyFrom(graph)
                 else:
                     self._pb_body = graph
             elif isinstance(graph, dict):
+                self._pb_body = jina_pb2.RoutingTableProto()
                 json_format.ParseDict(graph, self._pb_body)
             elif isinstance(graph, str):
+                self._pb_body = jina_pb2.RoutingTableProto()
                 json_format.Parse(graph, self._pb_body)
             elif isinstance(graph, bytes):
+                self._pb_body = jina_pb2.RoutingTableProto()
                 self._pb_body.ParseFromString(graph)
             elif graph is not None:
                 # note ``None`` is not considered as a bad type
                 raise ValueError(f'{typename(graph)} is not recognizable')
+            elif graph is None:
+                self._pb_body = jina_pb2.RoutingTableProto()
         except Exception as ex:
             raise BadRequestType(
                 f'fail to construct a {self.__class__} object from {graph}'

--- a/jina/types/routing/table.py
+++ b/jina/types/routing/table.py
@@ -20,7 +20,7 @@ class TargetPod(ProtoTypeMixin):
     """
 
     def __init__(self, target: Optional['jina_pb2.TargetPodProto'] = None) -> None:
-        self._pb_body = target or jina_pb2.TargetPodProto()
+        self._pb_body = target if target is not None else jina_pb2.TargetPodProto()
 
     @property
     def port(self) -> int:

--- a/jina/types/score/__init__.py
+++ b/jina/types/score/__init__.py
@@ -53,21 +53,24 @@ class NamedScore(ProtoTypeMixin):
         copy: bool = False,
         **kwargs,
     ):
-        self._pb_body = jina_pb2.NamedScoreProto()
         try:
             if isinstance(score, jina_pb2.NamedScoreProto):
                 if copy:
+                    self._pb_body = jina_pb2.NamedScoreProto()
                     self._pb_body.CopyFrom(score)
                 else:
                     self._pb_body = score
             elif isinstance(score, NamedScore):
                 if copy:
+                    self._pb_body = jina_pb2.NamedScoreProto()
                     self._pb_body.CopyFrom(score._pb_body)
                 else:
                     self._pb_body = score._pb_body
             elif score is not None:
                 # note ``None`` is not considered as a bad type
                 raise ValueError(f'{typename(score)} is not recognizable')
+            elif score is None:
+                self._pb_body = jina_pb2.NamedScoreProto()
         except Exception as ex:
             raise BadNamedScoreType(
                 f'fail to construct a NamedScore from {score}'

--- a/jina/types/struct.py
+++ b/jina/types/struct.py
@@ -20,7 +20,7 @@ class StructView(ProtoTypeMixin, MutableMapping):
 
         :param struct: the protobuf Struct object
         """
-        self._pb_body = struct or struct_pb2.Struct()
+        self._pb_body = struct if struct is not None else struct_pb2.Struct()
 
     def __setitem__(self, key, value):
         self._pb_body[key] = value

--- a/jina/types/struct.py
+++ b/jina/types/struct.py
@@ -1,5 +1,5 @@
 from collections.abc import MutableMapping
-from typing import Union, Dict
+from typing import Union, Dict, Optional
 
 from google.protobuf import struct_pb2
 
@@ -15,12 +15,12 @@ class StructView(ProtoTypeMixin, MutableMapping):
         This class behaves like :class:`defaultdict`.
     """
 
-    def __init__(self, struct: struct_pb2.Struct):
+    def __init__(self, struct: Optional[struct_pb2.Struct] = None):
         """Create a Python dict view of Protobuf Struct.
 
         :param struct: the protobuf Struct object
         """
-        self._pb_body = struct
+        self._pb_body = struct or struct_pb2.Struct()
 
     def __setitem__(self, key, value):
         self._pb_body[key] = value

--- a/tests/unit/types/arrays/mixins/test_parallel.py
+++ b/tests/unit/types/arrays/mixins/test_parallel.py
@@ -1,0 +1,32 @@
+import pytest
+
+from jina import DocumentArrayMemmap, DocumentArray, Document
+
+
+def foo(d: Document):
+    return (
+        d.load_uri_to_image_blob()
+        .set_image_blob_normalization()
+        .set_image_blob_channel_axis(-1, 0)
+        .set_image_blob_shape((222, 222), 0)
+    )
+
+
+@pytest.mark.parametrize('da_cls', [DocumentArray, DocumentArrayMemmap])
+@pytest.mark.parametrize('backend', ['process', 'thread'])
+@pytest.mark.parametrize('num_worker', [1, 2, None])
+def test_parallel_map(pytestconfig, da_cls, backend, num_worker):
+    da = da_cls.from_files(f'{pytestconfig.rootdir}/docs/**/*.png')[:10]
+
+    # use a generator
+    for d in da.map(foo, backend, num_worker=num_worker):
+        assert d.blob.shape == (3, 222, 222)
+
+    da = da_cls.from_files(f'{pytestconfig.rootdir}/docs/**/*.png')[:10]
+
+    # use as list, here the caveat is when using process backend you can not modify thing in-place
+    list(da.map(foo, backend, num_worker=num_worker))
+    if backend == 'thread':
+        assert da.blobs.shape == (len(da), 3, 222, 222)
+    else:
+        assert da.blobs is None

--- a/tests/unit/types/document/test_converters.py
+++ b/tests/unit/types/document/test_converters.py
@@ -121,7 +121,7 @@ def test_convert_image_blob_to_uri(arr_size, channel_axis, width, height):
     assert not doc.uri
     doc.set_image_blob_shape(channel_axis=channel_axis, shape=(width, height))
 
-    doc.convert_image_blob_to_uri()
+    doc.convert_image_blob_to_uri(channel_axis=channel_axis)
     assert doc.uri.startswith('data:image/png;base64,')
     assert doc.mime_type == 'image/png'
     assert doc.blob.any()  # assure after conversion blob still exist.

--- a/tests/unit/types/test_pickle.py
+++ b/tests/unit/types/test_pickle.py
@@ -1,0 +1,11 @@
+import pickle
+
+import pytest
+
+from jina.types.mixin import ProtoTypeMixin
+
+
+@pytest.mark.parametrize('cls', ProtoTypeMixin.__subclasses__())
+def test_pickle_dump_load(cls):
+    r = pickle.loads(pickle.dumps(cls()))
+    isinstance(r, cls)


### PR DESCRIPTION
```python
from jina import DocumentArray
from jina.logging.profile import TimeContext

docs = DocumentArray.from_files('/Users/hanxiao/Downloads/left/*.jpg')

def foo(d):
    return (d.load_uri_to_image_blob()
            .set_image_blob_normalization()
            .set_image_blob_channel_axis(-1, 0))


with TimeContext('map-process'):
    for d in docs.map(foo, backend='process'):
        pass

with TimeContext('map-thread'):
    for d in docs.map(foo, backend='thread'):
        pass

with TimeContext('for-loop'):
    for d in docs:
        foo(d)
```

```text
map-process ...	map-process takes 5 seconds (5.55s)
map-thread ...	map-thread takes 10 seconds (10.28s)
foo-loop ...	foo-loop takes 18 seconds (18.52s)
```