### PR TITLE
docs: unify docarray import

### DIFF
--- a/docs/fundamentals/clean-code.md
+++ b/docs/fundamentals/clean-code.md
@@ -19,7 +19,8 @@ Use a [Python generator](https://docs.python.org/3/glossary.html#term-generator)
 ---
 emphasize-lines: 3, 4, 5
 ---
-from jina import Flow, Document
+from docarray import Document
+from jina import Flow
 
 def my_input():
    for _ in range(1000):
@@ -33,7 +34,8 @@ with f:
 
 ````{tab} 😔 Don't
 ```python
-from jina import Flow, Document, DocumentArray
+from docarray import Document, DocumentArray
+from jina import Flow 
 
 my_input = DocumentArray([Document() for _ in range(1000)]) 
 
@@ -52,7 +54,8 @@ with f:
 ---
 emphasize-lines: 10
 ---
-from jina import Flow, Document
+from docarray import Document
+from jina import Flow
 
 def my_input():
    for _ in range(1000):
@@ -70,7 +73,8 @@ with f:
 ---
 emphasize-lines: 10
 ---
-from jina import Flow, Document
+from docarray import Document
+from jina import Flow
 
 def my_input():
    for _ in range(1000):
@@ -184,7 +188,8 @@ class MyExecutor(Executor):
 To debug an `Executor`, there is no need to use it in the Flow. Simply initiate it as an object and call its method.
 ````{tab} ✅ Do
 ```python
-from jina import Executor, requests, DocumentArray, Document
+from docarray import Document, DocumentArrayMemmap
+from jina import Executor, requests
 
 
 class MyExec(Executor):
@@ -204,7 +209,8 @@ print(da)
 
 ````{tab} 😔 Don't
 ```python
-from jina import Executor, requests, DocumentArray, Document, Flow
+from docarray import Document, DocumentArray
+from jina import Executor, requests, Flow
 
 
 class MyExec(Executor):
@@ -252,7 +258,8 @@ with f:
 ---
 emphasize-lines: 12
 ---
-from jina import Executor, Flow, Document, requests
+from docarray import Document
+from jina import Executor, Flow, requests
 
 class MyExecutor(Executor):
 
@@ -278,14 +285,15 @@ It also reduces the network overhead.
 ```python
 import glob
 
-from jina import Executor, Flow, requests, Document
+from docarray import Document
+from jina import Executor, Flow, requests
 
 class MyExecutor(Executor):
 
     @requests
     def to_blob_conversion(self, docs: DocumentArray, **kwargs):
         for doc in docs:
-            doc.load_uri_to_image_blob()  # conversion happens inside Flow
+            doc.load_uri_to_image_tensor()  # conversion happens inside Flow
 
 f = Flow().add(uses=MyExecutor, replicas=2)
 
@@ -303,13 +311,14 @@ with f:
 ```python
 import glob
 
-from jina import Executor, Document
+from docarray import Document
+from jina import Executor
 
 def my_input():
     image_uris = glob.glob('/.workspace/*.png')  # load high resolution images.
     for image_uri in image_uris:
         doc = Document(uri=image_uri)
-        doc.load_uri_to_image_blob()  # time consuming-job on client side
+        doc.load_uri_to_image_tensor()  # time consuming-job on client side
         yield doc
 
 f = Flow().add()

--- a/docs/fundamentals/executor/hub/use-hub-executor.md
+++ b/docs/fundamentals/executor/hub/use-hub-executor.md
@@ -62,7 +62,8 @@ For example: [PostgreSQLStorage](https://hub.jina.ai/executor/d45rawx6)
 will connect PostgreSQL server which was started locally. Then you must use it with:
 
 ```python
-from jina import Flow, Document
+from docarray import Document
+from jina import Flow
 
 f = Flow().add(uses='jinahub+docker://PostgreSQLStorage', 
                uses_with={'hostname': 'host.docker.internal'})

--- a/docs/fundamentals/executor/repository-structure.md
+++ b/docs/fundamentals/executor/repository-structure.md
@@ -6,7 +6,8 @@ Besides organizing your Executor code inline (i.e. with `Flow.add()` in the same
 
 
 ```python
-from jina import Executor, Flow, Document, requests
+from docarray import Document
+from jina import Executor, Flow, requests
 
 
 class MyExecutor(Executor):
@@ -31,7 +32,8 @@ with f:
 
 
 ```python
-from jina import Executor, Flow, Document, requests
+from docarray import Document
+from jina import Executor, Flow, requests
 
 
 class MyExecutor(Executor):
@@ -68,7 +70,8 @@ requests:
 ````{dropdown} flow.py
 
 ```python
-from jina import Flow, Document
+from docarray import Document
+from jina import Flow
 
 f = Flow().add(uses='my.yml')
 

--- a/docs/fundamentals/flow/create-flow.md
+++ b/docs/fundamentals/flow/create-flow.md
@@ -145,7 +145,8 @@ You can use Executors from code, being defined outside your current `PATH` envir
 ```
 `executor/my_executor.py`:
 ```python
-from jina import Executor, DocumentArray, requests
+from docarray import DocumentArray
+from jina import Executor, requests
 
 class MyExecutor(Executor):
     @requests
@@ -167,7 +168,8 @@ Now, in `app/main.py`, to correctly load the Executor, you can specify the direc
 ---
 emphasize-lines: 2
 ---
-from jina import Flow, Document
+from docarray import Document
+from jina import Flow
 f = Flow(extra_search_paths=['../executor']).add(uses='config.yml')
 with f:
     r = f.post('/', inputs=Document())
@@ -186,7 +188,8 @@ executors:
 
 `main.py`:
 ```python
-from jina import Flow, Document
+from docarray import Document
+from jina import Flow
 f = Flow.load_config('../flow/flow.yml')
 with f:
     r = f.post('/', inputs=Document())

--- a/docs/fundamentals/flow/flow-api.md
+++ b/docs/fundamentals/flow/flow-api.md
@@ -280,7 +280,8 @@ The Client can also send parameters to the Executors as shown below:
 ---
 emphasize-lines: 14
 ---
-from jina import Document, Executor, Flow, requests
+from docarray import Document
+from jina import Executor, Flow, requests
 
 class MyExecutor(Executor):
 

--- a/docs/fundamentals/flow/index.md
+++ b/docs/fundamentals/flow/index.md
@@ -66,7 +66,8 @@ with f:
 Client:
 
 ```python
-from jina import Client, Document
+from docarray import Document
+from jina import Client
 
 c = Client(port=12345)
 c.post(on='/bar', inputs=Document(), on_done=print)

--- a/docs/get-started/migrate.md
+++ b/docs/get-started/migrate.md
@@ -81,7 +81,7 @@ to have a better understanding of accessing attributes and elements with `DocArr
 ````{tab} Jina 2
 
 ```python
-from Jina import Document, DocumentArray
+from docarray import Document, DocumentArray
 
 docs = nested_docs()
 
@@ -98,7 +98,7 @@ print(docs.flatten().texts)
 ````{tab} Jina 3 
 
 ```python
-from Jina import Document, DocumentArray
+from docarray import Document, DocumentArray
 
 docs = nested_docs()
 
@@ -141,7 +141,7 @@ important when migrating code that checks for the presence of a certain attribut
 ````{tab} Jina 2
 
 ```python
-from Jina import Document, DocumentArray
+from docarray import Document, DocumentArray
 
 d = Document()
 print(d.text)
@@ -157,7 +157,7 @@ print(docs.texts)
 ````{tab} Jina 3 
 
 ```python
-from Jina import Document, DocumentArray
+from docarray import Document, DocumentArray
 
 d = Document()
 print(d.text)

--- a/docs/how-to/kubernetes.md
+++ b/docs/how-to/kubernetes.md
@@ -128,7 +128,7 @@ Once we see that all the Deployments in the Flow are ready, we can start indexin
 import portforward
 
 from jina.clients import Client
-from jina import DocumentArray
+from docarray import DocumentArray
 
 with portforward.forward(
     'custom-namespace', 'gateway-7df8765bd9-xf5tf', 8080, 8080

--- a/docs/how-to/sandbox.md
+++ b/docs/how-to/sandbox.md
@@ -17,7 +17,8 @@ Here is a graph to show the difference between using and not using Sandbox.
 ## Start a Flow using Jina Sandbox
 
 ```python
-from jina import Flow, Document
+from docarray import Document
+from jina import Flow
 
 f = Flow().add(uses='jinahub+sandbox://Hello')
 


### PR DESCRIPTION
unify all imports, not including `datatype`, `tutorial`.