### PR TITLE
fix: increase pytest timeout to 30

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -138,7 +138,7 @@ jobs:
           pytest --suppress-no-test-exit-code --force-flaky --min-passes 1 --max-runs 5 --cov=jina --cov-report=xml --timeout=600 -v -s --ignore-glob='tests/integration/hub_usage/dummyhub*' ${{ matrix.test-path }}
           echo "flag it as jina for codeoverage"
           echo "::set-output name=codecov_flag::jina"
-        timeout-minutes: 15
+        timeout-minutes: 30
         env:
           JINAHUB_USERNAME: ${{ secrets.JINAHUB_USERNAME }}
           JINAHUB_PASSWORD: ${{ secrets.JINAHUB_PASSWORD }}


### PR DESCRIPTION
# Increase CD pytest timeout to 30 min

## Description

Recently CD have been flaky. It seems that random tests timeout. I checked and the pytest timeout is actually set to 15 minutes only. [In CI it is 30 minutes](https://github.com/jina-ai/jina/blob/master/.github/workflows/ci.yml#L292), so we should set the same value here.