### PR TITLE
fix: better reporting of errors in the head

### DIFF
--- a/jina/serve/runtimes/head/__init__.py
+++ b/jina/serve/runtimes/head/__init__.py
@@ -189,7 +189,9 @@ class HeadRuntime(AsyncNewLoopRuntime, ABC):
                 else '',
                 exc_info=not self.args.quiet_error,
             )
-            raise
+            requests[0].add_exception(ex, executor=None)
+            context.set_trailing_metadata((('is-error', 'true'),))
+            return requests[0]
 
     async def process_control(self, request: ControlRequest, *args) -> ControlRequest:
         """

--- a/tests/unit/orchestrate/flow/flow-construct/test_flow_except.py
+++ b/tests/unit/orchestrate/flow/flow-construct/test_flow_except.py
@@ -2,11 +2,11 @@ import os
 
 import numpy as np
 import pytest
+from docarray.document.generators import from_ndarray
 
-from jina import Flow, Executor, requests, Document
+from jina import Document, Executor, Flow, requests
 from jina.excepts import RuntimeFailToStart
 from jina.proto import jina_pb2
-from docarray.document.generators import from_ndarray
 from tests import validate_callback
 
 
@@ -263,3 +263,23 @@ def test_flow_does_not_import_exec_depencies():
     with pytest.raises(RuntimeFailToStart):
         with f:
             pass
+
+
+def test_flow_head_runtime_failure(monkeypatch, capfd):
+    from jina.serve.runtimes.request_handlers.data_request_handler import (
+        DataRequestHandler,
+    )
+
+    def fail(*args, **kwargs):
+        raise NotImplementedError('Intentional error')
+
+    monkeypatch.setattr(DataRequestHandler, 'merge_routes', fail)
+
+    with Flow().add(shards=2) as f:
+        f.index(
+            [Document(text='abbcs')],
+        )
+
+    out, err = capfd.readouterr()
+    assert 'NotImplementedError' in out
+    assert 'Intentional error' in out

--- a/tests/unit/serve/runtimes/head/test_head_runtime.py
+++ b/tests/unit/serve/runtimes/head/test_head_runtime.py
@@ -49,10 +49,10 @@ def test_control_message_processing():
     cancel_event, handle_queue, runtime_thread = _create_runtime(args)
 
     # no connection registered yet
-    with pytest.raises(RpcError):
-        GrpcConnectionPool.send_request_sync(
-            _create_test_data_message(), f'{args.host}:{args.port}'
-        )
+    resp = GrpcConnectionPool.send_request_sync(
+        _create_test_data_message(), f'{args.host}:{args.port}'
+    )
+    assert resp.status.code == resp.status.ERROR
 
     _add_worker(args, 'ip1')
     # after adding a connection, sending should work
@@ -63,10 +63,10 @@ def test_control_message_processing():
 
     _remove_worker(args, 'ip1')
     # after removing the connection again, sending does not work anymore
-    with pytest.raises(RpcError):
-        GrpcConnectionPool.send_request_sync(
-            _create_test_data_message(), f'{args.host}:{args.port}'
-        )
+    resp = GrpcConnectionPool.send_request_sync(
+        _create_test_data_message(), f'{args.host}:{args.port}'
+    )
+    assert resp.status.code == resp.status.ERROR
 
     _destroy_runtime(args, cancel_event, runtime_thread)
 


### PR DESCRIPTION
This makes error that occur in the head behave the same way as error that occur in the worker, which increases clarity.


**Before and after**


<details>
  <summary>Before</summary>

````
executor0/head@39887[E]:NotImplementedError('Intentional error')
 add "--quiet-error" to suppress the exception details
Traceback (most recent call last):
  File "/home/johannes/Documents/jina/jina/jina/serve/runtimes/head/__init__.py", line 182, in process_data
    response, metadata = await self._handle_data_request(requests, endpoint)
  File "/home/johannes/Documents/jina/jina/jina/serve/runtimes/head/__init__.py", line 241, in _handle_data_request
    DataRequestHandler.merge_routes(requests)
  File "/home/johannes/Documents/jina/jina/tests/unit/orchestrate/flow/flow-construct/test_flow_except.py", line 274, in fail
    raise NotImplementedError('Intentional error')
NotImplementedError: Intentional error

tests/unit/orchestrate/flow/flow-construct/test_flow_except.py:267 (test_flow_head_runtime_failure)
self = <jina.clients.grpc.GRPCClient object at 0x7f78a90f0760>
inputs = [<Document ('id', 'text') at 0aa14cd876ff537cf4b8505086dcaca1>]
on_done = None, on_error = None, on_always = None, compression = 'NoCompression'
kwargs = {'exec_endpoint': '/index', 'parameters': {'__results__': {}}, 'request_size': 100, 'target_executor': None}
req_iter = <generator object request_generator at 0x7f78bcf71c80>
channel = <grpc.aio._channel.Channel object at 0x7f78bc7544f0>
stub = <jina.proto.jina_pb2_grpc.JinaRPCStub object at 0x7f78bc764640>
p_bar = <jina.logging.profile.ProgressBar object at 0x7f78bcb89040>

    async def _get_results(
        self,
        inputs: 'InputType',
        on_done: 'CallbackFnType',
        on_error: Optional['CallbackFnType'] = None,
        on_always: Optional['CallbackFnType'] = None,
        compression: str = 'NoCompression',
        **kwargs,
    ):
        try:
            if compression.lower() not in GRPC_COMPRESSION_MAP:
                import warnings
    
                warnings.warn(
                    message=f'Your compression "{compression}" is not supported. Supported '
                    f'algorithms are `Gzip`, `Deflate` and `NoCompression`. NoCompression will be used as '
                    f'default'
                )
                compression = 'NoCompression'
            self.inputs = inputs
            req_iter = self._get_requests(**kwargs)
            async with GrpcConnectionPool.get_grpc_channel(
                f'{self.args.host}:{self.args.port}',
                asyncio=True,
                tls=self.args.tls,
            ) as channel:
                stub = jina_pb2_grpc.JinaRPCStub(channel)
                self.logger.debug(f'connected to {self.args.host}:{self.args.port}')
    
                with ProgressBar(
                    total_length=self._inputs_length, disable=not (self.show_progress)
                ) as p_bar:
    
>                   async for resp in stub.Call(
                        req_iter,
                        compression=GRPC_COMPRESSION_MAP.get(
                            compression.lower(), grpc.Compression.NoCompression
                        ),
                    ):

../../../../../jina/clients/base/grpc.py:62: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <_AioCall of RPC that terminated with:
	status = Unexpected <class 'grpc.aio._call.AioRpcError'>: <AioRpcError of RPC ...,"grpc_message":"Unexpected <class 'NotImplementedError'>: Intentional error","grpc_status":2}"\n>","grpc_status":2}"
>

    async def _fetch_stream_responses(self) -> ResponseType:
        message = await self._read()
        while message is not cygrpc.EOF:
            yield message
            message = await self._read()
    
        # If the read operation failed, Core should explain why.
>       await self._raise_for_status()

../../../../../../githubeverything/lib/python3.8/site-packages/grpc/aio/_call.py:326: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <_AioCall of RPC that terminated with:
	status = Unexpected <class 'grpc.aio._call.AioRpcError'>: <AioRpcError of RPC ...,"grpc_message":"Unexpected <class 'NotImplementedError'>: Intentional error","grpc_status":2}"\n>","grpc_status":2}"
>

    async def _raise_for_status(self) -> None:
        if self._cython_call.is_locally_cancelled():
            raise asyncio.CancelledError()
        code = await self.code()
        if code != grpc.StatusCode.OK:
>           raise _create_rpc_error(await self.initial_metadata(), await
                                    self._cython_call.status())
E           grpc.aio._call.AioRpcError: <AioRpcError of RPC that terminated with:
E           	status = StatusCode.UNKNOWN
E           	details = "Unexpected <class 'grpc.aio._call.AioRpcError'>: <AioRpcError of RPC that terminated with:
E           	status = StatusCode.UNKNOWN
E           	details = "Unexpected <class 'NotImplementedError'>: Intentional error"
E           	debug_error_string = "{"created":"@1650438929.237044565","description":"Error received from peer ipv4:0.0.0.0:52084","file":"src/core/lib/surface/call.cc","file_line":903,"grpc_message":"Unexpected <class 'NotImplementedError'>: Intentional error","grpc_status":2}"
E           >"
E           	debug_error_string = "{"created":"@1650438929.237356687","description":"Error received from peer ipv4:0.0.0.0:58015","file":"src/core/lib/surface/call.cc","file_line":903,"grpc_message":"Unexpected <class 'grpc.aio._call.AioRpcError'>: <AioRpcError of RPC that terminated with:\n\tstatus = StatusCode.UNKNOWN\n\tdetails = "Unexpected <class 'NotImplementedError'>: Intentional error"\n\tdebug_error_string = "{"created":"@1650438929.237044565","description":"Error received from peer ipv4:0.0.0.0:52084","file":"src/core/lib/surface/call.cc","file_line":903,"grpc_message":"Unexpected <class 'NotImplementedError'>: Intentional error","grpc_status":2}"\n>","grpc_status":2}"
E           >

../../../../../../githubeverything/lib/python3.8/site-packages/grpc/aio/_call.py:236: AioRpcError

The above exception was the direct cause of the following exception:

monkeypatch = <_pytest.monkeypatch.MonkeyPatch object at 0x7f78a9a106a0>
capfd = <_pytest.capture.CaptureFixture object at 0x7f78a9a10370>

    def test_flow_head_runtime_failure(monkeypatch, capfd):
        from jina.serve.runtimes.request_handlers.data_request_handler import (
            DataRequestHandler,
        )
    
        def fail(*args, **kwargs):
            raise NotImplementedError('Intentional error')
    
        monkeypatch.setattr(DataRequestHandler, 'merge_routes', fail)
    
        with Flow().add(shards=2) as f:
>           f.index(
                [Document(text='abbcs')],
            )

test_flow_except.py:279: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
../../../../../jina/clients/mixin.py:156: in post
    return run_async(
../../../../../jina/helper.py:1336: in run_async
    return get_or_reuse_loop().run_until_complete(func(*args, **kwargs))
uvloop/loop.pyx:1501: in uvloop.loop.Loop.run_until_complete
    ???
../../../../../jina/clients/mixin.py:147: in _get_results
    async for resp in c._get_results(*args, **kwargs):
../../../../../jina/clients/base/grpc.py:128: in _get_results
    raise e
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <jina.clients.grpc.GRPCClient object at 0x7f78a90f0760>
inputs = [<Document ('id', 'text') at 0aa14cd876ff537cf4b8505086dcaca1>]
on_done = None, on_error = None, on_always = None, compression = 'NoCompression'
kwargs = {'exec_endpoint': '/index', 'parameters': {'__results__': {}}, 'request_size': 100, 'target_executor': None}
req_iter = <generator object request_generator at 0x7f78bcf71c80>
channel = <grpc.aio._channel.Channel object at 0x7f78bc7544f0>
stub = <jina.proto.jina_pb2_grpc.JinaRPCStub object at 0x7f78bc764640>
p_bar = <jina.logging.profile.ProgressBar object at 0x7f78bcb89040>

    async def _get_results(
        self,
        inputs: 'InputType',
        on_done: 'CallbackFnType',
        on_error: Optional['CallbackFnType'] = None,
        on_always: Optional['CallbackFnType'] = None,
        compression: str = 'NoCompression',
        **kwargs,
    ):
        try:
            if compression.lower() not in GRPC_COMPRESSION_MAP:
                import warnings
    
                warnings.warn(
                    message=f'Your compression "{compression}" is not supported. Supported '
                    f'algorithms are `Gzip`, `Deflate` and `NoCompression`. NoCompression will be used as '
                    f'default'
                )
                compression = 'NoCompression'
            self.inputs = inputs
            req_iter = self._get_requests(**kwargs)
            async with GrpcConnectionPool.get_grpc_channel(
                f'{self.args.host}:{self.args.port}',
                asyncio=True,
                tls=self.args.tls,
            ) as channel:
                stub = jina_pb2_grpc.JinaRPCStub(channel)
                self.logger.debug(f'connected to {self.args.host}:{self.args.port}')
    
                with ProgressBar(
                    total_length=self._inputs_length, disable=not (self.show_progress)
                ) as p_bar:
    
                    async for resp in stub.Call(
                        req_iter,
                        compression=GRPC_COMPRESSION_MAP.get(
                            compression.lower(), grpc.Compression.NoCompression
                        ),
                    ):
                        callback_exec(
                            response=resp,
                            on_error=on_error,
                            on_done=on_done,
                            on_always=on_always,
                            continue_on_error=self.continue_on_error,
                            logger=self.logger,
                        )
                        if self.show_progress:
                            p_bar.update()
                        yield resp
    
        except KeyboardInterrupt:
            self.logger.warning('user cancel the process')
        except asyncio.CancelledError as ex:
            self.logger.warning(f'process error: {ex!r}')
        except grpc.aio._call.AioRpcError as rpc_ex:
            # Since this object is guaranteed to be a grpc.Call, might as well include that in its name.
            my_code = rpc_ex.code()
            my_details = rpc_ex.details()
            msg = f'gRPC error: {my_code} {my_details}'
    
            try:
                if my_code == grpc.StatusCode.UNAVAILABLE:
                    self.logger.error(
                        f'{msg}\nthe ongoing request is terminated as the server is not available or closed already'
                    )
                    raise rpc_ex
                elif my_code == grpc.StatusCode.INTERNAL:
                    self.logger.error(f'{msg}\ninternal error on the server side')
                    raise rpc_ex
                elif (
                    my_code == grpc.StatusCode.UNKNOWN
                    and 'asyncio.exceptions.TimeoutError' in my_details
                ):
                    raise BadClientInput(
                        f'{msg}\n'
                        'often the case is that you define/send a bad input iterator to jina, '
                        'please double check your input iterator'
                    ) from rpc_ex
                else:
>                   raise BadClient(msg) from rpc_ex
E                   jina.excepts.BadClient: gRPC error: StatusCode.UNKNOWN Unexpected <class 'grpc.aio._call.AioRpcError'>: <AioRpcError of RPC that terminated with:
E                   	status = StatusCode.UNKNOWN
E                   	details = "Unexpected <class 'NotImplementedError'>: Intentional error"
E                   	debug_error_string = "{"created":"@1650438929.237044565","description":"Error received from peer ipv4:0.0.0.0:52084","file":"src/core/lib/surface/call.cc","file_line":903,"grpc_message":"Unexpected <class 'NotImplementedError'>: Intentional error","grpc_status":2}"
E                   >

../../../../../jina/clients/base/grpc.py:109: BadClient
````

</details>

<details>
  <summary>After</summary>
  
````
 executor0/head@40616[E]:NotImplementedError('Intentional error')
 add "--quiet-error" to suppress the exception details
Traceback (most recent call last):
  File "/home/johannes/Documents/jina/jina/jina/serve/runtimes/head/__init__.py", line 182, in process_data
    response, metadata = await self._handle_data_request(requests, endpoint)
  File "/home/johannes/Documents/jina/jina/jina/serve/runtimes/head/__init__.py", line 243, in _handle_data_request
    DataRequestHandler.merge_routes(requests)
  File "/home/johannes/Documents/jina/jina/tests/unit/orchestrate/flow/flow-construct/test_flow_except.py", line 274, in fail
    raise NotImplementedError('Intentional error')
NotImplementedError: Intentional error
````
</details>

_The below will be moved to a different PR and ticket_

~~Error message are to be assessed (and improved, if needed) for the following scenarios:~~

- [ ] ~~"Code failure" in the worker (e.g. bug in the Executor)~~
- [ ] ~~Connectivity failure in worker~~
- [ ] ~~Connectivity failure in head~~
- [ ] ~~Executor fails to start~~
- [ ] ~~Runtime fails to start~~