### PR TITLE
docs: complete containerization example

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,9 @@ You can containerize the Executors and play them in a sandbox thanks to [Hub](ht
     from docarray import DocumentArray
     from jina import Flow
 
-    index_data = DocumentArray.pull('demo-leftda', show_progress=True)
+    index_data = DocumentArray.pull(
+        'demo-leftda', show_progress=True
+    )  # Download the dataset as shown in the tutorial above
 
     f = Flow().add(uses='jinahub+sandbox://2k7gsejl')
 

--- a/README.md
+++ b/README.md
@@ -251,7 +251,10 @@ You can containerize the Executors and play them in a sandbox thanks to [Hub](ht
 
 4. In particular, sandbox hosts your Executor on Jina Cloud and allows you to play with it from local:
     ```python
+    from docarray import DocumentArray
     from jina import Flow
+
+    index_data = DocumentArray.pull('demo-leftda', show_progress=True)
 
     f = Flow().add(uses='jinahub+sandbox://2k7gsejl')
 


### PR DESCRIPTION
I think we should create the DA necessary for the example directly here. Otherwise the user needs to look this up in the previous example, which is awkward.