### PR TITLE
fix: client args are now parse in the client function

### DIFF
--- a/jina/clients/__init__.py
+++ b/jina/clients/__init__.py
@@ -2,6 +2,8 @@
 import argparse
 from typing import TYPE_CHECKING, Optional, Union, overload
 
+from jina.helper import parse_client
+
 __all__ = ['Client']
 
 from jina.enums import GatewayProtocolType
@@ -66,6 +68,10 @@ def Client(
     :param kwargs: Additional arguments.
     :return: An instance of :class:`GRPCClient` or :class:`WebSocketClient`.
     """
+    if not (
+        args and isinstance(args, argparse.Namespace)
+    ):  # we need to parse the kwargs as soon as possible otherwise to get the gateway type
+        args = parse_client(kwargs)
 
     protocol = (
         args.protocol if args else kwargs.get('protocol', GatewayProtocolType.GRPC)

--- a/jina/clients/base/__init__.py
+++ b/jina/clients/base/__init__.py
@@ -4,23 +4,12 @@ import argparse
 import inspect
 import os
 from abc import ABC
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    AsyncIterator,
-    Callable,
-    Dict,
-    Iterator,
-    Optional,
-    Tuple,
-    Union,
-)
+from typing import TYPE_CHECKING, AsyncIterator, Callable, Iterator, Optional, Union
 
 from jina.excepts import BadClientInput
-from jina.helper import ArgNamespace, T, typename
+from jina.helper import T, parse_client, typename
 from jina.logging.logger import JinaLogger
 from jina.logging.predefined import default_logger
-from jina.parsers import set_client_cli_parser
 
 if TYPE_CHECKING:
     from jina.clients.request import GeneratorSourceType
@@ -45,10 +34,7 @@ class BaseClient(ABC):
         if args and isinstance(args, argparse.Namespace):
             self.args = args
         else:
-            self._parse_kwargs(kwargs)
-            self.args = ArgNamespace.kwargs2namespace(
-                kwargs, set_client_cli_parser(), warn_unknown=True
-            )
+            self.args = parse_client(kwargs)
 
         self.logger = JinaLogger(self.__class__.__name__, **vars(self.args))
 
@@ -60,39 +46,6 @@ class BaseClient(ABC):
             os.unsetenv('http_proxy')
             os.unsetenv('https_proxy')
         self._inputs = None
-
-    def _parse_kwargs(self, kwargs: Dict[str, Any]):
-
-        if 'host' in kwargs.keys():
-            return_scheme = dict()
-            (
-                kwargs['host'],
-                return_scheme['port'],
-                return_scheme['protocol'],
-                return_scheme['tls'],
-            ) = self._parse_host_scheme(kwargs['host'])
-
-            for key, value in return_scheme.items():
-                if value:
-                    if key in kwargs:
-                        raise ValueError(
-                            f"You can't have two definitions of {key}: you have one in the host scheme and one in the keyword argument"
-                        )
-                    elif value:
-                        kwargs[key] = value
-
-    def _parse_host_scheme(self, host: str) -> Tuple[str, str, str, bool]:
-        scheme, _hostname, port = _parse_url(host)
-
-        tls = None
-        if scheme in ('grpcs', 'https', 'wss'):
-            scheme = scheme[:-1]
-            tls = True
-
-        if scheme == 'ws':
-            scheme = 'websocket'
-
-        return _hostname, port, scheme, tls
 
     @staticmethod
     def check_input(inputs: Optional['InputType'] = None, **kwargs) -> None:
@@ -206,17 +159,3 @@ class BaseClient(ABC):
         :return: the Client object
         """
         return self
-
-
-def _parse_url(host):
-    if '://' in host:
-        scheme, host = host.split('://')
-    else:
-        scheme = None
-
-    if ':' in host:
-        host, port = host.split(':')
-    else:
-        port = None
-
-    return scheme, host, port

--- a/tests/integration/gateway_clients/test_host_scheme.py
+++ b/tests/integration/gateway_clients/test_host_scheme.py
@@ -1,0 +1,14 @@
+import pytest
+from docarray import DocumentArray
+
+from jina import Client, Flow
+from jina.helper import random_port
+
+
+@pytest.mark.parametrize('protocol', ['grpc', 'ws', 'http'])
+def test_client_host_scheme(protocol):
+    port = random_port()
+    f = Flow(protocol='websocket' if protocol == 'ws' else protocol, port=port).add()
+    with f:
+        c = Client(host=f'{protocol}://localhost:{port}')
+        c.post('/', inputs=DocumentArray.empty(2))


### PR DESCRIPTION
Fix the issue where the client type was always grpc because the args were not parsed soon enough, i.e they were parsed in the `BaseClient` but the client type was define before in the `Client` function where the args were not parsed yet.