### PR TITLE
feat(polling): unify polling args

### DIFF
--- a/cli/autocomplete.py
+++ b/cli/autocomplete.py
@@ -103,7 +103,6 @@ ac_table = {
             '--uses-before-address',
             '--uses-after-address',
             '--connection-list',
-            '--endpoint-polling',
         ],
         'flow': [
             '--help',
@@ -186,7 +185,6 @@ ac_table = {
             '--uses-before-address',
             '--uses-after-address',
             '--connection-list',
-            '--endpoint-polling',
             '--k8s-uses-init',
             '--k8s-mount-path',
             '--k8s-init-container-command',
@@ -279,7 +277,6 @@ ac_table = {
             '--uses-before-address',
             '--uses-after-address',
             '--connection-list',
-            '--endpoint-polling',
         ],
         'pod': [
             '--help',
@@ -338,7 +335,6 @@ ac_table = {
             '--uses-before-address',
             '--uses-after-address',
             '--connection-list',
-            '--endpoint-polling',
             '--uses-before',
             '--uses-after',
             '--scheduling',

--- a/docs/fundamentals/flow/topology.md
+++ b/docs/fundamentals/flow/topology.md
@@ -236,16 +236,16 @@ For searching, you probably need to send the search request to all Shards, becau
 ```python Usage
 from jina import Flow
 
-flow = Flow().add(name='ExecutorWithShards', shards=3, polling='any', endpoint_polling={'/custom': 'ALL', '/search': 'ANY'})
+flow = Flow().add(name='ExecutorWithShards', shards=3, polling={'/custom': 'ALL', '/search': 'ANY', '*': 'ANY'})
 ```
 
 The example above will result in a Flow having the Executor `ExecutorWithShards` with the following polling options configured
 - `/index` has polling `ANY` (the default value is not changed here)
 - `/search` has polling `ANY` as it is explicitly set (usually that should not be necessary)
 - `/custom` has polling `ALL`
-- all other endpoints will have polling `ANY`
+- all other endpoints will have polling `ANY` due to the usage of `*` as a wildcard to catch all other cases
 
-`endpoint_polling` always takes precedence over `polling`. `endpoint_polling` can be configured for all endpoints, `polling` will only be applied to endpoints not mentioned in `endpoint_polling` and does never apply to `/index` and `/search`.
+
 
 ### Merging search results
 

--- a/jina/flow/base.py
+++ b/jina/flow/base.py
@@ -243,9 +243,14 @@ class Flow(PostMixin, JAMLCompatible, ExitStack, metaclass=FlowType):
                   Any executor that has `@requests(on=...)` bind with those values will receive data requests.
         :param no_debug_endpoints: If set, /status /post endpoints are removed from HTTP interface.
         :param pods_addresses: dictionary JSON with the input addresses of each Pod
-        :param polling: The polling strategy of the Pod (when `shards>1`)
+        :param polling: The polling strategy of the Pod and its endpoints (when `shards>1`).
+              Can be defined for all endpoints of a Pod or by endpoint.
+              Define per Pod:
               - ANY: only one (whoever is idle) Pea polls the message
               - ALL: all Peas poll the message (like a broadcast)
+              Define per Endpoint:
+              JSON dict, {endpoint: PollingType}
+              {'/custom': 'ALL', '/search': 'ANY', '*': 'ANY'}
         :param port_expose: The port that the gateway exposes for clients for GRPC connections.
         :param port_in: The port for input data to bind to, default a random port between [49152, 65535]
         :param prefetch: Number of requests fetched from the client before feeding into the first Executor.
@@ -328,9 +333,14 @@ class Flow(PostMixin, JAMLCompatible, ExitStack, metaclass=FlowType):
           - ...
 
           When not given, then the default naming strategy will apply.
-        :param polling: The polling strategy of the Pod (when `shards>1`)
+        :param polling: The polling strategy of the Pod and its endpoints (when `shards>1`).
+              Can be defined for all endpoints of a Pod or by endpoint.
+              Define per Pod:
               - ANY: only one (whoever is idle) Pea polls the message
               - ALL: all Peas poll the message (like a broadcast)
+              Define per Endpoint:
+              JSON dict, {endpoint: PollingType}
+              {'/custom': 'ALL', '/search': 'ANY', '*': 'ANY'}
         :param quiet: If set, then no log will be emitted from this object.
         :param quiet_error: If set, then exception stack information will not be added to the log
         :param timeout_ctrl: The timeout in milliseconds of the control request, -1 for waiting forever
@@ -674,9 +684,14 @@ class Flow(PostMixin, JAMLCompatible, ExitStack, metaclass=FlowType):
         :param peas_hosts: The hosts of the peas when shards greater than 1.
                   Peas will be evenly distributed among the hosts. By default,
                   peas are running on host provided by the argument ``host``
-        :param polling: The polling strategy of the Pod (when `shards>1`)
+        :param polling: The polling strategy of the Pod and its endpoints (when `shards>1`).
+              Can be defined for all endpoints of a Pod or by endpoint.
+              Define per Pod:
               - ANY: only one (whoever is idle) Pea polls the message
               - ALL: all Peas poll the message (like a broadcast)
+              Define per Endpoint:
+              JSON dict, {endpoint: PollingType}
+              {'/custom': 'ALL', '/search': 'ANY', '*': 'ANY'}
         :param port_in: The port for input data to bind to, default a random port between [49152, 65535]
         :param port_jinad: The port of the remote machine for usage with JinaD.
         :param pull_latest: Pull the latest image before running

--- a/jina/flow/base.py
+++ b/jina/flow/base.py
@@ -167,7 +167,6 @@ class Flow(PostMixin, JAMLCompatible, ExitStack, metaclass=FlowType):
         daemon: Optional[bool] = False,
         default_swagger_ui: Optional[bool] = False,
         description: Optional[str] = None,
-        endpoint_polling: Optional[str] = None,
         env: Optional[dict] = None,
         expose_endpoints: Optional[str] = None,
         expose_public: Optional[bool] = False,
@@ -221,7 +220,6 @@ class Flow(PostMixin, JAMLCompatible, ExitStack, metaclass=FlowType):
         :param daemon: The Pea attempts to terminate all of its Runtime child processes/threads on existing. setting it to true basically tell the Pea do not wait on the Runtime when closing
         :param default_swagger_ui: If set, the default swagger ui is used for `/docs` endpoint.
         :param description: The description of this HTTP server. It will be used in automatics docs such as Swagger UI.
-        :param endpoint_polling: dictionary JSON defining the polling type per endpoint
         :param env: The map of environment variables that are available inside runtime
         :param expose_endpoints: A JSON string that represents a map from executor endpoints (`@requests(on=...)`) to HTTP endpoints.
         :param expose_public: If set, expose the public IP address to remote when necessary, by default it exposesprivate IP address, which only allows accessing under the same network/subnet. Important to set this to true when the Pea will receive input connections from remote Peas
@@ -594,7 +592,6 @@ class Flow(PostMixin, JAMLCompatible, ExitStack, metaclass=FlowType):
         connection_list: Optional[str] = None,
         daemon: Optional[bool] = False,
         docker_kwargs: Optional[dict] = None,
-        endpoint_polling: Optional[str] = None,
         entrypoint: Optional[str] = None,
         env: Optional[dict] = None,
         expose_public: Optional[bool] = False,
@@ -646,7 +643,6 @@ class Flow(PostMixin, JAMLCompatible, ExitStack, metaclass=FlowType):
           container.
 
           More details can be found in the Docker SDK docs:  https://docker-py.readthedocs.io/en/stable/
-        :param endpoint_polling: dictionary JSON defining the polling type per endpoint
         :param entrypoint: The entrypoint command overrides the ENTRYPOINT in Docker image. when not set then the Docker image ENTRYPOINT takes effective.
         :param env: The map of environment variables that are available inside runtime
         :param expose_public: If set, expose the public IP address to remote when necessary, by default it exposesprivate IP address, which only allows accessing under the same network/subnet. Important to set this to true when the Pea will receive input connections from remote Peas

--- a/jina/parsers/peapods/base.py
+++ b/jina/parsers/peapods/base.py
@@ -119,12 +119,17 @@ When not given, then the default naming strategy will apply.
 
     gp.add_argument(
         '--polling',
-        type=PollingType.from_string,
-        choices=list(PollingType),
-        default=PollingType.ANY,
+        type=str,
+        default=PollingType.ANY.name,
         help='''
-    The polling strategy of the Pod (when `shards>1`)
+    The polling strategy of the Pod and its endpoints (when `shards>1`).
+    Can be defined for all endpoints of a Pod or by endpoint.
+    Define per Pod:
     - ANY: only one (whoever is idle) Pea polls the message
     - ALL: all Peas poll the message (like a broadcast)
+    Define per Endpoint:
+    JSON dict, {endpoint: PollingType}
+    {'/custom': 'ALL', '/search': 'ANY', '*': 'ANY'}
+    
     ''',
     )

--- a/jina/parsers/peapods/runtimes/head.py
+++ b/jina/parsers/peapods/runtimes/head.py
@@ -25,9 +25,3 @@ def mixin_head_parser(parser):
         type=str,
         help='dictionary JSON with a list of connections to configure',
     )
-
-    gp.add_argument(
-        '--endpoint-polling',
-        type=str,
-        help='dictionary JSON defining the polling type per endpoint',
-    )

--- a/jina/peapods/runtimes/head/__init__.py
+++ b/jina/peapods/runtimes/head/__init__.py
@@ -25,6 +25,8 @@ class HeadRuntime(AsyncNewLoopRuntime, ABC):
     Runtime is used in head peas. It responds to Gateway requests and sends to uses_before/uses_after and its workers
     """
 
+    DEFAULT_POLLING = PollingType.ANY
+
     def __init__(
         self,
         args: argparse.Namespace,
@@ -50,20 +52,31 @@ class HeadRuntime(AsyncNewLoopRuntime, ABC):
             k8s_namespace=args.k8s_namespace,
         )
 
-        self.polling = args.polling if hasattr(args, 'polling') else PollingType.ANY
-        self._endpoint_polling = defaultdict(
-            lambda: self.polling,
-            {'/search': PollingType.ALL, '/index': PollingType.ANY},
-        )
-        # by default search and index have polling defined, it can be overriden by the args if needed
-        if hasattr(args, 'endpoint_polling') and args.endpoint_polling:
-            endpoint_polling = json.loads(args.endpoint_polling)
+        polling = getattr(args, 'polling', self.DEFAULT_POLLING.name)
+        try:
+            # try loading the polling args as json
+            endpoint_polling = json.loads(polling)
+            # '*' is used a wildcard and will match all endpoints, except /index, /search and explicitly defined endpoins
+            default_polling = (
+                PollingType.from_string(endpoint_polling['*'])
+                if '*' in endpoint_polling
+                else self.DEFAULT_POLLING
+            )
+            self._polling = self._default_polling_dict(default_polling)
             for endpoint in endpoint_polling:
-                self._endpoint_polling[endpoint] = PollingType(
+                self._polling[endpoint] = PollingType(
                     endpoint_polling[endpoint]
                     if type(endpoint_polling[endpoint]) == int
                     else PollingType.from_string(endpoint_polling[endpoint])
                 )
+        except (ValueError, TypeError):
+            # polling args is not a valid json, try interpreting as a polling enum type
+            default_polling = (
+                polling
+                if type(polling) == PollingType
+                else PollingType.from_string(polling)
+            )
+            self._polling = self._default_polling_dict(default_polling)
 
         # In K8s the ConnectionPool needs the information about the Jina Pod its running in
         # This is stored in the environment variable JINA_POD_NAME in all Jina K8s default templates
@@ -96,6 +109,12 @@ class HeadRuntime(AsyncNewLoopRuntime, ABC):
                 pod='uses_after', address=self.uses_after_address
             )
         self._has_uses = args.uses is not None and args.uses != __default_executor__
+
+    def _default_polling_dict(self, default_polling):
+        return defaultdict(
+            lambda: default_polling,
+            {'/search': PollingType.ALL, '/index': PollingType.ANY},
+        )
 
     async def async_setup(self):
         """ Wait for the GRPC server to start """
@@ -230,7 +249,7 @@ class HeadRuntime(AsyncNewLoopRuntime, ABC):
         worker_send_tasks = self.connection_pool.send_requests(
             requests=requests,
             pod=self._pod_name,
-            polling_type=self._endpoint_polling[endpoint],
+            polling_type=self._polling[endpoint],
         )
 
         worker_results = await asyncio.gather(*worker_send_tasks)

--- a/tests/unit/flow-construct/test_flow.py
+++ b/tests/unit/flow-construct/test_flow.py
@@ -2,6 +2,7 @@ import datetime
 import inspect
 import json
 import os
+from typing import Union
 
 import numpy as np
 import pytest
@@ -645,12 +646,22 @@ def test_flow_auto_polling():
         )
     )
 
-    assert f['pod_replica_only_polling_any'].args.polling == PollingType.ANY
-    assert f['pod_replica_only_polling_ignored'].args.polling == PollingType.ANY
-    assert f['pod_replicas_shards_auto_polling_all'].args.polling == PollingType.ALL
-    assert f['pod_shards_default_polling_any'].args.polling == PollingType.ANY
-    assert f['pod_replicas_shards_manual_polling_any'].args.polling == PollingType.ANY
-    assert f['pod_replicas_shards_manual_polling_all'].args.polling == PollingType.ALL
+    def _assert_polling(value: Union[PollingType, str], expected: PollingType):
+        assert value == expected or value.lower() == expected.name.lower()
+
+    _assert_polling(f['pod_replica_only_polling_any'].args.polling, PollingType.ANY)
+
+    _assert_polling(f['pod_replica_only_polling_ignored'].args.polling, PollingType.ANY)
+    _assert_polling(
+        f['pod_replicas_shards_auto_polling_all'].args.polling, PollingType.ALL
+    )
+    _assert_polling(f['pod_shards_default_polling_any'].args.polling, PollingType.ANY)
+    _assert_polling(
+        f['pod_replicas_shards_manual_polling_any'].args.polling, PollingType.ANY
+    )
+    _assert_polling(
+        f['pod_replicas_shards_manual_polling_all'].args.polling, PollingType.ALL
+    )
 
 
 def test_flow_change_parameters():

--- a/tests/unit/flow-orchestrate/test_flow_routing.py
+++ b/tests/unit/flow-orchestrate/test_flow_routing.py
@@ -124,12 +124,11 @@ def test_flow_default_polling_endpoints(polling):
 
 @pytest.mark.parametrize('polling', ['any', 'all'])
 def test_flow_default_polling_endpoints(polling):
-    custom_polling_config = {'/custom': 'ALL', '/search': 'ANY'}
+    custom_polling_config = {'/custom': 'ALL', '/search': 'ANY', '*': polling}
     f = Flow().add(
         uses=DynamicPollingExecutorDefaultNames,
         shards=2,
-        polling=polling,
-        endpoint_polling=custom_polling_config,
+        polling=custom_polling_config,
     )
 
     with f:

--- a/tests/unit/peapods/pods/test_pods.py
+++ b/tests/unit/peapods/pods/test_pods.py
@@ -532,7 +532,7 @@ class DynamicPollingExecutor(Executor):
 
 @pytest.mark.parametrize('polling', ['any', 'all'])
 def test_dynamic_polling_with_config(polling):
-    endpoint_polling = {'/any': PollingType.ANY, '/all': PollingType.ALL}
+    endpoint_polling = {'/any': PollingType.ANY, '/all': PollingType.ALL, '*': polling}
 
     args = set_pod_parser().parse_args(
         [
@@ -541,8 +541,6 @@ def test_dynamic_polling_with_config(polling):
             '--shards',
             str(2),
             '--polling',
-            polling,
-            '--endpoint-polling',
             json.dumps(endpoint_polling),
         ]
     )
@@ -627,7 +625,7 @@ def test_dynamic_polling_default_config(polling):
 
 @pytest.mark.parametrize('polling', ['any', 'all'])
 def test_dynamic_polling_overwrite_default_config(polling):
-    endpoint_polling = {'/search': PollingType.ANY}
+    endpoint_polling = {'/search': PollingType.ANY, '*': polling}
     args = set_pod_parser().parse_args(
         [
             '--uses',
@@ -635,8 +633,6 @@ def test_dynamic_polling_overwrite_default_config(polling):
             '--shards',
             str(2),
             '--polling',
-            polling,
-            '--endpoint-polling',
             json.dumps(endpoint_polling),
         ]
     )


### PR DESCRIPTION
Will close https://github.com/jina-ai/internal-tasks/issues/359

This PR unifies the arguments for polling. With this PR there is only the `polling` option exposed to the user.
This can be used as before (just put any/all) or it can be used as a dict defining polling per endpoint. If used as a dict, the user does not need to provide a complete dict. There is also the wildcard `*`. This wildcard will match all endpoints, except /index, /search and the endpoints explicitly named in the dict.

Equivalent are the following definitions:
polling = 'any' and polling = {'*': 'any'}