### PR TITLE
feat: retry url to blob

### DIFF
--- a/docarray/document/mixins/image.py
+++ b/docarray/document/mixins/image.py
@@ -120,17 +120,21 @@ class ImageDataMixin:
         width: Optional[int] = None,
         height: Optional[int] = None,
         channel_axis: int = -1,
+        tries: int = 1,
+        retry_sleep: int = 1,
     ) -> T:
         """Convert the image-like :attr:`.uri` into :attr:`.blob`
 
         :param width: the width of the image blob.
         :param height: the height of the blob.
         :param channel_axis: the axis id of the color channel, ``-1`` indicates the color channel info at the last axis
+        :param tries: the number of retries
+        :param retry_sleep: seconds to wait before next retry
 
         :return: itself after processed
         """
 
-        buffer = _uri_to_buffer(self.uri)
+        buffer = _uri_to_buffer(self.uri, tries, retry_sleep)
         blob = _to_image_blob(io.BytesIO(buffer), width=width, height=height)
         self.blob = _move_channel_axis(blob, original_channel_axis=channel_axis)
         return self

--- a/tests/docarray/arrays/mixins/test_image.py
+++ b/tests/docarray/arrays/mixins/test_image.py
@@ -1,0 +1,88 @@
+import io
+from http.client import RemoteDisconnected
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+from PIL import Image
+
+from docarray import Document
+
+
+@pytest.fixture
+def fake_response():
+    class FakeResponse:
+        status: int
+        data: bytes
+
+        def __init__(self, *, data, status, num_fails):
+            self.data = data
+            self.status = status
+            self.num_fails = num_fails
+            self.current_fails = 0
+
+        def read(self):
+            if self.current_fails < self.num_fails:
+                self.current_fails += 1
+                raise RemoteDisconnected()
+            return self.data
+
+        def close(self):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc_val, exc_tb):
+            pass
+
+    return FakeResponse
+
+
+@pytest.fixture
+def image_blob():
+    return np.array(Image.new('RGB', (5, 5)))
+
+
+@pytest.fixture
+def image_bytes():
+    pil_img = Image.new('RGB', (5, 5))
+    with io.BytesIO() as output:
+        pil_img.save(output, format="png")
+        return output.getvalue()
+
+
+def urllib_patch(num_fails, fake_response, image_bytes):
+    return patch(
+        'urllib.request.urlopen',
+        return_value=fake_response(
+            data=bytes(image_bytes), status=200, num_fails=num_fails
+        ),
+    )
+
+
+def test_default(fake_response, image_bytes, image_blob):
+    with urllib_patch(0, fake_response, image_bytes):
+        d = Document(uri='http://test-uri').load_uri_to_image_blob()
+        assert np.alltrue(d.blob == image_blob)
+
+
+@pytest.mark.parametrize('num_tries,num_fails', [(1, 0), (2, 1), (3, 2)])
+@pytest.mark.parametrize('retry_sleep', [0, 1])
+def test_uri_to_image_blob_success(
+    fake_response, image_bytes, image_blob, num_tries, num_fails, retry_sleep
+):
+    with urllib_patch(num_fails, fake_response, image_bytes):
+        d = Document(uri='http://test-uri').load_uri_to_image_blob(
+            tries=num_tries, retry_sleep=retry_sleep
+        )
+        assert np.alltrue(d.blob == image_blob)
+
+
+@pytest.mark.parametrize('num_tries,num_fails', [(1, 1), (2, 2), (2, 3)])
+def test_uri_to_image_blob_fail(
+    fake_response, image_bytes, image_blob, num_tries, num_fails
+):
+    with pytest.raises(Exception):
+        with urllib_patch(num_fails, fake_response, image_bytes):
+            Document(uri='http://test-uri').load_uri_to_image_blob(tries=num_tries)


### PR DESCRIPTION
When mapping a large DocumentArray from URLs to Blobs it sometimes happens that the URL request fails.
This pr aims to let the user configure how often it should try fetching the URL and how long it should wait between the tries.