### PR TITLE
feat: use external pods from k8s

### DIFF
--- a/jina/orchestrate/pods/config/k8s.py
+++ b/jina/orchestrate/pods/config/k8s.py
@@ -229,8 +229,6 @@ class K8sPodConfig:
         self.k8s_namespace = k8s_namespace
         self.k8s_connection_pool = k8s_connection_pool
         self.k8s_pod_addresses = k8s_pod_addresses
-        if self.k8s_connection_pool is True:
-            self.k8s_pod_addresses = None
         self.head_deployment = None
         self.args = copy.copy(args)
         if k8s_namespace is not None:
@@ -354,7 +352,9 @@ class K8sPodConfig:
             .. # noqa: DAR201
             .. # noqa: DAR101
         """
-        if self.name == 'gateway':
+        if hasattr(self.args, 'external') and self.args.external:
+            return []
+        elif self.name == 'gateway':
             return [
                 (
                     'gateway',

--- a/jina/orchestrate/pods/config/k8s.py
+++ b/jina/orchestrate/pods/config/k8s.py
@@ -226,6 +226,8 @@ class K8sPodConfig:
         k8s_connection_pool: bool = True,
         k8s_pod_addresses: Optional[Dict[str, List[str]]] = None,
     ):
+        # External Pods should be ignored in a K8s based Flow
+        assert not (hasattr(args, 'external') and args.external)
         self.k8s_namespace = k8s_namespace
         self.k8s_connection_pool = k8s_connection_pool
         self.k8s_pod_addresses = k8s_pod_addresses
@@ -352,9 +354,7 @@ class K8sPodConfig:
             .. # noqa: DAR201
             .. # noqa: DAR101
         """
-        if hasattr(self.args, 'external') and self.args.external:
-            return []
-        elif self.name == 'gateway':
+        if self.name == 'gateway':
             return [
                 (
                     'gateway',

--- a/tests/k8s/conftest.py
+++ b/tests/k8s/conftest.py
@@ -40,7 +40,7 @@ def test_dir() -> str:
     return cur_dir
 
 
-@pytest.fixture
+@pytest.fixture(scope='session')
 def logger():
     return JinaLogger('kubernetes-testing')
 

--- a/tests/k8s/conftest.py
+++ b/tests/k8s/conftest.py
@@ -45,7 +45,7 @@ def logger():
     return JinaLogger('kubernetes-testing')
 
 
-@pytest.fixture
+@pytest.fixture(scope='session')
 def k8s_cluster(kind_cluster: KindCluster, logger: JinaLogger) -> KindClusterWrapper:
     return KindClusterWrapper(kind_cluster, logger)
 

--- a/tests/k8s/conftest.py
+++ b/tests/k8s/conftest.py
@@ -40,14 +40,14 @@ def test_dir() -> str:
     return cur_dir
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture
 def logger():
     return JinaLogger('kubernetes-testing')
 
 
 @pytest.fixture(scope='session')
-def k8s_cluster(kind_cluster: KindCluster, logger: JinaLogger) -> KindClusterWrapper:
-    return KindClusterWrapper(kind_cluster, logger)
+def k8s_cluster(kind_cluster: KindCluster) -> KindClusterWrapper:
+    return KindClusterWrapper(kind_cluster, JinaLogger('kubernetes-cluster-logger'))
 
 
 @pytest.fixture

--- a/tests/k8s/conftest.py
+++ b/tests/k8s/conftest.py
@@ -19,6 +19,7 @@ class KindClusterWrapper:
         )
         self._log = logger
         self._set_kube_config()
+        self._loaded_images = set()
 
     def _set_kube_config(self):
         self._log.debug(f'Setting KUBECONFIG to {self._kube_config_path}')
@@ -26,9 +27,12 @@ class KindClusterWrapper:
 
     def load_docker_images(self, images, image_tag_map):
         for image in images:
-            if image != 'alpine' and image != 'jinaai/jina':
-                build_docker_image(image, image_tag_map)
-            self._cluster.load_docker_image(image + ':' + image_tag_map[image])
+            full_image_name = image + ':' + image_tag_map[image]
+            if full_image_name not in self._loaded_images:
+                if image != 'alpine' and image != 'jinaai/jina':
+                    build_docker_image(image, image_tag_map)
+                self._cluster.load_docker_image(full_image_name)
+                self._loaded_images.add(full_image_name)
 
 
 @pytest.fixture()

--- a/tests/k8s/test_k8s.py
+++ b/tests/k8s/test_k8s.py
@@ -531,7 +531,7 @@ async def test_flow_with_workspace(logger, k8s_connection_pool, docker_images, t
     )
 
     dump_path = os.path.join(str(tmpdir), 'test-flow-with-workspace')
-    namespace = f'test-flow-with-workspace-{k8s_connection_pool}'
+    namespace = f'test-flow-with-workspace-{k8s_connection_pool}'.lower()
     flow.to_k8s_yaml(dump_path, k8s_namespace=namespace)
 
     from kubernetes import client
@@ -581,7 +581,7 @@ async def test_flow_connection_pool(logger, k8s_connection_pool, docker_images, 
     )
 
     dump_path = os.path.join(str(tmpdir), 'test-flow-connection-pool')
-    namespace = f'test-flow-connection-pool-{k8s_connection_pool}'
+    namespace = f'test-flow-connection-pool-{k8s_connection_pool}'.lower()
     flow.to_k8s_yaml(
         dump_path, k8s_namespace=namespace, k8s_connection_pool=k8s_connection_pool
     )

--- a/tests/k8s/test_k8s.py
+++ b/tests/k8s/test_k8s.py
@@ -39,7 +39,7 @@ async def create_all_flow_pods_and_wait_ready(
         pass
 
     while True:
-        ns_items = core_client.list_namespace().items()
+        ns_items = core_client.list_namespace().items
         if any(item.metadata.name == namespace for item in ns_items):
             logger.info(f'created Namespace {namespace}')
             break

--- a/tests/k8s/test_k8s.py
+++ b/tests/k8s/test_k8s.py
@@ -522,7 +522,7 @@ async def test_flow_with_workspace(logger, k8s_connection_pool, docker_images, t
     )
 
     dump_path = os.path.join(str(tmpdir), 'test-flow-with-workspace')
-    namespace = f'test-flow-with-workspace'
+    namespace = f'test-flow-with-workspace-{k8s_connection_pool}'
     flow.to_k8s_yaml(dump_path, k8s_namespace=namespace)
 
     from kubernetes import client
@@ -572,7 +572,7 @@ async def test_flow_connection_pool(logger, k8s_connection_pool, docker_images, 
     )
 
     dump_path = os.path.join(str(tmpdir), 'test-flow-connection-pool')
-    namespace = 'test-flow-connection-pool'
+    namespace = f'test-flow-connection-pool-{k8s_connection_pool}'
     flow.to_k8s_yaml(
         dump_path, k8s_namespace=namespace, k8s_connection_pool=k8s_connection_pool
     )

--- a/tests/k8s/test_k8s.py
+++ b/tests/k8s/test_k8s.py
@@ -262,6 +262,7 @@ async def test_flow_with_needs(
     assert len(docs) == 10
     for doc in docs:
         assert set(doc.tags['traversed-executors']) == expected_traversed_executors
+    core_client.delete_namespace(namespace)
 
 
 @pytest.mark.timeout(3600)
@@ -379,6 +380,7 @@ async def test_flow_with_configmap(
         assert doc.tags['k1'] == 'v1'
         assert doc.tags['k2'] == 'v2'
         assert doc.tags['env'] == {'k1': 'v1', 'k2': 'v2'}
+    core_client.delete_namespace(namespace)
 
 
 @pytest.mark.timeout(3600)
@@ -419,6 +421,7 @@ async def test_flow_with_gpu(k8s_flow_gpu, docker_images, tmpdir):
     assert len(docs) == 10
     for doc in docs:
         assert doc.tags['resources']['limits'] == {'nvidia.com/gpu:': 1}
+    core_client.delete_namespace(namespace)
 
 
 @pytest.mark.timeout(3600)
@@ -484,6 +487,7 @@ async def test_rolling_update_simple(
     assert len(docs) == 10
     for doc in docs:
         assert doc.tags['argument'] == 'value2'
+    core_client.delete_namespace(namespace)
 
 
 @pytest.mark.asyncio
@@ -532,6 +536,7 @@ async def test_flow_with_workspace(logger, k8s_connection_pool, docker_images, t
     assert len(docs) == 10
     for doc in docs:
         assert doc.tags['workspace'] == '/shared/TestExecutor/0'
+    core_client.delete_namespace(namespace)
 
 
 @pytest.mark.asyncio
@@ -647,6 +652,7 @@ async def test_flow_with_external_native_pod(logger, docker_images, tmpdir):
     assert len(docs) == 100
     for doc in docs:
         assert doc.text == 'executor was here'
+    core_client.delete_namespace(namespace)
 
 
 @pytest.mark.asyncio
@@ -686,6 +692,7 @@ async def test_flow_with_external_k8s_pod(logger, docker_images, tmpdir):
             'gateway': 1,
         },
     )
+
     resp = await run_test(
         flow=flow,
         namespace=namespace,
@@ -737,13 +744,4 @@ async def _create_external_pod(api_client, app_client, docker_images, tmpdir):
         except:
             pass
 
-    api_response = app_client.read_namespaced_deployment(
-        name='external-pod-head-0', namespace=namespace
-    )
-    while True:
-        if (
-            api_response.status.ready_replicas is not None
-            and api_response.status.ready_replicas == 1
-        ):
-            return
-        await asyncio.sleep(0.1)
+    await asyncio.sleep(1.0)

--- a/tests/k8s/test_k8s.py
+++ b/tests/k8s/test_k8s.py
@@ -27,6 +27,7 @@ async def create_all_flow_pods_and_wait_ready(
 ):
     from kubernetes import utils
 
+    namespace = namespace.lower()
     namespace_object = {
         'apiVersion': 'v1',
         'kind': 'Namespace',

--- a/tests/k8s/test_k8s.py
+++ b/tests/k8s/test_k8s.py
@@ -23,6 +23,7 @@ async def create_all_flow_pods_and_wait_ready(
     app_client,
     core_client,
     deployment_replicas_expected,
+    logger,
 ):
     from kubernetes import utils
 
@@ -32,6 +33,7 @@ async def create_all_flow_pods_and_wait_ready(
         'metadata': {'name': f'{namespace}'},
     }
     try:
+        logger.info(f'create Namespace {namespace}')
         utils.create_from_dict(api_client, namespace_object)
     except:
         pass
@@ -57,6 +59,7 @@ async def create_all_flow_pods_and_wait_ready(
             deployment_replicas_expected.values()
         ):
             break
+        logger.info('Waiting for all Pods to be created')
         await asyncio.sleep(1.0)
 
     # wait for all the pods to be up
@@ -78,6 +81,7 @@ async def create_all_flow_pods_and_wait_ready(
 
         for deployment_name in deployments_ready:
             deployment_names.remove(deployment_name)
+        logger.info(f'Waiting for {deployment_names} to be ready')
         await asyncio.sleep(1.0)
 
 
@@ -245,6 +249,7 @@ async def test_flow_with_needs(
             'merger-head-0': 1,
             'merger': 1,
         },
+        logger=logger,
     )
     resp = await run_test(
         flow=k8s_flow_with_needs,
@@ -275,7 +280,7 @@ async def test_flow_with_needs(
 )
 @pytest.mark.parametrize('polling', ['ANY', 'ALL'])
 async def test_flow_with_sharding(
-    k8s_flow_with_sharding, k8s_connection_pool, polling, tmpdir
+    k8s_flow_with_sharding, k8s_connection_pool, polling, tmpdir, logger
 ):
     dump_path = os.path.join(str(tmpdir), 'test-flow-with-sharding')
     namespace = f'test-flow-with-sharding-{polling}-{k8s_connection_pool}'.lower()
@@ -300,6 +305,7 @@ async def test_flow_with_sharding(
             'test-executor-0': 2,
             'test-executor-1': 2,
         },
+        logger=logger,
     )
     resp = await run_test(
         flow=k8s_flow_with_sharding,
@@ -341,7 +347,7 @@ async def test_flow_with_sharding(
     'docker_images', [['test-executor', 'jinaai/jina']], indirect=True
 )
 async def test_flow_with_configmap(
-    k8s_flow_configmap, k8s_connection_pool, docker_images, tmpdir
+    k8s_flow_configmap, k8s_connection_pool, docker_images, tmpdir, logger
 ):
     dump_path = os.path.join(str(tmpdir), 'test-flow-with-configmap')
     namespace = f'test-flow-with-configmap-{k8s_connection_pool}'.lower()
@@ -365,6 +371,7 @@ async def test_flow_with_configmap(
             'test-executor-head-0': 1,
             'test-executor': 1,
         },
+        logger=logger,
     )
     resp = await run_test(
         flow=k8s_flow_configmap,
@@ -389,7 +396,7 @@ async def test_flow_with_configmap(
 @pytest.mark.parametrize(
     'docker_images', [['test-executor', 'jinaai/jina']], indirect=True
 )
-async def test_flow_with_gpu(k8s_flow_gpu, docker_images, tmpdir):
+async def test_flow_with_gpu(k8s_flow_gpu, docker_images, tmpdir, logger):
     dump_path = os.path.join(str(tmpdir), 'test-flow-with-gpu')
     namespace = f'test-flow-with-gpu'
     k8s_flow_gpu.to_k8s_yaml(dump_path, k8s_namespace=namespace)
@@ -410,6 +417,7 @@ async def test_flow_with_gpu(k8s_flow_gpu, docker_images, tmpdir):
             'test-executor-head-0': 1,
             'test-executor': 1,
         },
+        logger=logger,
     )
     resp = await run_test(
         flow=k8s_flow_gpu,
@@ -430,7 +438,7 @@ async def test_flow_with_gpu(k8s_flow_gpu, docker_images, tmpdir):
     'docker_images', [['reload-executor', 'jinaai/jina']], indirect=True
 )
 async def test_rolling_update_simple(
-    k8s_flow_with_reload_executor, docker_images, tmpdir
+    k8s_flow_with_reload_executor, docker_images, tmpdir, logger
 ):
     dump_path = os.path.join(str(tmpdir), 'test-flow-with-reload')
     namespace = f'test-flow-with-reload-executor'
@@ -452,6 +460,7 @@ async def test_rolling_update_simple(
             'test-executor-head-0': 1,
             'test-executor': 2,
         },
+        logger=logger,
     )
     resp = await run_test(
         flow=k8s_flow_with_reload_executor,
@@ -525,6 +534,7 @@ async def test_flow_with_workspace(logger, k8s_connection_pool, docker_images, t
             'test-executor-head-0': 1,
             'test-executor': 1,
         },
+        logger=logger,
     )
     resp = await run_test(
         flow=flow,
@@ -576,6 +586,7 @@ async def test_flow_connection_pool(logger, k8s_connection_pool, docker_images, 
             'test-executor-head-0': 1,
             'test-executor': 2,
         },
+        logger=logger,
     )
 
     resp = await run_test(
@@ -641,6 +652,7 @@ async def test_flow_with_external_native_pod(logger, docker_images, tmpdir):
             deployment_replicas_expected={
                 'gateway': 1,
             },
+            logger=logger,
         )
         resp = await run_test(
             flow=flow,
@@ -691,6 +703,7 @@ async def test_flow_with_external_k8s_pod(logger, docker_images, tmpdir):
         deployment_replicas_expected={
             'gateway': 1,
         },
+        logger=logger,
     )
 
     resp = await run_test(

--- a/tests/k8s/test_k8s.py
+++ b/tests/k8s/test_k8s.py
@@ -38,6 +38,14 @@ async def create_all_flow_pods_and_wait_ready(
     except:
         pass
 
+    while True:
+        ns_items = core_client.list_namespace().items()
+        if any(item.metadata.name == namespace for item in ns_items):
+            logger.info(f'created Namespace {namespace}')
+            break
+        logger.info(f'waiting for Namespace {namespace}')
+        await asyncio.sleep(1.0)
+
     pod_set = set(os.listdir(flow_dump_path))
     for pod_name in pod_set:
         file_set = set(os.listdir(os.path.join(flow_dump_path, pod_name)))

--- a/tests/unit/orchestrate/pods/config/test_k8s_pod_config.py
+++ b/tests/unit/orchestrate/pods/config/test_k8s_pod_config.py
@@ -804,3 +804,10 @@ def test_k8s_yaml_regular_pod(
         assert shard_container_runtime_container_args[
             shard_container_runtime_container_args.index('--uses-metas') + 1
         ] == json.dumps(expected_uses_metas)
+
+
+def test_external_pod_is_ignored():
+    args = set_pod_parser().parse_args(['--external'])
+    pod_config = K8sPodConfig(args)
+    yaml_configs = pod_config.to_k8s_yaml()
+    assert len(yaml_configs) == 0

--- a/tests/unit/orchestrate/pods/config/test_k8s_pod_config.py
+++ b/tests/unit/orchestrate/pods/config/test_k8s_pod_config.py
@@ -388,11 +388,9 @@ def test_k8s_yaml_gateway(k8s_connection_pool_call, pod_addresses):
     assert args[args.index('--pea-role') + 1] == 'GATEWAY'
     if not k8s_connection_pool_call:
         assert args[-1] == '--k8s-disable-connection-pool'
-    if pod_addresses is not None and k8s_connection_pool_call is False:
+    if pod_addresses is not None:
         assert '--pods-addresses' in args
         assert args[args.index('--pods-addresses') + 1] == json.dumps(pod_addresses)
-    else:
-        assert '--pods-addresses' not in args
 
 
 def assert_port_config(port_dict: Dict, name: str, port: int):
@@ -804,10 +802,3 @@ def test_k8s_yaml_regular_pod(
         assert shard_container_runtime_container_args[
             shard_container_runtime_container_args.index('--uses-metas') + 1
         ] == json.dumps(expected_uses_metas)
-
-
-def test_external_pod_is_ignored():
-    args = set_pod_parser().parse_args(['--external'])
-    pod_config = K8sPodConfig(args)
-    yaml_configs = pod_config.to_k8s_yaml()
-    assert len(yaml_configs) == 0


### PR DESCRIPTION
This closes https://github.com/jina-ai/jina/issues/4145

This PR adds the possibility to use external Pods from a Flow in K8s. Before this PR, we would always generate K8s yaml files for the external Pods.
With this change those yamls for the external Pod are no longer generated. Also the Gateway pod address list logic is updated to cater for those external Pods. External Pods always need to be announced to the Gateway. It does not matter if the K8sConnectionPool is used or not. The gateway will always communicate to the head of the external Pod via a fixed address, configured in the Flow.