### PR TITLE
fix: sandbox tls

### DIFF
--- a/jina/serve/networking.py
+++ b/jina/serve/networking.py
@@ -902,12 +902,16 @@ class GrpcConnectionPool:
         response = reflection_stub.ServerReflectionInfo(
             iter([ServerReflectionRequest(list_services="")])
         )
+        service_names = []
         async for res in response:
-            return [
-                service.name
-                for service in res.list_services_response.service
-                if service.name != 'grpc.reflection.v1alpha.ServerReflection'
-            ]
+            service_names.append(
+                [
+                    service.name
+                    for service in res.list_services_response.service
+                    if service.name != 'grpc.reflection.v1alpha.ServerReflection'
+                ]
+            )
+        return service_names[0]
 
 
 def in_docker():

--- a/tests/integration/sandbox/test_sandbox.py
+++ b/tests/integration/sandbox/test_sandbox.py
@@ -1,0 +1,23 @@
+import pytest
+
+from jina import Document, Flow
+
+
+@pytest.mark.parametrize('endpoint', ['foo', 'bar'])
+def test_sandbox(endpoint):
+    with Flow().add(uses='jinahub+sandbox://Hello') as f:
+        da = f.post(
+            endpoint,
+            [
+                Document(text="dog world"),
+                Document(text="cat world"),
+                Document(id="a", text="elephant world"),
+                Document(id="b", text="monkey world"),
+            ],
+        )
+        assert da.texts == [
+            'hello dog world',
+            'hello cat world',
+            'hello elephant world',
+            'hello monkey world',
+        ]

--- a/tests/unit/serve/runtimes/gateway/grpc/test_grpc_gateway_runtime.py
+++ b/tests/unit/serve/runtimes/gateway/grpc/test_grpc_gateway_runtime.py
@@ -5,6 +5,7 @@ import multiprocessing
 import time
 from multiprocessing import Process
 
+import grpc
 import pytest
 
 from jina import Document, DocumentArray
@@ -430,7 +431,8 @@ def test_grpc_gateway_runtime_handle_empty_graph():
     assert p.exitcode == 0
 
 
-def test_grpc_gateway_runtime_reflection():
+@pytest.mark.asyncio
+async def test_grpc_gateway_runtime_reflection():
     deployment0_port = random_port()
     deployment1_port = random_port()
     port = random_port()
@@ -459,7 +461,9 @@ def test_grpc_gateway_runtime_reflection():
     time.sleep(1.0)
     assert AsyncNewLoopRuntime.is_ready(ctrl_address=f'127.0.0.1:{port}')
 
-    service_names = GrpcConnectionPool.get_available_services(f'127.0.0.1:{port}')
+    async with grpc.aio.insecure_channel(f'127.0.0.1:{port}') as channel:
+        service_names = await GrpcConnectionPool.get_available_services(channel)
+
     assert all(
         service_name in service_names
         for service_name in ['jina.JinaControlRequestRPC', 'jina.JinaRPC']

--- a/tests/unit/serve/runtimes/head/test_head_runtime.py
+++ b/tests/unit/serve/runtimes/head/test_head_runtime.py
@@ -246,7 +246,8 @@ def test_base_polling(polling):
     _destroy_runtime(args, cancel_event, runtime_thread)
 
 
-def test_head_runtime_reflection():
+@pytest.mark.asyncio
+async def test_head_runtime_reflection():
     args = set_pod_parser().parse_args([])
     cancel_event, handle_queue, runtime_thread = _create_runtime(args)
 
@@ -256,9 +257,9 @@ def test_head_runtime_reflection():
         ready_or_shutdown_event=multiprocessing.Event(),
     )
 
-    service_names = GrpcConnectionPool.get_available_services(
-        f'{args.host}:{args.port}'
-    )
+    async with grpc.aio.insecure_channel(f'{args.host}:{args.port}') as channel:
+        service_names = await GrpcConnectionPool.get_available_services(channel)
+
     assert all(
         service_name in service_names
         for service_name in [

--- a/tests/unit/serve/runtimes/worker/test_worker_runtime.py
+++ b/tests/unit/serve/runtimes/worker/test_worker_runtime.py
@@ -338,7 +338,8 @@ async def test_worker_runtime_slow_init_exec():
     assert not AsyncNewLoopRuntime.is_ready(f'{args.host}:{args.port}')
 
 
-def test_worker_runtime_reflection():
+@pytest.mark.asyncio
+async def test_worker_runtime_reflection():
     args = set_pod_parser().parse_args([])
 
     cancel_event = multiprocessing.Event()
@@ -360,9 +361,8 @@ def test_worker_runtime_reflection():
         ready_or_shutdown_event=Event(),
     )
 
-    service_names = GrpcConnectionPool.get_available_services(
-        f'{args.host}:{args.port}'
-    )
+    async with grpc.aio.insecure_channel(f'{args.host}:{args.port}') as channel:
+        service_names = await GrpcConnectionPool.get_available_services(channel)
     assert all(
         service_name in service_names
         for service_name in [


### PR DESCRIPTION
# Fix gRPC reflection using TLS

## Description

gRPC reflection is not respecting the TLS setttings. This makes all encrypted gRPC connections fail. This happens e.g. for sandbox.
This PR changes the logic so that we just reuse the existing channel for the reflection. This way I don't have to worry about the settings