### PR TITLE
feat: add support for cli plugins

### DIFF
--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -141,18 +141,19 @@ def _is_latest_version(package='jina', suppress_on_error=True):
 def _try_plugin_command():
     """Tries to call the CLI of an external Jina project."""
     argv = sys.argv
-    if len(argv) < 2:
+    if len(argv) < 2:  # no command given
+        return False
+
+    from .autocomplete import ac_table
+
+    if argv[1] in ac_table['commands']:  # native command can't be plugin command
         return False
 
     def _cmd_exists(cmd):
         return shutil.which(cmd) is not None
 
     subcommand = argv[1]
-    cmd = (
-        PLUGIN_INFO[subcommand]['internal-command']
-        if subcommand in PLUGIN_INFO
-        else 'jina-' + subcommand
-    )
+    cmd = 'jina-' + subcommand
     if _cmd_exists(cmd):
         if subcommand in PLUGIN_INFO:
             import threading

--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -6,7 +6,7 @@ import sys
 from packaging.version import Version, parse
 
 KNOWN_PLUGINS_URL = (
-    'https://raw.githubusercontent.com/jina-ai/jina/unified-cli/cli/known_plugins.json'
+    'https://raw.githubusercontent.com/jina-ai/jina/master/cli/known_plugins.json'
 )
 
 

--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -5,13 +5,6 @@ import sys
 
 from packaging.version import Version, parse
 
-PLUGIN_INFO = {
-    'now': {  # the subcommand your project should be reachable under, e.g. "jina now ..."
-        'name': 'Jina Now',  # what your project is called
-        'pip-package': 'jina-now',  # the pip package name of your project
-    }
-}
-
 
 def _get_run_args(print_args: bool = True):
     from jina.helper import get_rich_console
@@ -138,9 +131,18 @@ def _is_latest_version(package='jina', suppress_on_error=True):
             raise
 
 
+def _parse_known_plugins():
+    import json
+
+    dir_path = os.path.dirname(os.path.realpath(__file__))
+    with open(os.path.join(dir_path, 'known_plugins.json')) as f:
+        return json.load(f)
+
+
 def _is_latest_version_plugin(subcommand):
-    if subcommand in PLUGIN_INFO:
-        _is_latest_version(package=PLUGIN_INFO[subcommand]['pip-package'])
+    plugin_info = _parse_known_plugins()
+    if subcommand in plugin_info:
+        _is_latest_version(package=plugin_info[subcommand]['pip-package'])
 
 
 def _try_plugin_command():
@@ -170,15 +172,16 @@ def _try_plugin_command():
         subprocess.run([cmd] + argv[2:])
         return True
 
-    if subcommand in PLUGIN_INFO:
+    plugin_info = _parse_known_plugins()
+    if subcommand in plugin_info:
         from jina.helper import get_rich_console
 
-        cmd_info = PLUGIN_INFO[subcommand]
-        project, package = cmd_info['name'], cmd_info['pip-package']
+        cmd_info = plugin_info[subcommand]
+        project, package = cmd_info['display-name'], cmd_info['pip-package']
         console = get_rich_console()
         console.print(
             f"It seems like [yellow]{project}[/yellow] is not installed in your environment."
-            f"To use it via the [green]'jina {subcommand}'[/green] command,"
+            f"To use it via the [green]'jina {subcommand}'[/green] command, "
             f"install it first: [green]'pip install {package}'[/green]."
         )
         return True

--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -9,7 +9,6 @@ PLUGIN_INFO = {
     'now': {  # the subcommand your project should be reachable under, e.g. "jina now ..."
         'name': 'Jina Now',  # what your project is called
         'pip-package': 'jina-now',  # the pip package name of your project
-        'internal-command': 'jina-now',  # the command of your project, e.g. Now's cli is reachable via "jina-now ..."
     }
 }
 

--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -138,6 +138,11 @@ def _is_latest_version(package='jina', suppress_on_error=True):
             raise
 
 
+def _is_latest_version_plugin(subcommand):
+    if subcommand in PLUGIN_INFO:
+        _is_latest_version(package=PLUGIN_INFO[subcommand]['pip-package'])
+
+
 def _try_plugin_command():
     """Tries to call the CLI of an external Jina project."""
     argv = sys.argv
@@ -155,14 +160,13 @@ def _try_plugin_command():
     subcommand = argv[1]
     cmd = 'jina-' + subcommand
     if _cmd_exists(cmd):
-        if subcommand in PLUGIN_INFO:
-            import threading
+        import threading
 
-            threading.Thread(
-                target=_is_latest_version,
-                daemon=True,
-                args=(PLUGIN_INFO[subcommand]['pip-package'],),
-            ).start()
+        threading.Thread(
+            target=_is_latest_version_plugin,
+            daemon=True,
+            args=(subcommand,),
+        ).start()
         subprocess.run([cmd] + argv[2:])
         return True
 

--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -131,18 +131,9 @@ def _is_latest_version(package='jina', suppress_on_error=True):
             raise
 
 
-def _load_plugin_info():
-    import json
-    import os
-
-    cur_dir = os.path.dirname(os.path.realpath(__file__))
-    with open(os.path.join(cur_dir, 'known_plugins.json')) as f:
-        plugin_info = json.load(f)
-    return plugin_info
-
-
 def _is_latest_version_plugin(subcommand):
-    plugin_info = _load_plugin_info()
+    from .known_plugins import plugin_info
+
     if subcommand in plugin_info:
         _is_latest_version(package=plugin_info[subcommand]['pip-package'])
 
@@ -177,7 +168,8 @@ def _try_plugin_command():
         subprocess.run([cmd] + argv[2:])
         return True
 
-    plugin_info = _load_plugin_info()
+    from .known_plugins import plugin_info
+
     if subcommand in plugin_info:
         from jina.helper import get_rich_console
 

--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -5,10 +5,6 @@ import sys
 
 from packaging.version import Version, parse
 
-KNOWN_PLUGINS_URL = (
-    'https://raw.githubusercontent.com/jina-ai/jina/master/cli/known_plugins.json'
-)
-
 
 def _get_run_args(print_args: bool = True):
     from jina.helper import get_rich_console
@@ -135,28 +131,18 @@ def _is_latest_version(package='jina', suppress_on_error=True):
             raise
 
 
-def _fetch_known_plugins():
-    try:
-        import json
-        import warnings
-        from urllib.request import Request, urlopen
+def _load_plugin_info():
+    import json
+    import os
 
-        req = Request(
-            KNOWN_PLUGINS_URL,
-            headers={'User-Agent': 'Mozilla/5.0'},
-        )
-        with urlopen(
-            req, timeout=2
-        ) as resp:  # 'with' is important to close the resource after use
-            plugin_info = json.load(resp)
-            return plugin_info
-    except:
-        # no network, too slow, github is down
-        return dict()
+    cur_dir = os.path.dirname(os.path.realpath(__file__))
+    with open(os.path.join(cur_dir, 'known_plugins.json')) as f:
+        plugin_info = json.load(f)
+    return plugin_info
 
 
 def _is_latest_version_plugin(subcommand):
-    plugin_info = _fetch_known_plugins()
+    plugin_info = _load_plugin_info()
     if subcommand in plugin_info:
         _is_latest_version(package=plugin_info[subcommand]['pip-package'])
 
@@ -191,7 +177,7 @@ def _try_plugin_command():
         subprocess.run([cmd] + argv[2:])
         return True
 
-    plugin_info = _fetch_known_plugins()
+    plugin_info = _load_plugin_info()
     if subcommand in plugin_info:
         from jina.helper import get_rich_console
 

--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -162,7 +162,10 @@ def _is_latest_version_plugin(subcommand):
 
 
 def _try_plugin_command():
-    """Tries to call the CLI of an external Jina project."""
+    """Tries to call the CLI of an external Jina project.
+
+    :return: if the plugin has been found (locally or among the known plugins)
+    """
     argv = sys.argv
     if len(argv) < 2:  # no command given
         return False

--- a/cli/known_plugins.json
+++ b/cli/known_plugins.json
@@ -1,0 +1,6 @@
+{
+    "now": {
+        "display-name": "Jina Now",
+        "pip-package": "jina-now"
+    }
+}

--- a/cli/known_plugins.json
+++ b/cli/known_plugins.json
@@ -1,6 +1,0 @@
-{
-    "now": {
-        "display-name": "Jina Now",
-        "pip-package": "jina-now"
-    }
-}

--- a/cli/known_plugins.py
+++ b/cli/known_plugins.py
@@ -1,0 +1,6 @@
+plugin_info = {
+    'now': {  # your sub-command
+        'display-name': 'Jina Now',  # the name of your plugin/project
+        'pip-package': 'jina-now',  # the pip package to install
+    }
+}


### PR DESCRIPTION
**TODO**

- [x] automatically support commands if the start with 'jina-'
- [x] give sensible warning about uninstalled jina packages
- [x] enable suggestions for uninstalled jina packages
- [x] centralize checking for new versions of jina packages
- [x] move 'database' of known plugins/packages to github


**Adding a Jina project to the core CLI as a plugin**

Basic usage:
- The project defines its own CLI and command
- The command associated with the project need to look like `jina-whatever`. If it does, and it is installed on the user's system, then `jina whatever` will also work automatically, **no need to configure anything, no need to wait for a core release**
- Any changes to the plugin CLI will be reflected automatically in the core CLI

Slightly-more-advanced stuff:
- For these features, the new **project's name, pip-package,  and plugin sub-command must be added to a json** on the Jina master branch. This way this info is always accessible and not tied to core release cycles.
- When the user uses the plugin, the core CLI automatically checks if the plugin has a newer version released on pip, and alerts the user
- If the user tries to use the plugin through the core CLI, but the plugin is not installed, the core CLI tells the user what to install

**Known issues, will not work in this first iteration**

- Autocompletion with a plugin is not trivial. There are a few ideas, but none of them are perfect, so it is probably better to wait out on this.