### PR TITLE
docs: fix Jina on Kubernetes/docker-compose section

### DIFF
--- a/docs/advanced/experimental/docker-compose.md
+++ b/docs/advanced/experimental/docker-compose.md
@@ -64,26 +64,24 @@ docker-compose up -f docker-compose.yml
 Once we see that all the Services in the Flow are ready, we can start sending index and search requests.
 
 ```python
-import os
-
 from jina.clients import Client
 from jina import DocumentArray
 
 client = Client(host='localhost', port=8080)
 client.show_progress = True
-indexing_documents = DocumentArray.from_files('./imgs/*.jpg')
-indexed_documents = []
-for resp in client.post(
-    '/index', inputs=indexing_documents, return_results=True
-):
-    indexed_documents.extend(resp.docs)
+indexing_documents = DocumentArray.from_files('./imgs/*.jpg').apply(lambda d: d.load_uri_to_image_blob())
 
-print(f' Indexed documents: {[doc.uri for doc in indexed_documents]}')
+docs = client.post(
+    '/index', inputs=indexing_documents, return_results=True
+)
+
+print(f'Indexed documents: {len(docs)}')
+
 query_doc = indexing_documents[0]
 query_responses = client.post(
     '/search', inputs=query_doc, return_results=True
 )
 
-closest_match_uri = query_responses[0].docs[0].matches[0].uri
-print('closest_match_uri: ', closest_match_uri)
+matches = query_responses[0].data.docs[0].matches
+print(f'Matched documents: {len(matches)}')
 ```

--- a/docs/advanced/experimental/kubernetes.md
+++ b/docs/advanced/experimental/kubernetes.md
@@ -163,21 +163,16 @@ Finally, it prints the uri of the closest matches.
 
 ```python
 import requests
-from jina import DocumentArray, Document
+from jina import DocumentArray
 import os
 host = os.environ['EXTERNAL_IP']
 port = 80
 url = f'http://{host}:{port}'
 
-def preproc(d: Document):
-    d.tags['uri'] = d.uri
-    d.load_uri_to_image_blob()
-    return d
-
-doc = DocumentArray.from_files('./imgs/*.jpg').apply(preproc)[0].dict()
+doc = DocumentArray.from_files('./imgs/*.jpg').apply(lambda d: d.load_uri_to_image_blob())[0].to_dict()
 resp = requests.post(f'{url}/search', json={'data': [doc]})
-closest_match_uri = resp.json()['data']['docs'][0]['matches'][0]['tags']['uri']
-print('closest_match_uri: ', closest_match_uri)
+matches = resp.json()['data']['docs'][0]['matches']
+print(f'Matched documents: {len(matches)}')
 ```
 
 ## Scaling Executors on Kubernetes

--- a/docs/advanced/experimental/kubernetes.md
+++ b/docs/advanced/experimental/kubernetes.md
@@ -76,39 +76,59 @@ You should expect the following file structure generated:
 
 As you can see, the Flow contains configuration for the gateway and the rest of executors
 
+Let's create a kubernetes namespace for our Flow:
+
+```shell
+kubectl create namespace custom-namespace
+```
+
 Now, you can deploy this Flow to you cluster in the following way:
 ```shell
-kubectl apply -f ./k8s_flow
+kubectl apply -R -f ./k8s_flow
 ```
+
+We can check that the pods were created:
+```shell
+kubectl get pods -n custom-namespace
+```
+
+```text
+NAME                              READY   STATUS    RESTARTS   AGE
+encoder-8b5575cb9-bh2x8           1/1     Running   0          60m
+encoder-8b5575cb9-gx78g           1/1     Running   0          60m
+encoder-head-0-55bbb477ff-p2bmk   1/1     Running   0          60m
+gateway-7df8765bd9-xf5tf          1/1     Running   0          60m
+indexer-0-8f676fc9d-4fh52         1/1     Running   0          60m
+indexer-1-55b6cc9dd8-gtpf6        1/1     Running   0          60m
+indexer-head-0-6fcc679d95-8mrm6   1/1     Running   0          60m
+```
+
+Note that the Jina gateway was deployed with name `gateway-7df8765bd9-xf5tf`.
 
 Once we see that all the Deployments in the Flow are ready, we can start indexing documents.
 
 ```python
-import os
 import portforward
 
 from jina.clients import Client
 from jina import DocumentArray
 
-config_path = os.environ['KUBECONFIG']
-
 with portforward.forward(
-    'custom-namespace', 'gateway', 8080, 8080, config_path
+    'custom-namespace', 'gateway-7df8765bd9-xf5tf', 8080, 8080
 ):
     client = Client(host='localhost', port=8080)
     client.show_progress = True
-    indexed_documents = []
-    for resp in client.post(
-        '/index', inputs=DocumentArray.from_files('./imgs/*.jpg'), return_results=True
-    ):
-        indexed_documents.extend(resp.docs)
+    docs = client.post(
+        '/index', inputs=DocumentArray.from_files('./imgs/*.jpg').apply(lambda d: d.load_uri_to_image_blob()),
+        return_results=True
+    )
 
-    print(f' Indexed documents: {[doc.uri for doc in indexed_documents]}')
+    print(f' Indexed documents: {len(docs)}')
 ```
 
 ```{admonition} Caution
 :class: caution
-We heavily recommend you to deploy each `Flow` into a separate namespace. In particular it should not be deployed into namespaces, where other essential non Jina services are running. 
+We heavily recommend you to deploy each `Flow` into a separate namespace. In particular, it should not be deployed into namespaces, where other essential non Jina services are running. 
 If `custom-namespace` has been used by another `Flow`, please set a different `k8s_namespace` name.
 ```
 
@@ -143,14 +163,20 @@ Finally, it prints the uri of the closest matches.
 
 ```python
 import requests
-from jina import DocumentArray
+from jina import DocumentArray, Document
 import os
 host = os.environ['EXTERNAL_IP']
 port = 80
 url = f'http://{host}:{port}'
-doc = DocumentArray.from_files('./imgs/*.jpg')[0].dict()
+
+def preproc(d: Document):
+    d.tags['uri'] = d.uri
+    d.load_uri_to_image_blob()
+    return d
+
+doc = DocumentArray.from_files('./imgs/*.jpg').apply(preproc)[0].dict()
 resp = requests.post(f'{url}/search', json={'data': [doc]})
-closest_match_uri = resp.json()['data']['docs'][0]['matches'][0]['uri']
+closest_match_uri = resp.json()['data']['docs'][0]['matches'][0]['tags']['uri']
 print('closest_match_uri: ', closest_match_uri)
 ```
 


### PR DESCRIPTION
closes: https://github.com/jina-ai/jina/issues/4155

Since star routing is still not released, to perform the validation I did the following steps:
* build jinaai/jina:test-pip based on latest master
* build new encoder image from jinaai/jina:test-pip
* modify pqlite to rely on jina (latest master) and build new pqlite indexer from jinaai/jina:test-pip
* push all 3 images to a registry
* create config files and make sure to use the built images