### PR TITLE
fix(k8s): fix static cluster address config

### DIFF
--- a/jina/flow/base.py
+++ b/jina/flow/base.py
@@ -507,7 +507,7 @@ class Flow(PostMixin, JAMLCompatible, ExitStack, metaclass=FlowType):
                     from jina.peapods.networking import K8sGrpcConnectionPool
 
                     pod_k8s_address = (
-                        f'{v.name}.{self.args.k8s_namespace or self.args.name}.svc'
+                        f'{v.name}-head.{self.args.k8s_namespace or self.args.name}.svc'
                     )
 
                     graph_dict[node] = [

--- a/jina/peapods/networking.py
+++ b/jina/peapods/networking.py
@@ -153,6 +153,7 @@ class GrpcConnectionPool:
                     entity_id = 0
                 return self._get_connection_list(pod, type, entity_id)
             else:
+                self._logger.debug(f'Unknown pod {pod}, no replicas available')
                 return None
 
         def get_replicas_all_shards(self, pod: str) -> List[ReplicaList]:
@@ -191,6 +192,9 @@ class GrpcConnectionPool:
                     # This can happen as a race condition when removing connections while accessing it
                     # In this case we dont care for the concrete entity, so retry with the first one
                     return self._get_connection_list(pod, type, 0)
+                self._logger.debug(
+                    f'Did not find a connection for pod {pod}, type {type} and entity_id {entity_id}. There are {len(self._pods[pod][type]) if pod in self._pods else 0} available connections for this pod and type. '
+                )
                 return None
 
         def _add_pod(self, pod: str):

--- a/jina/peapods/runtimes/head/__init__.py
+++ b/jina/peapods/runtimes/head/__init__.py
@@ -64,7 +64,7 @@ class HeadRuntime(AsyncNewLoopRuntime, ABC):
                 self.connection_pool.add_connection(
                     pod=self._pod_name,
                     address=connection_list[shard_id],
-                    shard_id=shard_id,
+                    shard_id=int(shard_id),
                 )
 
         self.uses_before_address = args.uses_before_address


### PR DESCRIPTION
Fix https://github.com/jina-ai/internal-tasks/issues/346

There is a bug when a Flow is used in K8s without the K8sGrpcConnectionPool, but just with the static GrpcConnectionPool.
There are two things wrong:
1. The Gateway is configured to send to the worker deployments, not to the head deployment
2. The Head is not configuring its static worker addresses correctly, because the shard_id is interpreted as a string, but it should be an integer.

This was surfaced by a failing K8s test, this test should work now in this PR