### PR TITLE
fix: 8080 as default gateway port in k8s

### DIFF
--- a/jina/orchestrate/flow/base.py
+++ b/jina/orchestrate/flow/base.py
@@ -478,6 +478,8 @@ class Flow(PostMixin, JAMLCompatible, ExitStack, metaclass=FlowType):
         kwargs.update(self._common_kwargs)
         args = ArgNamespace.kwargs2namespace(kwargs, set_gateway_parser())
 
+        # We need to check later if the port was manually set or randomly
+        args.default_port = kwargs.get('port', None) is None
         args.noblock_on_start = True
         args.expose_graphql_endpoint = (
             self.args.expose_graphql_endpoint
@@ -1852,6 +1854,12 @@ class Flow(PostMixin, JAMLCompatible, ExitStack, metaclass=FlowType):
         for node, v in self._deployment_nodes.items():
             if v.external or (node == 'gateway' and not include_gateway):
                 continue
+            if node == 'gateway' and v.args.default_port:
+                from jina.serve.networking import GrpcConnectionPool
+
+                v.args.port = GrpcConnectionPool.K8S_PORT
+                v.args.default_port = False
+
             deployment_base = os.path.join(output_base_path, node)
             k8s_deployment = K8sDeploymentConfig(
                 args=v.args,

--- a/jina/orchestrate/flow/base.py
+++ b/jina/orchestrate/flow/base.py
@@ -1860,6 +1860,7 @@ class Flow(PostMixin, JAMLCompatible, ExitStack, metaclass=FlowType):
                 from jina.serve.networking import GrpcConnectionPool
 
                 v.args.port = GrpcConnectionPool.K8S_PORT
+                v.first_pod_args.port = GrpcConnectionPool.K8S_PORT
                 v.args.default_port = False
 
             deployment_base = os.path.join(output_base_path, node)

--- a/jina/orchestrate/flow/base.py
+++ b/jina/orchestrate/flow/base.py
@@ -479,7 +479,9 @@ class Flow(PostMixin, JAMLCompatible, ExitStack, metaclass=FlowType):
         args = ArgNamespace.kwargs2namespace(kwargs, set_gateway_parser())
 
         # We need to check later if the port was manually set or randomly
-        args.default_port = kwargs.get('port', None) is None
+        args.default_port = (
+            kwargs.get('port', None) is None and kwargs.get('port_expose', None) is None
+        )
         args.noblock_on_start = True
         args.expose_graphql_endpoint = (
             self.args.expose_graphql_endpoint

--- a/tests/unit/orchestrate/flow/flow-construct/test_flow_to_k8s_yaml.py
+++ b/tests/unit/orchestrate/flow/flow-construct/test_flow_to_k8s_yaml.py
@@ -4,12 +4,17 @@ import pytest
 import yaml
 
 from jina import Flow
+from jina.serve.networking import GrpcConnectionPool
 
 
 @pytest.mark.parametrize('protocol', ['http', 'grpc'])
-def test_flow_to_k8s_yaml(tmpdir, protocol):
+@pytest.mark.parametrize('flow_port', [1234, None])
+def test_flow_to_k8s_yaml(tmpdir, protocol, flow_port):
+    flow_kwargs = {'name': 'test-flow', 'protocol': protocol}
+    if flow_port:
+        flow_kwargs['port'] = flow_port
     flow = (
-        Flow(name='test-flow', port=8080, protocol=protocol)
+        Flow(**flow_kwargs)
         .add(name='executor0', uses_with={'param': 0})
         .add(name='executor1', shards=2, uses_with={'param': 0})
         .add(
@@ -85,7 +90,9 @@ def test_flow_to_k8s_yaml(tmpdir, protocol):
     ]
     assert gateway_args[0] == 'gateway'
     assert '--port' in gateway_args
-    assert gateway_args[gateway_args.index('--port') + 1] == '8080'
+    assert gateway_args[gateway_args.index('--port') + 1] == (
+        str(flow_port) if flow_port else str(GrpcConnectionPool.K8S_PORT)
+    )
     assert '--k8s-namespace' in gateway_args
     assert gateway_args[gateway_args.index('--k8s-namespace') + 1] == namespace
     assert '--graph-description' in gateway_args

--- a/tests/unit/orchestrate/flow/flow-construct/test_flow_to_k8s_yaml.py
+++ b/tests/unit/orchestrate/flow/flow-construct/test_flow_to_k8s_yaml.py
@@ -93,6 +93,7 @@ def test_flow_to_k8s_yaml(tmpdir, protocol, flow_port):
     assert gateway_args[gateway_args.index('--port') + 1] == (
         str(flow_port) if flow_port else str(GrpcConnectionPool.K8S_PORT)
     )
+    assert gateway_args[gateway_args.index('--port') + 1] == str(flow.port)
     assert '--k8s-namespace' in gateway_args
     assert gateway_args[gateway_args.index('--k8s-namespace') + 1] == namespace
     assert '--graph-description' in gateway_args


### PR DESCRIPTION
# 8080 as default gateway port in k8s

## Description

In K8s all Pods should use 8080 as the default port (expect monitoring and uses_before/uses_after). At the moment the Gateway is using a random port though unless specified otherwise.
The expected behavior is to respect user provided ports for the Gateway and use 8080 if there was no port specified.

My change fixes this in the Flow. Its fairly hacky/ugly, but I don't know how to do it differently really without breaking the parser. The main problem is that --port defaults to a random port, so its hard to check if the value was user set or just defaulted to. Thus I am using the `kwargs` in the Flow.