### PR TITLE
fix: better error messages when flow fails to start

### DIFF
--- a/jina/serve/runtimes/request_handlers/data_request_handler.py
+++ b/jina/serve/runtimes/request_handlers/data_request_handler.py
@@ -71,9 +71,9 @@ class DataRequestHandler:
         except FileNotFoundError as ex:
             self.logger.error(f'fail to load file dependency')
             raise ExecutorFailToLoad from ex
-        except Exception as ex:
+        except Exception:
             self.logger.critical(f'can not load the executor from {self.args.uses}')
-            raise ExecutorFailToLoad from ex
+            raise
 
     @staticmethod
     def _parse_params(parameters: Dict, executor_name: str):

--- a/jina/serve/runtimes/request_handlers/data_request_handler.py
+++ b/jina/serve/runtimes/request_handlers/data_request_handler.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING, Dict, List, Optional
 from docarray import DocumentArray
 
 from jina import __default_endpoint__
-from jina.excepts import BadConfigSource, ExecutorFailToLoad
+from jina.excepts import BadConfigSource
 from jina.serve.executors import BaseExecutor
 from jina.types.request.data import DataRequest
 
@@ -62,15 +62,15 @@ class DataRequestHandler:
                 extra_search_paths=self.args.extra_search_paths,
             )
 
-        except BadConfigSource as ex:
+        except BadConfigSource:
             self.logger.error(
                 f'fail to load config from {self.args.uses}, if you are using docker image for --uses, '
                 f'please use "docker://YOUR_IMAGE_NAME"'
             )
-            raise ExecutorFailToLoad from ex
-        except FileNotFoundError as ex:
+            raise
+        except FileNotFoundError:
             self.logger.error(f'fail to load file dependency')
-            raise ExecutorFailToLoad from ex
+            raise
         except Exception:
             self.logger.critical(f'can not load the executor from {self.args.uses}')
             raise


### PR DESCRIPTION
**ToDo:**

- [x] worker/executor fails to start
- [x] head fails to start
- [x] gateway fails to start

**Worker:**
Don't throw our ExecutorFailedToLoad exception, instead only show the actual cause of the problem to the user.

<details>
  <summary>Before</summary>
  
````
Traceback (most recent call last):
  File "/home/johannes/Documents/jina/jina/jina/serve/runtimes/request_handlers/data_request_handler.py", line 48, in _load_executor
    self._executor: BaseExecutor = BaseExecutor.load_config(
  File "/home/johannes/Documents/jina/jina/jina/jaml/__init__.py", line 753, in load_config
    return JAML.load(tag_yml, substitute=False, runtime_args=runtime_args)
  File "/home/johannes/Documents/jina/jina/jina/jaml/__init__.py", line 175, in load
    r = yaml.load(stream, Loader=get_jina_loader_with_runtime(runtime_args))
  File "/home/johannes/Documents/jina/githubeverything/lib/python3.8/site-packages/yaml/__init__.py", line 81, in load
    return loader.get_single_data()
  File "/home/johannes/Documents/jina/githubeverything/lib/python3.8/site-packages/yaml/constructor.py", line 51, in get_single_data
    return self.construct_document(node)
  File "/home/johannes/Documents/jina/githubeverything/lib/python3.8/site-packages/yaml/constructor.py", line 55, in construct_document
    data = self.construct_object(node)
  File "/home/johannes/Documents/jina/githubeverything/lib/python3.8/site-packages/yaml/constructor.py", line 100, in construct_object
    data = constructor(self, node)
  File "/home/johannes/Documents/jina/jina/jina/jaml/__init__.py", line 575, in _from_yaml
    return get_parser(cls, version=data.get('version', None)).parse(
  File "/home/johannes/Documents/jina/jina/jina/jaml/parsers/executor/legacy.py", line 75, in parse
    obj = cls(
  File "/home/johannes/Documents/jina/jina/jina/serve/executors/decorators.py", line 71, in arg_wrapper
    f = func(self, *args, **kwargs)
  File "/home/johannes/Documents/jina/jina/tests/unit/orchestrate/flow/flow-construct/test_flow_except.py", line 241, in __init__
    raise Exception
Exception

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/johannes/Documents/jina/jina/jina/orchestrate/pods/__init__.py", line 81, in run
    runtime = runtime_cls(
  File "/home/johannes/Documents/jina/jina/jina/serve/runtimes/worker/__init__.py", line 35, in __init__
    super().__init__(args, cancel_event, **kwargs)
  File "/home/johannes/Documents/jina/jina/jina/serve/runtimes/asyncio.py", line 67, in __init__
    self._loop.run_until_complete(self.async_setup())
  File "/usr/lib/python3.8/asyncio/base_events.py", line 616, in run_until_complete
    return future.result()
  File "/home/johannes/Documents/jina/jina/jina/serve/runtimes/worker/__init__.py", line 41, in async_setup
    await self._async_setup_grpc_server()
  File "/home/johannes/Documents/jina/jina/jina/serve/runtimes/worker/__init__.py", line 63, in _async_setup_grpc_server
    self._data_request_handler = DataRequestHandler(
  File "/home/johannes/Documents/jina/jina/jina/serve/runtimes/request_handlers/data_request_handler.py", line 40, in __init__
    self._load_executor(metrics_registry)
  File "/home/johannes/Documents/jina/jina/jina/serve/runtimes/request_handlers/data_request_handler.py", line 76, in _load_executor
    raise ExecutorFailToLoad from ex
jina.excepts.ExecutorFailToLoad
````
</details>


<details>
  <summary>After</summary>
  
````
Traceback (most recent call last):
  File "/home/johannes/Documents/jina/jina/jina/orchestrate/pods/__init__.py", line 81, in run
    runtime = runtime_cls(
  File "/home/johannes/Documents/jina/jina/jina/serve/runtimes/worker/__init__.py", line 35, in __init__
    super().__init__(args, cancel_event, **kwargs)
  File "/home/johannes/Documents/jina/jina/jina/serve/runtimes/asyncio.py", line 67, in __init__
    self._loop.run_until_complete(self.async_setup())
  File "/usr/lib/python3.8/asyncio/base_events.py", line 616, in run_until_complete
    return future.result()
  File "/home/johannes/Documents/jina/jina/jina/serve/runtimes/worker/__init__.py", line 41, in async_setup
    await self._async_setup_grpc_server()
  File "/home/johannes/Documents/jina/jina/jina/serve/runtimes/worker/__init__.py", line 63, in _async_setup_grpc_server
    self._data_request_handler = DataRequestHandler(
  File "/home/johannes/Documents/jina/jina/jina/serve/runtimes/request_handlers/data_request_handler.py", line 40, in __init__
    self._load_executor(metrics_registry)
  File "/home/johannes/Documents/jina/jina/jina/serve/runtimes/request_handlers/data_request_handler.py", line 48, in _load_executor
    self._executor: BaseExecutor = BaseExecutor.load_config(
  File "/home/johannes/Documents/jina/jina/jina/jaml/__init__.py", line 753, in load_config
    return JAML.load(tag_yml, substitute=False, runtime_args=runtime_args)
  File "/home/johannes/Documents/jina/jina/jina/jaml/__init__.py", line 175, in load
    r = yaml.load(stream, Loader=get_jina_loader_with_runtime(runtime_args))
  File "/home/johannes/Documents/jina/githubeverything/lib/python3.8/site-packages/yaml/__init__.py", line 81, in load
    return loader.get_single_data()
  File "/home/johannes/Documents/jina/githubeverything/lib/python3.8/site-packages/yaml/constructor.py", line 51, in get_single_data
    return self.construct_document(node)
  File "/home/johannes/Documents/jina/githubeverything/lib/python3.8/site-packages/yaml/constructor.py", line 55, in construct_document
    data = self.construct_object(node)
  File "/home/johannes/Documents/jina/githubeverything/lib/python3.8/site-packages/yaml/constructor.py", line 100, in construct_object
    data = constructor(self, node)
  File "/home/johannes/Documents/jina/jina/jina/jaml/__init__.py", line 575, in _from_yaml
    return get_parser(cls, version=data.get('version', None)).parse(
  File "/home/johannes/Documents/jina/jina/jina/jaml/parsers/executor/legacy.py", line 75, in parse
    obj = cls(
  File "/home/johannes/Documents/jina/jina/jina/serve/executors/decorators.py", line 71, in arg_wrapper
    f = func(self, *args, **kwargs)
  File "/home/johannes/Documents/jina/jina/tests/unit/orchestrate/flow/flow-construct/test_flow_except.py", line 241, in __init__
    raise Exception
Exception
````
</details>

**Head:**
It is already good enough for now, the only issue is that it might not always be 100% clear that the head failed and not the Executor itself.
Since having a Head is an edge case anyways, and the fix for this is non-obvious (to me at least..), we decided that is not worth the effort for now.

<details>
  <summary>Before</summary>
  
````
 executor0/head@88736[E]:Exception('intentional') during <class 'jina.serve.runtimes.head.HeadRuntime'> initialization
 add "--quiet-error" to suppress the exception details
Traceback (most recent call last):
  File "/home/johannes/Documents/jina/jina/jina/orchestrate/pods/__init__.py", line 81, in run
    runtime = runtime_cls(
  File "/home/johannes/Documents/jina/jina/jina/serve/runtimes/head/__init__.py", line 46, in __init__
    raise Exception('intentional')
Exception: intentional
⠦ 2/2 waiting  to be ready...           Flow@88726[E]:Flow is aborted due to ['executor0'] can not be started.
⠦ 2/2 waiting  to be ready...
╭───────────────────── Traceback (most recent call last) ──────────────────────╮
│                                                                              │
│ /home/johannes/.config/JetBrains/PyCharmCE2022.1/scratches/scratch_20.py:10  │
│ in <module>                                                                  │
│                                                                              │
│    7 │   raise Exception()                                                   │
│    8                                                                         │
│    9                                                                         │
│ ❱ 10 with Flow().add(shards=2) as f:                                         │
│   11 │   f.index(                                                            │
│   12 │   │   [Document(text='abbcs')],                                       │
│   13 │   )                                                                   │
│ /home/johannes/Documents/jina/jina/jina/orchestrate/flow/base.py:1123 in     │
│ __enter__                                                                    │
│                                                                              │
│   1120 │                                                                     │
│   1121 │   def __enter__(self):                                              │
│   1122 │   │   with CatchAllCleanupContextManager(self):                     │
│ ❱ 1123 │   │   │   return self.start()                                       │
│   1124 │                                                                     │
│   1125 │   def __exit__(self, exc_type, exc_val, exc_tb):                    │
│   1126 │   │   if hasattr(self, '_stop_event'):                              │
│                                                                              │
│ /home/johannes/Documents/jina/jina/jina/orchestrate/flow/base.py:1178 in     │
│ start                                                                        │
│                                                                              │
│   1175 │   │   │   if not v.external:                                        │
│   1176 │   │   │   │   self.enter_context(v)                                 │
│   1177 │   │                                                                 │
│ ❱ 1178 │   │   self._wait_until_all_ready()                                  │
│   1179 │   │                                                                 │
│   1180 │   │   self._build_level = FlowBuildLevel.RUNNING                    │
│   1181                                                                       │
│                                                                              │
│ /home/johannes/Documents/jina/jina/jina/orchestrate/flow/base.py:1258 in     │
│ _wait_until_all_ready                                                        │
│                                                                              │
│   1255 │   │   │   │   │   f'Flow is aborted due to {error_deployments} can  │
│   1256 │   │   │   │   )                                                     │
│   1257 │   │   │   │   self.close()                                          │
│ ❱ 1258 │   │   │   │   raise RuntimeFailToStart                              │
│   1259 │   │                                                                 │
│   1260 │   │   if addr_table:                                                │
│   1261 │   │   │   print(                                                    │
╰──────────────────────────────────────────────────────────────────────────────╯
RuntimeFailToStart

Process finished with exit code 1

````
</details>

<details>
  <summary>After</summary>
  
Unchanged
</details>

**Gateway:**
Works well as is:

<details>
  <summary>Before</summary>
  
````
   gateway/rep-0@89332[E]:Exception('intentional') during <class 'jina.serve.runtimes.gateway.websocket.WebSocketGatewayRuntime'> initialization
 add "--quiet-error" to suppress the exception details
Traceback (most recent call last):
  File "/home/johannes/Documents/jina/jina/jina/orchestrate/pods/__init__.py", line 81, in run
    runtime = runtime_cls(
  File "/home/johannes/Documents/jina/jina/jina/serve/runtimes/asyncio.py", line 67, in __init__
    self._loop.run_until_complete(self.async_setup())
  File "/usr/lib/python3.8/asyncio/base_events.py", line 616, in run_until_complete
    return future.result()
  File "/home/johannes/Documents/jina/jina/jina/serve/runtimes/gateway/websocket/__init__.py", line 16, in async_setup
    raise Exception('intentional')
Exception: intentional
⠦ 2/2 waiting  to be ready...           Flow@89321[E]:Flow is aborted due to ['gateway'] can not be started.
⠦ 2/2 waiting  to be ready...
╭───────────────────── Traceback (most recent call last) ──────────────────────╮
│                                                                              │
│ /home/johannes/.config/JetBrains/PyCharmCE2022.1/scratches/scratch_20.py:10  │
│ in <module>                                                                  │
│                                                                              │
│    7 │   raise Exception()                                                   │
│    8                                                                         │
│    9                                                                         │
│ ❱ 10 with Flow(protocol='websocket').add() as f:                             │
│   11 │   f.index(                                                            │
│   12 │   │   [Document(text='abbcs')],                                       │
│   13 │   )                                                                   │
│ /home/johannes/Documents/jina/jina/jina/orchestrate/flow/base.py:1123 in     │
│ __enter__                                                                    │
│                                                                              │
│   1120 │                                                                     │
│   1121 │   def __enter__(self):                                              │
│   1122 │   │   with CatchAllCleanupContextManager(self):                     │
│ ❱ 1123 │   │   │   return self.start()                                       │
│   1124 │                                                                     │
│   1125 │   def __exit__(self, exc_type, exc_val, exc_tb):                    │
│   1126 │   │   if hasattr(self, '_stop_event'):                              │
│                                                                              │
│ /home/johannes/Documents/jina/jina/jina/orchestrate/flow/base.py:1178 in     │
│ start                                                                        │
│                                                                              │
│   1175 │   │   │   if not v.external:                                        │
│   1176 │   │   │   │   self.enter_context(v)                                 │
│   1177 │   │                                                                 │
│ ❱ 1178 │   │   self._wait_until_all_ready()                                  │
│   1179 │   │                                                                 │
│   1180 │   │   self._build_level = FlowBuildLevel.RUNNING                    │
│   1181                                                                       │
│                                                                              │
│ /home/johannes/Documents/jina/jina/jina/orchestrate/flow/base.py:1258 in     │
│ _wait_until_all_ready                                                        │
│                                                                              │
│   1255 │   │   │   │   │   f'Flow is aborted due to {error_deployments} can  │
│   1256 │   │   │   │   )                                                     │
│   1257 │   │   │   │   self.close()                                          │
│ ❱ 1258 │   │   │   │   raise RuntimeFailToStart                              │
│   1259 │   │                                                                 │
│   1260 │   │   if addr_table:                                                │
│   1261 │   │   │   print(                                                    │
╰──────────────────────────────────────────────────────────────────────────────╯
RuntimeFailToStart

Process finished with exit code 1


````
</details>

<details>
  <summary>After</summary>
  
Unchanged
</details>