### PR TITLE
feat(types): support lambda function in parallel mixin

### DIFF
--- a/docs/fundamentals/document/documentarray-api.md
+++ b/docs/fundamentals/document/documentarray-api.md
@@ -860,7 +860,7 @@ map-thread ...	map-thread takes 10 seconds (10.28s)
 foo-loop ...	foo-loop takes 18 seconds (18.52s)
 ```
 
-One can see big improvement with `.map()`.
+One can see a significant speedup with `.map()`.
 
 ```{admonition} When to choose process or thread backend?
 :class: important
@@ -875,15 +875,9 @@ If you only modify elements in-place, and do not need return values, you can wri
 
 ```python
 da = DocumentArray(...)
-list(da.map(func))
+da.apply(func)
 ```
-
-This follows the same convention as you using Python built-in `map()`.
-
-You can also use `.apply()` which always returns a `DocumentArray`.
-
 ````
-
 
 
 

--- a/extra-requirements.txt
+++ b/extra-requirements.txt
@@ -78,6 +78,6 @@ pytest-lazy-fixture:        test
 datasets:                   cicd
 av:                         cicd
 trimesh:                    cicd
-paddlepaddle:               cicd
+paddlepaddle==2.2.0:        cicd
 onnx:                       cicd
 onnxruntime:                cicd

--- a/jina/resources/extra-requirements.txt
+++ b/jina/resources/extra-requirements.txt
@@ -78,6 +78,6 @@ pytest-lazy-fixture:        test
 datasets:                   cicd
 av:                         cicd
 trimesh:                    cicd
-paddlepaddle:               cicd
+paddlepaddle==2.2.0:        cicd
 onnx:                       cicd
 onnxruntime:                cicd

--- a/jina/types/arrays/mixins/parallel.py
+++ b/jina/types/arrays/mixins/parallel.py
@@ -78,7 +78,7 @@ class ParallelMixin:
         :param num_worker: the number of parallel workers. If not given, then the number of CPUs in the system will be used.
         :yield: anything return from ``func``
         """
-        if _is_lambda_function(func) and backend == 'process':
+        if _is_lambda_or_local_function(func) and backend == 'process':
             func = _globalize_lambda_function(func)
         with _get_pool(backend, num_worker) as p:
             for x in p.imap(func, self):
@@ -159,7 +159,7 @@ class ParallelMixin:
         :yield: anything return from ``func``
         """
 
-        if _is_lambda_function(func) and backend == 'process':
+        if _is_lambda_or_local_function(func) and backend == 'process':
             func = _globalize_lambda_function(func)
         with _get_pool(backend, num_worker) as p:
             for x in p.imap(func, self.batch(batch_size=batch_size, shuffle=shuffle)):
@@ -181,8 +181,10 @@ def _get_pool(backend, num_worker):
         )
 
 
-def _is_lambda_function(func):
-    return isinstance(func, LambdaType) and func.__name__ == '<lambda>'
+def _is_lambda_or_local_function(func):
+    return (isinstance(func, LambdaType) and func.__name__ == '<lambda>') or (
+        '<locals>' in func.__qualname__
+    )
 
 
 def _globalize_lambda_function(func):

--- a/jina/types/document/mixins/sugar.py
+++ b/jina/types/document/mixins/sugar.py
@@ -28,6 +28,7 @@ class SingletonSugarMixin:
         exclude_self: bool = False,
         only_id: bool = False,
         use_scipy: bool = False,
+        num_worker: Optional[int] = None,
     ) -> 'T':
         """Matching the current Document against a set of Documents.
 
@@ -45,14 +46,17 @@ class SingletonSugarMixin:
                                 the min distance will be rescaled to `a`, the max distance will be rescaled to `b`
                                 all values will be rescaled into range `[a, b]`.
         :param metric_name: if provided, then match result will be marked with this string.
-        :param batch_size: if provided, then `darray` is loaded in chunks of, at most, batch_size elements. This option
-                           will be slower but more memory efficient. Specialy indicated if `darray` is a big
-                           DocumentArrayMemmap.
+        :param batch_size: if provided, then ``darray`` is loaded in batches, where each of them is at most ``batch_size``
+            elements. When `darray` is big, this can significantly speedup the computation.
         :param exclude_self: if set, Documents in ``darray`` with same ``id`` as the left-hand values will not be
                         considered as matches.
         :param only_id: if set, then returning matches will only contain ``id``
         :param use_scipy: if set, use ``scipy`` as the computation backend. Note, ``scipy`` does not support distance
             on sparse matrix.
+        :param num_worker: the number of parallel workers. If not given, then the number of CPUs in the system will be used.
+
+                .. note::
+                    This argument is only effective when ``batch_size`` is set.
         """
         ...
 


### PR DESCRIPTION
```python
import onnxruntime

from jina import DocumentArray, Document

model = onnxruntime.InferenceSession('resnet.onnx')

pre_proc = lambda d: (
    d.load_uri_to_image_blob()
    .set_image_blob_shape((224, 224))
    .set_image_blob_normalization()
    .set_image_blob_channel_axis(-1, 0)
)


def post_proc(d: Document):
    return d.set_image_blob_channel_axis(0, -1).set_image_blob_inv_normalization()


docs = (
    DocumentArray.from_files('/Users/hanxiao/Downloads/left/*.jpg')[:1000]
    .apply(pre_proc)
    .apply_batch(lambda d: d.embed(model), batch_size=64)
    .apply(post_proc)
)

```