### PR TITLE
feat: add grpc reflection support

### DIFF
--- a/docs/how-to/external-executor.md
+++ b/docs/how-to/external-executor.md
@@ -37,6 +37,11 @@ f = Flow().add(host=exec_host, port=exec_port, external=True)
 After that, the external Executor will behave just like an internal one. And you can even add the same Executor to multiple
 Flows!
 
+````{admonition} Note
+:class: note
+If an external Executor needs multiple predecessors, reducing needs to be enabled. So setting disable_reduce=True is not allowed for these cases. 
+````
+
 ## Starting standalone Executors
 
 The example above assumes that there already is an Executor running, and you just want to access

--- a/extra-requirements.txt
+++ b/extra-requirements.txt
@@ -45,6 +45,7 @@ uvloop:                     perf, standard,devel
 numpy:                      core
 protobuf>=3.19.1:           core
 grpcio>=1.33.1:             core
+grpcio-reflection>=1.33.1:  core
 pyyaml>=5.3.1:              core
 docarray>=0.9.10:           core
 packaging>=20.0:            core

--- a/jina/orchestrate/flow/base.py
+++ b/jina/orchestrate/flow/base.py
@@ -881,6 +881,11 @@ class Flow(PostMixin, JAMLCompatible, ExitStack, metaclass=FlowType):
             port = helper.random_port()
             args.port = port
 
+        if len(needs) > 1 and args.external and args.disable_reduce:
+            raise ValueError(
+                'External Executors with multiple needs have to do auto reduce.'
+            )
+
         op_flow._deployment_nodes[deployment_name] = Deployment(args, needs)
 
         op_flow.last_deployment = deployment_name

--- a/jina/resources/extra-requirements.txt
+++ b/jina/resources/extra-requirements.txt
@@ -45,6 +45,7 @@ uvloop:                     perf, standard,devel
 numpy:                      core
 protobuf>=3.19.1:           core
 grpcio>=1.33.1:             core
+grpcio-reflection>=1.33.1:  core
 pyyaml>=5.3.1:              core
 docarray>=0.9.10:           core
 packaging>=20.0:            core

--- a/jina/serve/networking.py
+++ b/jina/serve/networking.py
@@ -855,10 +855,7 @@ class GrpcConnectionPool:
 
     @staticmethod
     def create_async_channel_stub(
-        address,
-        tls=False,
-        root_certificates: Optional[str] = None,
-        summary: Optional['Summary'] = None
+        address, tls=False, root_certificates: Optional[str] = None, summary=None
     ) -> Tuple[_ConnectionStubs, grpc.aio.Channel,]:
         """
         Creates an async GRPC Channel. This channel has to be closed eventually!
@@ -866,6 +863,7 @@ class GrpcConnectionPool:
         :param address: the address to create the connection to, like 127.0.0.0.1:8080
         :param tls: if True, use tls for the grpc channel
         :param root_certificates: the path to the root certificates for tls, only u
+        :param summary: Optional Prometheus summary object
 
         :returns: DataRequest/ControlRequest stubs and an async grpc channel
         """

--- a/jina/serve/networking.py
+++ b/jina/serve/networking.py
@@ -2,6 +2,7 @@ import asyncio
 import contextlib
 import ipaddress
 import os
+from collections import defaultdict
 from typing import Dict, List, Optional, Tuple
 from urllib.parse import urlparse
 
@@ -30,11 +31,12 @@ class ReplicaList:
     Maintains a list of connections to replicas and uses round robin for selecting a replica
     """
 
-    def __init__(self):
+    def __init__(self, summary):
         self._connections = []
         self._address_to_connection_idx = {}
         self._address_to_channel = {}
         self._rr_counter = 0
+        self.summary = summary
 
     def add_connection(self, address: str):
         """
@@ -50,15 +52,12 @@ class ReplicaList:
                 use_tls = False
 
             self._address_to_connection_idx[address] = len(self._connections)
-            (
-                single_data_stub,
-                data_stub,
-                control_stub,
-                channel,
-            ) = GrpcConnectionPool.create_async_channel_stub(address, tls=use_tls)
+            stubs, channel = GrpcConnectionPool.create_async_channel_stub(
+                address, tls=use_tls, summary=self.summary
+            )
             self._address_to_channel[address] = channel
 
-            self._connections.append((single_data_stub, data_stub, control_stub))
+            self._connections.append(stubs)
 
     async def remove_connection(self, address: str):
         """
@@ -147,13 +146,105 @@ class GrpcConnectionPool:
     K8S_PORT_USES_BEFORE = 8081
     K8S_PORT = 8080
 
+    class _ConnectionStubs:
+        """
+        Maintains a list of grpc stubs available for a particular connection
+        """
+
+        STUB_MAPPING = {
+            'jina.JinaControlRequestRPC': jina_pb2_grpc.JinaControlRequestRPCStub,
+            'jina.JinaDataRequestRPC': jina_pb2_grpc.JinaDataRequestRPCStub,
+            'jina.JinaSingleDataRequestRPC': jina_pb2_grpc.JinaSingleDataRequestRPCStub,
+            'jina.JinaRPC': jina_pb2_grpc.JinaRPCStub,
+        }
+
+        def __init__(self, address, channel, summary):
+            self.address = address
+            self.channel = channel
+            self._summary_time = summary
+            self._initialized = False
+
+        # This has to be done lazily, because the target endpoint may not be available
+        # when a connection is added
+        def _init_stubs(self):
+            available_services = GrpcConnectionPool.get_available_services(self.address)
+            stubs = defaultdict(lambda: None)
+            for service in available_services:
+                # skip the reflection service, it will not be used anymore
+                if service != 'grpc.reflection.v1alpha.ServerReflection':
+                    stubs[service] = self.STUB_MAPPING[service](self.channel)
+            self.control_stub = stubs['jina.JinaControlRequestRPC']
+            self.data_list_stub = stubs['jina.JinaDataRequestRPC']
+            self.single_data_stub = stubs['jina.JinaSingleDataRequestRPC']
+            self.stream_stub = stubs['jina.JinaRPC']
+            self._initialized = True
+
+        async def send_requests(
+            self, requests: List[Request], metadata, compression
+        ) -> Tuple:
+            if not self._initialized:
+                self._init_stubs()
+            request_type = type(requests[0])
+            if request_type == DataRequest and len(requests) == 1:
+                if self.single_data_stub:
+                    call_result = self.single_data_stub.process_single_data(
+                        requests[0],
+                        metadata=metadata,
+                        compression=compression,
+                    )
+                    with self._summary_time:
+                        metadata, response = (
+                            await call_result.trailing_metadata(),
+                            await call_result,
+                        )
+                    return response, metadata
+                elif self.stream_stub:
+                    with self._summary_time:
+                        async for resp in self.stream_stub.Call(
+                            iter(requests),
+                            compression=compression,
+                        ):
+                            return resp, None
+            if request_type == DataRequest and len(requests) > 1:
+                if self.data_list_stub:
+                    call_result = self.data_list_stub.process_data(
+                        requests,
+                        metadata=metadata,
+                        compression=compression,
+                    )
+                    with self._summary_time:
+                        metadata, response = (
+                            await call_result.trailing_metadata(),
+                            await call_result,
+                        )
+                    return response, metadata
+                else:
+                    raise ValueError(
+                        'Can not send list of DataRequests. gRPC endpoint not available.'
+                    )
+            elif request_type == ControlRequest:
+                if self.control_stub:
+                    call_result = self.control_stub.process_control(requests[0])
+                    metadata, response = (
+                        await call_result.trailing_metadata(),
+                        await call_result,
+                    )
+                    return response, metadata
+                else:
+                    raise ValueError(
+                        'Can not send ControlRequest. gRPC endpoint not available.'
+                    )
+            else:
+                raise ValueError(f'Unsupported request type {type(requests[0])}')
+
     class _ConnectionPoolMap:
-        def __init__(self, logger: Optional[JinaLogger]):
+        def __init__(self, logger: Optional[JinaLogger], summary):
             self._logger = logger
             # this maps deployments to shards or heads
             self._deployments: Dict[str, Dict[str, Dict[int, ReplicaList]]] = {}
             # dict stores last entity id used for a particular deployment, used for round robin
             self._access_count: Dict[str, int] = {}
+            self.summary = summary
 
             if os.name != 'nt':
                 os.unsetenv('http_proxy')
@@ -241,7 +332,7 @@ class GrpcConnectionPool:
         ):
             self._add_deployment(deployment)
             if entity_id not in self._deployments[deployment][type]:
-                connection_list = ReplicaList()
+                connection_list = ReplicaList(self.summary)
                 self._deployments[deployment][type][entity_id] = connection_list
 
             if not self._deployments[deployment][type][entity_id].has_connection(
@@ -289,7 +380,6 @@ class GrpcConnectionPool:
         metrics_registry: Optional['CollectorRegistry'] = None,
     ):
         self._logger = logger or JinaLogger(self.__class__.__name__)
-        self._connections = self._ConnectionPoolMap(self._logger)
         GRPC_COMPRESSION_MAP = {
             'NoCompression'.lower(): grpc.Compression.NoCompression,
             'Gzip'.lower(): grpc.Compression.Gzip,
@@ -317,6 +407,7 @@ class GrpcConnectionPool:
             ).time()
         else:
             self._summary_time = contextlib.nullcontext()
+        self._connections = self._ConnectionPoolMap(self._logger, self._summary_time)
 
     def send_request(
         self,
@@ -486,52 +577,24 @@ class GrpcConnectionPool:
         await self._connections.close()
 
     def _send_requests(
-        self, requests: List[Request], connection, endpoint: Optional[str] = None
+        self,
+        requests: List[Request],
+        connection: _ConnectionStubs,
+        endpoint: Optional[str] = None,
     ) -> asyncio.Task:
         # this wraps the awaitable object from grpc as a coroutine so it can be used as a task
         # the grpc call function is not a coroutine but some _AioCall
-        async def task_wrapper(requests, stubs, endpoint):
+        async def task_wrapper(
+            requests, connection: GrpcConnectionPool._ConnectionStubs, endpoint
+        ):
             metadata = (('endpoint', endpoint),) if endpoint else None
             for i in range(3):
                 try:
-                    request_type = type(requests[0])
-                    if request_type == DataRequest and len(requests) == 1:
-
-                        call_result = stubs[0].process_single_data(
-                            requests[0],
-                            metadata=metadata,
-                            compression=self.compression,
-                        )
-                        with self._summary_time:
-                            metadata, response = (
-                                await call_result.trailing_metadata(),
-                                await call_result,
-                            )
-                        return response, metadata
-                    if request_type == DataRequest and len(requests) > 1:
-                        call_result = stubs[1].process_data(
-                            requests,
-                            metadata=metadata,
-                            compression=self.compression,
-                        )
-
-                        with self._summary_time:  # todo count the fact that there are multiple request
-                            metadata, response = (
-                                await call_result.trailing_metadata(),
-                                await call_result,
-                            )
-                        return response, metadata
-                    elif request_type == ControlRequest:
-                        call_result = stubs[2].process_control(requests[0])
-                        metadata, response = (
-                            await call_result.trailing_metadata(),
-                            await call_result,
-                        )
-                        return response, metadata
-                    else:
-                        raise ValueError(
-                            f'Unsupported request type {type(requests[0])}'
-                        )
+                    return await connection.send_requests(
+                        requests=requests,
+                        metadata=metadata,
+                        compression=self.compression,
+                    )
                 except AioRpcError as e:
                     if e.code() != grpc.StatusCode.UNAVAILABLE:
                         raise
@@ -795,12 +858,8 @@ class GrpcConnectionPool:
         address,
         tls=False,
         root_certificates: Optional[str] = None,
-    ) -> Tuple[
-        jina_pb2_grpc.JinaSingleDataRequestRPCStub,
-        jina_pb2_grpc.JinaDataRequestRPCStub,
-        jina_pb2_grpc.JinaControlRequestRPCStub,
-        grpc.aio.Channel,
-    ]:
+        summary: Optional['Summary'] = None
+    ) -> Tuple[_ConnectionStubs, grpc.aio.Channel,]:
         """
         Creates an async GRPC Channel. This channel has to be closed eventually!
 
@@ -818,9 +877,7 @@ class GrpcConnectionPool:
         )
 
         return (
-            jina_pb2_grpc.JinaSingleDataRequestRPCStub(channel),
-            jina_pb2_grpc.JinaDataRequestRPCStub(channel),
-            jina_pb2_grpc.JinaControlRequestRPCStub(channel),
+            GrpcConnectionPool._ConnectionStubs(address, channel, summary),
             channel,
         )
 
@@ -833,8 +890,7 @@ class GrpcConnectionPool:
 
         :returns: List of services offered
         """
-        channel = grpc.insecure_channel(address)
-        reflection_stub = ServerReflectionStub(channel)
+        reflection_stub = ServerReflectionStub(grpc.insecure_channel(address))
         response = reflection_stub.ServerReflectionInfo(
             iter([ServerReflectionRequest(list_services="")])
         )

--- a/jina/serve/networking.py
+++ b/jina/serve/networking.py
@@ -890,12 +890,13 @@ class GrpcConnectionPool:
 
         :returns: List of services offered
         """
-        reflection_stub = ServerReflectionStub(grpc.insecure_channel(address))
-        response = reflection_stub.ServerReflectionInfo(
-            iter([ServerReflectionRequest(list_services="")])
-        )
-        res = next(response)
-        return [service.name for service in res.list_services_response.service]
+        with grpc.insecure_channel(address) as channel:
+            reflection_stub = ServerReflectionStub(channel)
+            response = reflection_stub.ServerReflectionInfo(
+                iter([ServerReflectionRequest(list_services="")])
+            )
+            res = next(response)
+            return [service.name for service in res.list_services_response.service]
 
 
 def in_docker():

--- a/jina/serve/runtimes/gateway/graph/topology_graph.py
+++ b/jina/serve/runtimes/gateway/graph/topology_graph.py
@@ -65,7 +65,7 @@ class TopologyGraph:
             if previous_task is not None:
                 result = await previous_task
                 request, metadata = result[0], result[1]
-            if 'is-error' in metadata:
+            if metadata and 'is-error' in metadata:
                 return request, metadata
             elif request is not None:
                 self.parts_to_send.append(request)
@@ -86,7 +86,7 @@ class TopologyGraph:
                         endpoint=endpoint,
                     )
                     self.end_time = datetime.utcnow()
-                    if 'is-error' in metadata:
+                    if metadata and 'is-error' in metadata:
                         self.status = resp.header.status
                     return resp, metadata
 

--- a/jina/serve/runtimes/worker/__init__.py
+++ b/jina/serve/runtimes/worker/__init__.py
@@ -7,8 +7,9 @@ from abc import ABC
 from typing import List, Optional, Union
 
 import grpc
+from grpc_reflection.v1alpha import reflection
 
-from jina.proto import jina_pb2_grpc
+from jina.proto import jina_pb2, jina_pb2_grpc
 from jina.serve.runtimes.asyncio import AsyncNewLoopRuntime
 from jina.serve.runtimes.request_handlers.data_request_handler import DataRequestHandler
 from jina.types.request.control import ControlRequest
@@ -74,6 +75,13 @@ class WorkerRuntime(AsyncNewLoopRuntime, ABC):
         jina_pb2_grpc.add_JinaControlRequestRPCServicer_to_server(
             self, self._grpc_server
         )
+        service_names = (
+            jina_pb2.DESCRIPTOR.services_by_name['JinaSingleDataRequestRPC'].full_name,
+            jina_pb2.DESCRIPTOR.services_by_name['JinaDataRequestRPC'].full_name,
+            jina_pb2.DESCRIPTOR.services_by_name['JinaControlRequestRPC'].full_name,
+            reflection.SERVICE_NAME,
+        )
+        reflection.enable_server_reflection(service_names, self._grpc_server)
         bind_addr = f'0.0.0.0:{self.args.port}'
         self.logger.debug(f'Start listening on {bind_addr}')
         self._grpc_server.add_insecure_port(bind_addr)

--- a/tests/integration/external_deployment/test_external_deployment.py
+++ b/tests/integration/external_deployment/test_external_deployment.py
@@ -275,7 +275,6 @@ def external_deployment_join_args(num_shards):
         str(num_shards),
         '--polling',
         'all',
-        '--disable-reduce',
     ]
     return set_deployment_parser().parse_args(args)
 
@@ -320,5 +319,5 @@ def test_flow_with_external_deployment_join(
         with flow:
             resp = flow.index(inputs=input_docs)
 
-        # Reducing applied for shards, not for uses, expect 100 docs
-        validate_response(resp, 100)
+        # Reducing applied everywhere, expect 50 docs, same as the input
+        validate_response(resp, len(input_docs))

--- a/tests/unit/orchestrate/flow/flow-orchestrate/test_flow_complex_topology.py
+++ b/tests/unit/orchestrate/flow/flow-orchestrate/test_flow_complex_topology.py
@@ -41,6 +41,7 @@ def test_flow_external_executor_with_gateway():
         name='serve-exec',
         target=serve_exec,
         kwargs={'port_expose': external_gateway_port, 'stop_event': e},
+        daemon=True,
     )
     t.start()
     time.sleep(3)  # allow exec to start
@@ -52,7 +53,6 @@ def test_flow_external_executor_with_gateway():
         assert docs.texts == ['foo']
 
     e.set()
-    t.join()
 
 
 class BarExec(Executor):

--- a/tests/unit/serve/runtimes/head/test_head_runtime.py
+++ b/tests/unit/serve/runtimes/head/test_head_runtime.py
@@ -9,14 +9,14 @@ import grpc
 import pytest
 from grpc import RpcError
 
-from jina import DocumentArray, Document
+from jina import Document, DocumentArray
 from jina.clients.request import request_generator
 from jina.enums import PollingType
 from jina.parsers import set_pod_parser
+from jina.proto import jina_pb2_grpc
 from jina.serve.networking import GrpcConnectionPool
 from jina.serve.runtimes.asyncio import AsyncNewLoopRuntime
 from jina.serve.runtimes.head import HeadRuntime
-from jina.proto import jina_pb2_grpc
 from jina.types.request import Request
 from jina.types.request.control import ControlRequest
 from jina.types.request.data import DataRequest
@@ -242,6 +242,31 @@ def test_base_polling(polling):
 
     assert response
     assert _queue_length(handle_queue) == 4 if polling == 'all' else 2
+
+    _destroy_runtime(args, cancel_event, runtime_thread)
+
+
+def test_head_runtime_reflection():
+    args = set_pod_parser().parse_args([])
+    cancel_event, handle_queue, runtime_thread = _create_runtime(args)
+
+    assert AsyncNewLoopRuntime.wait_for_ready_or_shutdown(
+        timeout=3.0,
+        ctrl_address=f'{args.host}:{args.port}',
+        ready_or_shutdown_event=multiprocessing.Event(),
+    )
+
+    service_names = GrpcConnectionPool.get_available_services(
+        f'{args.host}:{args.port}'
+    )
+    assert all(
+        service_name in service_names
+        for service_name in [
+            'jina.JinaControlRequestRPC',
+            'jina.JinaDataRequestRPC',
+            'jina.JinaSingleDataRequestRPC',
+        ]
+    )
 
     _destroy_runtime(args, cancel_event, runtime_thread)
 


### PR DESCRIPTION
This PR allows external Executor to be fronted by our gRPC Gateway. This enables us to deploy external Executors together with a Gateway (as `Executor.serve()` is doing.). In theory this also allows us to integrate complete Flows as external Executors into another Flow. See the tests for some examples.

Implementation details:
I've added support for gRPC reflection with this PR. When we add a new connection, we first check the available gRPC endpoints using reflection. This way we can figure out automatically if the GrpcConnctionPool is used to target a Worker/Head or Gateway. This is necessary because they have different gRPC interfaces (streaming and non streaming). There is no configuration necessary to enable this. The reflection call is done lazily before the first request is send to the target.
 
- [x] Support reflection via grpc. Find out if the target is gateway or head/worker. Create the right stubs and hide this in the GrpcConnectionPool
- [x] Add test case for the g2g scenario
- [x] Check on parsing that merging is not required at the external Executor
- [x] Mention merge limitations in docs

Closes https://github.com/jina-ai/jina/issues/4556

Unblocks: https://github.com/jina-ai/jina/issues/4502