### PR TITLE
refactor: avoid threadpool

### DIFF
--- a/jina/helper.py
+++ b/jina/helper.py
@@ -1271,12 +1271,6 @@ def iscoroutinefunction(func: Callable):
     return inspect.iscoroutinefunction(func)
 
 
-async def run_in_threadpool(func: Callable, executor=None, *args, **kwargs):
-    return await get_or_reuse_loop().run_in_executor(
-        executor, functools.partial(func, *args, **kwargs)
-    )
-
-
 def run_async(func, *args, **kwargs):
     """Generalized asyncio.run for jupyter notebook.
 

--- a/jina/serve/executors/__init__.py
+++ b/jina/serve/executors/__init__.py
@@ -2,21 +2,13 @@ import inspect
 import multiprocessing
 import os
 import threading
-import uuid
 import warnings
-from concurrent.futures import ThreadPoolExecutor
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type, Union
 
 from jina import __args_executor_init__, __default_endpoint__
 from jina.enums import BetterEnum
-from jina.helper import (
-    ArgNamespace,
-    T,
-    iscoroutinefunction,
-    run_in_threadpool,
-    typename,
-)
+from jina.helper import ArgNamespace, T, iscoroutinefunction, typename
 from jina.jaml import JAML, JAMLCompatible, env_var_regex, internal_var_regex
 from jina.serve.executors.decorators import requests, store_init_kwargs, wrap_func
 
@@ -109,7 +101,6 @@ class BaseExecutor(JAMLCompatible, metaclass=ExecutorType):
         :param runtime_args: a dict of arguments injected from :class:`Runtime` during runtime
         :param kwargs: additional extra keyword arguments to avoid failing when extra params ara passed that are not expected
         """
-        self._thread_pool = ThreadPoolExecutor(max_workers=1)
         self._add_metas(metas)
         self._add_requests(requests)
         self._add_runtime_args(runtime_args)
@@ -239,7 +230,7 @@ class BaseExecutor(JAMLCompatible, metaclass=ExecutorType):
         if iscoroutinefunction(func):
             return await func(self, **kwargs)
         else:
-            return await run_in_threadpool(func, self._thread_pool, self, **kwargs)
+            return func(self, **kwargs)
 
     @property
     def workspace(self) -> Optional[str]:

--- a/tests/unit/serve/executors/test_executor.py
+++ b/tests/unit/serve/executors/test_executor.py
@@ -497,8 +497,10 @@ async def test_blocking_sync_exec():
             )
         )
 
-    await asyncio.gather(*send_tasks)
+    results = await asyncio.gather(*send_tasks)
     end_time = time.time()
+
+    assert all(result.docs.texts == ['BlockingExecutor'] for result in results)
     assert end_time - start_time < (REQUEST_COUNT * SLEEP_TIME) + 0.2
 
     cancel_event.set()

--- a/tests/unit/serve/executors/test_executor.py
+++ b/tests/unit/serve/executors/test_executor.py
@@ -493,7 +493,7 @@ async def test_blocking_sync_exec():
     )
 
     results = await asyncio.gather(send_task1, send_task2)
-    assert float(results[1].docs.texts[0]) - float(results[0].docs.texts[0]) < 0.1
+    assert float(results[1].docs.texts[0]) - float(results[0].docs.texts[0]) < 1.1
 
     cancel_event.set()
     runtime_thread.join()

--- a/tests/unit/serve/executors/test_executor.py
+++ b/tests/unit/serve/executors/test_executor.py
@@ -1,6 +1,10 @@
+import asyncio
+import multiprocessing
 import os
+import time
 from copy import deepcopy
-from pathlib import Path
+from multiprocessing import Process
+from threading import Event
 from unittest import mock
 
 import pytest
@@ -8,8 +12,13 @@ import yaml
 from docarray import Document, DocumentArray
 
 from jina import Client, Executor, Flow, requests
+from jina.clients.request import request_generator
+from jina.parsers import set_pod_parser
 from jina.serve.executors import ReducerExecutor
 from jina.serve.executors.metas import get_default_metas
+from jina.serve.networking import GrpcConnectionPool
+from jina.serve.runtimes.asyncio import AsyncNewLoopRuntime
+from jina.serve.runtimes.worker import WorkerRuntime
 
 PORT = 12350
 
@@ -435,3 +444,56 @@ def test_to_docker_compose_yaml(tmpdir, exec_type):
             assert services['gateway']['ports'][0] == '2020:2020'
             gateway_args = services['gateway']['command']
             assert gateway_args[gateway_args.index('--port') + 1] == '2020'
+
+
+def _create_test_data_message(counter=0):
+    return list(request_generator('/', DocumentArray([Document(text=str(counter))])))[0]
+
+
+@pytest.mark.asyncio
+async def test_blocking_sync_exec():
+    class BlockingExecutor(Executor):
+        @requests
+        def foo(self, docs: DocumentArray, **kwargs):
+            time.sleep(1.0)
+            for doc in docs:
+                doc.text = str(time.time())
+            return docs
+
+    args = set_pod_parser().parse_args(['--uses', 'BlockingExecutor'])
+
+    cancel_event = multiprocessing.Event()
+
+    def start_runtime(args, cancel_event):
+        with WorkerRuntime(args, cancel_event) as runtime:
+            runtime.run_forever()
+
+    runtime_thread = Process(
+        target=start_runtime,
+        args=(args, cancel_event),
+        daemon=True,
+    )
+    runtime_thread.start()
+
+    assert AsyncNewLoopRuntime.wait_for_ready_or_shutdown(
+        timeout=5.0,
+        ctrl_address=f'{args.host}:{args.port}',
+        ready_or_shutdown_event=Event(),
+    )
+
+    send_task1 = asyncio.create_task(
+        GrpcConnectionPool.send_request_async(
+            _create_test_data_message(), target=f'{args.host}:{args.port}', timeout=3.0
+        )
+    )
+    send_task2 = asyncio.create_task(
+        GrpcConnectionPool.send_request_async(
+            _create_test_data_message(), target=f'{args.host}:{args.port}', timeout=3.0
+        )
+    )
+
+    results = await asyncio.gather(send_task1, send_task2)
+    assert float(results[1].docs.texts[0]) - float(results[0].docs.texts[0]) < 0.1
+
+    cancel_event.set()
+    runtime_thread.join()


### PR DESCRIPTION
# Pull Request Title

## Description

This PR disables the `ThreadPool` at Request level.

By having a threadpool with `num_workers` to 1, the benefit of having the `ThreadPool` is really minimal and can have some unwanted consequences. 