### PR TITLE
feat(executor): add serve function

### DIFF
--- a/docs/fundamentals/executor/executor-api.md
+++ b/docs/fundamentals/executor/executor-api.md
@@ -315,7 +315,54 @@ print(docs.embeddings.shape)
 ```
 ````
 
+## Serve Executor without Flow
 
+Executors can be served - and remotely accessed - directly, without the need to instantiate a Flow manually.
+This is especially useful when debugging an Executor in a remote setting.
+
+An Executor can be served using the `.serve()` class method:
+
+````{tab} Serve Executor
+
+```python
+from jina import Executor, requests
+from docarray import DocumentArray, Document
+
+
+class MyExec(Executor):
+    @requests
+    def foo(self, docs: DocumentArray, **kwargs):
+        docs[0] = 'executed MyExec'  # custom logic goes here
+
+
+MyExec.serve(port=12345)
+```
+
+````
+
+````{tab} Access served Executor
+
+```python
+from jina import Client
+from docarray import DocumentArray, Document
+
+print(Client(port=12345).post(inputs=DocumentArray.empty(1), on='/foo').texts)
+```
+```console
+
+```
+['executed MyExec']
+````
+
+Internally, the `.serve()` method creates a Flow and starts it. Therefore, it can take all associated parameters:
+`uses_with`, `uses_metas`, `uses_requests` are passed to the internal `flow.add()` call, `stop_event` is an Event that stops
+the Executor, and `**kwargs` is passed to the internal `Flow()` initialisation call.
+
+````{admonition} See Also
+:class: seealso
+
+For more details on these arguments and the workings of `Flow`, see the {ref}`Flow section <flow-cookbook>`.
+````
 
 ### Use async Executors
 

--- a/docs/fundamentals/executor/executor-api.md
+++ b/docs/fundamentals/executor/executor-api.md
@@ -315,7 +315,7 @@ print(docs.embeddings.shape)
 ```
 ````
 
-## Serve Executor without Flow
+## Serve Executor stand-alone
 
 Executors can be served - and remotely accessed - directly, without the need to instantiate a Flow manually.
 This is especially useful when debugging an Executor in a remote setting.

--- a/jina/serve/executors/__init__.py
+++ b/jina/serve/executors/__init__.py
@@ -1,21 +1,21 @@
-from concurrent.futures import ThreadPoolExecutor
-from typing import TYPE_CHECKING, Any
 import inspect
+import multiprocessing
 import os
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from types import SimpleNamespace
-from typing import Dict, Optional, Type, List
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type, Union
 
-from jina.serve.executors.decorators import store_init_kwargs, wrap_func, requests
-from jina import __default_endpoint__, __args_executor_init__
+from jina import __args_executor_init__, __default_endpoint__
 from jina.helper import (
-    typename,
     ArgNamespace,
     T,
     iscoroutinefunction,
     run_in_threadpool,
+    typename,
 )
-from jina.jaml import JAMLCompatible, JAML, env_var_regex, internal_var_regex
-
+from jina.jaml import JAML, JAMLCompatible, env_var_regex, internal_var_regex
+from jina.serve.executors.decorators import requests, store_init_kwargs, wrap_func
 
 if TYPE_CHECKING:
     from jina import DocumentArray
@@ -316,6 +316,35 @@ class BaseExecutor(JAMLCompatible, metaclass=ExecutorType):
             uses_metas=uses_metas,
             uses_requests=uses_requests,
         )
+
+    def serve(
+        self,
+        uses_with: Optional[Dict] = None,
+        uses_metas: Optional[Dict] = None,
+        uses_requests: Optional[Dict] = None,
+        stop_event: Optional[Union[threading.Event, multiprocessing.Event]] = None,
+        **kwargs,
+    ):
+        """Serve this Executor in a temporary Flow. Useful in testing an Executor in remote settings.
+
+        :param uses_with: dictionary of parameters to overwrite from the default config's with field
+        :param uses_metas: dictionary of parameters to overwrite from the default config's metas field
+        :param uses_requests: dictionary of parameters to overwrite from the default config's requests field
+        :param stop_event: a threading event or a multiprocessing event that once set will resume the control Flow
+            to main thread.
+        :param kwargs: other kwargs accepted by the Flow, full list can be found in INSERT_DOC_URL
+
+        """
+        from jina import Flow
+
+        f = Flow(**kwargs).add(
+            uses=type(self),
+            uses_with=uses_with,
+            uses_metas=uses_metas,
+            uses_requests=uses_requests,
+        )
+        with f:
+            f.block(stop_event)
 
 
 class ReducerExecutor(BaseExecutor):

--- a/jina/serve/executors/__init__.py
+++ b/jina/serve/executors/__init__.py
@@ -317,8 +317,9 @@ class BaseExecutor(JAMLCompatible, metaclass=ExecutorType):
             uses_requests=uses_requests,
         )
 
+    @classmethod
     def serve(
-        self,
+        cls,
         uses_with: Optional[Dict] = None,
         uses_metas: Optional[Dict] = None,
         uses_requests: Optional[Dict] = None,
@@ -332,13 +333,13 @@ class BaseExecutor(JAMLCompatible, metaclass=ExecutorType):
         :param uses_requests: dictionary of parameters to overwrite from the default config's requests field
         :param stop_event: a threading event or a multiprocessing event that once set will resume the control Flow
             to main thread.
-        :param kwargs: other kwargs accepted by the Flow, full list can be found in INSERT_DOC_URL
+        :param kwargs: other kwargs accepted by the Flow, full list can be found in INSERT_DOC_URL  # TODO(johannes)
 
         """
         from jina import Flow
 
         f = Flow(**kwargs).add(
-            uses=type(self),
+            uses=cls,
             uses_with=uses_with,
             uses_metas=uses_metas,
             uses_requests=uses_requests,

--- a/jina/serve/executors/__init__.py
+++ b/jina/serve/executors/__init__.py
@@ -333,7 +333,7 @@ class BaseExecutor(JAMLCompatible, metaclass=ExecutorType):
         :param uses_requests: dictionary of parameters to overwrite from the default config's requests field
         :param stop_event: a threading event or a multiprocessing event that once set will resume the control Flow
             to main thread.
-        :param kwargs: other kwargs accepted by the Flow, full list can be found in INSERT_DOC_URL  # TODO(johannes)
+        :param kwargs: other kwargs accepted by the Flow, full list can be found `here <https://docs.jina.ai/api/jina.orchestrate.flow.base/>`
 
         """
         from jina import Flow

--- a/tests/unit/serve/executors/test_executor.py
+++ b/tests/unit/serve/executors/test_executor.py
@@ -2,11 +2,41 @@ import os
 from copy import deepcopy
 
 import pytest
-
 from docarray import Document, DocumentArray
-from jina import Executor, requests
+
+from jina import Client, Executor, requests
 from jina.serve.executors import ReducerExecutor
 from jina.serve.executors.metas import get_default_metas
+
+PORT = 12350
+
+
+@pytest.fixture(autouse=False)
+def served_exec():
+    import threading
+    import time
+
+    def serve_exec(**kwargs):
+        MyExec().serve(**kwargs)
+
+    e = threading.Event()
+    t = threading.Thread(
+        name='serve-exec',
+        target=serve_exec,
+        kwargs={'port_expose': PORT, 'stop_event': e},
+    )
+    t.start()
+    time.sleep(1)  # allow Flow to start
+
+    yield
+
+    e.set()  # set event and stop (unblock) the Flow
+
+
+class MyExec(Executor):
+    @requests
+    def foo(self, docs, **kwargs):
+        docs.texts = ['foo' for _ in docs]
 
 
 def test_executor_load_from_hub():
@@ -294,3 +324,9 @@ async def test_async_apply():
     exec = AsyncExecutor()
     da1 = await exec.foo(da)
     assert da1.texts == ['hello'] * N
+
+
+def test_serve(served_exec):
+    docs = Client(port=PORT).post(on='/foo', inputs=DocumentArray.empty(5))
+
+    assert docs.texts == ['foo' for _ in docs]

--- a/tests/unit/serve/executors/test_executor.py
+++ b/tests/unit/serve/executors/test_executor.py
@@ -2,13 +2,19 @@ import os
 from copy import deepcopy
 
 import pytest
-from docarray import Document, DocumentArray
 
+from docarray import Document, DocumentArray
 from jina import Client, Executor, requests
 from jina.serve.executors import ReducerExecutor
 from jina.serve.executors.metas import get_default_metas
 
 PORT = 12350
+
+
+class MyServeExec(Executor):
+    @requests
+    def foo(self, docs, **kwargs):
+        docs.texts = ['foo' for _ in docs]
 
 
 @pytest.fixture(autouse=False)
@@ -17,7 +23,7 @@ def served_exec():
     import time
 
     def serve_exec(**kwargs):
-        MyExec().serve(**kwargs)
+        MyServeExec.serve(**kwargs)
 
     e = threading.Event()
     t = threading.Thread(
@@ -31,12 +37,7 @@ def served_exec():
     yield
 
     e.set()  # set event and stop (unblock) the Flow
-
-
-class MyExec(Executor):
-    @requests
-    def foo(self, docs, **kwargs):
-        docs.texts = ['foo' for _ in docs]
+    t.join()
 
 
 def test_executor_load_from_hub():

--- a/tests/unit/serve/executors/test_executor.py
+++ b/tests/unit/serve/executors/test_executor.py
@@ -26,7 +26,7 @@ def served_exec():
         kwargs={'port_expose': PORT, 'stop_event': e},
     )
     t.start()
-    time.sleep(1)  # allow Flow to start
+    time.sleep(3)  # allow Flow to start
 
     yield
 


### PR DESCRIPTION
on developing remote Executor, I have to quickly make an Executor "served", I hope there is a shortcut for doing the following work:

```python
from jina import Flow

f = Flow(port=12345).add(uses=MyExec)
with f:
    f.block()
```

so now I can:

```python
from jina import Executor

class MyExec(Executor):
  ...

MyExec().serve()
```

Please improve doc or whatever needs. I wont have time to revisit this PR, hope to see it merge soon.