### PR TITLE
docs: adjust readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ If you are upgrading from Jina 2: Please remove version 2 first and install vers
 
 Check our **[comprehensive docs](https://docs.jina.ai)** for more in depth tutorials, advanced topics and API reference.
 
-This is the readme for Jina 3. The old readme for Jina 2 can be found <a href="https://github.com/jina-ai/jina/blob/v2.6.4/README.md">here</a>.
+This is the readme for Jina 3. The documentation for Jina 2 can be found <a href="https://docs2.jina.ai">here</a>.
 
 ## Get Started
 You can follow our basic example below to get started from building a local `Executor` to deploying your search application in a `Flow` to Kubernetes.

--- a/README.md
+++ b/README.md
@@ -24,19 +24,25 @@
 
 Jina is a neural search framework that empowers anyone to build SOTA and scalable deep learning search applications in minutes.
 
-Jina is split into Docarray, Finetuner and Jina Core:
+Jina is composed of Docarray, Finetuner and Jina Core:
 * <a href="https://github.com/jina-ai/docarray/">DocArray</a>: Library for working with unstructured data. It allows deep-learning engineers to efficiently process, embed, search, recommend, store, and transfer the data with a Pythonic API.
 * <a href="https://github.com/jina-ai/finetuner/">Finetuner</a>: Tune the weights of any deep neural network for better embeddings on search tasks. It helps you to deliver the last mile of performance and quality for domain-specific neural search applications.
-* <a href="https://github.com/jina-ai/jina/">Jina Core</a>: Framework to orchestrate and deploy neural search applications. Develop your own DocArray based search application easily and run it locally or in the cloud.  
+* <a href="https://github.com/jina-ai/jina/">Jina Core</a>: Framework to orchestrate, serve, scale and deploy neural search applications. Develop your own DocArray based search application easily and run it locally or in the cloud.  
 
 <!-- end ecosystem-description -->
-With Jina Core you th following features:
+Jina Core comes equipped with the following features:
 
-🏗️ **Modular Building Blocks** - [explain value of working with docs in Executors, ]
+**Orchestrate** - Define your neural search application as a pipeline of Executors. Each Executor performing specific tasks like generating embeddings or indexing. Jina exposes the necessary concepts to orchestrate your neural search application in such a composable way.
 
-**Serve** - [Explain gateway API]
+**Serve** - Jina uses industry standard technologies like gRPC/protobuf to exchange information. Your Jina search application can be easily exposed via an API using http, websockets or gRPC. 
 
-🌩️ **Local & cloud friendly** - Distributed architecture, scalable & cloud-native from day one. Same developer experience on both local and cloud.
+**Scale** - Jina allows you to scale your neural search applications horizontally by adding more machines. High availability and throughput setups can be easily achieved with Jina. 
+
+**Cloud Native** - Jina is built as Cloud native framework. All your workloads can be containerized. They can be easily deployed with Docker Compose or Kubernetes. Thus making any Cloud deployment working similarly to your local installation of Jina.
+
+🏗️ **Modular Building Blocks** - Jina pipelines are modularized and each Executor can be easily shared via the <a href="https://hub.jina.ai">Hub</a>. This enables you to share pipelines with co-workers or to leverage pre built building blocks. 
+
+
 
 
 
@@ -55,21 +61,27 @@ Check our **[comprehensive docs](https://docs.jina.ai)** for more in depth tutor
 This is the readme for Jina 3. The old readme for Jina 2 can be found <a href="https://github.com/jina-ai/jina/blob/v2.6.4/README.md">here</a>.
 
 ## Get Started
+You can follow our basic example below to get started from building a local `Executor` to eventually deploying your search application in a `Flow` to Kubernetes.
 
-<p align="center">
-<a href="https://docs.jina.ai"><img src="https://github.com/jina-ai/jina/blob/master/.github/images/readme-get-started.svg?raw=true" alt="Get started with Jina to build production-ready neural search solution via ResNet in less than 20 minutes" width="100%"></a>
-</p>
-
-We promise you can build a scalable ResNet-powered image search service in 20 minutes or less, from scratch. If not, you can forget about Jina.
+We recommend familiarizing yourself before with the <a href="https://github.com/jina-ai/docarray/">DocArray</a> library and the basic concepts of `Executor` and `Flow`.
 
 
-### Basic Concepts <img align="right" src="https://github.com/jina-ai/jina/blob/master/.github/images/clock-1min.svg?raw=true"></img>
+### Basic Concepts
+
+
+
+Use simpl executors and flow (doc logic based on docarray readme),
+
+locally
+containrize
+compose
+k8s
 
 Document, Executor, and Flow are three fundamental concepts in Jina.
 
-- [**Document**](https://docs.jina.ai/fundamentals/document/) is the basic data type in Jina;
-- [**Executor**](https://docs.jina.ai/fundamentals/executor/) is how Jina processes Documents;
-- [**Flow**](https://docs.jina.ai/fundamentals/flow/) is how Jina streamlines and distributes Executors.
+- [**Document**](https://docs.jina.ai/fundamentals/document/): The basic data type in Jina, which can be used as well in the standalone <a href="https://github.com/jina-ai/docarray/">Docarray</a> library
+- [**Executor**](https://docs.jina.ai/fundamentals/executor/): Self-contained module to manipulate Documents. It offers both a Pythonic and a gRPC interface to interact with. Typically, it is tasked with things like generating embeddings or indexing. Multiple Executors can be orchestrated to form a `Flow` to model your neural search application. They can be <a href="https://docs.jina.ai/advanced/hub/">shared via the Jina Hub</a>.
+- [**Flow**](https://docs.jina.ai/fundamentals/flow/): Orchestrates Executors into a Pipeline defining the Flow of Documents. It comes with a ready to use API to serve requests to the Flow. It also offers utility functions to generate Docker Compose and Kubernetes deployment configurations.
 
 
 Leveraging these three components, let's build an app that **find similar images using ResNet50**.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 
 Jina is a neural search framework that empowers anyone to build SOTA and scalable deep learning search applications in minutes.
 
-Jina is composed of Docarray, Finetuner and Jina Core:
+The ecosystem of Jina AI is composed of Docarray, Finetuner and Jina Core:
 * <a href="https://github.com/jina-ai/docarray/">DocArray</a>: Library for working with unstructured data. It allows deep-learning engineers to efficiently process, embed, search, recommend, store, and transfer the data with a Pythonic API.
 * <a href="https://github.com/jina-ai/finetuner/">Finetuner</a>: Tune the weights of any deep neural network for better embeddings on search tasks. It helps you to deliver the last mile of performance and quality for domain-specific neural search applications.
 * <a href="https://github.com/jina-ai/jina/">Jina Core</a>: Framework to orchestrate, serve, scale and deploy neural search applications. Develop your own DocArray based search application easily and run it locally or in the cloud.  
@@ -32,13 +32,13 @@ Jina is composed of Docarray, Finetuner and Jina Core:
 <!-- end ecosystem-description -->
 Jina Core comes equipped with the following **_features_**:
 
-🗄️**Orchestrate** - Define your neural search application as a pipeline of Executors. Each Executor performing specific tasks like generating embeddings or indexing. Executors can be easily shared via the <a href="https://hub.jina.ai">Hub</a>. This enables you to share pipelines with co-workers or to leverage pre-built Executors. 
+🗄️**Orchestrate** - Define your neural search application as a pipeline of Executors. Each Executor performs specific tasks like generating embeddings or indexing. Executors can be easily shared via the <a href="https://hub.jina.ai">Hub</a>. This enables you to share pipelines with co-workers or to leverage pre-built Executors. 
 
 🥤**Serve** - Jina uses industry standard technologies like gRPC to exchange information. Your Jina search application can be easily exposed via an API using HTTP, websockets or gRPC. 
 
 🚀**Scale** - Jina allows you to scale your neural search applications horizontally by adding more machines. High availability and throughput setups can be easily achieved with Jina. 
 
-☁️ **Cloud Native** - Jina is built as a Cloud native framework. All your workloads can be containerized. They can be easily deployed with Docker Compose or Kubernetes. Thus making any Cloud deployment working similarly to your local installation of Jina.
+☁️ **Cloud Native** - Jina is built to be a Cloud native framework. All your workloads can be containerized. They can be easily deployed with Docker Compose or Kubernetes. This way you can be sure that any cloud deployment works the same way as in your local installation of Jina.
 
 ## Install 
 ```
@@ -55,7 +55,7 @@ Check our **[comprehensive docs](https://docs.jina.ai)** for more in depth tutor
 This is the readme for Jina 3. The old readme for Jina 2 can be found <a href="https://github.com/jina-ai/jina/blob/v2.6.4/README.md">here</a>.
 
 ## Get Started
-You can follow our basic example below to get started from building a local `Executor` to eventually deploying your search application in a `Flow` to Kubernetes.
+You can follow our basic example below to get started from building a local `Executor` to deploying your search application in a `Flow` to Kubernetes.
 
 We recommend familiarizing yourself before with the <a href="https://github.com/jina-ai/docarray/">DocArray</a> library and the basic concepts of `Executor` and `Flow`.
 

--- a/README.md
+++ b/README.md
@@ -20,20 +20,25 @@
 <a href="https://slack.jina.ai"><img src="https://img.shields.io/badge/Slack-2.2k%2B-blueviolet?logo=slack&amp;logoColor=white"></a>
 </p>
 
-<!-- start elevator-pitch -->
+<!-- start ecosystem-description -->
 
 Jina is a neural search framework that empowers anyone to build SOTA and scalable deep learning search applications in minutes.
 
-⏱️ **Save time** - *The* design pattern of neural search systems. Native support for PyTorch/Keras/ONNX/Paddle. Build solutions in just minutes.
+Jina is split into Docarray, Finetuner and Jina Core:
+* <a href="https://github.com/jina-ai/docarray/">DocArray</a>: Library for working with unstructured data. It allows deep-learning engineers to efficiently process, embed, search, recommend, store, and transfer the data with a Pythonic API.
+* <a href="https://github.com/jina-ai/finetuner/">Finetuner</a>: Tune the weights of any deep neural network for better embeddings on search tasks. It helps you to deliver the last mile of performance and quality for domain-specific neural search applications.
+* <a href="https://github.com/jina-ai/jina/">Jina Core</a>: Framework to orchestrate and deploy neural search applications. Develop your own DocArray based search application easily and run it locally or in the cloud.  
 
-🌌 **All data types** - Process, index, query, and understand videos, images, long/short text, audio, source code, PDFs, etc.
+<!-- end ecosystem-description -->
+With Jina Core you th following features:
 
-🌩️ **Local & cloud friendly** - Distributed architecture, scalable & cloud-native from day one. Same developer experience on both local and cloud. 
+🏗️ **Modular Building Blocks** - [explain value of working with docs in Executors, ]
 
-🍱 **Own your stack** - Keep end-to-end stack ownership of your solution. Avoid integration pitfalls you get with
-fragmented, multi-vendor, generic legacy tools.
+**Serve** - [Explain gateway API]
 
-<!-- end elevator-pitch -->
+🌩️ **Local & cloud friendly** - Distributed architecture, scalable & cloud-native from day one. Same developer experience on both local and cloud.
+
+
 
 ## Install 
 ```
@@ -41,10 +46,9 @@ pip install -U jina
 ```
 More install options including Conda, Docker, Windows [can be found here](https://docs.jina.ai/get-started/install/). 
 
-## Learning and Docs
+## Documentation
 
-- Brand new to Jina? Check our **[Learning Bootcamp](https://learn.jina.ai)** to get up to speed.
-- Check our **[comprehensive docs](https://docs.jina.ai)** for deeper tutorials, more advanced topics, and API reference.
+Check our **[comprehensive docs](https://docs.jina.ai)** for more in depth tutorials, advanced topics and API reference.
 
 ## Get Started
 

--- a/README.md
+++ b/README.md
@@ -46,9 +46,13 @@ pip install -U jina
 ```
 More install options including Conda, Docker, Windows [can be found here](https://docs.jina.ai/get-started/install/). 
 
+If you are upgrading from Jina 2: Please remove version 2 first and install version 3 then. (`pip uninstall jina && pip install -U jina`)
+
 ## Documentation
 
 Check our **[comprehensive docs](https://docs.jina.ai)** for more in depth tutorials, advanced topics and API reference.
+
+This is the readme for Jina 3. The old readme for Jina 2 can be found <a href="https://github.com/jina-ai/jina/blob/v2.6.4/README.md">here</a>.
 
 ## Get Started
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 <!-- start ecosystem-description -->
 
-Jina is a neural search framework that empowers anyone to build SOTA and scalable deep learning search applications in minutes.
+Jina is a neural search framework that empowers anyone to build SOTA and scalable neural search applications in minutes.
 
 The ecosystem of Jina AI is composed of Docarray, Finetuner and Jina Core:
 * <a href="https://github.com/jina-ai/docarray/">DocArray</a>: Library for working with unstructured data. It allows deep-learning engineers to efficiently process, embed, search, recommend, store, and transfer the data with a Pythonic API.
@@ -30,15 +30,15 @@ The ecosystem of Jina AI is composed of Docarray, Finetuner and Jina Core:
 * <a href="https://github.com/jina-ai/jina/">Jina Core</a>: Framework to orchestrate, serve, scale and deploy neural search applications. Develop your own DocArray based search application easily and run it locally or in the cloud.  
 
 <!-- end ecosystem-description -->
-Jina Core comes equipped with the following **_features_**:
+This is what Jina Core offers developers:
 
 🗄️**Orchestrate** - Define your neural search application as a pipeline of Executors. Each Executor performs specific tasks like generating embeddings or indexing. Executors can be easily shared via the <a href="https://hub.jina.ai">Hub</a>. This enables you to share pipelines with co-workers or to leverage pre-built Executors. 
 
-🥤**Serve** - Jina uses industry standard technologies like gRPC to exchange information. Your Jina search application can be easily exposed via an API using HTTP, websockets or gRPC. 
+🥤**Serve** - Jina enables you to easily expose your neural search application via an API using HTTP, websockets or gRPC. 
 
-🚀**Scale** - Jina allows you to scale your neural search applications horizontally by adding more machines. High availability and throughput setups can be easily achieved with Jina. 
+🚀**Scale** - Jina allows you to scale your neural search applications to meet your availability and throughput requirements. All of Jina's microservices can be scaled independently as needed.
 
-☁️ **Cloud Native** - Jina is built to be a Cloud native framework. All your workloads can be containerized. They can be easily deployed with Docker Compose or Kubernetes. This way you can be sure that any cloud deployment works the same way as in your local installation of Jina.
+☁️ **Cloud Native** - Jina is built and designed to work and scale in the Cloud. All components can be deployed in the cloud to be used in your favourite cloud orchestrator. By default, Jina offers easy integration with docker compose and Kubernetes.
 
 ## Install 
 ```
@@ -65,7 +65,7 @@ We recommend familiarizing yourself before with the <a href="https://github.com/
 Document, Executor, and Flow are three fundamental concepts in Jina.
 
 - [**Document**](https://docs.jina.ai/fundamentals/document/): The basic data type in Jina, which can be used as well in the standalone <a href="https://github.com/jina-ai/docarray/">Docarray</a> library
-- [**Executor**](https://docs.jina.ai/fundamentals/executor/): Self-contained module to manipulate Documents. It offers both a Pythonic and a gRPC interface to interact with. Typically, it is tasked with things like generating embeddings or indexing. Multiple Executors can be orchestrated to form a `Flow` to model your neural search application. They can be <a href="https://docs.jina.ai/advanced/hub/">shared via the Jina Hub</a>.
+- [**Executor**](https://docs.jina.ai/fundamentals/executor/): Self-contained module to manipulate Documents. Typically, it is tasked with things like generating embeddings or indexing. Multiple Executors can be orchestrated to form a `Flow` to model your neural search application. They can be <a href="https://docs.jina.ai/advanced/hub/">shared via the Jina Hub</a>.
 - [**Flow**](https://docs.jina.ai/fundamentals/flow/): Orchestrates Executors into a Pipeline defining the Flow of Documents. It comes with a ready to use API to serve requests to the Flow. It also offers utility functions to generate Docker Compose and Kubernetes deployment configurations.
 
 


### PR DESCRIPTION
This is part of https://github.com/jina-ai/internal-tasks/issues/376

[Original PR](https://github.com/jina-ai/jina/pull/4232) was against master, it was moved to the docs branch now instead.

Main changes for the README are complete. Please provide feedback here. I think the overall structure we cant really change anymore now but style, language and code snippets can be improved if you see anything.
If we have time we could also improve the dark mode reading experience and improve the examples linked in the README

TODO:

 Add intro to the Jina eco system in the beginning. Mention docarray and finetuner
 Remove learning boot camp link and mention uprade problem
 Change the values/features provided by Jina Core
 Mention that the README is for 3.0 and link old 2.0 README
 Replace the Resnet example by a more compact example focussing on Executor, Hub and Flow
 Improv Run Quick Demo section. Link better examples and explain their purpose.
 Fix Colors in pictures for darkmode
 Improve style, grammar and typos