### PR TITLE
fix: dont test thread backend in jinad

### DIFF
--- a/tests/distributed/test_remote_peas/test_remote_peas.py
+++ b/tests/distributed/test_remote_peas/test_remote_peas.py
@@ -103,9 +103,8 @@ def test_jinad_process_target(worker_cls, event, pea_args):
     assert not is_pea_ready(pea_args)
 
 
-@pytest.mark.parametrize('runtime_backend', ['PROCESS', 'THREAD'])
-def test_jinad_pea(runtime_backend):
-    args = set_pea_parser().parse_args(['--runtime-backend', runtime_backend])
+def test_jinad_pea():
+    args = set_pea_parser().parse_args([])
     assert not is_pea_ready(args)
 
     with JinaDPea(args):

--- a/tests/unit/peapods/peas/test_jinad.py
+++ b/tests/unit/peapods/peas/test_jinad.py
@@ -18,13 +18,12 @@ def mock_is_ready(*args):
 @pytest.mark.skip(
     "Does not work for some reason, should be reenabled when jinad is properly implemented"
 )
-@pytest.mark.parametrize('runtime_backend', ['PROCESS', 'THREAD'])
-def test_events(monkeypatch, runtime_backend):
+def test_events(monkeypatch):
     monkeypatch.setattr(JinaDProcessTarget, '_create_remote_pea', mock_sleep)
     monkeypatch.setattr(JinaDProcessTarget, '_terminate_remote_pea', mock_sleep)
     monkeypatch.setattr(JinaDProcessTarget, '_stream_logs', mock_sleep)
     monkeypatch.setattr(jinad, 'is_ready', mock_is_ready)
-    args = set_pea_parser().parse_args(['--runtime-backend', runtime_backend])
+    args = set_pea_parser().parse_args([])
 
     pea = JinaDPea(args)
     assert not pea.is_started.is_set()


### PR DESCRIPTION
Thread backend for a runtime worker does not work well with containers. Dont test it in jinad