### PR TITLE
fix(hub): disk_cache_offline to return chached mark

### DIFF
--- a/jina/hubble/helper.py
+++ b/jina/hubble/helper.py
@@ -313,12 +313,12 @@ def disk_cache_offline(
 
             if cache_db is None:
                 # if we failed to load cache, do not raise, it is only an optimization thing
-                return func(*args, **kwargs)
+                return func(*args, **kwargs), False
             else:
                 with cache_db as dict_db:
                     try:
                         if call_hash in dict_db and not kwargs.get('force', False):
-                            return dict_db[call_hash]
+                            return dict_db[call_hash], True
 
                         result = func(*args, **kwargs)
                         dict_db[call_hash] = result
@@ -327,10 +327,10 @@ def disk_cache_offline(
                             default_logger.warning(
                                 message.format(func_name=func.__name__)
                             )
-                            return dict_db[call_hash]
+                            return dict_db[call_hash], True
                         else:
                             raise
-                return result
+                return result, False
 
         return wrapper
 

--- a/jina/hubble/hubio.py
+++ b/jina/hubble/hubio.py
@@ -669,7 +669,9 @@ with f:
                 scheme, name, tag, secret = parse_hub_uri(self.args.uri)
 
                 st.update(f'Fetching [bold]{name}[/bold] from Jina Hub ...')
-                executor = HubIO.fetch_meta(name, tag, secret=secret, force=need_pull)
+                executor, from_cache = HubIO.fetch_meta(
+                    name, tag, secret=secret, force=need_pull
+                )
 
                 presented_id = getattr(executor, 'name', executor.uuid)
                 executor_name = (
@@ -728,9 +730,10 @@ with f:
 
                         if need_pull:
                             # pull the latest executor meta, as the cached data would expire
-                            executor = HubIO.fetch_meta(
-                                name, tag, secret=secret, force=True
-                            )
+                            if from_cache:
+                                executor, _ = HubIO.fetch_meta(
+                                    name, tag, secret=secret, force=True
+                                )
 
                             cache_dir = Path(
                                 os.environ.get(

--- a/tests/integration/hub_usage/test_hub_usage.py
+++ b/tests/integration/hub_usage/test_hub_usage.py
@@ -74,14 +74,17 @@ def test_use_from_local_hub_pod_level(
 
     def _mock_fetch(name, tag=None, secret=None, force=False):
         mock(name=name)
-        return HubExecutor(
-            uuid='hello',
-            name='alias_dummy',
-            tag='v0',
-            image_name='jinahub/pod.dummy_mwu_encoder',
-            md5sum=None,
-            visibility=True,
-            archive_url=None,
+        return (
+            HubExecutor(
+                uuid='hello',
+                name='alias_dummy',
+                tag='v0',
+                image_name='jinahub/pod.dummy_mwu_encoder',
+                md5sum=None,
+                visibility=True,
+                archive_url=None,
+            ),
+            False,
         )
 
     monkeypatch.setattr(HubIO, 'fetch_meta', _mock_fetch)
@@ -99,14 +102,17 @@ def test_use_from_local_hub_flow_level(
 
     def _mock_fetch(name, tag=None, secret=None, force=False):
         mock(name=name)
-        return HubExecutor(
-            uuid='hello',
-            name='alias_dummy',
-            tag='v0',
-            image_name='jinahub/pod.dummy_mwu_encoder',
-            md5sum=None,
-            visibility=True,
-            archive_url=None,
+        return (
+            HubExecutor(
+                uuid='hello',
+                name='alias_dummy',
+                tag='v0',
+                image_name='jinahub/pod.dummy_mwu_encoder',
+                md5sum=None,
+                visibility=True,
+                archive_url=None,
+            ),
+            False,
         )
 
     monkeypatch.setattr(HubIO, 'fetch_meta', _mock_fetch)

--- a/tests/unit/hubble/test_helper.py
+++ b/tests/unit/hubble/test_helper.py
@@ -133,16 +133,16 @@ def test_disk_cache(tmpfile):
 
     raise_exception = False
     # returns latest, saves result in cache
-    assert _myfunc() == 1
+    assert _myfunc() == (1, False)
 
     result = 2
     # does not return latest, defaults to cache since force == False
-    assert _myfunc() == 1
+    assert _myfunc() == (1, True)
 
     # returns latest since force == True
-    assert _myfunc(force=True) == 2
+    assert _myfunc(force=True) == (2, False)
 
     raise_exception = True
     result = 3
     # does not return latest and exception is not raised, defaults to cache
-    assert _myfunc(force=True) == 2
+    assert _myfunc(force=True) == (2, True)

--- a/tests/unit/hubble/test_hubio.py
+++ b/tests/unit/hubble/test_hubio.py
@@ -172,7 +172,7 @@ def test_fetch(mocker, monkeypatch):
     monkeypatch.setattr(requests, 'get', _mock_get)
     args = set_hub_pull_parser().parse_args(['jinahub://dummy_mwu_encoder'])
 
-    executor = HubIO(args).fetch_meta('dummy_mwu_encoder', None)
+    executor, _ = HubIO(args).fetch_meta('dummy_mwu_encoder', None)
 
     assert executor.uuid == 'dummy_mwu_encoder'
     assert executor.name == 'alias_dummy'
@@ -180,10 +180,10 @@ def test_fetch(mocker, monkeypatch):
     assert executor.image_name == 'jinahub/pod.dummy_mwu_encoder'
     assert executor.md5sum == 'ecbe3fdd9cbe25dbb85abaaf6c54ec4f'
 
-    executor = HubIO(args).fetch_meta('dummy_mwu_encoder', '')
+    executor, _ = HubIO(args).fetch_meta('dummy_mwu_encoder', '')
     assert executor.tag == 'v0'
 
-    executor = HubIO(args).fetch_meta('dummy_mwu_encoder', 'v0.1')
+    executor, _ = HubIO(args).fetch_meta('dummy_mwu_encoder', 'v0.1')
     assert executor.tag == 'v0.1'
 
 
@@ -206,14 +206,17 @@ def test_pull(test_envs, mocker, monkeypatch):
 
     def _mock_fetch(name, tag=None, secret=None, force=False):
         mock(name=name)
-        return HubExecutor(
-            uuid='dummy_mwu_encoder',
-            name='alias_dummy',
-            tag='v0',
-            image_name='jinahub/pod.dummy_mwu_encoder',
-            md5sum=None,
-            visibility=True,
-            archive_url=None,
+        return (
+            HubExecutor(
+                uuid='dummy_mwu_encoder',
+                name='alias_dummy',
+                tag='v0',
+                image_name='jinahub/pod.dummy_mwu_encoder',
+                md5sum=None,
+                visibility=True,
+                archive_url=None,
+            ),
+            False,
         )
 
     monkeypatch.setattr(HubIO, 'fetch_meta', _mock_fetch)


### PR DESCRIPTION
Now, `fetch_meta` is called twice when `force=True`. This would pollute the count of pulls of each executor in Hubble system. 

In this PR, the decorator `disk_cache_offline` is revised to return a tuple consisting of *returned value* and *bool value* (indicate whether the value is get from cache).