### PR TITLE
fix: close peas correctly

### DIFF
--- a/jina/peapods/peas/__init__.py
+++ b/jina/peapods/peas/__init__.py
@@ -164,7 +164,7 @@ class BasePea(ABC):
         This method makes sure that the `Process/thread` is properly finished and its resources properly released
         """
         self.logger.debug('waiting for ready or shutdown signal from runtime')
-        if not self.is_shutdown.is_set():
+        if not self.is_shutdown.is_set() and self.is_started.is_set():
             try:
                 self.logger.debug(f'terminate')
                 self._terminate()
@@ -190,7 +190,7 @@ class BasePea(ABC):
         else:
             # here shutdown has been set already, therefore `run` will gracefully finish
             self.logger.debug(
-                'shutdown is already set. Runtime will end gracefully on its own'
+                f'{"shutdown is is already set" if self.is_shutdown.is_set() else "Runtime was never started"}. Runtime will end gracefully on its own'
             )
             pass
         self.logger.debug(__stop_msg__)

--- a/jina/peapods/peas/__init__.py
+++ b/jina/peapods/peas/__init__.py
@@ -92,10 +92,11 @@ def run(
             exc_info=not args.quiet_error,
         )
     else:
-        is_started.set()
-        with runtime:
-            is_ready.set()
-            runtime.run_forever()
+        if not is_shutdown.is_set():
+            is_started.set()
+            with runtime:
+                is_ready.set()
+                runtime.run_forever()
     finally:
         _unset_envs()
         is_shutdown.set()
@@ -193,6 +194,7 @@ class BasePea(ABC):
                 f'{"shutdown is is already set" if self.is_shutdown.is_set() else "Runtime was never started"}. Runtime will end gracefully on its own'
             )
             pass
+        self.is_shutdown.set()
         self.logger.debug(__stop_msg__)
         self.logger.close()
 

--- a/tests/unit/peapods/peas/test_pea.py
+++ b/tests/unit/peapods/peas/test_pea.py
@@ -241,3 +241,28 @@ def test_close_before_start(monkeypatch):
     pea = Pea(set_pea_parser().parse_args(['--noblock-on-start']))
     pea.start()
     pea.close()
+
+
+@pytest.mark.timeout(4)
+def test_close_before_start_slow_enter(monkeypatch):
+    class SlowFakeRuntime:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def __enter__(self):
+            time.sleep(5.0)
+
+        def __exit__(self, exc_type, exc_val, exc_tb):
+            pass
+
+        def run_forever(self):
+            pass
+
+    monkeypatch.setattr(
+        runtimes,
+        'get_runtime',
+        lambda *args, **kwargs: SlowFakeRuntime,
+    )
+    pea = Pea(set_pea_parser().parse_args(['--noblock-on-start']))
+    pea.start()
+    pea.close()


### PR DESCRIPTION
It can happen that a Pod closes a Pea before it was started (meaning its worker process has not yet been started). We should not wait for its termination then.