### PR TITLE
fix(hubble): pathspec match

### DIFF
--- a/jina/hubble/helper.py
+++ b/jina/hubble/helper.py
@@ -165,7 +165,7 @@ def archive_package(package_folder: 'Path') -> 'io.BytesIO':
 
         for p in path.iterdir():
             rel_path = p.relative_to(base_path)
-            if ignored_spec.match_file(rel_path):
+            if ignored_spec.match_file(str(rel_path)):
                 continue
             if p.is_dir():
                 _zip(base_path, p, archive)


### PR DESCRIPTION

This PR aims to address the following error during `jina hub push ...`:

```
HubIO@48228[E]:Please report this session_id: 58edbc16-8faf-11ec-801d-6a44b164189a to https://github.com/jina-ai/jina/issues’
                AttributeError(“‘PosixPath’ object has no attribute ‘startswith’“)
Traceback (most recent call last):
  File “/Users/jemfu/opt/anaconda3/bin/jina”, line 8, in <module>
    sys.exit(main())
  File “/Users/jemfu/opt/anaconda3/lib/python3.9/site-packages/cli/__init__.py”, line 116, in main
    getattr(api, args.cli.replace(‘-’, ‘_’))(args)
  File “/Users/jemfu/opt/anaconda3/lib/python3.9/site-packages/cli/api.py”, line 226, in hub
    getattr(HubIO(args), args.hub)()
  File “/Users/jemfu/opt/anaconda3/lib/python3.9/site-packages/jina/hubble/hubio.py”, line 448, in push
    raise e
  File “/Users/jemfu/opt/anaconda3/lib/python3.9/site-packages/jina/hubble/hubio.py”, line 354, in push
    bytesio = archive_package(work_path)
  File “/Users/jemfu/opt/anaconda3/lib/python3.9/site-packages/jina/hubble/helper.py”, line 175, in archive_package
    _zip(root_path, root_path, zfile)
  File “/Users/jemfu/opt/anaconda3/lib/python3.9/site-packages/jina/hubble/helper.py”, line 168, in _zip
    if ignored_spec.match_file(rel_path):
  File “/Users/jemfu/opt/anaconda3/lib/python3.9/site-packages/pathspec/pathspec.py”, line 90, in match_file
    norm_file = util.normalize_file(file, separators=separators)
  File “/Users/jemfu/opt/anaconda3/lib/python3.9/site-packages/pathspec/util.py”, line 204, in normalize_file
    if norm_file.startswith(‘./’):
AttributeError: ‘PosixPath’ object has no attribute ‘startswith’
```