### PR TITLE
fix: add meaningful error on docarray issue

### DIFF
--- a/jina/__init__.py
+++ b/jina/__init__.py
@@ -65,7 +65,12 @@ __version__ = '3.0.0'
 # do not change this line manually
 # this is managed by proto/build-proto.sh and updated on every execution
 __proto_version__ = '0.1.8'
-__docarray_version__ = _docarray.__version__
+try:
+    __docarray_version__ = _docarray.__version__
+except AttributeError as e:
+    raise OSError(
+        '`docarray` dependency is not installed correctly, please reinstall with `pip install -U --force-reinstall docarray`'
+    )
 
 __uptime__ = _datetime.datetime.now().isoformat()
 


### PR DESCRIPTION
Issue https://github.com/jina-ai/jina/issues/4194 was meant to be fixed by https://github.com/jina-ai/jina/pull/4203

Unfortunately it did not, because the post install trigger is not happening when installing Jina as a wheel.
I dont see a proper way of working around it, so I changed at least the error message to something more meaningful