### PR TITLE
docs(readme): add link to learning portal, disambiguate difference with docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ More install options including Conda, Docker, Windows [can be found here](https:
 
 ## Learning and Docs
 
-- Brand new to Jina? Check our **[Learning Bootcamp](https://learn.jina.ai)** to get up to speed
+- Brand new to Jina? Check our **[Learning Bootcamp](https://learn.jina.ai)** to get up to speed.
 - Check our **[comprehensive docs](https://docs.jina.ai)** for deeper tutorials, more advanced topics, and API reference.
 
 ## Get Started

--- a/README.md
+++ b/README.md
@@ -41,7 +41,10 @@ pip install -U jina
 ```
 More install options including Conda, Docker, Windows [can be found here](https://docs.jina.ai/get-started/install/). 
 
-## [Documentation](https://docs.jina.ai)
+## Learning and Docs
+
+- Brand new to Jina? Check our **[Learning Bootcamp](https://learn.jina.ai)** to get up to speed
+- Check our **[comprehensive docs](https://docs.jina.ai)** for deeper tutorials, more advanced topics, and API reference.
 
 ## Get Started
 


### PR DESCRIPTION
Based on analytics data, a [major source of traffic for our docs is our repo](https://jinaai.slack.com/archives/C018JCT47PV/p1641389346181900?thread_ts=1641389018.181100&cid=C018JCT47PV). This PR adds the learning portal to the readme to hopefully drive similar engagement. It also explains what each property offers to make it clear to user.
