### PR TITLE
fix(dependency): prometheus client should be a core dependency

### DIFF
--- a/extra-requirements.txt
+++ b/extra-requirements.txt
@@ -75,4 +75,4 @@ kubernetes>=18.20.0:        test
 pytest-kind==21.1.3:        test
 pytest-lazy-fixture:        test
 sgqlc:                      cicd, graphql
-prometheus_client:          standard
+prometheus_client:          core

--- a/jina/resources/extra-requirements.txt
+++ b/jina/resources/extra-requirements.txt
@@ -75,4 +75,4 @@ kubernetes>=18.20.0:        test
 pytest-kind==21.1.3:        test
 pytest-lazy-fixture:        test
 sgqlc:                      cicd, graphql
-prometheus_client:          standard
+prometheus_client:          core


### PR DESCRIPTION
Prometheus client should be a core dependency otherwise we can't monitor executor running in k8s
