### PR TITLE
fix: install linkerd in cd pipeline

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -239,6 +239,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Test k8s
         run: |
+          curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/install | sh
           pytest -v -s --suppress-no-test-exit-code --force-flaky --min-passes 1 --max-runs 5 --cov=jina --cov-report=xml ./tests/k8s/
         timeout-minutes: 30
       - name: Check codecov file


### PR DESCRIPTION
I noticed that I forgot to[ install linkerd](https://github.com/jina-ai/jina/blob/master/.github/workflows/ci.yml#L193) in the CD pipeline as well so the[ k8s tests are failing there](https://github.com/jina-ai/jina/runs/5718721397?check_suite_focus=true)