### PR TITLE
fix: remove return_results

### DIFF
--- a/jina/clients/mixin.py
+++ b/jina/clients/mixin.py
@@ -43,7 +43,6 @@ class PostMixin:
         request_size: int = 100,
         show_progress: bool = False,
         continue_on_error: bool = False,
-        return_results: bool = False,
         **kwargs,
     ) -> Optional[Union['DocumentArray', List['Response']]]:
         """Post a general data request to the Flow.
@@ -58,7 +57,6 @@ class PostMixin:
         :param request_size: the number of Documents per request. <=0 means all inputs in one request.
         :param show_progress: if set, client will show a progress bar on receiving every request.
         :param continue_on_error: if set, a Request that causes callback error will be logged only without blocking the further requests.
-        :param return_results: if set, the Documents resulting from all Requests will be returned as a DocumentArray. This is useful when one wants process Responses in bulk instead of using callback.
         :param kwargs: additional parameters
         :return: None or DocumentArray containing all response Documents
 
@@ -66,6 +64,8 @@ class PostMixin:
             ``target_executor`` uses ``re.match`` for checking if the pattern is matched.
              ``target_executor=='foo'`` will match both deployments with the name ``foo`` and ``foo_what_ever_suffix``.
         """
+
+        return_results = False
 
         async def _get_results(*args, **kwargs):
             result = []

--- a/tests/daemon/unit/api/endpoints/partial/test_flow.py
+++ b/tests/daemon/unit/api/endpoints/partial/test_flow.py
@@ -22,7 +22,7 @@ def test_flow_api(monkeypatch, partial_flow_client):
     get_response = partial_flow_client.get(api)
 
     endpoint_responses = Client(port=56789, return_responses=True).post(
-        on='/any_endpoint', inputs=Document(), return_results=True
+        on='/any_endpoint', inputs=Document()
     )
 
     rolling_update_response = partial_flow_client.put(

--- a/tests/distributed/test_dir_structures/test_remote_executors.py
+++ b/tests/distributed/test_dir_structures/test_remote_executors.py
@@ -96,7 +96,6 @@ def test_remote_executor_via_config_yaml(upload_files, config_yml):
         resp = Client(port=exposed_port, return_responses=True).post(
             on='/',
             inputs=Document(text=config_yml),
-            return_results=True,
         )
     assert resp[0].data.docs[0].text == config_yml * 2
 
@@ -129,6 +128,5 @@ def test_remote_executor_via_pymodules(upload_files, uses, py_modules):
         resp = Client(port=exposed_port, return_responses=True).post(
             on='/',
             inputs=Document(text=py_modules),
-            return_results=True,
         )
     assert resp[0].data.docs[0].text == py_modules * 2

--- a/tests/distributed/test_dir_structures/test_remote_flows.py
+++ b/tests/distributed/test_dir_structures/test_remote_flows.py
@@ -42,6 +42,5 @@ def test_remote_flow_with_directory(directory, filename, mul):
         resp = Client(port=12345, return_responses=True).post(
             on='/',
             inputs=Document(text=directory),
-            return_results=True,
         )
     assert resp[0].data.docs[0].text == directory * mul

--- a/tests/distributed/test_local_flow_use_remote_executor/test_integration.py
+++ b/tests/distributed/test_local_flow_use_remote_executor/test_integration.py
@@ -45,7 +45,7 @@ def test_local_flow_use_external_executor(
 ):
     with local_flow as f:
         responses = Client(port=exposed_port, return_responses=True).index(
-            inputs=documents_to_index, return_results=True, request_size=100
+            inputs=documents_to_index, request_size=100
         )
         assert len(responses) == 2
         for resp in responses:

--- a/tests/distributed/test_remote_flows/test_remote_flow.py
+++ b/tests/distributed/test_remote_flows/test_remote_flow.py
@@ -84,7 +84,6 @@ def test_remote_jinad_flow(jinad_client, flow_envs):
     ).post(
         on='/',
         inputs=[Document(id=str(idx)) for idx in range(NUM_DOCS)],
-        return_results=True,
     )
     assert len(resp[0].data.docs) == NUM_DOCS
     assert jinad_client.flows.delete(flow_id)
@@ -120,7 +119,6 @@ async def test_remote_jinad_flow_async(async_jinad_client, flow_envs):
     ).post(
         on='/',
         inputs=[Document(id=str(idx)) for idx in range(NUM_DOCS)],
-        return_results=True,
     )
     num_items_in_response = 0
     async for item in resp:
@@ -160,7 +158,6 @@ async def test_remote_jinad_flow_get_delete_all(async_jinad_client):
     ).post(
         on='/',
         inputs=[Document(id=str(idx)) for idx in range(NUM_DOCS)],
-        return_results=True,
     )
     num_items_in_response = 0
     async for item in resp:
@@ -198,7 +195,6 @@ async def test_jinad_flow_container_runtime(async_jinad_client, executor_image):
     ).post(
         on='/',
         inputs=[Document(id=str(idx)) for idx in range(NUM_DOCS)],
-        return_results=True,
     )
     num_items_in_response = 0
     async for item in resp:

--- a/tests/distributed/test_remote_flows/test_remote_flow_env.py
+++ b/tests/distributed/test_remote_flows/test_remote_flow_env.py
@@ -50,7 +50,6 @@ def test_remote_flow_local_executors(replicas, jinad_client):
         resp = Client(host=HOST, port=FLOW_PORT, return_responses=True).post(
             on='/',
             inputs=[Document(id=str(idx)) for idx in range(NUM_DOCS)],
-            return_results=True,
         )
         for doc in resp[0].data.docs:
             assert doc.tags['key1'] == 'val1'
@@ -74,7 +73,6 @@ def test_port_expose_env_var(port_expose, func, jinad_client):
     ).post(
         on='/blah',
         inputs=(Document(text=f'text {i}') for i in range(2)),
-        return_results=True,
     )
     for d in r[0].data.docs:
         assert d.text.endswith(func)

--- a/tests/distributed/test_remote_flows/test_remote_flow_scale.py
+++ b/tests/distributed/test_remote_flows/test_remote_flow_scale.py
@@ -68,7 +68,6 @@ def test_scale_remote_flow(docker_image_built, jinad_client, deployment_params):
         host=HOST, port=FLOW_PORT, protocol='http', asyncio=False, return_responses=True
     ).index(
         inputs=DocumentArray([Document() for _ in range(200)]),
-        return_results=True,
         request_size=10,
     )
 
@@ -87,7 +86,6 @@ def test_scale_remote_flow(docker_image_built, jinad_client, deployment_params):
         host=HOST, port=FLOW_PORT, protocol='http', asyncio=False, return_responses=True
     ).index(
         inputs=DocumentArray([Document() for _ in range(200)]),
-        return_results=True,
         request_size=10,
     )
 
@@ -125,7 +123,6 @@ async def test_scale_remote_flow_async(
         host=HOST, port=FLOW_PORT, protocol='http', asyncio=True, return_responses=True
     ).index(
         inputs=DocumentArray([Document() for _ in range(1000)]),
-        return_results=True,
         request_size=10,
     )
 
@@ -144,7 +141,6 @@ async def test_scale_remote_flow_async(
         host=HOST, port=FLOW_PORT, protocol='http', asyncio=True, return_responses=True
     ).index(
         inputs=DocumentArray([Document() for _ in range(1000)]),
-        return_results=True,
         request_size=10,
     )
 

--- a/tests/distributed/test_remote_peas/test_remote_peas.py
+++ b/tests/distributed/test_remote_peas/test_remote_peas.py
@@ -233,9 +233,7 @@ async def test_pseudo_remote_pods_topologies(gateway, head, worker):
         c = Client(
             host='127.0.0.1', port=port_expose, asyncio=True, return_responses=True
         )
-        responses = c.post(
-            '/', inputs=async_inputs, request_size=1, return_results=True
-        )
+        responses = c.post('/', inputs=async_inputs, request_size=1)
         response_list = []
         async for response in responses:
             response_list.append(response)
@@ -298,7 +296,7 @@ async def test_pseudo_remote_pods_shards(gateway, head, worker, polling):
     await asyncio.sleep(1.0)
 
     c = Client(host='localhost', port=port_expose, asyncio=True, return_responses=True)
-    responses = c.post('/', inputs=async_inputs, request_size=1, return_results=True)
+    responses = c.post('/', inputs=async_inputs, request_size=1)
     response_list = []
     async for response in responses:
         response_list.append(response)
@@ -366,7 +364,7 @@ async def test_pseudo_remote_pods_replicas(gateway, head, worker):
     await asyncio.sleep(1.0)
 
     c = Client(host='localhost', port=port_expose, asyncio=True, return_responses=True)
-    responses = c.post('/', inputs=async_inputs, request_size=1, return_results=True)
+    responses = c.post('/', inputs=async_inputs, request_size=1)
     response_list = []
     async for response in responses:
         response_list.append(response)
@@ -486,7 +484,7 @@ async def test_pseudo_remote_pods_executor(
     await asyncio.sleep(1.0)
 
     c = Client(host=HOST, port=port_expose, asyncio=True, return_responses=True)
-    responses = c.post('/', inputs=async_inputs, request_size=1, return_results=True)
+    responses = c.post('/', inputs=async_inputs, request_size=1)
     response_list = []
     async for response in responses:
         response_list.append(response.docs)

--- a/tests/distributed/test_rolling_update_container_runtime/test_rolling_update.py
+++ b/tests/distributed/test_rolling_update_container_runtime/test_rolling_update.py
@@ -69,13 +69,13 @@ def test_dump_dbms_remote(executor_images, docker_compose):
     # check that there are no matches in Query Flow
     r = Client(
         host=HOST, port=REST_PORT_QUERY, protocol='http', return_responses=True
-    ).search(inputs=[doc for doc in docs[:nr_search]], return_results=True)
+    ).search(inputs=[doc for doc in docs[:nr_search]])
     assert r[0].data.docs[0].matches is None or len(r[0].data.docs[0].matches) == 0
 
     # index on DBMS flow
     Client(
         host=HOST, port=REST_PORT_DBMS, protocol='http', return_responses=True
-    ).index(inputs=docs, return_results=True)
+    ).index(inputs=docs)
 
     # dump data for DBMS flow
     Client(host=HOST, port=REST_PORT_DBMS, protocol='http', return_responses=True).post(
@@ -101,7 +101,6 @@ def test_dump_dbms_remote(executor_images, docker_compose):
         host=HOST, port=REST_PORT_QUERY, protocol='http', return_responses=True
     ).search(
         inputs=[doc for doc in docs[:nr_search]],
-        return_results=True,
         parameters={'top_k': 10},
     )
     for doc in r[0].data.docs:

--- a/tests/distributed/test_scale_remote_executors/test_remote_executors.py
+++ b/tests/distributed/test_scale_remote_executors/test_remote_executors.py
@@ -71,13 +71,11 @@ def test_scale_success(remote_flow_with_runtime: Flow, deployment_params):
     with remote_flow_with_runtime as f:
         ret1 = Client(port=exposed_port, return_responses=True).index(
             inputs=DocumentArray([Document() for _ in range(200)]),
-            return_results=True,
             request_size=10,
         )
         f.scale(deployment_name='executor', replicas=scale_to)
         ret2 = Client(port=exposed_port, return_responses=True).index(
             inputs=DocumentArray([Document() for _ in range(200)]),
-            return_results=True,
             request_size=10,
         )
 
@@ -117,7 +115,6 @@ def test_scale_with_concurrent_client(
         rv = Client(protocol=protocol, port=port, return_responses=True).index(
             [Document(text=peer_hash) for _ in range(NUM_DOCS_SENT_BY_CLIENTS)],
             request_size=5,
-            return_results=True,
         )
         for r in rv:
             for doc in r.docs:
@@ -146,9 +143,7 @@ def test_scale_with_concurrent_client(
             t.join()
 
         c = Client(protocol=protocol, port=port_expose, return_responses=True)
-        rv = c.index(
-            [Document() for _ in range(5)], request_size=1, return_results=True
-        )
+        rv = c.index([Document() for _ in range(5)], request_size=1)
 
     all_docs = []
     while not queue.empty():

--- a/tests/distributed/test_topologies/test_topologies.py
+++ b/tests/distributed/test_topologies/test_topologies.py
@@ -208,7 +208,7 @@ def test_remote_workspace_value():
         port=args['port_expose'],
         protocol=args['protocol'],
         return_responses=True,
-    ).post(on='/', inputs=[Document()], show_progress=True, return_results=True)
+    ).post(on='/', inputs=[Document()], show_progress=True)
     assert (
         response[0]
         .data.docs[0]

--- a/tests/distributed/test_workspaces/test_cache_validate.py
+++ b/tests/distributed/test_workspaces/test_cache_validate.py
@@ -22,7 +22,7 @@ def RemoteFlow(workspace_id):
         port=args['port_expose'],
         protocol=args['protocol'],
         return_responses=True,
-    ).post(on='/', inputs=[Document()], show_progress=True, return_results=True)
+    ).post(on='/', inputs=[Document()], show_progress=True)
     assert client.flows.delete(flow_id)
 
 
@@ -71,7 +71,7 @@ def test_cache_validate_remote_executor():
     )
     with f:
         response = Client(port=exposed_port, return_responses=True).post(
-            on='/', inputs=[Document()], show_progress=True, return_results=True
+            on='/', inputs=[Document()], show_progress=True
         )
         assert not response[0].data.docs[0].tags['exists']
 
@@ -85,6 +85,6 @@ def test_cache_validate_remote_executor():
     )
     with f:
         response = Client(port=exposed_port, return_responses=True).post(
-            on='/', inputs=[Document()], show_progress=True, return_results=True
+            on='/', inputs=[Document()], show_progress=True
         )
         assert response[0].data.docs[0].tags['exists']

--- a/tests/distributed/test_workspaces/test_custom_dockerfile.py
+++ b/tests/distributed/test_workspaces/test_custom_dockerfile.py
@@ -23,6 +23,6 @@ def test_custom_dockerfile():
                 Document(text=f'{i}', embedding=np.random.rand(2, 3)) for i in range(5)
             ),
         )
-        resp = c.search(inputs=[Document(text='3')], return_results=True)
+        resp = c.search(inputs=[Document(text='3')])
         assert resp[0].docs[0].matches[0].text == '3'
         assert resp[0].docs[0].matches[0].embedding.shape == (2, 3)

--- a/tests/distributed/test_workspaces/test_remote_workspaces.py
+++ b/tests/distributed/test_workspaces/test_remote_workspaces.py
@@ -50,7 +50,6 @@ def test_upload_via_pymodule(replicas):
             inputs=(
                 Document(tensor=np.random.random([1, 100])) for _ in range(NUM_DOCS)
             ),
-            return_results=True,
         )
     assert len(responses) > 0
     assert len(responses[0].docs) > 0
@@ -76,7 +75,6 @@ def test_upload_via_yaml(replicas):
             inputs=(
                 Document(tensor=np.random.random([1, 100])) for _ in range(NUM_DOCS)
             ),
-            return_results=True,
         )
     assert len(responses) > 0
     assert len(responses[0].docs) > 0
@@ -111,7 +109,6 @@ def test_upload_multiple_workspaces(replicas):
             inputs=(
                 Document(tensor=np.random.random([1, 100])) for _ in range(NUM_DOCS)
             ),
-            return_results=True,
         )
     assert len(responses) > 0
     assert len(responses[0].docs) > 0
@@ -195,7 +192,6 @@ async def test_custom_project():
     ).post(
         on='/search',
         inputs=Document(tags={'key': 'first', 'value': 's'}),
-        return_results=True,
     ):
         tags = resp.data.docs[0].matches[0].tags
         assert tags['first'] == 's'
@@ -235,7 +231,6 @@ def test_upload_simple_non_standard_rootworkspace(docker_compose):
             inputs=(
                 Document(tensor=np.random.random([1, 100])) for _ in range(NUM_DOCS)
             ),
-            return_results=True,
         )
     assert len(responses) > 0
     assert len(responses[0].docs) > 0

--- a/tests/docker_compose/test_docker_compose.py
+++ b/tests/docker_compose/test_docker_compose.py
@@ -40,7 +40,6 @@ async def run_test(flow, endpoint, num_docs=10, request_size=10):
     async for resp in client.post(
         endpoint,
         inputs=[Document() for _ in range(num_docs)],
-        return_results=True,
         request_size=request_size,
     ):
         responses.append(resp)

--- a/tests/integration/container_runtime_args/test_container_get_args.py
+++ b/tests/integration/container_runtime_args/test_container_get_args.py
@@ -37,7 +37,6 @@ def test_containerruntime_args(docker_image_built, shards, replicas):
     with f:
         ret1 = Client(return_responses=True, port=exposed_port).index(
             inputs=DocumentArray([Document() for _ in range(2000)]),
-            return_results=True,
             request_size=10,
         )
 

--- a/tests/integration/crud/test_crud.py
+++ b/tests/integration/crud/test_crud.py
@@ -55,9 +55,7 @@ def test_crud(tmpdir, rest):
             for doc in results['data']:
                 assert Document.from_dict(doc).text == 'hello world'
         else:
-            results = c.post(
-                on='/search', inputs=inputs, parameters=PARAMS, return_results=True
-            )
+            results = c.post(on='/search', inputs=inputs, parameters=PARAMS)
             matches = results[0].docs[0].matches
             for doc in results[0].docs:
                 assert doc.text == 'hello world'
@@ -83,9 +81,7 @@ def test_crud(tmpdir, rest):
             matches = results['data'][0]['matches']
 
         else:
-            results = c.post(
-                on='/search', inputs=inputs, parameters=PARAMS, return_results=True
-            )
+            results = c.post(on='/search', inputs=inputs, parameters=PARAMS)
             matches = results[0].docs[0].matches
 
         assert len(matches) == 5
@@ -110,9 +106,7 @@ def test_crud(tmpdir, rest):
                 results['data'][0]['matches'], key=lambda match: match['id']
             )
         else:
-            results = c.post(
-                on='/search', inputs=inputs, parameters=PARAMS, return_results=True
-            )
+            results = c.post(on='/search', inputs=inputs, parameters=PARAMS)
             matches = sorted(results[0].docs[0].matches, key=lambda match: match.id)
 
         assert len(matches) == 5

--- a/tests/integration/deployments/test_deployment.py
+++ b/tests/integration/deployments/test_deployment.py
@@ -34,9 +34,7 @@ async def test_deployments_trivial_topology(port_generator):
         c = Client(
             host='localhost', port=port_expose, asyncio=True, return_responses=True
         )
-        responses = c.post(
-            '/', inputs=async_inputs, request_size=1, return_results=True
-        )
+        responses = c.post('/', inputs=async_inputs, request_size=1)
 
         response_list = []
         async for response in responses:
@@ -105,7 +103,7 @@ async def test_deployments_flow_topology(
 
     # send requests to the gateway
     c = Client(host='localhost', port=port_expose, asyncio=True, return_responses=True)
-    responses = c.post('/', inputs=async_inputs, request_size=1, return_results=True)
+    responses = c.post('/', inputs=async_inputs, request_size=1)
     response_list = []
     async for response in responses:
         response_list.append(response)
@@ -148,7 +146,7 @@ async def test_deployments_shards(polling, port_generator):
     await asyncio.sleep(1.0)
 
     c = Client(host='localhost', port=port_expose, asyncio=True, return_responses=True)
-    responses = c.post('/', inputs=async_inputs, request_size=1, return_results=True)
+    responses = c.post('/', inputs=async_inputs, request_size=1)
     response_list = []
     async for response in responses:
         response_list.append(response)
@@ -183,7 +181,7 @@ async def test_deployments_replicas(port_generator):
     await asyncio.sleep(1.0)
 
     c = Client(host='localhost', port=port_expose, asyncio=True, return_responses=True)
-    responses = c.post('/', inputs=async_inputs, request_size=1, return_results=True)
+    responses = c.post('/', inputs=async_inputs, request_size=1)
     response_list = []
     async for response in responses:
         response_list.append(response)
@@ -223,7 +221,7 @@ async def test_deployments_with_executor(port_generator):
     await asyncio.sleep(1.0)
 
     c = Client(host='localhost', port=port_expose, asyncio=True, return_responses=True)
-    responses = c.post('/', inputs=async_inputs, request_size=1, return_results=True)
+    responses = c.post('/', inputs=async_inputs, request_size=1)
     response_list = []
     async for response in responses:
         response_list.append(response.docs)
@@ -263,7 +261,7 @@ async def test_deployments_with_replicas_advance_faster(port_generator):
 
     c = Client(host='localhost', port=port_expose, asyncio=True, return_responses=True)
     input_docs = [Document(text='slow'), Document(text='fast')]
-    responses = c.post('/', inputs=input_docs, request_size=1, return_results=True)
+    responses = c.post('/', inputs=input_docs, request_size=1)
     response_list = []
     async for response in responses:
         response_list.append(response)

--- a/tests/integration/external_deployment/test_external_deployment.py
+++ b/tests/integration/external_deployment/test_external_deployment.py
@@ -80,7 +80,7 @@ def test_flow_with_external_deployment(
             external=True,
         )
         with flow:
-            resp = flow.index(inputs=input_docs, return_results=True)
+            resp = flow.index(inputs=input_docs)
 
         # expect 50 reduced Documents in total after sharding
         validate_response(resp, 50)
@@ -113,13 +113,13 @@ def test_two_flow_with_shared_external_deployment(
             )
         )
         with flow1, flow2:
-            results = flow1.index(inputs=input_docs, return_results=True)
+            results = flow1.index(inputs=input_docs)
 
             # Reducing applied after shards, expect only 50 docs
             validate_response(results, 50)
 
             # Reducing applied after sharding, but not for the needs, expect 100 docs
-            results = flow2.index(inputs=input_docs, return_results=True)
+            results = flow2.index(inputs=input_docs)
             validate_response(results, 100)
 
 
@@ -210,7 +210,7 @@ def test_flow_with_external_deployment_shards(
         )
 
         with flow:
-            resp = flow.index(inputs=input_docs, return_results=True)
+            resp = flow.index(inputs=input_docs)
 
         # Reducing applied on shards and needs, expect 50 docs
         validate_response(resp, 50)
@@ -272,7 +272,7 @@ def test_flow_with_external_deployment_pre_shards(
             .join(needs=['executor1', 'executor2'])
         )
         with flow:
-            resp = flow.index(inputs=input_docs, return_results=True)
+            resp = flow.index(inputs=input_docs)
 
         # Reducing applied on shards and needs, expect 50 docs
         validate_response(resp, 50)
@@ -339,7 +339,7 @@ def test_flow_with_external_deployment_join(
             )
         )
         with flow:
-            resp = flow.index(inputs=input_docs, return_results=True)
+            resp = flow.index(inputs=input_docs)
 
         # Reducing applied for shards, not for uses, expect 100 docs
         validate_response(resp, 100)

--- a/tests/integration/gateway_clients/test_clients_gateways.py
+++ b/tests/integration/gateway_clients/test_clients_gateways.py
@@ -174,9 +174,7 @@ def client_send(client_id: int, port_in: int, protocol: str):
 
     # send requests
     return c.post(
-        on='/',
-        inputs=DocumentArray([Document(text=f'client{client_id}-Request')]),
-        return_results=True,
+        on='/', inputs=DocumentArray([Document(text=f'client{client_id}-Request')])
     )
 
 

--- a/tests/integration/gateway_clients/test_streaming.py
+++ b/tests/integration/gateway_clients/test_streaming.py
@@ -371,7 +371,7 @@ def test_multiple_clients(prefetch, protocol, monkeypatch, simple_graph_dict_ind
 
     order_of_ids = list(
         Client(protocol=protocol, port=port_in, return_responses=True)
-        .post(on='/status', inputs=[Document()], return_results=True)[0]
+        .post(on='/status', inputs=[Document()])[0]
         .docs[0]
         .tags['ids']
     )

--- a/tests/integration/high_order_matches/test_document.py
+++ b/tests/integration/high_order_matches/test_document.py
@@ -36,7 +36,6 @@ def test_single_executor():
         results = Client(port=exposed_port, return_responses=True).post(
             on='index',
             inputs=Document(),
-            return_results=True,
         )
     validate_results(results)
 
@@ -53,6 +52,5 @@ def test_multi_executor():
         results = Client(port=exposed_port, return_responses=True).post(
             on='index',
             inputs=Document(),
-            return_results=True,
         )
     validate_results(results)

--- a/tests/integration/inspect_deployments_flow/test_inspect_deployments_flow.py
+++ b/tests/integration/inspect_deployments_flow/test_inspect_deployments_flow.py
@@ -58,7 +58,7 @@ def test_flow1(inspect, protocol, temp_folder):
     )
 
     with f:
-        res = f.post(on='/index', inputs=docs, return_results=True)
+        res = f.post(on='/index', inputs=docs)
 
     assert len(res) > 0
 
@@ -76,7 +76,7 @@ def test_flow2(inspect, protocol, temp_folder):
     )
 
     with f:
-        res = f.index(docs, return_results=True)
+        res = f.index(docs)
 
     assert len(res) > 0
     validate([1], expect=f.args.inspect.is_keep)
@@ -97,7 +97,7 @@ def test_flow3(inspect, protocol, temp_folder):
     )
 
     with f:
-        res = f.index(docs, return_results=True)
+        res = f.index(docs)
 
     assert len(res) > 0
     validate([1, 2], expect=f.args.inspect.is_keep)
@@ -120,7 +120,7 @@ def test_flow4(inspect, protocol, temp_folder):
     )
 
     with f:
-        res = f.index(docs, return_results=True)
+        res = f.index(docs)
 
     assert len(res) > 0
     validate([1, 2, 3], expect=f.args.inspect.is_keep)
@@ -162,7 +162,7 @@ def test_flow_returned_collect(protocol):
     with f:
         response = Client(
             port=exposed_port, protocol=protocol, return_responses=True
-        ).index(inputs=docs, return_results=True)
+        ).index(inputs=docs)
     validate_func(response[0])
 
 
@@ -184,7 +184,7 @@ def test_flow_not_returned(inspect, protocol):
 
     with f:
         res = Client(protocol=protocol, port=exposed_port, return_responses=True).index(
-            inputs=docs, return_results=True
+            inputs=docs
         )
 
     validate_func(res[0])

--- a/tests/integration/issues/hanging_termination/test_hanging_termination.py
+++ b/tests/integration/issues/hanging_termination/test_hanging_termination.py
@@ -131,8 +131,6 @@ def test_dump_reload(tmpdir, shards, nr_docs, emb_size, times_to_index=2):
                     )
 
                 for i in range(5):
-                    result = client_query.post(
-                        on='/search', inputs=[Document()], return_results=True
-                    )
+                    result = client_query.post(on='/search', inputs=[Document()])
 
                     assert len(docs) == len(result[0].docs)

--- a/tests/integration/override_config_params/container/test_override_config_params.py
+++ b/tests/integration/override_config_params/container/test_override_config_params.py
@@ -41,7 +41,7 @@ def flow(request):
 def test_override_config_params(docker_image, flow):
     with flow:
         resps = Client(port=exposed_port, return_responses=True).search(
-            inputs=[Document()], return_results=True
+            inputs=[Document()]
         )
     doc = resps[0].docs[0]
     assert doc.tags['param1'] == 50
@@ -52,7 +52,7 @@ def test_override_config_params(docker_image, flow):
 
 
 def test_override_config_params_shards(docker_image):
-    flow = Flow(port_expose=exposed_port, return_results=True).add(
+    flow = Flow(port_expose=exposed_port).add(
         uses='docker://override-config-test',
         uses_with={'param1': 50, 'param2': 30},
         uses_metas={'workspace': 'different_workspace'},
@@ -60,7 +60,7 @@ def test_override_config_params_shards(docker_image):
     )
     with flow:
         resps = Client(port=exposed_port, return_responses=True).search(
-            inputs=[Document()], return_results=True
+            inputs=[Document()]
         )
     doc = resps[0].docs[0]
     assert doc.tags['param1'] == 50

--- a/tests/integration/override_config_params/worker/test_override_config_params.py
+++ b/tests/integration/override_config_params/worker/test_override_config_params.py
@@ -15,7 +15,7 @@ def flow(request):
     if flow_src == 'flow-yml':
         return Flow().load_config(os.path.join(cur_dir, 'flow.yml'))
     elif flow_src == 'uses-yml':
-        return Flow(return_results=True, port_expose=exposed_port).add(
+        return Flow(port_expose=exposed_port).add(
             uses=os.path.join(cur_dir, 'default_config.yml'),
             uses_with={'param1': 50, 'param2': 30},
             uses_metas={'workspace': 'different_workspace'},
@@ -23,7 +23,7 @@ def flow(request):
     elif flow_src == 'class':
         from .executor import Override
 
-        return Flow(return_results=True, port_expose=exposed_port).add(
+        return Flow(port_expose=exposed_port).add(
             uses=Override,
             uses_with={'param1': 50, 'param2': 30, 'param3': 10},
             uses_metas={'workspace': 'different_workspace', 'name': 'name'},
@@ -34,7 +34,7 @@ def flow(request):
 def test_override_config_params(flow):
     with flow:
         resps = Client(port=exposed_port, return_responses=True).search(
-            inputs=[Document()], return_results=True
+            inputs=[Document()]
         )
     doc = resps[0].docs[0]
     assert doc.tags['param1'] == 50
@@ -45,7 +45,7 @@ def test_override_config_params(flow):
 
 
 def test_override_config_params_shards():
-    flow = Flow(return_results=True, port_expose=exposed_port).add(
+    flow = Flow(port_expose=exposed_port).add(
         uses=os.path.join(cur_dir, 'default_config.yml'),
         uses_with={'param1': 50, 'param2': 30},
         uses_metas={'workspace': 'different_workspace'},
@@ -53,7 +53,7 @@ def test_override_config_params_shards():
     )
     with flow:
         resps = Client(port=exposed_port, return_responses=True).search(
-            inputs=[Document()], return_results=True
+            inputs=[Document()]
         )
     doc = resps[0].docs[0]
     assert doc.tags['param1'] == 50
@@ -83,7 +83,7 @@ def test_override_requests():
     f = Flow(port_expose=exposed_port).add(uses=MyExec)
     with f:
         req = Client(port=exposed_port, return_responses=True).post(
-            '/index', Document(), return_results=True
+            '/index', Document()
         )
         assert req[0].docs[0].text == 'foo'
 
@@ -91,13 +91,11 @@ def test_override_requests():
     f = Flow(port_expose=exposed_port).add(uses=MyExec, uses_requests={'/index': 'bar'})
     with f:
         req = Client(port=exposed_port, return_responses=True).post(
-            '/index', Document(), return_results=True
+            '/index', Document()
         )
         assert req[0].docs[0].text == 'bar'
 
-        req = Client(port=exposed_port, return_responses=True).post(
-            '/1', Document(), return_results=True
-        )
+        req = Client(port=exposed_port, return_responses=True).post('/1', Document())
         assert req[0].docs[0].text == 'foobar'
 
     # change bind to foobar()
@@ -106,12 +104,12 @@ def test_override_requests():
     )
     with f:
         req = Client(port=exposed_port, return_responses=True).post(
-            '/index', Document(), return_results=True
+            '/index', Document()
         )
         assert req[0].docs[0].text == 'foobar'
 
         req = Client(port=exposed_port, return_responses=True).post(
-            '/index-blah', Document(), return_results=True
+            '/index-blah', Document()
         )
         assert req[0].docs[0].text == 'foo'
 
@@ -121,6 +119,6 @@ def test_override_requests():
     )
     with f:
         req = Client(port=exposed_port, return_responses=True).post(
-            '/index', Document(), return_results=True
+            '/index', Document()
         )
         assert req[0].docs[0].text == 'bar'

--- a/tests/integration/override_executor_specific_params/test_specific_params.py
+++ b/tests/integration/override_executor_specific_params/test_specific_params.py
@@ -49,7 +49,6 @@ def test_override_params(mocker):
             inputs=DocumentArray([Document()]),
             parameters={'param1': 50, 'param2': 60, 'exec_name': {'param1': 'changed'}},
             on_error=error_mock,
-            return_results=True,
         )
     error_mock.assert_not_called()
 

--- a/tests/integration/pods/container/test_pod.py
+++ b/tests/integration/pods/container/test_pod.py
@@ -94,9 +94,7 @@ async def test_pods_trivial_topology(
         c = Client(
             return_responses=True, host='localhost', port=port_expose, asyncio=True
         )
-        responses = c.post(
-            '/', inputs=async_inputs, request_size=1, return_results=True
-        )
+        responses = c.post('/', inputs=async_inputs, request_size=1)
         response_list = []
         async for response in responses:
             response_list.append(response)

--- a/tests/integration/pods/test_pod.py
+++ b/tests/integration/pods/test_pod.py
@@ -45,9 +45,7 @@ async def test_pods_trivial_topology(port_generator):
         c = Client(
             return_responses=True, host='localhost', port=port_expose, asyncio=True
         )
-        responses = c.post(
-            '/', inputs=async_inputs, request_size=1, return_results=True
-        )
+        responses = c.post('/', inputs=async_inputs, request_size=1)
 
         response_list = []
         async for response in responses:
@@ -143,7 +141,7 @@ async def test_pods_flow_topology(
 
     # send requests to the gateway
     c = Client(return_responses=True, host='localhost', port=port_expose, asyncio=True)
-    responses = c.post('/', inputs=async_inputs, request_size=1, return_results=True)
+    responses = c.post('/', inputs=async_inputs, request_size=1)
     response_list = []
     async for response in responses:
         response_list.append(response)
@@ -200,7 +198,7 @@ async def test_pods_shards(polling, port_generator):
 
     gateway_pod.wait_start_success()
     c = Client(return_responses=True, host='localhost', port=port_expose, asyncio=True)
-    responses = c.post('/', inputs=async_inputs, request_size=1, return_results=True)
+    responses = c.post('/', inputs=async_inputs, request_size=1)
     response_list = []
     async for response in responses:
         response_list.append(response)
@@ -255,7 +253,7 @@ async def test_pods_replicas(port_generator):
 
     gateway_pod.wait_start_success()
     c = Client(return_responses=True, host='localhost', port=port_expose, asyncio=True)
-    responses = c.post('/', inputs=async_inputs, request_size=1, return_results=True)
+    responses = c.post('/', inputs=async_inputs, request_size=1)
     response_list = []
     async for response in responses:
         response_list.append(response)
@@ -323,7 +321,7 @@ async def test_pods_with_executor(port_generator):
     await asyncio.sleep(1.0)
 
     c = Client(return_responses=True, host='localhost', port=port_expose, asyncio=True)
-    responses = c.post('/', inputs=async_inputs, request_size=1, return_results=True)
+    responses = c.post('/', inputs=async_inputs, request_size=1)
     response_list = []
     async for response in responses:
         response_list.append(response.docs)
@@ -367,7 +365,7 @@ async def test_pods_gateway_worker_direct_connection(port_generator):
     worker_pod.wait_start_success()
     gateway_pod.wait_start_success()
     c = Client(return_responses=True, host='localhost', port=port_expose, asyncio=True)
-    responses = c.post('/', inputs=async_inputs, request_size=1, return_results=True)
+    responses = c.post('/', inputs=async_inputs, request_size=1)
     response_list = []
     async for response in responses:
         response_list.append(response)
@@ -418,7 +416,7 @@ async def test_pods_with_replicas_advance_faster(port_generator):
 
     c = Client(return_responses=True, host='localhost', port=port_expose, asyncio=True)
     input_docs = [Document(text='slow'), Document(text='fast')]
-    responses = c.post('/', inputs=input_docs, request_size=1, return_results=True)
+    responses = c.post('/', inputs=input_docs, request_size=1)
     response_list = []
     async for response in responses:
         response_list.append(response)

--- a/tests/integration/reduce/test_reduce.py
+++ b/tests/integration/reduce/test_reduce.py
@@ -58,7 +58,7 @@ def test_reduce_shards(n_docs):
     with search_flow as f:
         da = DocumentArray([Document() for _ in range(5)])
         resp = Client(port=exposed_port, return_responses=True).post(
-            '/search', inputs=da, return_results=True
+            '/search', inputs=da
         )
 
     assert len(resp[0].docs) == 5
@@ -97,7 +97,7 @@ def test_uses_after_no_reduce(n_shards, n_docs):
     with search_flow as f:
         da = DocumentArray([Document() for _ in range(5)])
         resp = Client(port=exposed_port, return_responses=True).post(
-            '/search', inputs=da, return_results=True
+            '/search', inputs=da
         )
 
     # assert no reduce happened
@@ -151,9 +151,7 @@ def test_reduce_needs():
 
     with flow as f:
         da = DocumentArray([Document() for _ in range(5)])
-        resp = Client(port=exposed_port, return_responses=True).post(
-            '/', inputs=da, return_results=True
-        )
+        resp = Client(port=exposed_port, return_responses=True).post('/', inputs=da)
 
     assert len(resp[0].docs) == 5
     for doc in resp[0].docs:
@@ -174,9 +172,7 @@ def test_uses_before_reduce():
 
     with flow as f:
         da = DocumentArray([Document() for _ in range(5)])
-        resp = Client(port=exposed_port, return_responses=True).post(
-            '/', inputs=da, return_results=True
-        )
+        resp = Client(port=exposed_port, return_responses=True).post('/', inputs=da)
 
     # assert reduce happened because there is only BaseExecutor as uses_before
     assert len(resp[0].docs) == 5
@@ -193,9 +189,7 @@ def test_uses_before_no_reduce_real_executor():
 
     with flow as f:
         da = DocumentArray([Document() for _ in range(5)])
-        resp = Client(port=exposed_port, return_responses=True).post(
-            '/', inputs=da, return_results=True
-        )
+        resp = Client(port=exposed_port, return_responses=True).post('/', inputs=da)
 
     # assert no reduce happened
     assert len(resp[0].docs) == 1
@@ -213,9 +207,7 @@ def test_uses_before_no_reduce_real_executor_uses():
 
     with flow as f:
         da = DocumentArray([Document() for _ in range(5)])
-        resp = Client(port=exposed_port, return_responses=True).post(
-            '/', inputs=da, return_results=True
-        )
+        resp = Client(port=exposed_port, return_responses=True).post('/', inputs=da)
 
     # assert no reduce happened
     assert len(resp[0].docs) == 1
@@ -231,7 +223,7 @@ def test_reduce_status():
     with flow as f:
         da = DocumentArray([Document() for _ in range(5)])
         resp = Client(port=exposed_port, return_responses=True).post(
-            '/status', parameters={'foo': 'bar'}, inputs=da, return_results=True
+            '/status', parameters={'foo': 'bar'}, inputs=da
         )
 
     assert resp[0].parameters['foo'] == 'bar'

--- a/tests/integration/rolling_update/test_rolling_update.py
+++ b/tests/integration/rolling_update/test_rolling_update.py
@@ -248,9 +248,7 @@ def test_override_uses_with(docs):
     )
     with flow:
         # test rolling update does not hang
-        ret1 = Client(port=exposed_port, return_responses=True).search(
-            docs, return_results=True
-        )
+        ret1 = Client(port=exposed_port, return_responses=True).search(docs)
         flow.rolling_update(
             'executor1',
             uses_with={
@@ -259,9 +257,7 @@ def test_override_uses_with(docs):
                 'argument2': 'version2',
             },
         )
-        ret2 = Client(port=exposed_port, return_responses=True).search(
-            docs, return_results=True
-        )
+        ret2 = Client(port=exposed_port, return_responses=True).search(docs)
 
     assert len(ret1) > 0
     assert len(ret1[0].docs) > 0
@@ -291,12 +287,12 @@ def test_scale_after_rolling_update(docs, replicas, scale_to):
     )
     with flow:
         ret1 = Client(port=exposed_port, return_responses=True).search(
-            docs, return_results=True, request_size=1
+            docs, request_size=1
         )
         flow.rolling_update('executor1', None)
         flow.scale('executor1', replicas=scale_to)
         ret2 = Client(port=exposed_port, return_responses=True).search(
-            docs, return_results=True, request_size=1
+            docs, request_size=1
         )
 
     replicas_before = set()
@@ -325,7 +321,6 @@ def send_requests(
         responses = client.search(
             [Document(id=f'{idx}', text=f'doc{idx}') for idx in range(doc_count)],
             request_size=10,
-            return_results=True,
         )
         for r in responses:
             result_queue.put(r.docs.texts)

--- a/tests/integration/runtimes/test_runtimes.py
+++ b/tests/integration/runtimes/test_runtimes.py
@@ -72,7 +72,7 @@ async def test_runtimes_trivial_topology(port_generator):
 
     # send requests to the gateway
     c = Client(host='localhost', port=port_expose, asyncio=True, return_responses=True)
-    responses = c.post('/', inputs=async_inputs, request_size=1, return_results=True)
+    responses = c.post('/', inputs=async_inputs, request_size=1)
     response_list = []
     async for response in responses:
         response_list.append(response)
@@ -194,7 +194,7 @@ async def test_runtimes_flow_topology(
 
     # send requests to the gateway
     c = Client(host='localhost', port=port_expose, asyncio=True, return_responses=True)
-    responses = c.post('/', inputs=async_inputs, request_size=1, return_results=True)
+    responses = c.post('/', inputs=async_inputs, request_size=1)
     response_list = []
     async for response in responses:
         response_list.append(response)
@@ -265,7 +265,7 @@ async def test_runtimes_shards(polling, port_generator):
     )
 
     c = Client(host='localhost', port=port_expose, asyncio=True, return_responses=True)
-    responses = c.post('/', inputs=async_inputs, request_size=1, return_results=True)
+    responses = c.post('/', inputs=async_inputs, request_size=1)
     response_list = []
     async for response in responses:
         response_list.append(response)
@@ -338,7 +338,7 @@ async def test_runtimes_replicas(port_generator):
     )
 
     c = Client(host='localhost', port=port_expose, asyncio=True, return_responses=True)
-    responses = c.post('/', inputs=async_inputs, request_size=1, return_results=True)
+    responses = c.post('/', inputs=async_inputs, request_size=1)
     response_list = []
     async for response in responses:
         response_list.append(response)
@@ -426,7 +426,7 @@ async def test_runtimes_with_executor(port_generator):
     )
 
     c = Client(host='localhost', port=port_expose, asyncio=True, return_responses=True)
-    responses = c.post('/', inputs=async_inputs, request_size=1, return_results=True)
+    responses = c.post('/', inputs=async_inputs, request_size=1)
     response_list = []
     async for response in responses:
         response_list.append(response.docs)
@@ -484,7 +484,7 @@ async def test_runtimes_gateway_worker_direct_connection(port_generator):
     )
 
     c = Client(host='localhost', port=port_expose, asyncio=True, return_responses=True)
-    responses = c.post('/', inputs=async_inputs, request_size=1, return_results=True)
+    responses = c.post('/', inputs=async_inputs, request_size=1)
     response_list = []
     async for response in responses:
         response_list.append(response)
@@ -550,7 +550,7 @@ async def test_runtimes_with_replicas_advance_faster(port_generator):
 
     c = Client(host='localhost', port=port_expose, asyncio=True, return_responses=True)
     input_docs = [Document(text='slow'), Document(text='fast')]
-    responses = c.post('/', inputs=input_docs, request_size=1, return_results=True)
+    responses = c.post('/', inputs=input_docs, request_size=1)
     response_list = []
     async for response in responses:
         response_list.append(response)

--- a/tests/integration/scale/test_scale.py
+++ b/tests/integration/scale/test_scale.py
@@ -91,13 +91,11 @@ def test_scale_success(flow_with_runtime, deployment_params):
     with flow_with_runtime as f:
         ret1 = Client(port=exposed_port, return_responses=True).index(
             inputs=DocumentArray([Document() for _ in range(200)]),
-            return_results=True,
             request_size=10,
         )
         f.scale(deployment_name='executor', replicas=scale_to)
         ret2 = Client(port=exposed_port, return_responses=True).index(
             inputs=DocumentArray([Document() for _ in range(200)]),
-            return_results=True,
             request_size=10,
         )
 
@@ -141,7 +139,6 @@ def test_scale_with_concurrent_client(flow_with_runtime, deployment_params, prot
         rv = Client(protocol=protocol, port=port, return_responses=True).index(
             [Document(text=peer_hash) for _ in range(NUM_DOCS_SENT_BY_CLIENTS)],
             request_size=5,
-            return_results=True,
         )
         for r in rv:
             for doc in r.docs:
@@ -169,9 +166,7 @@ def test_scale_with_concurrent_client(flow_with_runtime, deployment_params, prot
             t.join()
 
         c = Client(protocol=protocol, port=port_expose, return_responses=True)
-        rv = c.index(
-            [Document() for _ in range(5)], request_size=1, return_results=True
-        )
+        rv = c.index([Document() for _ in range(5)], request_size=1)
 
     all_docs = []
     while not queue.empty():

--- a/tests/integration/streaming/test_clients_streaming.py
+++ b/tests/integration/streaming/test_clients_streaming.py
@@ -251,7 +251,7 @@ def test_multiple_clients(prefetch, protocol):
 
         order_of_ids = list(
             Client(protocol=protocol, port=f.port_expose, return_responses=True)
-            .post(on='/status', inputs=[Document()], return_results=True)[0]
+            .post(on='/status', inputs=[Document()])[0]
             .docs[0]
             .tags['ids']
         )

--- a/tests/integration/v2_api/test_docs_matrix_tail_pea.py
+++ b/tests/integration/v2_api/test_docs_matrix_tail_pea.py
@@ -63,7 +63,6 @@ def test_sharding_tail_pod(num_replicas, num_shards):
         results = Client(port=1234, return_responses=True).post(
             on='/search',
             inputs=Document(matches=[Document()]),
-            return_results=True,
         )
         assert len(results[0].docs[0].matches) == num_shards
 
@@ -92,7 +91,6 @@ def test_merging_head_pod():
         results = Client(port=1234, return_responses=True).post(
             on='/search',
             inputs=multimodal_generator(),
-            return_results=True,
         )
         assert len(results[0].docs[0].chunks) == 2
         assert len(results[0].docs) == 5

--- a/tests/integration/v2_api/test_func_routing.py
+++ b/tests/integration/v2_api/test_func_routing.py
@@ -19,7 +19,6 @@ def test_func_simple_routing():
             on='/search',
             inputs=[(Document(), Document()) for _ in range(3)],
             parameters={'hello': 'world', 'topk': 10},
-            return_results=True,
         )
         assert results[0].header.status.code == 0
         assert results[0].data.docs[0].tags['hello'] == 'world'
@@ -29,7 +28,6 @@ def test_func_simple_routing():
             on='/random',
             inputs=[Document() for _ in range(3)],
             parameters={'hello': 'world', 'topk': 10},
-            return_results=True,
         )
         assert results[0].header.status.code == 0
 
@@ -46,7 +44,6 @@ def test_func_failure():
         results = Client(return_responses=True, port=1234).post(
             on='/search',
             inputs=[(Document(), Document()) for _ in range(3)],
-            return_results=True,
         )
         assert results[0].header.status.code == 3
 
@@ -210,7 +207,6 @@ def test_target_executor_with_one_pathways():
         results = Client(return_responses=True, port=1234).post(
             on='/search',
             inputs=Document(),
-            return_results=True,
             target_executor='my_target',
         )
         assert len(results[0].data.docs) == 1
@@ -226,7 +222,6 @@ def test_target_executor_with_two_pathways():
         results = Client(return_responses=True, port=1234).post(
             on='/search',
             inputs=Document(),
-            return_results=True,
             target_executor='my_target',
         )
         assert len(results[0].data.docs) == 1
@@ -243,7 +238,6 @@ def test_target_executor_with_two_pathways_one_skip():
         results = Client(return_responses=True, port=1234).post(
             on='/search',
             inputs=Document(),
-            return_results=True,
             target_executor='my_target',
         )
         assert len(results[0].data.docs) == 1
@@ -255,7 +249,6 @@ def test_target_executor_with_shards():
         results = Client(return_responses=True, port=1234).post(
             on='/search',
             inputs=Document(),
-            return_results=True,
             target_executor='my_target',
         )
         assert len(results[0].data.docs) == 1

--- a/tests/integration/v2_api/test_override_requests.py
+++ b/tests/integration/v2_api/test_override_requests.py
@@ -14,13 +14,10 @@ def test_override_requests():
         uses=FooExecutor, uses_requests={'/non_foo': 'foo'}
     ) as f:
         c = Client(port=exposed_port, return_responses=True)
-        resp1 = c.post(
-            on='/foo', inputs=DocumentArray([Document(text='')]), return_results=True
-        )
+        resp1 = c.post(on='/foo', inputs=DocumentArray([Document(text='')]))
         resp2 = c.post(
             on='/non_foo',
             inputs=DocumentArray([Document(text='')]),
-            return_results=True,
         )
 
     assert resp1[0].docs[0].text == ''
@@ -47,17 +44,12 @@ def test_override_requests_uses_after():
         uses_before=OtherExecutor,
     ) as f:
         c = Client(port=exposed_port, return_responses=True)
-        resp1 = c.post(
-            on='/foo', inputs=DocumentArray([Document(text='')]), return_results=True
-        )
+        resp1 = c.post(on='/foo', inputs=DocumentArray([Document(text='')]))
         resp2 = c.post(
             on='/non_foo',
             inputs=DocumentArray([Document(text='')]),
-            return_results=True,
         )
-        resp3 = c.post(
-            on='/bar', inputs=DocumentArray([Document(text='')]), return_results=True
-        )
+        resp3 = c.post(on='/bar', inputs=DocumentArray([Document(text='')]))
 
     assert resp1[0].docs[0].text == 'foo called'
     assert resp2[0].docs[0].text == ''

--- a/tests/integration/v2_api/test_yaml_dump_load.py
+++ b/tests/integration/v2_api/test_yaml_dump_load.py
@@ -69,6 +69,6 @@ def test_load_yaml_route(req_endpoint, doc_text):
     c = Client(port=exposed_port, return_responses=True)
 
     with f:
-        results = c.post(req_endpoint, Document(), return_results=True)
+        results = c.post(req_endpoint, Document())
 
     assert results[0].docs[0].text == doc_text

--- a/tests/k8s/test_k8s.py
+++ b/tests/k8s/test_k8s.py
@@ -132,7 +132,6 @@ async def run_test(flow, core_client, namespace, endpoint, n_docs=10, request_si
         async for resp in client.post(
             endpoint,
             inputs=[Document() for _ in range(n_docs)],
-            return_results=True,
             request_size=request_size,
         ):
             responses.append(resp)

--- a/tests/unit/orchestrate/flow/flow-async/test_asyncflow.py
+++ b/tests/unit/orchestrate/flow/flow-async/test_asyncflow.py
@@ -135,29 +135,21 @@ async def test_run_async_flow_other_task_concurrent(protocol):
 
 @pytest.mark.slow
 @pytest.mark.asyncio
-@pytest.mark.parametrize('return_results', [False])
 @pytest.mark.parametrize('protocol', ['websocket', 'grpc', 'http'])
 @pytest.mark.parametrize('flow_cls', [Flow, AsyncFlow])
-async def test_return_results_async_flow(return_results, protocol, flow_cls):
-    with flow_cls(
-        protocol=protocol, asyncio=True, return_results=return_results
-    ).add() as f:
+async def test_return_results_async_flow(protocol, flow_cls):
+    with flow_cls(protocol=protocol, asyncio=True).add() as f:
         async for r in f.index(from_ndarray(np.random.random([10, 2]))):
             assert isinstance(r.response, Response)
 
 
 @pytest.mark.slow
 @pytest.mark.asyncio
-@pytest.mark.parametrize('return_results', [False, True])
 @pytest.mark.parametrize('protocol', ['websocket', 'grpc', 'http'])
 @pytest.mark.parametrize('flow_api', ['delete', 'index', 'update', 'search'])
 @pytest.mark.parametrize('flow_cls', [Flow, AsyncFlow])
-async def test_return_results_async_flow_crud(
-    return_results, protocol, flow_api, flow_cls
-):
-    with flow_cls(
-        protocol=protocol, asyncio=True, return_results=return_results
-    ).add() as f:
+async def test_return_results_async_flow_crud(protocol, flow_api, flow_cls):
+    with flow_cls(protocol=protocol, asyncio=True).add() as f:
         async for r in getattr(f, flow_api)(documents(0, 10)):
             assert isinstance(r.response, Response)
 

--- a/tests/unit/orchestrate/flow/flow-construct/test_flow.py
+++ b/tests/unit/orchestrate/flow/flow-construct/test_flow.py
@@ -235,9 +235,7 @@ def test_flow_with_publish_driver(protocol):
     )
 
     with f:
-        da = f.index(
-            [Document(text='text_1'), Document(text='text_2')], return_results=True
-        )
+        da = f.index([Document(text='text_1'), Document(text='text_2')])
         _validate_flow(f)
 
     validate(da)
@@ -331,17 +329,15 @@ def test_flow_with_pod_envs():
 
 
 @pytest.mark.slow
-@pytest.mark.parametrize('return_results', [False, True])
 @pytest.mark.parametrize('protocol', ['websocket', 'grpc', 'http'])
 @pytest.mark.parametrize('on_done', [None, lambda x: x])
-def test_return_results_sync_flow(return_results, protocol, on_done):
+def test_return_results_sync_flow(protocol, on_done):
     with Flow(protocol=protocol).add() as f:
         da = f.index(
             from_ndarray(np.random.random([10, 2])),
-            return_results=return_results,
             on_done=on_done,
         )
-        if return_results or on_done is None:
+        if on_done is None:
             assert isinstance(da, DocumentArray)
             assert len(da) == 10
             for doc in da:
@@ -561,12 +557,12 @@ def test_flow_routes_list():
         )
 
     with Flow().add(name='executor1') as simple_flow:
-        simple_flow.index(inputs=Document(), return_results=True, on_done=my_cb_one)
+        simple_flow.index(inputs=Document(), on_done=my_cb_one)
 
     with Flow().add(name='a1').add(name='a2').add(name='b1', needs='gateway').add(
         name='merge', needs=['a2', 'b1']
     ) as shards_flow:
-        shards_flow.index(inputs=Document(), return_results=True, on_done=my_cb_two)
+        shards_flow.index(inputs=Document(), on_done=my_cb_two)
 
 
 def _extract_route_entries(gateway_entry, routes):
@@ -589,14 +585,14 @@ def test_flow_load_executor_yaml_extra_search_paths():
         uses='config.yml'
     )
     with f:
-        da = f.post('/', inputs=Document(), return_results=True)
+        da = f.post('/', inputs=Document())
     assert da[0].text == 'done'
 
 
 def test_flow_load_yaml_extra_search_paths():
     f = Flow.load_config(os.path.join(cur_dir, 'flow/flow.yml'))
     with f:
-        da = f.post('/', inputs=Document(), return_results=True)
+        da = f.post('/', inputs=Document())
     assert da[0].text == 'done'
 
 

--- a/tests/unit/orchestrate/flow/flow-construct/test_flow_except.py
+++ b/tests/unit/orchestrate/flow/flow-construct/test_flow_except.py
@@ -152,7 +152,6 @@ def test_no_error_callback(mocker, protocol):
         results = f.index(
             [Document(text='abbcs'), Document(text='efgh')],
             on_error=on_error_mock,
-            return_results=True,
         )
 
     assert len(results) > 0

--- a/tests/unit/orchestrate/flow/flow-construct/test_flow_yaml_parser.py
+++ b/tests/unit/orchestrate/flow/flow-construct/test_flow_yaml_parser.py
@@ -49,11 +49,11 @@ def test_add_needs_inspect(tmpdir):
         .needs(['executor0', 'executor1'])
     )
     with f1:
-        _ = f1.index(from_ndarray(np.random.random([5, 5])), return_results=True)
+        _ = f1.index(from_ndarray(np.random.random([5, 5])))
         f2 = Flow.load_config('yaml/flow-v1.0-syntax.yml')
 
         with f2:
-            _ = f2.index(from_ndarray(np.random.random([5, 5])), return_results=True)
+            _ = f2.index(from_ndarray(np.random.random([5, 5])))
 
             assert f1 == f2
 

--- a/tests/unit/orchestrate/flow/flow-orchestrate/test_flow_change_gateway.py
+++ b/tests/unit/orchestrate/flow/flow-orchestrate/test_flow_change_gateway.py
@@ -12,7 +12,7 @@ def test_change_gateway(protocol, changeto_protocol):
     f = Flow(protocol=protocol).add().add().add(needs='executor1').needs_all()
 
     with f:
-        da = f.post('/', random_docs(10), return_results=True)
+        da = f.post('/', random_docs(10))
         assert len(da) == 10
         with pytest.raises(RuntimeError):
             f.protocol = changeto_protocol

--- a/tests/unit/orchestrate/flow/flow-orchestrate/test_flow_complex_topology.py
+++ b/tests/unit/orchestrate/flow/flow-orchestrate/test_flow_complex_topology.py
@@ -16,6 +16,6 @@ def test_flow_complex_toploogy(protocol):
     )
 
     with f:
-        res = f.index(Document(), return_results=True)
+        res = f.index(Document())
 
     assert len(res) > 0

--- a/tests/unit/orchestrate/flow/flow-orchestrate/test_flow_docarray_return.py
+++ b/tests/unit/orchestrate/flow/flow-orchestrate/test_flow_docarray_return.py
@@ -13,7 +13,7 @@ class SimplExecutor(Executor):
 def test_simple_docarray_return():
     f = Flow().add(uses=SimplExecutor)
     with f:
-        docs = f.post(on='/index', inputs=[Document()], return_results=True)
+        docs = f.post(on='/index', inputs=[Document()])
     assert docs[0].text == 'Hello World!'
 
 
@@ -24,7 +24,6 @@ def test_flatten_docarrays():
             on='/index',
             inputs=[Document() for _ in range(100)],
             request_size=10,
-            return_results=True,
         )
     assert isinstance(docs, DocumentArray)
     assert len(docs) == 100
@@ -35,23 +34,21 @@ def my_cb(resp):
     return resp
 
 
-@pytest.mark.parametrize('return_results', [True, False])
 @pytest.mark.parametrize('on_done', [None, my_cb])
 @pytest.mark.parametrize('on_always', [None, my_cb])
 @pytest.mark.parametrize('on_error', [None, my_cb])
-def test_automatically_set_returnresults(return_results, on_done, on_always, on_error):
+def test_automatically_set_returnresults(on_done, on_always, on_error):
     f = Flow().add(uses=SimplExecutor)
     with f:
         docs = f.post(
             on='/index',
             inputs=[Document() for _ in range(100)],
             request_size=10,
-            return_results=return_results,
             on_done=on_done,
             on_always=on_always,
             on_error=on_error,
         )
-    if return_results or (on_done is None and on_always is None):
+    if on_done is None and on_always is None:
         assert isinstance(docs, DocumentArray)
         assert len(docs) == 100
         assert docs[0].text == 'Hello World!'
@@ -72,8 +69,8 @@ def test_flow_client_defaults():
     f = Flow(port_expose=exposed_port).add(uses=SimplExecutor)
     c = Client(port=exposed_port)
     with f:
-        docs = f.post(on='/index', inputs=[Document()], return_results=True)
-        results = c.post(on='/index', inputs=[Document()], return_results=True)
+        docs = f.post(on='/index', inputs=[Document()])
+        results = c.post(on='/index', inputs=[Document()])
     assert isinstance(docs, DocumentArray)
     assert docs[0].text == 'Hello World!'
     assert isinstance(results, DocumentArray)

--- a/tests/unit/orchestrate/flow/flow-orchestrate/test_flow_merge.py
+++ b/tests/unit/orchestrate/flow/flow-orchestrate/test_flow_merge.py
@@ -48,7 +48,7 @@ def test_this_will_fail(protocol):
     )
 
     with f:
-        da = f.index(inputs=random_docs(10, chunks_per_doc=0), return_results=True)
+        da = f.index(inputs=random_docs(10, chunks_per_doc=0))
 
     validate(da)
 
@@ -70,6 +70,6 @@ def test_this_should_work(protocol):
     )
 
     with f:
-        da = f.index(inputs=random_docs(10, chunks_per_doc=0), return_results=True)
+        da = f.index(inputs=random_docs(10, chunks_per_doc=0))
 
     validate(da)

--- a/tests/unit/orchestrate/flow/flow-orchestrate/test_flow_routing.py
+++ b/tests/unit/orchestrate/flow/flow-orchestrate/test_flow_routing.py
@@ -13,7 +13,7 @@ class SimplExecutor(Executor):
 def test_simple_routing():
     f = Flow().add(uses=SimplExecutor)
     with f:
-        docs = f.post(on='/index', inputs=[Document()], return_results=True)
+        docs = f.post(on='/index', inputs=[Document()])
         assert docs[0].text == 'Hello World!'
 
 
@@ -32,7 +32,7 @@ def test_expected_messages_routing():
     )
 
     with f:
-        docs = f.post(on='/index', inputs=[Document(text='1')], return_results=True)
+        docs = f.post(on='/index', inputs=[Document(text='1')])
         # there merge executor actually does not merge despite its name
         assert len(docs) == 2
         assert docs[0].text == 'merged'
@@ -48,7 +48,7 @@ def test_shards():
     f = Flow().add(uses=SimpleAddExecutor, shards=2)
 
     with f:
-        docs = f.post(on='/index', inputs=[Document(text='1')], return_results=True)
+        docs = f.post(on='/index', inputs=[Document(text='1')])
         assert len(docs) == 2
 
 
@@ -79,7 +79,7 @@ def test_complex_flow():
     )
 
     with f:
-        docs = f.post(on='/index', inputs=[Document(text='1')], return_results=True)
+        docs = f.post(on='/index', inputs=[Document(text='1')])
     assert len(docs) == 6
 
 
@@ -108,15 +108,9 @@ def test_flow_default_polling_endpoints(polling):
     f = Flow().add(uses=DynamicPollingExecutorDefaultNames, shards=2, polling=polling)
 
     with f:
-        docs_index = f.post(
-            on='/index', inputs=[Document(text='1')], return_results=True
-        )
-        docs_search = f.post(
-            on='/search', inputs=[Document(text='1')], return_results=True
-        )
-        docs_custom = f.post(
-            on='/custom', inputs=[Document(text='1')], return_results=True
-        )
+        docs_index = f.post(on='/index', inputs=[Document(text='1')])
+        docs_search = f.post(on='/search', inputs=[Document(text='1')])
+        docs_custom = f.post(on='/custom', inputs=[Document(text='1')])
     assert len(docs_index) == 2
     assert len(docs_search) == 3
     assert len(docs_custom) == 3 if polling == 'all' else 2
@@ -132,15 +126,9 @@ def test_flow_default_custom_polling_endpoints(polling):
     )
 
     with f:
-        docs_index = f.post(
-            on='/index', inputs=[Document(text='1')], return_results=True
-        )
-        docs_search = f.post(
-            on='/search', inputs=[Document(text='1')], return_results=True
-        )
-        docs_custom = f.post(
-            on='/custom', inputs=[Document(text='1')], return_results=True
-        )
+        docs_index = f.post(on='/index', inputs=[Document(text='1')])
+        docs_search = f.post(on='/search', inputs=[Document(text='1')])
+        docs_custom = f.post(on='/custom', inputs=[Document(text='1')])
     assert len(docs_index) == 2
     assert len(docs_search) == 2
     assert len(docs_custom) == 3

--- a/tests/unit/test_gateway.py
+++ b/tests/unit/test_gateway.py
@@ -16,7 +16,7 @@ def test_compression(compress_algo):
     f = Flow(compress=str(compress_algo)).add().add(name='DummyEncoder', shards=2).add()
 
     with f:
-        results = f.index(random_docs(10), return_results=True)
+        results = f.index(random_docs(10))
 
     assert len(results) > 0
 
@@ -46,7 +46,6 @@ def test_gateway_concurrency(protocol, reraise):
                 port=PORT_EXPOSE, protocol=protocol, return_responses=True
             ).index(
                 inputs=(Document() for _ in range(256)),
-                return_results=True,
                 _size=16,
             )
             assert len(results) > 0


### PR DESCRIPTION
# Remove return_results option from the Client

## Description

This removes the `return_results` option from the Client. The logic now is that the Client checks if on_done or on_always are set. If so, no results will be returned. If those callbacks are not set, the Client will return results.
I did not add extra tests because we actually having tests already for this exact logic. In the past it was just possible to override this behavior, which is effectively removed by this PR.