### PR TITLE
fix: sandbox usage from k8s/docker-compose

### DIFF
--- a/jina/orchestrate/flow/base.py
+++ b/jina/orchestrate/flow/base.py
@@ -531,7 +531,7 @@ class Flow(PostMixin, JAMLCompatible, ExitStack, metaclass=FlowType):
 
             external_port = v.head_port if v.head_port else v.port
             graph_dict[node] = [
-                f'{deployment_k8s_address}:{external_port if v.external else GrpcConnectionPool.K8S_PORT}'
+                f'{v.protocol}://{deployment_k8s_address}:{external_port if v.external else GrpcConnectionPool.K8S_PORT}'
             ]
 
         return graph_dict if graph_dict else None
@@ -544,6 +544,9 @@ class Flow(PostMixin, JAMLCompatible, ExitStack, metaclass=FlowType):
         for node, v in self._deployment_nodes.items():
             if node == 'gateway':
                 continue
+
+            if v.external:
+                deployment_docker_compose_address = f'{v.protocol}://{v.host}:{v.port}'
             elif v.head_args:
                 deployment_docker_compose_address = (
                     f'{to_compatible_name(v.head_args.name)}:{port}'


### PR DESCRIPTION
# fix: sandbox usage from k8s/docker-compose

## Description

We don't include the protocol part in the deployment addresses for K8s/Docker-Compose config files. This makes sandbox unusable from those environments. In docker-compose we actually had external executors never working before as well. Those issues are fixed in this PR. 

Closes 4664 ([issue](https://github.com/jina-ai/jina/issues/4664))