### PR TITLE
fix: relax time constraint in block exec test

### DIFF
--- a/tests/unit/serve/executors/test_executor.py
+++ b/tests/unit/serve/executors/test_executor.py
@@ -501,7 +501,7 @@ async def test_blocking_sync_exec():
     end_time = time.time()
 
     assert all(result.docs.texts == ['BlockingExecutor'] for result in results)
-    assert end_time - start_time < (REQUEST_COUNT * SLEEP_TIME) + 0.2
+    assert end_time - start_time < (REQUEST_COUNT * SLEEP_TIME) * 2.0
 
     cancel_event.set()
     runtime_thread.join()


### PR DESCRIPTION
CI being slow made the blocking exec test [fail occassionally](https://github.com/jina-ai/jina/runs/6109701525?check_suite_focus=true)

This PR relaxes the asserted execution time constraint a bit. Its a magic number, but I think assuming that it should take less than 2 times the expected time should be fair