### PR TITLE
refactor(monitoring): add jina namespace to current metrics

### DIFF
--- a/jina/serve/networking.py
+++ b/jina/serve/networking.py
@@ -414,6 +414,7 @@ class GrpcConnectionPool:
                 'sending_request_seconds',
                 'Time spent between sending a request to the Pod and receiving the response',
                 registry=metrics_registry,
+                namespace='jina',
             ).time()
         else:
             self._summary_time = contextlib.nullcontext()

--- a/jina/serve/runtimes/worker/__init__.py
+++ b/jina/serve/runtimes/worker/__init__.py
@@ -47,6 +47,7 @@ class WorkerRuntime(AsyncNewLoopRuntime, ABC):
                 'receiving_request_seconds',
                 'Time spent processing request',
                 registry=self.metrics_registry,
+                namespace='jina',
             ).time()
         else:
             self._summary_time = contextlib.nullcontext()


### PR DESCRIPTION
This PR renamed the two current Prometheus metrics implemented in jina and add `jina` as a namespace to follow the prometheus naming guidelines https://prometheus.io/docs/practices/naming/

new metrics name:
`receiving_request_seconds` -> `jina_receiving_request_seconds`
`sending_request_seconds` -> `jina_sending_request_seconds`