### PR TITLE
feat: impose docs and parameters as attribute for request

### DIFF
--- a/jina/types/request/__init__.py
+++ b/jina/types/request/__init__.py
@@ -33,14 +33,22 @@ class Request(ProtoTypeMixin):
         """Get the documents attached with the Request
         :return: documents attached to the Request
         """
-        return self.docs
+        return self.proto.docs
+
+    @docs.setter
+    def docs(self, docs: 'DocumentArray'):
+        self.proto.docs = docs
 
     @property
     def parameters(self) -> Dict:
         """Get the parameters attached with the Request
         :return: parameters attached to the Request.
         """
-        return self.parameters
+        return self.proto.parameters
+
+    @parameters.setter
+    def parameters(self, parameters: Dict):
+        self.proto.parameters = parameters
 
     def add_exception(
         self, ex: Optional['Exception'] = None, executor: 'BaseExecutor' = None

--- a/jina/types/request/__init__.py
+++ b/jina/types/request/__init__.py
@@ -1,9 +1,12 @@
 import traceback
-from typing import Optional
+from typing import Optional, Dict, TYPE_CHECKING
 
 from jina.serve.executors import BaseExecutor
 from jina.proto import jina_pb2
 from jina.types.mixin import ProtoTypeMixin
+
+if TYPE_CHECKING:
+    from docarray import DocumentArray
 
 
 class Request(ProtoTypeMixin):
@@ -24,6 +27,20 @@ class Request(ProtoTypeMixin):
 
     def __getattr__(self, name: str):
         return getattr(self.proto, name)
+
+    @property
+    def docs(self) -> 'DocumentArray':
+        """Get the documents attached with the Request
+        :return: documents attached to the Request
+        """
+        return self.docs
+
+    @property
+    def parameters(self) -> Dict:
+        """Get the parameters attached with the Request
+        :return: parameters attached to the Request.
+        """
+        return self.parameters
 
     def add_exception(
         self, ex: Optional['Exception'] = None, executor: 'BaseExecutor' = None


### PR DESCRIPTION
# add more docstring in the Request object

## Description

When looking at the documentation, especially the docstring, of the `Request` classes there is no way to know that it has a `docs` and `parameters` attributes which are essential. This is because these attribute are access "on the fly" by overloading the `__getattr__` method and hunder the hood accessing the proto attributes which can't be found from the documentation. Even by looking at mother classes of `Request` you can't find it because it is defined in the proto files which are out of the scope of the documentation. 

This very simple PR make these two attributes part of the `Request` class, by hard-coded their existences. 

* It make things clearer in the documentation: a user can quickly use the `Request` without reading the whole tutorial because he know that there is a `docs` and `parameters` attributes
* more important: it makes this attributes searchable in in the documentation, i.e before this PR they were no way to know that the classes `Request` was linked to the `docs``by searching request and docs key-word. No it is possible and docQA can even benefice from it