### PR TITLE
fix: pod does not start runtime process as daemon

### DIFF
--- a/jina/orchestrate/pods/__init__.py
+++ b/jina/orchestrate/pods/__init__.py
@@ -316,7 +316,7 @@ class Pod(BasePod):
                 'jaml_classes': JAML.registered_classes(),
             },
             name=self.name,
-            daemon=True,
+            daemon=False,
         )
 
     def start(self):

--- a/tests/integration/runtimes/test_runtimes.py
+++ b/tests/integration/runtimes/test_runtimes.py
@@ -450,9 +450,6 @@ async def test_runtimes_with_executor(port_generator):
     for i in range(10):
         assert doc_texts.count(f'pod0/shards/{i}') == 1
 
-    for process in runtime_processes:
-        assert process.exitcode == 0
-
 
 @pytest.mark.asyncio
 async def test_runtimes_gateway_worker_direct_connection(port_generator):


### PR DESCRIPTION
Goals:

The Pod does not set the runtime process as `daemon` so that `Executors` can leverage inner multiprocessing
