### PR TITLE
feat: add isort and flake8 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,12 @@
 repos:
+-   repo: https://github.com/pycqa/flake8
+    rev: 4.0.1
+    hooks:
+    -   id: flake8
+        exclude: ^(.git|__pycache__|docs/source/conf.py|old|build|dist|tests|jina/resources/)
+        args:
+          - --max-complexity=10
+          - --max-line-length=127
 - repo: https://github.com/terrencepreilly/darglint
   rev: v1.5.8
   hooks:
@@ -32,3 +40,9 @@ repos:
     -   id: blacken-docs
         args:
           - -S
+- repo: https://github.com/pycqa/isort
+  rev: 5.10.1
+  hooks:
+    - id: isort
+      args: ["--profile", "black"]
+

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,12 +34,12 @@ repos:
     exclude: ^(jina/proto/jina_pb2.py|docs/|jina/resources/)
     args:
       - -S
--   repo: https://github.com/asottile/blacken-docs
-    rev: v1.12.1
-    hooks:
-    -   id: blacken-docs
-        args:
-          - -S
+- repo: https://github.com/asottile/blacken-docs
+  rev: v1.12.1
+  hooks:
+  -   id: blacken-docs
+      args:
+        - -S
 - repo: https://github.com/pycqa/isort
   rev: 5.10.1
   hooks:


### PR DESCRIPTION
Add isort and flake8 to pre-commit.

* Isort : automatic import sorting https://github.com/PyCQA/isort
* We check flake8 in the CI so it might be usefull to check it in the precommit as well
