### PR TITLE
fix: remove prometheus import from the top of the files

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -163,22 +163,27 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ 3.7 ]
-        test-path: ${{fromJson(needs.prep-testbed.outputs.matrix)}}
+        core: ['', 'true']
+        perf: ['', 'true']
+        exclude: 
+          - core: 'true'
+            perf: 'true'
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python 3.7
         uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: 3.7
       - name: Prepare enviroment
         run: |
           python -m pip install --upgrade pip
           python -m pip install wheel
           pip install --no-cache-dir .
+        env:
+          JINA_PIP_INSTALL_CORE: ${{ matrix.core }}
+          JINA_PIP_INSTALL_PERF: ${{ matrix.perf }}
       - name: Test basic import
         run: python -c 'from jina import Executor,requests'
-
   docker-image-test:
     needs: update-schema
     runs-on: ubuntu-latest

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -157,6 +157,28 @@ jobs:
           flags: ${{ steps.test.outputs.codecov_flag }}
           fail_ci_if_error: false
 
+  import-test:
+    runs-on: ubuntu-latest
+    needs: [ commit-lint, lint-flake-8, code-injection ]
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [ 3.7 ]
+        test-path: ${{fromJson(needs.prep-testbed.outputs.matrix)}}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Prepare enviroment
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install wheel
+          pip install --no-cache-dir .
+      - name: Test basic import
+        run: python -c 'from jina import Executor,requests'
+
   docker-image-test:
     needs: update-schema
     runs-on: ubuntu-latest
@@ -317,7 +339,7 @@ jobs:
   # just for blocking the merge until all parallel core-test are successful
   success-all-steps:
     runs-on: ubuntu-latest
-    needs: [core-test, hub-test, k8s-test, docker-compose-test, docker-image-test, benchmark-pre-release, update-schema, update-docker]
+    needs: [core-test, import-test, hub-test, k8s-test, docker-compose-test, docker-image-test, benchmark-pre-release, update-schema, update-docker]
     if: always()
     steps:
       - uses: technote-space/workflow-conclusion-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -310,19 +310,25 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ 3.7 ]
-        test-path: ${{fromJson(needs.prep-testbed.outputs.matrix)}}
+        core: ['', 'true']
+        perf: ['', 'true']
+        exclude: 
+          - core: 'true'
+            perf: 'true'
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python 3.7
         uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: 3.7
       - name: Prepare enviroment
         run: |
           python -m pip install --upgrade pip
           python -m pip install wheel
           pip install --no-cache-dir .
+        env:
+          JINA_PIP_INSTALL_CORE: ${{ matrix.core }}
+          JINA_PIP_INSTALL_PERF: ${{ matrix.perf }}
       - name: Test basic import
         run: python -c 'from jina import Executor,requests'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -304,10 +304,33 @@ jobs:
           flags: ${{ steps.test.outputs.codecov_flag }}
           fail_ci_if_error: false
 
+  import-test:
+    runs-on: ubuntu-latest
+    needs: [ commit-lint, lint-flake-8, code-injection ]
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [ 3.7 ]
+        test-path: ${{fromJson(needs.prep-testbed.outputs.matrix)}}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Prepare enviroment
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install wheel
+          pip install --no-cache-dir .
+      - name: Test basic import
+        run: python -c 'from jina import Executor,requests'
+
+
   # just for blocking the merge until all parallel core-test are successful
   success-all-test:
     runs-on: ubuntu-latest
-    needs: [core-test, hub-test, k8s-test, docker-compose-test, docker-image-test, check-docstring, check-black, code-injection]
+    needs: [core-test, import-test, hub-test, k8s-test, docker-compose-test, docker-image-test, check-docstring, check-black, code-injection]
     if: always()
     steps:
       - uses: technote-space/workflow-conclusion-action@v2

--- a/jina/serve/executors/__init__.py
+++ b/jina/serve/executors/__init__.py
@@ -6,8 +6,6 @@ import warnings
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type, Union
 
-from prometheus_client import Summary
-
 from jina import __args_executor_init__, __default_endpoint__
 from jina.enums import BetterEnum
 from jina.helper import ArgNamespace, T, iscoroutinefunction, typename
@@ -115,7 +113,12 @@ class BaseExecutor(JAMLCompatible, metaclass=ExecutorType):
             self.runtime_args = SimpleNamespace()
 
     def _init_monitoring(self):
-        if hasattr(self.runtime_args, 'metrics_registry'):
+        if (
+            hasattr(self.runtime_args, 'metrics_registry')
+            and self.runtime_args.metrics_registry
+        ):
+            from prometheus_client import Summary
+
             self._summary_method = Summary(
                 'process_request_seconds',
                 'Time spent when calling the executor request method',

--- a/jina/serve/executors/__init__.py
+++ b/jina/serve/executors/__init__.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type, Union
 from jina import __args_executor_init__, __default_endpoint__
 from jina.enums import BetterEnum
 from jina.helper import ArgNamespace, T, iscoroutinefunction, typename
+from jina.importer import ImportExtensions
 from jina.jaml import JAML, JAMLCompatible, env_var_regex, internal_var_regex
 from jina.serve.executors.decorators import requests, store_init_kwargs, wrap_func
 
@@ -117,7 +118,11 @@ class BaseExecutor(JAMLCompatible, metaclass=ExecutorType):
             hasattr(self.runtime_args, 'metrics_registry')
             and self.runtime_args.metrics_registry
         ):
-            from prometheus_client import Summary
+            with ImportExtensions(
+                required=True,
+                help_text='You need to install the `prometheus_client` to use the montitoring functionality of jina',
+            ):
+                from prometheus_client import Summary
 
             self._summary_method = Summary(
                 'process_request_seconds',

--- a/jina/serve/executors/__init__.py
+++ b/jina/serve/executors/__init__.py
@@ -113,10 +113,10 @@ class BaseExecutor(JAMLCompatible, metaclass=ExecutorType):
             self.runtime_args = SimpleNamespace()
 
     def _init_monitoring(self):
-        if not hasattr(self.runtime_args, 'metrics_registry'):
-            self.runtime_args.metrics_registry = None
-
-        if self.runtime_args.metrics_registry:
+        if (
+            hasattr(self.runtime_args, 'metrics_registry')
+            and self.runtime_args.metrics_registry
+        ):
             from prometheus_client import Summary
 
             self._summary_method = Summary(

--- a/jina/serve/executors/__init__.py
+++ b/jina/serve/executors/__init__.py
@@ -113,10 +113,10 @@ class BaseExecutor(JAMLCompatible, metaclass=ExecutorType):
             self.runtime_args = SimpleNamespace()
 
     def _init_monitoring(self):
-        if (
-            hasattr(self.runtime_args, 'metrics_registry')
-            and self.runtime_args.metrics_registry
-        ):
+        if not hasattr(self.runtime_args, 'metrics_registry'):
+            self.runtime_args.metrics_registry = None
+
+        if self.runtime_args.metrics_registry:
             from prometheus_client import Summary
 
             self._summary_method = Summary(

--- a/jina/serve/executors/decorators.py
+++ b/jina/serve/executors/decorators.py
@@ -14,12 +14,12 @@ from typing import (
     Union,
 )
 
-from prometheus_client import Summary
-
 from jina.helper import convert_tuple_to_list, iscoroutinefunction
 from jina.serve.executors.metas import get_default_metas
 
 if TYPE_CHECKING:
+    from prometheus_client import Summary
+
     from jina import DocumentArray
 
 

--- a/jina/serve/networking.py
+++ b/jina/serve/networking.py
@@ -12,6 +12,7 @@ from grpc_reflection.v1alpha.reflection_pb2 import ServerReflectionRequest
 from grpc_reflection.v1alpha.reflection_pb2_grpc import ServerReflectionStub
 
 from jina.enums import PollingType
+from jina.importer import ImportExtensions
 from jina.logging.logger import JinaLogger
 from jina.proto import jina_pb2_grpc
 from jina.types.request import Request
@@ -408,7 +409,11 @@ class GrpcConnectionPool:
         )
 
         if metrics_registry:
-            from prometheus_client import Summary
+            with ImportExtensions(
+                required=True,
+                help_text='You need to install the `prometheus_client` to use the montitoring functionality of jina',
+            ):
+                from prometheus_client import Summary
 
             self._summary_time = Summary(
                 'sending_request_seconds',

--- a/jina/serve/runtimes/gateway/request_handling.py
+++ b/jina/serve/runtimes/gateway/request_handling.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Callable, List, Optional
 
 from docarray import DocumentArray
 
+from jina.importer import ImportExtensions
 from jina.serve.networking import GrpcConnectionPool
 from jina.serve.runtimes.gateway.graph.topology_graph import TopologyGraph
 
@@ -25,7 +26,11 @@ class RequestHandler:
         self.request_init_time = {} if metrics_registry else None
 
         if metrics_registry:
-            from prometheus_client import Summary
+            with ImportExtensions(
+                required=True,
+                help_text='You need to install the `prometheus_client` to use the montitoring functionality of jina',
+            ):
+                from prometheus_client import Summary
 
             self._summary = Summary(
                 'receiving_request_seconds',

--- a/jina/serve/runtimes/head/__init__.py
+++ b/jina/serve/runtimes/head/__init__.py
@@ -13,6 +13,7 @@ import grpc
 from grpc_reflection.v1alpha import reflection
 
 from jina.enums import PollingType
+from jina.importer import ImportExtensions
 from jina.proto import jina_pb2, jina_pb2_grpc
 from jina.serve.networking import GrpcConnectionPool
 from jina.serve.runtimes.asyncio import AsyncNewLoopRuntime
@@ -54,7 +55,11 @@ class HeadRuntime(AsyncNewLoopRuntime, ABC):
         )
 
         if self.metrics_registry:
-            from prometheus_client import Summary
+            with ImportExtensions(
+                required=True,
+                help_text='You need to install the `prometheus_client` to use the montitoring functionality of jina',
+            ):
+                from prometheus_client import Summary
 
             self._summary = Summary(
                 'receiving_request_seconds',

--- a/jina/serve/runtimes/monitoring.py
+++ b/jina/serve/runtimes/monitoring.py
@@ -1,10 +1,5 @@
-from prometheus_client import CollectorRegistry
-
-
 class MonitoringMixin:
     """The Monitoring Mixin for pods"""
-
-    metrics_registry: CollectorRegistry
 
     def _setup_monitoring(self):
         """

--- a/jina/serve/runtimes/worker/__init__.py
+++ b/jina/serve/runtimes/worker/__init__.py
@@ -9,6 +9,7 @@ from typing import List, Optional, Union
 import grpc
 from grpc_reflection.v1alpha import reflection
 
+from jina.importer import ImportExtensions
 from jina.proto import jina_pb2, jina_pb2_grpc
 from jina.serve.runtimes.asyncio import AsyncNewLoopRuntime
 from jina.serve.runtimes.request_handlers.data_request_handler import DataRequestHandler
@@ -41,7 +42,11 @@ class WorkerRuntime(AsyncNewLoopRuntime, ABC):
         await self._async_setup_grpc_server()
 
         if self.metrics_registry:
-            from prometheus_client import Summary
+            with ImportExtensions(
+                required=True,
+                help_text='You need to install the `prometheus_client` to use the montitoring functionality of jina',
+            ):
+                from prometheus_client import Summary
 
             self._summary_time = Summary(
                 'receiving_request_seconds',


### PR DESCRIPTION
We want to be able to remove prometheus from core dependency if needed. Therefore we need to remove the import from the top of the file