### PR TITLE
feat: add process request seconds for executor

### DIFF
--- a/jina/serve/executors/__init__.py
+++ b/jina/serve/executors/__init__.py
@@ -130,7 +130,7 @@ class BaseExecutor(JAMLCompatible, metaclass=ExecutorType):
                 'Time spent when calling the executor request method',
                 registry=self.runtime_args.metrics_registry,
                 namespace='jina',
-                labelnames=('method',),
+                labelnames=('method', 'executor'),
             )
         else:
             self._summary_method = None

--- a/jina/serve/executors/__init__.py
+++ b/jina/serve/executors/__init__.py
@@ -8,6 +8,8 @@ from concurrent.futures import ThreadPoolExecutor
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type, Union
 
+from prometheus_client import Summary
+
 from jina import __args_executor_init__, __default_endpoint__
 from jina.enums import BetterEnum
 from jina.helper import (
@@ -113,12 +115,25 @@ class BaseExecutor(JAMLCompatible, metaclass=ExecutorType):
         self._add_metas(metas)
         self._add_requests(requests)
         self._add_runtime_args(runtime_args)
+        self._init_monitoring()
 
     def _add_runtime_args(self, _runtime_args: Optional[Dict]):
         if _runtime_args:
             self.runtime_args = SimpleNamespace(**_runtime_args)
         else:
             self.runtime_args = SimpleNamespace()
+
+    def _init_monitoring(self):
+        if hasattr(self.runtime_args, 'metrics_registry'):
+            self._summary_method = Summary(
+                'process_request_seconds',
+                'Time spent when calling the executor request method',
+                registry=self.runtime_args.metrics_registry,
+                namespace='jina',
+                labelnames=('method',),
+            )
+        else:
+            self._summary_method = None
 
     def _add_requests(self, _requests: Optional[Dict]):
         if not hasattr(self, 'requests'):

--- a/jina/serve/executors/decorators.py
+++ b/jina/serve/executors/decorators.py
@@ -1,12 +1,23 @@
 """Decorators and wrappers designed for wrapping :class:`BaseExecutor` functions. """
-
+import contextlib
 import functools
 import inspect
 from functools import wraps
-from typing import Callable, Union, List, Optional, Dict, Sequence, TYPE_CHECKING
+from typing import (
+    TYPE_CHECKING,
+    Callable,
+    ContextManager,
+    Dict,
+    List,
+    Optional,
+    Sequence,
+    Union,
+)
 
-from jina.serve.executors.metas import get_default_metas
+from prometheus_client import Summary
+
 from jina.helper import convert_tuple_to_list, iscoroutinefunction
+from jina.serve.executors.metas import get_default_metas
 
 if TYPE_CHECKING:
     from jina import DocumentArray
@@ -87,7 +98,7 @@ def requests(
     :param on: the endpoint string, by convention starts with `/`
     :return: decorated function
     """
-    from jina import __default_endpoint__, __args_executor_func__
+    from jina import __args_executor_func__, __default_endpoint__
 
     class FunctionMapper:
         def __init__(self, fn):
@@ -104,15 +115,22 @@ def requests(
             if iscoroutinefunction(fn):
 
                 @functools.wraps(fn)
-                async def arg_wrapper(*args, **kwargs):
-                    return await fn(*args, **kwargs)
+                async def arg_wrapper(
+                    self2, *args, **kwargs
+                ):  # we need to get the summary from the executor, so we need to access the self
+                    with self._get_summary(self2._summary_method, fn.__name__):
+                        return await fn(self2, *args, **kwargs)
 
                 self.fn = arg_wrapper
             else:
 
                 @functools.wraps(fn)
-                def arg_wrapper(*args, **kwargs):
-                    return fn(*args, **kwargs)
+                def arg_wrapper(
+                    self2, *args, **kwargs
+                ):  # we need to get the summary from the executor, so we need to access the self
+
+                    with self._get_summary(self2._summary_method, fn.__name__):
+                        return fn(self2, *args, **kwargs)
 
                 self.fn = arg_wrapper
 
@@ -128,6 +146,15 @@ def requests(
                 owner.requests[on or __default_endpoint__] = self.fn
 
             setattr(owner, name, self.fn)
+
+        def _get_summary(
+            self, summary: Optional['Summary'], method_name: str
+        ) -> ContextManager:
+            return (
+                summary.labels(method_name).time()
+                if summary
+                else contextlib.nullcontext()
+            )
 
     if func:
         return FunctionMapper(func)

--- a/jina/serve/executors/decorators.py
+++ b/jina/serve/executors/decorators.py
@@ -116,21 +116,25 @@ def requests(
 
                 @functools.wraps(fn)
                 async def arg_wrapper(
-                    self2, *args, **kwargs
+                    executor_instance, *args, **kwargs
                 ):  # we need to get the summary from the executor, so we need to access the self
-                    with self._get_summary(self2._summary_method, fn.__name__):
-                        return await fn(self2, *args, **kwargs)
+                    with self._get_summary(
+                        executor_instance._summary_method, fn.__name__
+                    ):
+                        return await fn(executor_instance, *args, **kwargs)
 
                 self.fn = arg_wrapper
             else:
 
                 @functools.wraps(fn)
                 def arg_wrapper(
-                    self2, *args, **kwargs
+                    executor_instance, *args, **kwargs
                 ):  # we need to get the summary from the executor, so we need to access the self
 
-                    with self._get_summary(self2._summary_method, fn.__name__):
-                        return fn(self2, *args, **kwargs)
+                    with self._get_summary(
+                        executor_instance._summary_method, fn.__name__
+                    ):
+                        return fn(executor_instance, *args, **kwargs)
 
                 self.fn = arg_wrapper
 

--- a/jina/serve/executors/decorators.py
+++ b/jina/serve/executors/decorators.py
@@ -119,7 +119,9 @@ def requests(
                     executor_instance, *args, **kwargs
                 ):  # we need to get the summary from the executor, so we need to access the self
                     with self._get_summary(
-                        executor_instance._summary_method, fn.__name__
+                        executor_instance._summary_method,
+                        executor_instance.__class__.__name__,
+                        fn.__name__,
                     ):
                         return await fn(executor_instance, *args, **kwargs)
 
@@ -130,9 +132,10 @@ def requests(
                 def arg_wrapper(
                     executor_instance, *args, **kwargs
                 ):  # we need to get the summary from the executor, so we need to access the self
-
                     with self._get_summary(
-                        executor_instance._summary_method, fn.__name__
+                        executor_instance._summary_method,
+                        executor_instance.__class__.__name__,
+                        fn.__name__,
                     ):
                         return fn(executor_instance, *args, **kwargs)
 
@@ -152,10 +155,10 @@ def requests(
             setattr(owner, name, self.fn)
 
         def _get_summary(
-            self, summary: Optional['Summary'], method_name: str
+            self, summary: Optional['Summary'], executor_name: str, method_name: str
         ) -> ContextManager:
             return (
-                summary.labels(method_name).time()
+                summary.labels(method_name, executor_name).time()
                 if summary
                 else contextlib.nullcontext()
             )

--- a/jina/serve/runtimes/worker/__init__.py
+++ b/jina/serve/runtimes/worker/__init__.py
@@ -60,7 +60,9 @@ class WorkerRuntime(AsyncNewLoopRuntime, ABC):
         # Keep this initialization order
         # otherwise readiness check is not valid
         # The DataRequestHandler needs to be started BEFORE the grpc server
-        self._data_request_handler = DataRequestHandler(self.args, self.logger)
+        self._data_request_handler = DataRequestHandler(
+            self.args, self.logger, self.metrics_registry
+        )
 
         self._grpc_server = grpc.aio.server(
             options=[

--- a/tests/integration/monitoring/test_monitoring.py
+++ b/tests/integration/monitoring/test_monitoring.py
@@ -1,13 +1,20 @@
+import time
+
 import pytest
 import requests as req
+from docarray import DocumentArray
 
 from jina import Executor, Flow, requests
 
 
 class DummyExecutor(Executor):
-    @requests
+    @requests(on='/foo')
     def foo(self, docs, **kwargs):
-        print('here')
+        ...
+
+    @requests(on='/bar')
+    def bar(self, docs, **kwargs):
+        ...
 
 
 def test_enable_monitoring_deployment(port_generator):
@@ -16,10 +23,17 @@ def test_enable_monitoring_deployment(port_generator):
 
     with Flow().add(uses=DummyExecutor, monitoring=True, port_monitoring=port1).add(
         uses=DummyExecutor, monitoring=True, port_monitoring=port2
-    ):
+    ) as f:
         for port in [port1, port2]:
             resp = req.get(f'http://localhost:{port}/')
             assert resp.status_code == 200
+
+        for meth in ['bar', 'foo']:
+            f.post(f'/{meth}', inputs=DocumentArray())
+            resp = req.get(f'http://localhost:{port2}/')
+            assert f'process_request_seconds_created{{method="{meth}"}}' in str(
+                resp.content
+            )
 
 
 @pytest.mark.parametrize('protocol', ['websocket', 'grpc', 'http'])
@@ -43,7 +57,6 @@ def test_monitoring_head(port_generator):
     with Flow().add(uses=DummyExecutor, monitoring=True, port_monitoring=port1).add(
         uses=DummyExecutor, port_monitoring=port2, monitoring=True, shards=2
     ) as f:
-
         port3 = f._deployment_nodes['executor0'].pod_args['pods'][0][0].port_monitoring
         port4 = f._deployment_nodes['executor1'].pod_args['pods'][0][0].port_monitoring
 

--- a/tests/integration/monitoring/test_monitoring.py
+++ b/tests/integration/monitoring/test_monitoring.py
@@ -31,8 +31,9 @@ def test_enable_monitoring_deployment(port_generator):
         for meth in ['bar', 'foo']:
             f.post(f'/{meth}', inputs=DocumentArray())
             resp = req.get(f'http://localhost:{port2}/')
-            assert f'process_request_seconds_created{{method="{meth}"}}' in str(
-                resp.content
+            assert (
+                f'process_request_seconds_created{{executor="DummyExecutor",method="{meth}"}}'
+                in str(resp.content)
             )
 
 


### PR DESCRIPTION
Add `process_request_seconds` (on requests method) as a prometheus metrics to the Executor.

The goal of this metric is to monitor how much time each method decorated with the `@requests` takes to be processed

The metrics name is the same for all of the decorated method but there is a label for filtering.

![Screenshot from 2022-04-19 15-29-08](https://user-images.githubusercontent.com/55492238/164015479-8b31b6fd-5305-4b97-8414-727a71d92946.png)

