### PR TITLE
fix(hubble): use commit id instead of serial number

### DIFF
--- a/jina/hubble/__init__.py
+++ b/jina/hubble/__init__.py
@@ -8,7 +8,7 @@ class HubExecutor:
 
     uuid: str = None
     name: Optional[str] = None
-    sn: Optional[int] = None
+    commit_id: Optional[str] = None
     tag: Optional[str] = None
     visibility: Optional[bool] = None
     image_name: Optional[str] = None

--- a/jina/hubble/hubapi.py
+++ b/jina/hubble/hubapi.py
@@ -6,14 +6,14 @@ import shutil
 from pathlib import Path
 from typing import Tuple
 
+from jina.helper import random_identity
 from jina.hubble import HubExecutor
 from jina.hubble.helper import (
-    unpack_package,
+    get_hub_packages_dir,
     install_requirements,
     is_requirements_installed,
-    get_hub_packages_dir,
+    unpack_package,
 )
-from jina.helper import random_identity
 
 
 def get_dist_path(uuid: str, tag: str) -> Tuple[Path, Path]:
@@ -155,10 +155,10 @@ def install_local(
     if manifest_path.exists():
         shutil.copyfile(manifest_path, pkg_dist_path / 'manifest.yml')
 
-    # store the serial number in local
-    if executor.sn is not None:
-        sn_file = pkg_dist_path / f'PKG-SN-{executor.sn}'
-        sn_file.touch()
+    # store the commit id in local
+    if executor.commit_id is not None:
+        commit_file = pkg_dist_path / f'PKG-COMMIT-{executor.commit_id}'
+        commit_file.touch()
 
 
 def install_package_dependencies(

--- a/jina/hubble/hubio.py
+++ b/jina/hubble/hubio.py
@@ -611,7 +611,7 @@ f = Flow().add(uses='jinahub+sandbox://{executor_name}')
         return HubExecutor(
             uuid=resp['id'],
             name=resp.get('name', None),
-            sn=resp.get('sn', None),
+            commit_id=resp['commit'].get('id'),
             tag=tag or resp['commit'].get('tags', [None])[0],
             visibility=resp['visibility'],
             image_name=image_name,
@@ -819,10 +819,12 @@ f = Flow().add(uses='jinahub+sandbox://{executor_name}')
                             pkg_path, pkg_dist_path = get_dist_path_of_executor(
                                 executor
                             )
-                            # check serial number to upgrade
-                            sn_file_path = pkg_dist_path / f'PKG-SN-{executor.sn or 0}'
-                            if (not sn_file_path.exists()) and any(
-                                pkg_dist_path.glob('PKG-SN-*')
+                            # check commit id to upgrade
+                            commit_file_path = (
+                                pkg_dist_path / f'PKG-COMMIT-{executor.commit_id or 0}'
+                            )
+                            if (not commit_file_path.exists()) and any(
+                                pkg_dist_path.glob('PKG-COMMIT-*')
                             ):
                                 raise FileNotFoundError(
                                     f'{pkg_path} need to be upgraded'

--- a/tests/unit/hubble/test_hubapi.py
+++ b/tests/unit/hubble/test_hubapi.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import pytest
 
-from jina.hubble import hubapi, HubExecutor
+from jina.hubble import HubExecutor, hubapi
 from jina.hubble.hubapi import list_local
 
 cur_dir = os.path.dirname(os.path.abspath(__file__))
@@ -16,7 +16,7 @@ def executor_zip_file():
 
 @pytest.fixture
 def test_executor():
-    return HubExecutor(uuid='hello', name=None, sn=0, tag='v0')
+    return HubExecutor(uuid='hello', name=None, commit_id='test_commit', tag='v0')
 
 
 @pytest.mark.parametrize('install_deps', [True, False])


### PR DESCRIPTION
`sn` no longer exists instead now we use commits to manage the executor version.

Closes https://github.com/jina-ai/hubble/issues/299