### PR TITLE
chore: remove tornado

### DIFF
--- a/extra-requirements.txt
+++ b/extra-requirements.txt
@@ -1,6 +1,6 @@
 # JINA PACKAGE DEPENDENCIES
 #
-# Essential: only 6, they are labeled with `core`: numpy, tornado, grpcio, protobuf, pyyaml. They will be installed
+# Essential: only 6, they are labeled with `core`: numpy, grpcio, protobuf, pyyaml. They will be installed
 #           when you do `pip install jina`. They are essential to run 90% features & functionalities of Jina.
 # Extensions: they are labeled with different tags. They will NOT be installed by default. One can install a group of
 #           of dependencies labeled `tag` by `pip install "jina[tag]"`
@@ -46,7 +46,6 @@ numpy:                      core
 protobuf>=3.19.1:           core
 grpcio>=1.33.1:             core
 pyyaml>=5.3.1:              core
-tornado>=5.1.0:             core
 pytest:                     test
 pytest-timeout:             test
 pytest-mock:                test

--- a/jina/resources/extra-requirements.txt
+++ b/jina/resources/extra-requirements.txt
@@ -1,6 +1,6 @@
 # JINA PACKAGE DEPENDENCIES
 #
-# Essential: only 6, they are labeled with `core`: numpy, tornado, grpcio, protobuf, pyyaml. They will be installed
+# Essential: only 6, they are labeled with `core`: numpy, grpcio, protobuf, pyyaml. They will be installed
 #           when you do `pip install jina`. They are essential to run 90% features & functionalities of Jina.
 # Extensions: they are labeled with different tags. They will NOT be installed by default. One can install a group of
 #           of dependencies labeled `tag` by `pip install "jina[tag]"`
@@ -46,7 +46,6 @@ numpy:                      core
 protobuf>=3.19.1:           core
 grpcio>=1.33.1:             core
 pyyaml>=5.3.1:              core
-tornado>=5.1.0:             core
 pytest:                     test
 pytest-timeout:             test
 pytest-mock:                test


### PR DESCRIPTION
not needed anymore with removing zmq