### PR TITLE
fix: dont reduce if uses exist

### DIFF
--- a/jina/peapods/peas/factory.py
+++ b/jina/peapods/peas/factory.py
@@ -6,6 +6,7 @@ from ... import __default_host__
 from . import Pea
 from .jinad import JinaDPea
 from .container import ContainerPea
+from ...enums import PeaRoleType
 
 from ...hubble.helper import is_valid_huburi
 from ...hubble.hubio import HubIO
@@ -39,7 +40,11 @@ class PeaFactory:
             _hub_args.no_usage = True
             cargs.uses = HubIO(_hub_args).pull()
 
-        if cargs.uses and cargs.uses.startswith('docker://'):
+        if (
+            cargs.pea_role != PeaRoleType.HEAD
+            and cargs.uses
+            and cargs.uses.startswith('docker://')
+        ):
             return ContainerPea(cargs)
         else:
             return Pea(args)

--- a/jina/peapods/pods/__init__.py
+++ b/jina/peapods/pods/__init__.py
@@ -138,7 +138,7 @@ class BasePod(ExitStack):
             _head_args.port_in = helper.random_port()
         else:
             _head_args.port_in = args.port_in
-        _head_args.uses = None
+        _head_args.uses = args.uses
         _head_args.pea_role = PeaRoleType.HEAD
 
         # for now the head is not being scaled, so its always the first head

--- a/tests/integration/external_pod/test_external_pod.py
+++ b/tests/integration/external_pod/test_external_pod.py
@@ -119,9 +119,9 @@ def test_two_flow_with_shared_external_pod(
             # Reducing applied after shards, expect only 50 docs
             validate_response(results[0], 50)
 
-            # Reducing applied, expect 50 docs
+            # Reducing applied after sharding, but not for the needs, expect 100 docs
             results = flow2.index(inputs=input_docs, return_results=True)
-            validate_response(results[0], 50)
+            validate_response(results[0], 100)
 
 
 @pytest.fixture(scope='function')
@@ -342,5 +342,5 @@ def test_flow_with_external_pod_join(
         with flow:
             resp = flow.index(inputs=input_docs, return_results=True)
 
-        # Reducing applied, expect 50 docs
-        validate_response(resp[0], 50)
+        # Reducing applied for shards, not for uses, expect 100 docs
+        validate_response(resp[0], 100)

--- a/tests/integration/v2_api/test_func_routing.py
+++ b/tests/integration/v2_api/test_func_routing.py
@@ -118,7 +118,7 @@ def test_func_joiner(mocker):
 
     def validate(req):
         texts = {d.text for d in req.docs}
-        assert len(texts) == 3
+        assert len(texts) == 6
         mock()
 
     with f:

--- a/tests/unit/flow-orchestrate/test_flow_routing.py
+++ b/tests/unit/flow-orchestrate/test_flow_routing.py
@@ -17,7 +17,7 @@ def test_simple_routing():
 class MergeExecutor(Executor):
     @requests
     def add_text(self, docs, docs_matrix, **kwargs):
-        if len(docs) == 1:
+        if len(docs) == 2:
             docs[0].text = 'merged'
 
 
@@ -30,7 +30,8 @@ def test_expected_messages_routing():
 
     with f:
         results = f.post(on='/index', inputs=[Document(text='1')], return_results=True)
-        assert len(results[0].docs) == 1
+        # there merge executor actually does not merge despite its name
+        assert len(results[0].docs) == 2
         assert results[0].docs[0].text == 'merged'
 
 
@@ -76,4 +77,4 @@ def test_complex_flow():
 
     with f:
         results = f.post(on='/index', inputs=[Document(text='1')], return_results=True)
-    assert len(results[0].docs) == 5
+    assert len(results[0].docs) == 6


### PR DESCRIPTION
Before this change we are always reducing if there is no uses_before.
With this PR we also check for `uses` and dont reduce if a meaningful `uses` exists.
I've adjusted some tests, there might be some more tests I need to adjust for this changed design.