### PR TITLE
feat(types): make apply and apply_batch self-returning

### DIFF
--- a/jina/types/arrays/mixins/embed.py
+++ b/jina/types/arrays/mixins/embed.py
@@ -18,7 +18,7 @@ class EmbedMixin:
         device: str = 'cpu',
         batch_size: int = 256,
         to_numpy: bool = False,
-    ) -> None:
+    ) -> 'T':
         """Fill the embedding of Documents inplace by using `embed_model`
 
         :param embed_model: the embedding model written in Keras/Pytorch/Paddle
@@ -26,12 +26,14 @@ class EmbedMixin:
             `cpu` or `cuda`.
         :param batch_size: number of Documents in a batch for embedding
         :param to_numpy: if to store embeddings back to Document in ``numpy.ndarray`` or original framework format.
+        :return: itself after modified.
         """
 
         fm = get_framework(embed_model)
         getattr(self, f'_set_embeddings_{fm}')(
             embed_model, device, batch_size, to_numpy
         )
+        return self
 
     def _set_embeddings_keras(
         self: 'T',

--- a/jina/types/document/mixins/sugar.py
+++ b/jina/types/document/mixins/sugar.py
@@ -6,6 +6,7 @@ if TYPE_CHECKING:
     from ...arrays.memmap import DocumentArrayMemmap
     from ...ndarray import ArrayType
     from ...arrays.mixins.embed import AnyDNN
+    from ....helper import T
 
     import numpy as np
 
@@ -67,11 +68,11 @@ class SingletonSugarMixin:
 
     @overload
     def embed(
-        self,
+        self: 'T',
         embed_model: 'AnyDNN',
         device: str = 'cpu',
         batch_size: int = 256,
-    ) -> None:
+    ) -> 'T':
         """Fill the embedding of Documents inplace by using `embed_model`
 
         :param embed_model: the embedding model written in Keras/Pytorch/Paddle
@@ -80,12 +81,14 @@ class SingletonSugarMixin:
         :param batch_size: number of Documents in a batch for embedding
         """
 
-    def embed(self, *args, **kwargs) -> None:
+    def embed(self: 'T', *args, **kwargs) -> 'T':
         """
         # noqa: D102
         # noqa: DAR101
+        :return: itself after modified.
         """
         from ...arrays import DocumentArray
 
         _tmp = DocumentArray([self])
         _tmp.embed(*args, **kwargs)
+        return self


### PR DESCRIPTION
```python

import onnxruntime

model = onnxruntime.InferenceSession('resnet.onnx')

from jina import DocumentArray, Document


def pre_proc(d: Document):
    return (
        d.load_uri_to_image_blob()
        .set_image_blob_shape((224, 224))
        .set_image_blob_normalization()
        .set_image_blob_channel_axis(-1, 0)
    )


def post_proc(d: Document):
    return d.set_image_blob_channel_axis(0, -1).set_image_blob_inv_normalization()


def embed(da):
    return da.embed(model)


(
    DocumentArray.from_files('/Users/hanxiao/Downloads/left/*.jpg')[:1000]
    .apply(pre_proc)
    .apply_batch(embed, batch_size=16)
    .apply(post_proc)
    .plot_embeddings(image_sprites=True)
)


```