### PR TITLE
fix: set the multiprocessing start_method spawn

### DIFF
--- a/extra-requirements.txt
+++ b/extra-requirements.txt
@@ -44,7 +44,7 @@ lz4<3.1.2:                  perf, standard,devel
 uvloop:                     perf, standard,devel
 numpy:                      core
 protobuf>=3.19.1:           core
-grpcio>=1.33.1:             core
+grpcio>=1.33.1,<1.44.0:     core
 grpcio-reflection>=1.33.1:  core
 pyyaml>=5.3.1:              core
 docarray>=0.9.10:           core

--- a/jina/__init__.py
+++ b/jina/__init__.py
@@ -39,13 +39,18 @@ _os.environ['OBJC_DISABLE_INITIALIZE_FORK_SAFETY'] = 'YES'
 
 # JINA_MP_START_METHOD has higher priority than os-patch
 _start_method = _os.environ.get('JINA_MP_START_METHOD', None)
-
 if _start_method and _start_method.lower() in {'fork', 'spawn', 'forkserver'}:
     from multiprocessing import set_start_method as _set_start_method
 
-    _set_start_method(_start_method.lower())
-    _warnings.warn(f'multiprocessing start method is set to `{_start_method.lower()}`')
-    _os.environ.pop('JINA_MP_START_METHOD')
+    try:
+        _set_start_method(_start_method.lower())
+        _warnings.warn(
+            f'multiprocessing start method is set to `{_start_method.lower()}`'
+        )
+    except Exception as e:
+        _warnings.warn(
+            f'failed to set multiprocessing start_method to `{_start_method.lower()}`: {e!r}'
+        )
 elif _sys.version_info >= (3, 8, 0) and _platform.system() == 'Darwin':
     # DO SOME OS-WISE PATCHES
 
@@ -54,6 +59,7 @@ elif _sys.version_info >= (3, 8, 0) and _platform.system() == 'Darwin':
     from multiprocessing import set_start_method as _set_start_method
 
     _set_start_method('fork')
+
 
 # do not change this line manually
 # this is managed by git tag and updated on every release

--- a/jina/resources/extra-requirements.txt
+++ b/jina/resources/extra-requirements.txt
@@ -44,7 +44,7 @@ lz4<3.1.2:                  perf, standard,devel
 uvloop:                     perf, standard,devel
 numpy:                      core
 protobuf>=3.19.1:           core
-grpcio>=1.33.1:             core
+grpcio>=1.33.1,<1.44.0:     core
 grpcio-reflection>=1.33.1:  core
 pyyaml>=5.3.1:              core
 docarray>=0.9.10:           core


### PR DESCRIPTION
# Pull Request Title

## Description

Failed to set the multiprocessing start_method `spawn` via `JINA_MP_START_METHOD`

```python
# example.py

from jina import Flow

if __name__ == '__main__':
    with Flow().add() as f:
        f.block()
```

Start the flow service
```
JINA_MP_START_METHOD=spawn python example.py
```
it raises the following error
```
RuntimeError: context has already been set
```