### PR TITLE
fix: rescue docarray in setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,11 +74,32 @@ def register_ac():
         pass
 
 
+def rescue_docarray():
+    """Upgrading from 2.x to 3.x is broken (https://github.com/jina-ai/jina/issues/4194)
+    This function checks if docarray is broken and if so attempts to rescue it
+    """
+    try:
+        import docarray as docarray
+
+        __docarray_version__ = docarray.__version__
+
+    except AttributeError:
+        # Being here means docarray is not installed correctly, attempt to reinstall it
+        # as recommended by pip https://pip.pypa.io/en/latest/user_guide/#using-pip-from-your-program
+        import subprocess
+
+        subprocess.check_call(
+            [sys.executable, '-m', 'pip', 'uninstall', '--yes', 'docarray']
+        )
+        subprocess.check_call([sys.executable, '-m', 'pip', 'install', 'docarray'])
+
+
 class PostDevelopCommand(develop):
     """Post-installation for development mode."""
 
     def run(self):
         develop.run(self)
+        rescue_docarray()
         register_ac()
 
 
@@ -87,6 +108,7 @@ class PostInstallCommand(install):
 
     def run(self):
         install.run(self)
+        rescue_docarray()
         register_ac()
 
 


### PR DESCRIPTION
This closes https://github.com/jina-ai/jina/issues/4194

Upgrading from Jina 2.x to 3.x is broken because pip will install first the new `docarray` pip package and then remove the old docarray package (which was part of jina repo). Because both are installed in the same folder, this will leave the new `docarray` package in some invalid state.
This change to the setup introduces a hack to rescue those cases: My code is checking if `docarray` can be imported correctly (by checking access to the version, this fails for master now). If this fails `docarray` is reinstalled via pip.

In non upgrading cases we will not enter the exception handler and my hack will not do anything (when installing jina in a new venv).