### PR TITLE
feat(client): add total_docs to client post kwargs

### DIFF
--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -1,13 +1,12 @@
 import os
 import sys
 
-from rich import print as pprint
-from rich.table import Table
 from rich import box
-from jina.helper import get_rich_console
+from rich.table import Table
 
 
 def _get_run_args(print_args: bool = True):
+    from jina.helper import get_rich_console
     from jina.parsers import get_main_parser
 
     console = get_rich_console()
@@ -45,18 +44,16 @@ def _get_run_args(print_args: bool = True):
             param_str.add_column('Value', justify='left')
 
             for k, v in sorted(vars(args).items()):
-
                 sign = ' ' if default_args.get(k, None) == v else '🔧️'
-                param = f'{k.replace("_", "-"): >30.30}'
-                value = f'=  {str(v):30.30}'
+                param = k.replace('_', '-')
+                value = str(v)
 
                 style = None if default_args.get(k, None) == v else 'blue on yellow'
 
                 param_str.add_row(sign, param, value, style=style)
 
             print(f'\n{logo_str}\n')
-            console.print(f'▶️  {" ".join(sys.argv)}')
-            console.print(param_str)
+            console.print(f'▶️  {" ".join(sys.argv)}', param_str)
         return args
     else:
         parser.print_help()
@@ -86,10 +83,11 @@ def _quick_ac_lookup():
 
 def _is_latest_version(suppress_on_error=True):
     try:
-        from urllib.request import Request, urlopen
         import json
-        from jina import __version__
         import warnings
+        from urllib.request import Request, urlopen
+
+        from jina import __version__
 
         req = Request(
             'https://api.jina.ai/latest', headers={'User-Agent': 'Mozilla/5.0'}

--- a/jina/clients/base/__init__.py
+++ b/jina/clients/base/__init__.py
@@ -145,9 +145,16 @@ class BaseClient(ABC):
         _kwargs.update(kwargs)
 
         if hasattr(self._inputs, '__len__'):
-            self._inputs_length = max(1, len(self._inputs) / _kwargs['request_size'])
+            total_docs = len(self._inputs)
+        elif 'total_docs' in _kwargs:
+            total_docs = _kwargs['total_docs']
         else:
-            self._inputs_length = None
+            total_docs = None
+
+        self._inputs_length = None
+
+        if total_docs:
+            self._inputs_length = max(1, total_docs / _kwargs['request_size'])
 
         if inspect.isasyncgen(self.inputs):
             from jina.clients.request.asyncio import request_generator


### PR DESCRIPTION
e.g. adding test if needed. 

usage: `.post(..., total_docs=100000)`

rational: 
it is possible that user input is an iterator for saving memory but they know its length, e.g. if i want to load all `iglob('**/*.jpg')` i would easily know the length of the iterator in advance
yet, i would still construct it as an iterator (with no-length) as it is more memory friendly