### PR TITLE
fix: fix configuration of addresses in docker compose

### DIFF
--- a/jina/orchestrate/flow/base.py
+++ b/jina/orchestrate/flow/base.py
@@ -560,10 +560,12 @@ class Flow(PostMixin, JAMLCompatible, ExitStack, metaclass=FlowType):
                         f'{to_compatible_name(v.name)}:{port}'
                     ]
                 else:
-                    deployment_docker_compose_address = [
-                        f'{to_compatible_name(v.name)}/rep-{rep_id}:{port}'
-                        for rep_id in range(v.args.replicas)
-                    ]
+                    deployment_docker_compose_address = []
+                    for rep_id in range(v.args.replicas):
+                        node_name = f'{v.name}/rep-{rep_id}'
+                        deployment_docker_compose_address.append(
+                            f'{to_compatible_name(node_name)}:{port}'
+                        )
             graph_dict[node] = deployment_docker_compose_address
 
         return graph_dict

--- a/jina/orchestrate/flow/base.py
+++ b/jina/orchestrate/flow/base.py
@@ -547,16 +547,24 @@ class Flow(PostMixin, JAMLCompatible, ExitStack, metaclass=FlowType):
                 continue
 
             if v.external:
-                deployment_docker_compose_address = f'{v.protocol}://{v.host}:{v.port}'
+                deployment_docker_compose_address = [
+                    f'{v.protocol}://{v.host}:{v.port}'
+                ]
             elif v.head_args:
-                deployment_docker_compose_address = (
+                deployment_docker_compose_address = [
                     f'{to_compatible_name(v.head_args.name)}:{port}'
-                )
+                ]
             else:
-                deployment_docker_compose_address = (
-                    f'{to_compatible_name(v.name)}:{port}'
-                )
-            graph_dict[node] = [deployment_docker_compose_address]
+                if v.args.replicas == 1:
+                    deployment_docker_compose_address = [
+                        f'{to_compatible_name(v.name)}:{port}'
+                    ]
+                else:
+                    deployment_docker_compose_address = [
+                        f'{to_compatible_name(v.name)}/rep-{rep_id}:{port}'
+                        for rep_id in range(v.args.replicas)
+                    ]
+            graph_dict[node] = deployment_docker_compose_address
 
         return graph_dict
 

--- a/jina/serve/networking.py
+++ b/jina/serve/networking.py
@@ -273,10 +273,10 @@ class GrpcConnectionPool:
             self, deployment: str, head: bool, entity_id: Optional[int] = None
         ) -> ReplicaList:
             if deployment in self._deployments:
-                type = 'heads' if head else 'shards'
+                type_ = 'heads' if head else 'shards'
                 if entity_id is None and head:
                     entity_id = 0
-                return self._get_connection_list(deployment, type, entity_id)
+                return self._get_connection_list(deployment, type_, entity_id)
             else:
                 self._logger.debug(
                     f'Unknown deployment {deployment}, no replicas available'
@@ -303,27 +303,27 @@ class GrpcConnectionPool:
             self._deployments.clear()
 
         def _get_connection_list(
-            self, deployment: str, type: str, entity_id: Optional[int] = None
+            self, deployment: str, type_: str, entity_id: Optional[int] = None
         ) -> ReplicaList:
             try:
-                if entity_id is None and len(self._deployments[deployment][type]) > 0:
+                if entity_id is None and len(self._deployments[deployment][type_]) > 0:
                     # select a random entity
                     self._access_count[deployment] += 1
-                    return self._deployments[deployment][type][
+                    return self._deployments[deployment][type_][
                         self._access_count[deployment]
-                        % len(self._deployments[deployment][type])
+                        % len(self._deployments[deployment][type_])
                     ]
                 else:
-                    return self._deployments[deployment][type][entity_id]
+                    return self._deployments[deployment][type_][entity_id]
             except KeyError:
                 if (
                     entity_id is None
                     and deployment in self._deployments
-                    and len(self._deployments[deployment][type])
+                    and len(self._deployments[deployment][type_])
                 ):
                     # This can happen as a race condition when removing connections while accessing it
                     # In this case we don't care for the concrete entity, so retry with the first one
-                    return self._get_connection_list(deployment, type, 0)
+                    return self._get_connection_list(deployment, type_, 0)
                 self._logger.debug(
                     f'Did not find a connection for deployment {deployment}, type {type} and entity_id {entity_id}. There are {len(self._deployments[deployment][type]) if deployment in self._deployments else 0} available connections for this deployment and type. '
                 )

--- a/tests/docker_compose/test_docker_compose.py
+++ b/tests/docker_compose/test_docker_compose.py
@@ -79,7 +79,6 @@ async def run_test(flow, endpoint, num_docs=10, request_size=10):
     client_kwargs = dict(
         host='localhost',
         port=flow.port,
-        return_responses=True,
         asyncio=True,
     )
     client_kwargs.update(flow._common_kwargs)
@@ -91,6 +90,7 @@ async def run_test(flow, endpoint, num_docs=10, request_size=10):
         endpoint,
         inputs=[Document() for _ in range(num_docs)],
         request_size=request_size,
+        return_responses=True,
     ):
         responses.append(resp)
 
@@ -168,8 +168,13 @@ async def test_flow_with_needs(logger, flow_with_needs, tmpdir, docker_images):
             flow=flow_with_needs,
             endpoint='/debug',
         )
-        expected_traversed_executors = {
-            'segmenter',
+        expected_traversed_executors_0 = {
+            'segmenter/rep-0',
+            'imageencoder',
+            'textencoder',
+        }
+        expected_traversed_executors_1 = {
+            'segmenter/rep-1',
             'imageencoder',
             'textencoder',
         }
@@ -177,7 +182,13 @@ async def test_flow_with_needs(logger, flow_with_needs, tmpdir, docker_images):
         docs = resp[0].docs
         assert len(docs) == 10
         for doc in docs:
-            assert set(doc.tags['traversed-executors']) == expected_traversed_executors
+            path_1 = (
+                set(doc.tags['traversed-executors']) == expected_traversed_executors_0
+            )
+            path_2 = (
+                set(doc.tags['traversed-executors']) == expected_traversed_executors_1
+            )
+            assert path_1 or path_2
 
 
 @pytest.mark.asyncio

--- a/tests/docker_compose/test_docker_compose.py
+++ b/tests/docker_compose/test_docker_compose.py
@@ -131,6 +131,7 @@ def flow_with_needs(docker_images):
         .add(
             name='segmenter',
             uses=f'docker://{docker_images[0]}',
+            replicas=2,
         )
         .add(
             name='textencoder',


### PR DESCRIPTION
Goals:
Problem when using `to_docker_compose` of a Flow, the gateway deployment addresses to the Executor replicas is not properly set.

This PR fixes it.

Logic is:

- Local and Docker-compose: Gateway connects directly to each replicas doing the load balancing
- K8s: Gateway connects to a single address corresponding to the LinkerD or lstio load balancer