### PR TITLE
fix(executor): runtime args are now passed directly without any parsing

### DIFF
--- a/jina/jaml/__init__.py
+++ b/jina/jaml/__init__.py
@@ -168,7 +168,7 @@ class JAML:
         :param stream: the stream to load
         :param substitute: substitute environment, internal reference and context variables.
         :param context: context replacement variables in a dict, the value of the dict is the replacement.
-        :param runtime_args: Optional runtime_args to be passed to the created object without coming from the JAML file
+        :param runtime_args: Optional runtime_args to be directly passed without being parsed into a yaml config
         :return: the Python object
 
         """
@@ -569,13 +569,12 @@ class JAMLCompatible(metaclass=JAMLCompatibleType):
         :param node: the node to traverse
         :return: the parser associated with the class
         """
-        data = constructor.construct_mapping(node, deep=True)  # todo update
+        data = constructor.construct_mapping(node, deep=True)
         from jina.jaml.parsers import get_parser
 
         return get_parser(cls, version=data.get('version', None)).parse(
             cls, data, runtime_args=constructor.runtime_args
         )
-        # return get_parser(cls, version=data.get('version', None)).parse(cls, data)
 
     def save_config(self, filename: Optional[str] = None):
         """
@@ -639,11 +638,11 @@ class JAMLCompatible(metaclass=JAMLCompatibleType):
             # load Executor from yaml file and substitute environment variables
             os.environ['VAR_A'] = 'hello-world'
             b = BaseExecutor.load_config('a.yml')
-            assert b.name == hello - world
+            assert b.name == 'hello-world'
 
             # load Executor from yaml file and substitute variables from a dict
             b = BaseExecutor.load_config('a.yml', context={'VAR_A': 'hello-world'})
-            assert b.name == hello - world
+            assert b.name == 'hello-world'
 
             # disable substitute
             b = BaseExecutor.load_config('a.yml', substitute=False)
@@ -658,7 +657,7 @@ class JAMLCompatible(metaclass=JAMLCompatibleType):
         :param uses_metas: dictionary of parameters to overwrite from the default config's metas field
         :param uses_requests: dictionary of parameters to overwrite from the default config's requests field
         :param extra_search_paths: extra paths used when looking for executor yaml files
-        :param runtime_args: Optional runtime_args to be passed to the init function without parsing them into the JAML file
+        :param runtime_args: Optional runtime_args to be directly passed without being parsed into a yaml config
         :param kwargs: kwargs for parse_config_source
         :return: :class:`JAMLCompatible` object
         """

--- a/jina/jaml/__init__.py
+++ b/jina/jaml/__init__.py
@@ -5,16 +5,17 @@ import string
 import tempfile
 import warnings
 from types import SimpleNamespace
-from typing import Dict, Any, Union, TextIO, Optional, List, Tuple
+from typing import Any, Dict, List, Optional, TextIO, Tuple, Union
 
 import yaml
 from yaml.constructor import FullConstructor
 
 from jina.jaml.helper import (
-    JinaResolver,
     JinaLoader,
-    parse_config_source,
+    JinaResolver,
+    get_jina_loader_with_runtime,
     load_py_modules,
+    parse_config_source,
 )
 
 __all__ = ['JAML', 'JAMLCompatible']
@@ -73,8 +74,10 @@ class JAML:
         JAML.load(...)
         JAML.dump(...)
 
+
         class DummyClass:
             pass
+
 
         JAML.register(DummyClass)
 
@@ -125,9 +128,9 @@ class JAML:
     .. highlight:: python
     .. code-block:: python
 
-        obj = JAML.load(fp, substitute=True,
-                            context={'context_var': 3.14,
-                                    'context_var2': 'hello-world'})
+        obj = JAML.load(
+            fp, substitute=True, context={'context_var': 3.14, 'context_var2': 'hello-world'}
+        )
 
     Internal references point to other variables in the yaml file itself, and can be accessed using the following syntax:
 
@@ -148,7 +151,12 @@ class JAML:
     """
 
     @staticmethod
-    def load(stream, substitute: bool = False, context: Dict[str, Any] = None):
+    def load(
+        stream,
+        substitute: bool = False,
+        context: Dict[str, Any] = None,
+        runtime_args: Optional[Dict[str, Any]] = None,
+    ):
         """Parse the first YAML document in a stream and produce the corresponding Python object.
 
         .. note::
@@ -157,13 +165,15 @@ class JAML:
             to load YAML config into objects, please use :meth:`Flow.load_config`,
             :meth:`BaseExecutor.load_config`, etc.
 
+        :param stream: the stream to load
         :param substitute: substitute environment, internal reference and context variables.
         :param context: context replacement variables in a dict, the value of the dict is the replacement.
-        :param stream: the stream to load
+        :param runtime_args: Optional runtime_args to be passed to the created object without coming from the JAML file
         :return: the Python object
 
         """
-        r = yaml.load(stream, Loader=JinaLoader)
+        r = yaml.load(stream, Loader=get_jina_loader_with_runtime(runtime_args))
+
         if substitute:
             r = JAML.expand_dict(r, context)
         return r
@@ -559,10 +569,13 @@ class JAMLCompatible(metaclass=JAMLCompatibleType):
         :param node: the node to traverse
         :return: the parser associated with the class
         """
-        data = constructor.construct_mapping(node, deep=True)
+        data = constructor.construct_mapping(node, deep=True)  # todo update
         from jina.jaml.parsers import get_parser
 
-        return get_parser(cls, version=data.get('version', None)).parse(cls, data)
+        return get_parser(cls, version=data.get('version', None)).parse(
+            cls, data, runtime_args=constructor.runtime_args
+        )
+        # return get_parser(cls, version=data.get('version', None)).parse(cls, data)
 
     def save_config(self, filename: Optional[str] = None):
         """
@@ -594,6 +607,7 @@ class JAMLCompatible(metaclass=JAMLCompatibleType):
         uses_metas: Optional[Dict] = None,
         uses_requests: Optional[Dict] = None,
         extra_search_paths: Optional[List[str]] = None,
+        runtime_args: Optional[Dict[str, Any]] = None,
         **kwargs,
     ) -> 'JAMLCompatible':
         """A high-level interface for loading configuration with features
@@ -625,11 +639,11 @@ class JAMLCompatible(metaclass=JAMLCompatibleType):
             # load Executor from yaml file and substitute environment variables
             os.environ['VAR_A'] = 'hello-world'
             b = BaseExecutor.load_config('a.yml')
-            assert b.name == hello-world
+            assert b.name == hello - world
 
             # load Executor from yaml file and substitute variables from a dict
             b = BaseExecutor.load_config('a.yml', context={'VAR_A': 'hello-world'})
-            assert b.name == hello-world
+            assert b.name == hello - world
 
             # disable substitute
             b = BaseExecutor.load_config('a.yml', substitute=False)
@@ -644,10 +658,10 @@ class JAMLCompatible(metaclass=JAMLCompatibleType):
         :param uses_metas: dictionary of parameters to overwrite from the default config's metas field
         :param uses_requests: dictionary of parameters to overwrite from the default config's requests field
         :param extra_search_paths: extra paths used when looking for executor yaml files
+        :param runtime_args: Optional runtime_args to be passed to the init function without parsing them into the JAML file
         :param kwargs: kwargs for parse_config_source
         :return: :class:`JAMLCompatible` object
         """
-
         if isinstance(source, str) and os.path.exists(source):
             extra_search_paths = (extra_search_paths or []) + [os.path.dirname(source)]
 
@@ -723,7 +737,7 @@ class JAMLCompatible(metaclass=JAMLCompatibleType):
                 # revert yaml's tag and load again, this time with substitution
                 tag_yml = JAML.unescape(JAML.dump(no_tag_yml))
             # load into object, no more substitute
-            return JAML.load(tag_yml, substitute=False)
+            return JAML.load(tag_yml, substitute=False, runtime_args=runtime_args)
 
     @classmethod
     def _override_yml_params(cls, raw_yaml, field_name, override_field):

--- a/jina/jaml/__init__.py
+++ b/jina/jaml/__init__.py
@@ -606,6 +606,7 @@ class JAMLCompatible(metaclass=JAMLCompatibleType):
         uses_metas: Optional[Dict] = None,
         uses_requests: Optional[Dict] = None,
         extra_search_paths: Optional[List[str]] = None,
+        py_modules: Optional[str] = None,
         runtime_args: Optional[Dict[str, Any]] = None,
         **kwargs,
     ) -> 'JAMLCompatible':
@@ -657,10 +658,23 @@ class JAMLCompatible(metaclass=JAMLCompatibleType):
         :param uses_metas: dictionary of parameters to overwrite from the default config's metas field
         :param uses_requests: dictionary of parameters to overwrite from the default config's requests field
         :param extra_search_paths: extra paths used when looking for executor yaml files
-        :param runtime_args: Optional runtime_args to be directly passed without being parsed into a yaml config
+        :param py_modules: Optional py_module from which the object need to be loaded
+        :param runtime_args: Optional dictionary of parameters runtime_args to be directly passed without being parsed into a yaml config
+        :param : runtime_args that need to be passed to the yaml
+
         :param kwargs: kwargs for parse_config_source
         :return: :class:`JAMLCompatible` object
         """
+        if runtime_args:
+            kwargs[
+                'runtimes_args'
+            ] = (
+                dict()
+            )  # when we have runtime args it is needed to have an empty runtime args session in the yam config
+
+        if py_modules:
+            kwargs['runtimes_args']['py_modules'] = py_modules
+
         if isinstance(source, str) and os.path.exists(source):
             extra_search_paths = (extra_search_paths or []) + [os.path.dirname(source)]
 

--- a/jina/jaml/helper.py
+++ b/jina/jaml/helper.py
@@ -2,11 +2,11 @@ import collections
 import json
 import os
 import warnings
-from typing import Union, TextIO, Dict, Tuple, Optional, List
+from typing import Any, Dict, List, Optional, TextIO, Tuple, Union
 
 from yaml import MappingNode
 from yaml.composer import Composer
-from yaml.constructor import FullConstructor, ConstructorError
+from yaml.constructor import ConstructorError, FullConstructor
 from yaml.parser import Parser
 from yaml.reader import Reader
 from yaml.resolver import Resolver
@@ -91,13 +91,29 @@ class JinaLoader(Reader, Scanner, Parser, Composer, JinaConstructor, JinaResolve
     :param stream: the stream to load.
     """
 
-    def __init__(self, stream):
+    def __init__(self, stream, runtime_args=None):
         Reader.__init__(self, stream)
         Scanner.__init__(self)
         Parser.__init__(self)
         Composer.__init__(self)
         JinaConstructor.__init__(self)
         JinaResolver.__init__(self)
+        self.runtime_args = runtime_args
+
+
+def get_jina_loader_with_runtime(runtime_args: Optional[Dict[str, Any]] = None):
+    """Create a JinaLoader init function which already stored the runtime_args in the init function, usefully for
+    `yaml.load(stream,loader=JinaLoader)` which needs a class with a init function with only one parameter
+
+    :param runtime_args: Optional runtime_args to be passed to the created object without coming from the JAML file
+    :return: A function that initialize a JinaLoader with the runtime_args stored within the function
+
+    """
+
+    def _get_loader(stream):
+        return JinaLoader(stream, runtime_args)
+
+    return _get_loader
 
 
 # remove on|On|ON resolver

--- a/jina/jaml/helper.py
+++ b/jina/jaml/helper.py
@@ -105,7 +105,7 @@ def get_jina_loader_with_runtime(runtime_args: Optional[Dict[str, Any]] = None):
     """Create a JinaLoader init function which already stored the runtime_args in the init function, usefully for
     `yaml.load(stream,loader=JinaLoader)` which needs a class with a init function with only one parameter
 
-    :param runtime_args: Optional runtime_args to be passed to the created object without coming from the JAML file
+    :param runtime_args: Optional runtime_args to be directly passed without being parsed into a yaml config
     :return: A function that initialize a JinaLoader with the runtime_args stored within the function
 
     """

--- a/jina/jaml/parsers/base.py
+++ b/jina/jaml/parsers/base.py
@@ -1,4 +1,4 @@
-from typing import Dict, Union, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 
 if TYPE_CHECKING:
     from jina.orchestrate.flow.base import Flow
@@ -16,13 +16,16 @@ class VersionedYAMLParser:
 
     version = 'legacy'  #: the version number this parser designed for
 
-    def parse(self, cls: type, data: Dict) -> Union['Flow', 'BaseExecutor']:
+    def parse(
+        self, cls: type, data: Dict, runtime_args: Optional[Dict[str, Any]]
+    ) -> Union['Flow', 'BaseExecutor']:
         """Return the Flow YAML parser given the syntax version number
 
 
         .. # noqa: DAR401
         :param cls: target class type to parse into, must be a :class:`JAMLCompatible` type
         :param data: flow yaml file loaded as python dict
+        :param runtime_args: Optional runtime_args to be passed to the created object without coming from the JAML file
         """
         raise NotImplementedError
 

--- a/jina/jaml/parsers/base.py
+++ b/jina/jaml/parsers/base.py
@@ -25,7 +25,7 @@ class VersionedYAMLParser:
         .. # noqa: DAR401
         :param cls: target class type to parse into, must be a :class:`JAMLCompatible` type
         :param data: flow yaml file loaded as python dict
-        :param runtime_args: Optional runtime_args to be passed to the created object without coming from the JAML file
+        :param runtime_args: Optional runtime_args to be directly passed without being parsed into a yaml config
         """
         raise NotImplementedError
 

--- a/jina/jaml/parsers/default/v1.py
+++ b/jina/jaml/parsers/default/v1.py
@@ -1,7 +1,7 @@
-from typing import Dict, Type
+from typing import Any, Dict, Optional, Type
 
+from jina.jaml import JAML, JAMLCompatible
 from jina.jaml.parsers.base import VersionedYAMLParser
-from jina.jaml import JAMLCompatible, JAML
 
 
 class V1Parser(VersionedYAMLParser):
@@ -9,10 +9,16 @@ class V1Parser(VersionedYAMLParser):
 
     version = '1'  # the version number this parser designed for
 
-    def parse(self, cls: Type['JAMLCompatible'], data: Dict) -> 'JAMLCompatible':
+    def parse(
+        self,
+        cls: Type['JAMLCompatible'],
+        data: Dict,
+        runtime_args: Optional[Dict[str, Any]] = None,
+    ) -> 'JAMLCompatible':
         """
         :param cls: target class type to parse into, must be a :class:`JAMLCompatible` type
         :param data: flow yaml file loaded as python dict
+        :param runtime_args: Optional runtime_args to be passed to the created object without coming from the JAML file
         :return: the YAML parser given the syntax version number
         """
         expanded_data = JAML.expand_dict(data, None)

--- a/jina/jaml/parsers/default/v1.py
+++ b/jina/jaml/parsers/default/v1.py
@@ -18,7 +18,7 @@ class V1Parser(VersionedYAMLParser):
         """
         :param cls: target class type to parse into, must be a :class:`JAMLCompatible` type
         :param data: flow yaml file loaded as python dict
-        :param runtime_args: Optional runtime_args to be passed to the created object without coming from the JAML file
+        :param runtime_args: Optional runtime_args to be directly passed without being parsed into a yaml config
         :return: the YAML parser given the syntax version number
         """
         expanded_data = JAML.expand_dict(data, None)

--- a/jina/jaml/parsers/executor/legacy.py
+++ b/jina/jaml/parsers/executor/legacy.py
@@ -60,7 +60,7 @@ class LegacyParser(VersionedYAMLParser):
         """
         :param cls: target class type to parse into, must be a :class:`JAMLCompatible` type
         :param data: flow yaml file loaded as python dict
-        :param runtime_args: Optional runtime_args to be passed to the created object without coming from the JAML file
+        :param runtime_args: Optional runtime_args to be directly passed without being parsed into a yaml config
         :return: the Flow YAML parser given the syntax version number
         """
         from jina.logging.predefined import default_logger

--- a/jina/jaml/parsers/executor/legacy.py
+++ b/jina/jaml/parsers/executor/legacy.py
@@ -1,6 +1,6 @@
 import inspect
 from functools import reduce
-from typing import Dict, Type, Set
+from typing import Any, Dict, Optional, Set, Type
 
 from jina.jaml.parsers.base import VersionedYAMLParser
 from jina.serve.executors import BaseExecutor
@@ -51,10 +51,16 @@ class LegacyParser(VersionedYAMLParser):
         args = list(map(lambda x: get_class_arguments(x), all_classes))
         return set(reduce(lambda x, y: x + y, args))
 
-    def parse(self, cls: Type['BaseExecutor'], data: Dict) -> 'BaseExecutor':
+    def parse(
+        self,
+        cls: Type['BaseExecutor'],
+        data: Dict,
+        runtime_args: Optional[Dict[str, Any]] = None,
+    ) -> 'BaseExecutor':
         """
         :param cls: target class type to parse into, must be a :class:`JAMLCompatible` type
         :param data: flow yaml file loaded as python dict
+        :param runtime_args: Optional runtime_args to be passed to the created object without coming from the JAML file
         :return: the Flow YAML parser given the syntax version number
         """
         from jina.logging.predefined import default_logger
@@ -70,7 +76,7 @@ class LegacyParser(VersionedYAMLParser):
             **data.get('with', {}),
             metas=data.get('metas', {}),
             requests=data.get('requests', {}),
-            runtime_args=data.get('runtime_args', {}),
+            runtime_args=runtime_args,
         )
         cls._init_from_yaml = False
 

--- a/jina/jaml/parsers/flow/v1.py
+++ b/jina/jaml/parsers/flow/v1.py
@@ -1,11 +1,11 @@
-import os
 import argparse
-from typing import Dict, Any
+import os
+from typing import Any, Dict, Optional
 
-from jina.jaml.parsers.base import VersionedYAMLParser
 from jina import Flow
 from jina.enums import DeploymentRoleType
-from jina.helper import expand_env_var, ArgNamespace
+from jina.helper import ArgNamespace, expand_env_var
+from jina.jaml.parsers.base import VersionedYAMLParser
 from jina.parsers import set_deployment_parser, set_gateway_parser
 
 
@@ -50,10 +50,13 @@ class V1Parser(VersionedYAMLParser):
 
     version = '1'  # the version number this parser designed for
 
-    def parse(self, cls: type, data: Dict) -> 'Flow':
+    def parse(
+        self, cls: type, data: Dict, runtime_args: Optional[Dict[str, Any]] = None
+    ) -> 'Flow':
         """
         :param cls: the class registered for dumping/loading
         :param data: flow yaml file loaded as python dict
+        :param runtime_args: Optional runtime_args to be passed to the created object without coming from the JAML file
         :return: the Flow YAML parser given the syntax version number
         """
         p = data.get('with', {})  # type: Dict[str, Any]

--- a/jina/jaml/parsers/flow/v1.py
+++ b/jina/jaml/parsers/flow/v1.py
@@ -56,7 +56,7 @@ class V1Parser(VersionedYAMLParser):
         """
         :param cls: the class registered for dumping/loading
         :param data: flow yaml file loaded as python dict
-        :param runtime_args: Optional runtime_args to be passed to the created object without coming from the JAML file
+        :param runtime_args: Optional runtime_args to be directly passed without being parsed into a yaml config
         :return: the Flow YAML parser given the syntax version number
         """
         p = data.get('with', {})  # type: Dict[str, Any]

--- a/jina/serve/runtimes/request_handlers/data_request_handler.py
+++ b/jina/serve/runtimes/request_handlers/data_request_handler.py
@@ -47,6 +47,7 @@ class DataRequestHandler:
                     'py_modules': self.args.py_modules,
                 },
                 extra_search_paths=self.args.extra_search_paths,
+                kwargs={'runtime_args': {}},
             )
         except BadConfigSource as ex:
             self.logger.error(

--- a/jina/serve/runtimes/request_handlers/data_request_handler.py
+++ b/jina/serve/runtimes/request_handlers/data_request_handler.py
@@ -38,16 +38,15 @@ class DataRequestHandler:
                 uses_with=self.args.uses_with,
                 uses_metas=self.args.uses_metas,
                 uses_requests=self.args.uses_requests,
-                runtime_args={
+                runtime_args={  # these are not parsed to the yaml config file but are pass directly during init
                     'workspace': self.args.workspace,
                     'shard_id': self.args.shard_id,
                     'shards': self.args.shards,
                     'replicas': self.args.replicas,
                     'name': self.args.name,
-                    'py_modules': self.args.py_modules,
                 },
+                py_modules=self.args.py_modules,
                 extra_search_paths=self.args.extra_search_paths,
-                kwargs={'runtime_args': {}},
             )
         except BadConfigSource as ex:
             self.logger.error(

--- a/tests/unit/serve/executors/test_runtime_args.py
+++ b/tests/unit/serve/executors/test_runtime_args.py
@@ -1,0 +1,29 @@
+import pickle
+from threading import Lock
+
+import pytest
+
+from jina.serve.executors import BaseExecutor
+
+
+class NotSerialisable:
+    def __init__(self):
+        self.lock = Lock()
+
+
+def test_object_not_seri():
+    with pytest.raises(TypeError):
+        serialized = pickle.dumps(NotSerialisable())
+
+
+def test_runtime_args_not_serialisable():
+
+    param = NotSerialisable()
+
+    b = BaseExecutor.load_config(
+        'BaseExecutor',
+        runtime_args={'hello': 'world', 'not_seri': param},
+    )
+
+    assert b.runtime_args.hello == 'world'
+    assert b.runtime_args.not_seri is param


### PR DESCRIPTION
done with @alaeddine-13 
The `JinaLoader` now allow to pass `runtime_args` to the init of the Executor without parsing them to a yaml before