### PR TITLE
docs: renamed method to be named differently from property

### DIFF
--- a/docs/fundamentals/flow/flow-yaml.md
+++ b/docs/fundamentals/flow/flow-yaml.md
@@ -63,7 +63,7 @@ class LocalExecutor(Executor):
         self.foo = foo
 
     @requests
-    def foo(self, **kwargs):
+    def bar(self, **kwargs):
         print(f'foo={self.foo}')
 ```
 


### PR DESCRIPTION
Updated docs such that property and method name of the executor differ