### PR TITLE
fix: several issues for jinad pods

### DIFF
--- a/daemon/api/dependencies.py
+++ b/daemon/api/dependencies.py
@@ -11,6 +11,7 @@ from pydantic.errors import PathNotAFileError
 from jina import Flow
 from jina.enums import (
     RemoteWorkspaceState,
+    PeaRoleType,
 )
 from jina.helper import cached_property
 from jina.peapods.peas.container_helper import get_gpu_device_requests
@@ -236,7 +237,18 @@ class PeaDepends:
 
         :return: dict of port mappings
         """
-        return {f'{self.params.port_in}/tcp': self.params.port_in}
+        # Container peas are started in separate docker containers, so we should not expose port_in here
+        if (
+            (
+                self.params.pea_role
+                and PeaRoleType.from_string(self.params.pea_role) != PeaRoleType.HEAD
+            )
+            and self.params.uses
+            and self.params.uses.startswith('docker://')
+        ):
+            return {}
+        else:
+            return {f'{self.params.port_in}/tcp': self.params.port_in}
 
     def update_args(self):
         """TODO: update docs"""

--- a/daemon/models/ports.py
+++ b/daemon/models/ports.py
@@ -7,8 +7,6 @@ class Ports(BaseModel):
     """Port names"""
 
     port_in: Optional[int]
-    port_out: Optional[int]
-    port_ctrl: Optional[int]
     port_expose: Optional[int]
 
     def __len__(self):

--- a/daemon/stores/partial.py
+++ b/daemon/stores/partial.py
@@ -80,9 +80,10 @@ class PartialPeaStore(PartialStore):
             ] = self.__class__.peapod_constructor(args).__enter__()
             self.object.env = envs
         except Exception as e:
-            if hasattr(self, 'object'):
+            if hasattr(self, 'object') and self.object:
                 self.object.__exit__(type(e), e, e.__traceback__)
             self._logger.error(f'{e!r}')
+
             raise
         else:
             self.item = PartialStoreItem(arguments=vars(args))

--- a/jina/flow/base.py
+++ b/jina/flow/base.py
@@ -1600,6 +1600,7 @@ class Flow(PostMixin, JAMLCompatible, ExitStack, metaclass=FlowType):
         self.args.workspace = value
         for k, p in self:
             p.args.workspace = value
+            p.update_pea_args()
 
     @property
     def workspace_id(self) -> Dict[str, str]:

--- a/jina/peapods/networking.py
+++ b/jina/peapods/networking.py
@@ -883,3 +883,18 @@ def create_connection_pool(
         )
     else:
         return GrpcConnectionPool(logger=logger)
+
+
+def host_is_local(hostname):
+    """
+    Check if hostname is point to localhost
+    :param hostname: host to check
+    :return: True if hostname means localhost, False otherwise
+    """
+    import socket
+
+    fqn = socket.getfqdn(hostname)
+    if fqn in ("localhost", "0.0.0.0") or hostname == '0.0.0.0':
+        return True
+
+    return ipaddress.ip_address(hostname).is_loopback

--- a/jina/peapods/pods/__init__.py
+++ b/jina/peapods/pods/__init__.py
@@ -6,9 +6,11 @@ from itertools import cycle
 from typing import Dict, Union, Set, List, Optional
 
 from .. import Pea
-from ..networking import GrpcConnectionPool
+from ..networking import GrpcConnectionPool, host_is_local
+from ..peas.container import ContainerPea
 from ..peas.factory import PeaFactory
-from ... import __default_executor__, __default_host__
+from ..peas.jinad import JinaDPea
+from ... import __default_executor__, __default_host__, __docker_host__
 from ... import helper
 from ...enums import (
     PodRoleType,
@@ -527,13 +529,28 @@ class Pod(BasePod):
         """
         if self.head_pea is not None:
             for shard_id in self.peas_args['peas']:
-                for pea_args in self.peas_args['peas'][shard_id]:
+                for pea_idx, pea_args in enumerate(self.peas_args['peas'][shard_id]):
+                    # Check if the current pea and head are both containerized on the same host
+                    # If so __docker_host__ needs to be advertised as the worker's address to the head
+                    worker_host = (
+                        __docker_host__
+                        if self._is_container_to_container(pea_idx, shard_id)
+                        and host_is_local(pea_args.host)
+                        else pea_args.host
+                    )
                     GrpcConnectionPool.activate_worker_sync(
-                        pea_args.host,
+                        worker_host,
                         int(pea_args.port_in),
                         self.head_pea.runtime_ctrl_address,
                         shard_id,
                     )
+
+    def _is_container_to_container(self, pea_idx, shard_id):
+        # Check if both shard_id/pea_idx and the head are containerized
+        return (
+            type(self.shards[shard_id]._peas[pea_idx]) == ContainerPea
+            or type(self.shards[shard_id]._peas[pea_idx]) == JinaDPea
+        ) and (type(self.head_pea) == ContainerPea or type(self.head_pea) == JinaDPea)
 
     def start(self) -> 'Pod':
         """

--- a/jina/peapods/pods/__init__.py
+++ b/jina/peapods/pods/__init__.py
@@ -1,4 +1,5 @@
 import copy
+import os
 from abc import abstractmethod
 from argparse import Namespace
 from contextlib import ExitStack
@@ -546,11 +547,24 @@ class Pod(BasePod):
                     )
 
     def _is_container_to_container(self, pea_idx, shard_id):
+        def _in_docker():
+            path = '/proc/self/cgroup'
+            return (
+                os.path.exists('/.dockerenv')
+                or os.path.isfile(path)
+                and any('docker' in line for line in open(path))
+            )
+
         # Check if both shard_id/pea_idx and the head are containerized
+        # if the head is not containerized, it still could mean that the pod itself is containerized
         return (
             type(self.shards[shard_id]._peas[pea_idx]) == ContainerPea
             or type(self.shards[shard_id]._peas[pea_idx]) == JinaDPea
-        ) and (type(self.head_pea) == ContainerPea or type(self.head_pea) == JinaDPea)
+        ) and (
+            type(self.head_pea) == ContainerPea
+            or type(self.head_pea) == JinaDPea
+            or _in_docker()
+        )
 
     def start(self) -> 'Pod':
         """

--- a/jina/peapods/runtimes/worker/__init__.py
+++ b/jina/peapods/runtimes/worker/__init__.py
@@ -56,8 +56,8 @@ class WorkerRuntime(AsyncNewLoopRuntime, ABC):
             self, self._grpc_server
         )
         bind_addr = f'0.0.0.0:{self.args.port_in}'
-        self._grpc_server.add_insecure_port(bind_addr)
         self.logger.debug(f'Start listening on {bind_addr}')
+        self._grpc_server.add_insecure_port(bind_addr)
         await self._grpc_server.start()
 
     async def async_run_forever(self):

--- a/tests/daemon/unit/models/test_ports.py
+++ b/tests/daemon/unit/models/test_ports.py
@@ -4,12 +4,12 @@ d = [
     {
         'pod_name': 'query_indexer',
         'pea_name': 'query_indexer/head',
-        'ports': {'port_in': 1234, 'port_out': 2345},
+        'ports': {'port_in': 1234},
     },
     {
         'pod_name': 'query_indexer',
         'pea_name': 'query_indexer/tail',
-        'ports': {'port_in': 3456, 'port_out': 4567},
+        'ports': {'port_in': 3456},
     },
     {
         'pod_name': 'encoder',
@@ -33,4 +33,4 @@ def test_port_mappings():
     assert 'query_indexer/head' in p.pea_names
     assert 'query_indexer/tail' in p.pea_names
     assert p['encoder/pea-0'].ports.port_in == 12345
-    assert p.ports == [1234, 2345, 3456, 4567, 12345]
+    assert p.ports == [1234, 3456, 12345]

--- a/tests/jinahub/test_integration.sh
+++ b/tests/jinahub/test_integration.sh
@@ -10,7 +10,7 @@ if [ "${PWD##*/}" != "jina" ]
     exit 1
 fi
 
-CONTAINER_ID=$(docker run -v /var/run/docker.sock:/var/run/docker.sock --network=host -d jinaai/test_hubapp_hubpods)
+CONTAINER_ID=$(docker run -v /var/run/docker.sock:/var/run/docker.sock -p 45678:45678 --add-host host.docker.internal:host-gateway -d jinaai/test_hubapp_hubpods)
 
 sleep 10
 


### PR DESCRIPTION
* Add a check in the Pod when sending activate to use the correct address (localhost or host.docker.internal depending on the circumstances)
* Prevent exposing the `port_in` in the partial daemon containers if that starts a separate docker container
* Update pea args on overwriting the `workspace` in the Flow. This was breaking some JinaD assumptions.
* Remove usage of port_out  in some test (this was not breaking anything, but its not necessary anymore)