### PR TITLE
feat: functionnal API for executors

### DIFF
--- a/jina/__init__.py
+++ b/jina/__init__.py
@@ -16,7 +16,6 @@ import types as _types
 import warnings as _warnings
 import docarray as _docarray
 
-
 if _sys.version_info < (3, 7, 0):
     raise OSError(f'Jina requires Python >= 3.7, but yours is {_sys.version_info}')
 
@@ -203,7 +202,7 @@ from docarray import Document, DocumentArray
 
 # Executor
 from jina.serve.executors import BaseExecutor as Executor
-from jina.serve.executors.decorators import requests
+from jina.serve.executors.decorators import requests, executable
 
 # Flow
 from jina.orchestrate.flow.base import Flow

--- a/tests/integration/test_flow_init.py
+++ b/tests/integration/test_flow_init.py
@@ -1,0 +1,18 @@
+from jina import executable, Flow
+from docarray import Document, DocumentArray
+
+
+def test_executor_decorator():
+    @executable
+    def my_awesome_function(docs, **kwargs):
+        for doc in docs:
+            doc.text = "wow"
+
+    def assert_result(resp):
+        for doc in resp.docs:
+            assert doc.text == "wow"
+
+    f = Flow().add(uses=my_awesome_function)
+
+    with f:
+        f.search(DocumentArray([Document(text="")]), on_done=assert_result)


### PR DESCRIPTION
The actual plan is not to merge this PR

it simply wrap an function into an Executor.


```python
@executable
    def my_awesome_function(docs, **kwargs):
        ...
```

in practice :

```python
from jina import  Flow,executable
from docarray import Document, DocumentArray

@executable
def my_awesome_function(docs, **kwargs):
    for doc in docs:
        doc.text = "wow"

f = Flow().add(uses=my_awesome_function)

with f:
    f.search(DocumentArray([Document(text="")]))
```


Pro: 
* make it even easier for docarray users to put their function into a flow
*  nice syntax 

Cons:
* we don't want another syntax to define executor
* the new syntax is simpler but the original one with the class is almost as simple
* as soon as the executor start to be serious it will need some internal state, like a loaded pretrained model, we will need  a class so this decorator will only be used for small executor


The decorator actual transform the function into an executor --> so it will theoretically "never" break