### PR TITLE
feat: Expose Executors as first class citizens

### DIFF
--- a/docs/fundamentals/executor/executor-api.md
+++ b/docs/fundamentals/executor/executor-api.md
@@ -372,7 +372,7 @@ the Executor, and `**kwargs` is passed to the internal `Flow()` initialisation c
 For more details on these arguments and the workings of `Flow`, see the {ref}`Flow section <flow-cookbook>`.
 ````
 
-### Run Executor in Kubernetes
+### Run Executors in Kubernetes
 You can generate Kubernetes configuration files for your containerized Executor by using the static `Executor.to_k8s_yaml()` method. This works very similar to {ref}`deploying a Flow in Kubernetes <kubernetes>`, because your Executor is wrapped automatically in a Flow and using the very same deployment techniques.
 
 ```python
@@ -389,17 +389,20 @@ Executor.to_k8s_yaml(
 kubectl apply -R -f /tmp/config_out_folder
 ```
 The above example will deploy the `DummyHubExecutor` from Jina Hub into your Kubernetes cluster.
-(external-shared-executor)=
-#### External and shared Executor
-The type of stand-alone Executors can be either external or shared. By default, it will be external. An external Executor is deployd alongside a {ref}`Gatway <architecture-overview>`. A shared Executor has no Gateway. Both types of Executor {ref}`can be used directly in any Flow <external-executor>`.
-Having a Gateway may be useful if you want to be able to access your Executor with the {ref}`Client <client>` without an additional Flow. If the Executor will only be used inside other Flows, you should define a shared Executor to save the costs of running the Gateway Pod in Kubernetes.
 
 ````{admonition} Note
 :class: note
 The Executor you are using, needs to be already containerized and stored in a registry accessible from your Kubernetes cluster. We recommend Jina Hub for this.
 ````
 
-### Run Executor with Docker Compose
+(external-shared-executor)=
+#### External and shared Executors
+The type of stand-alone Executors can be either *external* or *shared*. By default, it will be external.
+An external Executor is deployd alongside a {ref}`Gateway <architecture-overview>`. 
+A shared Executor has no Gateway. Both types of Executor {ref}`can be used directly in any Flow <external-executor>`.
+Having a Gateway may be useful if you want to be able to access your Executor with the {ref}`Client <client>` without an additional Flow. If the Executor will only be used inside other Flows, you should define a shared Executor to save the costs of running the Gateway Pod in Kubernetes.
+
+### Run Executors with Docker Compose
 You can generate a Docker Compose service file for your containerized Executor by using the static `Executor.to_docker_compose_yaml()` method. This works very similar to {ref}`running a Flow with Docker Compose <docker-compose>`, because your Executor is wrapped automatically in a Flow and using the very same deployment techniques.
 
 ```python

--- a/docs/fundamentals/executor/executor-api.md
+++ b/docs/fundamentals/executor/executor-api.md
@@ -317,6 +317,7 @@ print(docs.embeddings.shape)
 ```
 ````
 
+(serve-executor-standalone)=
 ## Serve Executor stand-alone
 
 Executors can be served - and remotely accessed - directly, without the need to instantiate a Flow manually.

--- a/docs/fundamentals/executor/executor-api.md
+++ b/docs/fundamentals/executor/executor-api.md
@@ -320,8 +320,13 @@ print(docs.embeddings.shape)
 ## Serve Executor stand-alone
 
 Executors can be served - and remotely accessed - directly, without the need to instantiate a Flow manually.
-This is especially useful when debugging an Executor in a remote setting.
+This is especially useful when debugging an Executor in a remote setting. It can also be used to run external/shared Executors to be used in multiple Flows.
+There are different options how you can deploy and run a stand-alone Executor:
+* Run the Executor directly from Python with the `.serve()` class method
+* Run the static `Executor.to_k8s_yaml()` method to generate K8s deployment configuration files
+* Run the static `Executor.to_docker_compose_yaml()` method to generate a docker-compose service file
 
+### Serving Executors
 An Executor can be served using the `.serve()` class method:
 
 ````{tab} Serve Executor
@@ -364,6 +369,55 @@ the Executor, and `**kwargs` is passed to the internal `Flow()` initialisation c
 :class: seealso
 
 For more details on these arguments and the workings of `Flow`, see the {ref}`Flow section <flow-cookbook>`.
+````
+
+### Run Executor in Kubernetes
+You can generate Kubernetes configuration files for your containerized Executor by using the static `Executor.to_k8s_yaml()` method. This works very similar to {ref}`deploying a Flow in Kubernetes <kubernetes>`, because your Executor is wrapped automatically in a Flow and using the very same deployment techniques.
+
+```python
+from jina import Executor
+
+Executor.to_k8s_yaml(
+    output_base_path='/tmp/config_out_folder',
+    port_expose=8080,
+    uses='jinahub+docker://DummyHubExecutor',
+    executor_type=Executor.StandaloneExecutorType.EXTERNAL,
+)
+```
+```shell
+kubectl apply -R -f /tmp/config_out_folder
+```
+The above example will deploy the `DummyHubExecutor` from Jina Hub into your Kubernetes cluster.
+(external-shared-executor)=
+#### External and shared Executor
+The type of stand-alone Executors can be either external or shared. By default, it will be external. An external Executor is deployd alongside a {ref}`Gatway <architecture-overview>`. A shared Executor has no Gateway. Both types of Executor {ref}`can be used directly in any Flow <external-executor>`.
+Having a Gateway may be useful if you want to be able to access your Executor with the {ref}`Client <client>` without an additional Flow. If the Executor will only be used inside other Flows, you should define a shared Executor to save the costs of running the Gateway Pod in Kubernetes.
+
+````{admonition} Note
+:class: note
+The Executor you are using, needs to be already containerized and stored in a registry accessible from your Kubernetes cluster. We recommend Jina Hub for this.
+````
+
+### Run Executor with Docker Compose
+You can generate a Docker Compose service file for your containerized Executor by using the static `Executor.to_docker_compose_yaml()` method. This works very similar to {ref}`running a Flow with Docker Compose <docker-compose>`, because your Executor is wrapped automatically in a Flow and using the very same deployment techniques.
+
+```python
+from jina import Executor
+
+Executor.to_docker_compose_yaml(
+    output_path='/tmp/docker-compose.yml',
+    port_expose=8080,
+    uses='jinahub+docker://DummyHubExecutor',
+)
+```
+```shell
+ docker-compose -f /tmp/docker-compose.ym up
+```
+The above example will run the `DummyHubExecutor` from Jina Hub locally on your computer using Docker Compose.
+
+````{admonition} Note
+:class: note
+The Executor you are using, needs to be already containerized and stored in an accessible registry. We recommend Jina Hub for this.
 ````
 
 ### Use async Executors

--- a/docs/how-to/external-executor.md
+++ b/docs/how-to/external-executor.md
@@ -47,7 +47,7 @@ You can, however, also start your own standalone Executors, which can then be ac
 In the following sections we will describe how to run standalone Executors via the Jina command line interface (CLI). For more options to run your Executor, including in Kubernetes and Docker Compose, please read the {ref}`Executor API section <serve-executor-standalone>`.
 
 
-````{admonition} Advanced CLI options
+````{admonition} Advanced deployment options
 :class: seealso
 This tutorial walks through the basics of spawing a standalone (external) Executor. For more advanced options, refer to the
 {ref}`CLI <api/cli>` and {ref}`Executor API section <serve-executor-standalone>`

--- a/docs/how-to/external-executor.md
+++ b/docs/how-to/external-executor.md
@@ -42,14 +42,15 @@ Flows!
 The example above assumes that there already is an Executor running, and you just want to access
 it from your Flow.
 
-You can, however, also start your own standalone Executors, which can then be accessed from anywhere. There are two
-ways of doing this: Pulling an Executor from Jina Hub, and using a locally defined Executor. In either case, you will
-launch the Executor using the Jina command line interface (CLI).
+
+You can, however, also start your own standalone Executors, which can then be accessed from anywhere.
+In the following sections we will describe how to run standalone Executors via the Jina command line interface (CLI). For more options to run your Executor, including in Kubernetes and Docker Compose, please read the {ref}`Executor API section <serve-executor-standalone>`.
+
 
 ````{admonition} Advanced CLI options
 :class: seealso
 This tutorial walks through the basics of spawing a standalone (external) Executor. For more advanced options, refer to the
-{ref}`CLI <api/cli>`
+{ref}`CLI <api/cli>` and {ref}`Executor API section <serve-executor-standalone>`
 ````
 
 ## Using Jina Hub

--- a/jina/orchestrate/flow/base.py
+++ b/jina/orchestrate/flow/base.py
@@ -1818,7 +1818,7 @@ class Flow(PostMixin, JAMLCompatible, ExitStack, metaclass=FlowType):
         self,
         output_base_path: str,
         k8s_namespace: Optional[str] = None,
-        include_gateway: Optional[bool] = True,
+        include_gateway: bool = True,
     ):
         """
         Converts the Flow into a set of yaml deployments to deploy in Kubernetes.
@@ -1870,7 +1870,7 @@ class Flow(PostMixin, JAMLCompatible, ExitStack, metaclass=FlowType):
         self,
         output_path: Optional[str] = None,
         network_name: Optional[str] = None,
-        include_gateway: Optional[bool] = True,
+        include_gateway: bool = True,
     ):
         """
         Converts the Flow into a yaml file to run with `docker-compose up`

--- a/jina/orchestrate/flow/base.py
+++ b/jina/orchestrate/flow/base.py
@@ -1814,7 +1814,12 @@ class Flow(PostMixin, JAMLCompatible, ExitStack, metaclass=FlowType):
     # for backward support
     join = needs
 
-    def to_k8s_yaml(self, output_base_path: str, k8s_namespace: Optional[str] = None):
+    def to_k8s_yaml(
+        self,
+        output_base_path: str,
+        k8s_namespace: Optional[str] = None,
+        include_gateway: Optional[bool] = True,
+    ):
         """
         Converts the Flow into a set of yaml deployments to deploy in Kubernetes.
 
@@ -1823,6 +1828,7 @@ class Flow(PostMixin, JAMLCompatible, ExitStack, metaclass=FlowType):
 
         :param output_base_path: The base path where to dump all the yaml files
         :param k8s_namespace: The name of the k8s namespace to set for the configurations. If None, the name of the Flow will be used.
+        :param include_gateway: Defines if the gateway deployment should be included, defaults to True
         """
         import yaml
 
@@ -1834,7 +1840,7 @@ class Flow(PostMixin, JAMLCompatible, ExitStack, metaclass=FlowType):
         k8s_namespace = k8s_namespace or self.args.name or 'default'
 
         for node, v in self._deployment_nodes.items():
-            if v.external:
+            if v.external or (node == 'gateway' and not include_gateway):
                 continue
             deployment_base = os.path.join(output_base_path, node)
             k8s_deployment = K8sDeploymentConfig(
@@ -1864,11 +1870,13 @@ class Flow(PostMixin, JAMLCompatible, ExitStack, metaclass=FlowType):
         self,
         output_path: Optional[str] = None,
         network_name: Optional[str] = None,
+        include_gateway: Optional[bool] = True,
     ):
         """
         Converts the Flow into a yaml file to run with `docker-compose up`
         :param output_path: The output path for the yaml file
         :param network_name: The name of the network that will be used by the deployment name
+        :param include_gateway: Defines if the gateway deployment should be included, defaults to True
         """
         import yaml
 
@@ -1890,6 +1898,9 @@ class Flow(PostMixin, JAMLCompatible, ExitStack, metaclass=FlowType):
         services = {}
 
         for node, v in self._deployment_nodes.items():
+            if v.external or (node == 'gateway' and not include_gateway):
+                continue
+
             docker_compose_deployment = DockerComposeConfig(
                 args=v.args,
                 deployments_addresses=self._get_docker_compose_deployments_addresses(),


### PR DESCRIPTION
# Expose Executors as first class citizens

## Description

This adds  `to_k8s_yaml()` and `to_docker_compose_yaml()` for the Executors. It works similar to `serve()` in the sense that it creates a `Flow` behind the scenes and uses its existing methods to provide a similar user experience.
These features are also added to the docs and some basic tests have been added.

- [x] Implement `to_k8s_yaml()` and `to_docker_compose_yaml()` as a static convenience wrapper for Executors
- [x] Update the docs: Executors can now be deployed via the k8s/docker-compose mechanism. Explain the difference between external/shared Executors.

Closes [# (4502)](https://github.com/jina-ai/jina/issues/4502)