### PR TITLE
docs: add link to Jina 2 docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -122,6 +122,7 @@ get-started/migrate
 api
 cli/index
 proto/docs
+Jina 2 Documentation <https://docs2.jina.ai/>
 ```
 
 


### PR DESCRIPTION
This adds a link to the [old Jina 2 documentation](https://docs2.jina.ai/) in the "Developer Reference" section. This might be useful for people to maintain and migrate old projects written for version 2.