### PR TITLE
fix: pass extra search paths 

### DIFF
--- a/jina/jaml/__init__.py
+++ b/jina/jaml/__init__.py
@@ -724,7 +724,7 @@ class JAMLCompatible(metaclass=JAMLCompatibleType):
                     no_tag_yml,
                     extra_search_paths=(_extra_search_paths + [os.path.dirname(s_path)])
                     if s_path
-                    else None,
+                    else _extra_search_paths,
                 )
 
             from jina.orchestrate.flow.base import Flow


### PR DESCRIPTION
# Pull Request Title

## Description

The `extra_search_paths` in the following example is not considered:
```
f = Flow.load_config('clip.yml', extra_search_paths=['/path/to/folder'])
```

```
# clip.yml
jtype: Flow
version: '1'
with:
  port: 51000
executors:
  - name: clip_t
    uses:
      jtype: CLIPEncoder
      metas:
        py_modules:
          - executors/clip_torch.py
```

Closes [# (issue)](https://github.com/jina-ai/clip-as-service/issues/682)