### PR TITLE
chore: add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,9 @@
+# Pull Request Title
+
+## Description
+
+Please describe what your PR is doing and why. Are there any parts which need extra attention during review? Are there any dependencies from other PRs or projcts? Is this a breaking change?
+
+Is this PR ready or work in progress (WIP)? Ready means it can be reviewed and merged from the author's perspective. If the PR is WIP: Make it a draft PR and state open questions and TODO items.
+
+Closes # (issue)


### PR DESCRIPTION
We decided in the Retro that we want more information in PRs as they also serve as a type of documentation. One tool of achieving this goal is the addition of a PR template.

This PR adds a template for PRs to our repo as described [here](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository).

The template now is super basic, it basically just asks you to provide a minimal description and to check if the PR is ready for review. In theory we could also have a more extensive checklist like "have you added tests", "did you read the contributor guide" etc. I think a checklist is not necessary at this point but might become in the future. 