### PR TITLE
feat: immutable tags for executors

### DIFF
--- a/cli/autocomplete.py
+++ b/cli/autocomplete.py
@@ -191,6 +191,7 @@ ac_table = {
             '--verbose',
             '--dockerfile',
             '--tag',
+            '--immutable-tag',
             '--force-update',
             '--force',
             '--secret',

--- a/docs/fundamentals/executor/hub/push-executor.md
+++ b/docs/fundamentals/executor/hub/push-executor.md
@@ -68,7 +68,8 @@ If you want to create a new tag for an existing Executor, you can also add the `
 jina hub push [--public/--private] --force-update <NAME> --secret <SECRET> -t TAG <path_to_executor_folder>
 ```
 
-If you want to create an immutable tag, that could not be modified again after push, you can leverage the `--immutable-tag` option:
+If you want to create an immutable tag, you can leverage the `--immutable-tag` option. 
+After being pushed for the first time, the immutable tags can not be pushed again.
 
 ```bash
 jina hub push [--public/--private] --force-update <NAME> --secret <SECRET> --immutable-tag <IMMUTABLE_TAG> <path_to_executor_folder>

--- a/docs/fundamentals/executor/hub/push-executor.md
+++ b/docs/fundamentals/executor/hub/push-executor.md
@@ -67,3 +67,9 @@ If you want to create a new tag for an existing Executor, you can also add the `
 ```bash
 jina hub push [--public/--private] --force-update <NAME> --secret <SECRET> -t TAG <path_to_executor_folder>
 ```
+
+If you want to create an immutable tag, that could not be modified again after push, you can leverage the `--immutable-tag` option:
+
+```bash
+jina hub push [--public/--private] --force-update <NAME> --secret <SECRET> --immutable-tag <IMMUTABLE_TAG> <path_to_executor_folder>
+```

--- a/jina/hubble/hubio.py
+++ b/jina/hubble/hubio.py
@@ -332,8 +332,11 @@ metas:
         work_path = Path(self.args.path)
 
         exec_tags = None
+        exec_immutable_tags = None
         if self.args.tag:
             exec_tags = ','.join(self.args.tag)
+        if self.args.immutable_tag:
+            exec_immutable_tags = ','.join(self.args.immutable_tag)
 
         dockerfile = None
         if self.args.dockerfile:
@@ -375,6 +378,9 @@ metas:
 
                 if exec_tags:
                     form_data['tags'] = exec_tags
+                
+                if exec_immutable_tags:
+                    form_data['immutableTags'] = exec_immutable_tags
 
                 if dockerfile:
                     form_data['dockerfile'] = str(dockerfile)

--- a/jina/parsers/hubble/push.py
+++ b/jina/parsers/hubble/push.py
@@ -50,6 +50,12 @@ One can later fetch a tagged Executor via `jinahub[+docker]://MyExecutor/gpu`
     )
 
     gp.add_argument(
+        '--immutable-tag',
+        action='append',
+        help='A list of immutable tags. Like tag but immutable after first push. ',
+    )
+
+    gp.add_argument(
         '--force-update',
         '--force',
         type=str,


### PR DESCRIPTION
Goals:

- Allow user to push executor with immutable tags to Jina Hub using the `--immutable-tag` option.
- Document this new feature inside the docs
- [x] check and update documentation. See [guide](https://github.com/jina-ai/jina/CONTRIBUTING.md#documentation-guidelines) and ask the team.
