### PR TITLE
chore: remove the legacy codes for force register

### DIFF
--- a/jina/enums.py
+++ b/jina/enums.py
@@ -41,7 +41,7 @@ class EnumType(EnumMeta):
         :return: Registered class.
         """
         reg_cls_set = getattr(cls, '_registered_class', set())
-        if cls.__name__ not in reg_cls_set or getattr(cls, 'force_register', False):
+        if cls.__name__ not in reg_cls_set:
             reg_cls_set.add(cls.__name__)
             setattr(cls, '_registered_class', reg_cls_set)
         from jina.jaml import JAML

--- a/jina/serve/executors/__init__.py
+++ b/jina/serve/executors/__init__.py
@@ -49,7 +49,7 @@ class ExecutorType(type(JAMLCompatible), type):
         reg_cls_set = getattr(cls, '_registered_class', set())
 
         cls_id = f'{cls.__module__}.{cls.__name__}'
-        if cls_id not in reg_cls_set or getattr(cls, 'force_register', False):
+        if cls_id not in reg_cls_set:
             arg_spec = inspect.getfullargspec(cls.__init__)
 
             if not arg_spec.varkw and not __args_executor_init__.issubset(
@@ -78,7 +78,7 @@ class BaseExecutor(JAMLCompatible, metaclass=ExecutorType):
     .. code-block:: python
 
         class MyAwesomeExecutor:
-            def __init__(awesomeness = 5):
+            def __init__(awesomeness=5):
                 pass
 
     is equal to


### PR DESCRIPTION
# Pull Request Title

## Description

`force_register` is legacy codes used to force ExecutorType to register an executor type. This is only used when we maintain the various executors within the jina codes with the legacy importing mechanism. This is part of the Jina 1.X

Closes # (issue)