### PR TITLE
fix: replace docker id with uids

### DIFF
--- a/tests/integration/container_runtime_args/replica-exec/__init__.py
+++ b/tests/integration/container_runtime_args/replica-exec/__init__.py
@@ -1,26 +1,19 @@
+import uuid
+
 from jina import Executor, requests
 
 
 class ReplicatedExec(Executor):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.docker_id = self.get_docker_id()
+        self.uid = str(uuid.uuid4())
         self.shard_id = self.runtime_args.shard_id
         self.shards = self.runtime_args.shards
 
     @requests
     def foo(self, docs, **kwargs):
-        print(f' self.docker_id {self.docker_id}')
         for doc in docs:
-            doc.tags[
-                'replica'
-            ] = self.docker_id  # identify replicas via docker container id
+            doc.tags['replica'] = self.uid  # identify replicas via uid
 
             doc.tags['shard_id'] = self.shard_id
             doc.tags['shards'] = self.shards
-
-    def get_docker_id(self):
-        import subprocess
-
-        bash_command = """head -1 /proc/self/cgroup|cut -d/ -f3"""
-        return subprocess.check_output(['bash', '-c', bash_command]).decode("utf-8")

--- a/tests/integration/scale/scale-executor/__init__.py
+++ b/tests/integration/scale/scale-executor/__init__.py
@@ -1,21 +1,16 @@
+import uuid
+
 from jina import Executor, requests
 
 
 class ScalableExecutor(Executor):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.docker_id = self.get_docker_id()
-        print(self.docker_id)
+        self.uid = str(uuid.uuid4())
         self.shard_id = self.runtime_args.shard_id
 
     @requests
     def foo(self, docs, **kwargs):
         for doc in docs:
-            doc.tags['docker_id'] = self.docker_id
+            doc.tags['uid'] = self.uid
             doc.tags['shard_id'] = self.shard_id
-
-    def get_docker_id(self):
-        import subprocess
-
-        bash_command = """head -1 /proc/self/cgroup|cut -d/ -f3"""
-        return subprocess.check_output(['bash', '-c', bash_command]).decode("utf-8")

--- a/tests/integration/scale/test_scale.py
+++ b/tests/integration/scale/test_scale.py
@@ -103,31 +103,28 @@ def test_scale_success(flow_with_runtime, pod_params):
 
         assert len(ret1) == 20
         process_ids = set()
-        docker_ids = set()
+        uids = set()
         for i_r, r in enumerate(ret1):
             assert len(r.docs) == 10
-            p_ids, d_ids = r.docs[:, ['tags__process_id', 'tags__docker_id']]
+            p_ids, d_ids = r.docs[:, ['tags__process_id', 'tags__uid']]
             process_ids = process_ids.union(set(p_ids))
-            docker_ids = docker_ids.union(set(d_ids))
+            uids = uids.union(set(d_ids))
 
         assert (
             len(process_ids) == num_replicas * shards
-            or len(docker_ids) == num_replicas * shards
+            or len(uids) == num_replicas * shards
         )
 
         assert len(ret2) == 20
         process_ids = set()
-        docker_ids = set()
+        uids = set()
         for r in ret2:
             assert len(r.docs) == 10
-            p_ids, d_ids = r.docs[:, ['tags__process_id', 'tags__docker_id']]
+            p_ids, d_ids = r.docs[:, ['tags__process_id', 'tags__uid']]
             process_ids = process_ids.union(set(p_ids))
-            docker_ids = docker_ids.union(set(d_ids))
+            uids = uids.union(set(d_ids))
 
-        assert (
-            len(process_ids) == scale_to * shards
-            or len(docker_ids) == scale_to * shards
-        )
+        assert len(process_ids) == scale_to * shards or len(uids) == scale_to * shards
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
the hack to retrieve the container id was too unreliable. I replaced it with some simple uid mechanism. No need to get the actual container id.