### PR TITLE
fix(document): fix conversion from blob to file with iobuffer

### DIFF
--- a/jina/types/document/mixins/image.py
+++ b/jina/types/document/mixins/image.py
@@ -109,10 +109,10 @@ class ImageDataMixin:
         :return: itself after processed
         """
         fp = _get_file_context(file)
-        with fp:
+        with fp as fpx_ctx:
             blob = _move_channel_axis(self.blob, channel_axis, -1)
             buffer = _to_png_buffer(blob)
-            fp.write(buffer)
+            fpx_ctx.write(buffer)
         return self
 
     def load_uri_to_image_blob(

--- a/tests/unit/types/document/test_converters.py
+++ b/tests/unit/types/document/test_converters.py
@@ -1,4 +1,5 @@
 import os
+import io
 
 import numpy as np
 import pytest
@@ -81,6 +82,18 @@ def test_buffer_to_blob():
     assert isinstance(doc.blob, np.ndarray)
     assert doc.mime_type == 'image/png'
     assert doc.blob.shape == (85, 152, 3)  # h,w,c
+
+
+def test_image_blob_to_file_with_buffer():
+    doc = Document(uri=os.path.join(cur_dir, 'test.png'))
+
+    output = io.BytesIO()
+
+    (doc.load_uri_to_image_blob().dump_image_blob_to_file(output))
+
+    output.seek(0)
+
+    assert output.read() != b''
 
 
 def test_convert_buffer_to_blob():


### PR DESCRIPTION
Using now the context return object instead of the actual manager which fixes #4008 