### PR TITLE
chore: disable console color with envvar

### DIFF
--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -56,7 +56,8 @@ def _get_run_args(print_args: bool = True):
 
                 param_str.add_row(sign, param, value, style=style)
 
-            print(f'\n{logo_str}\n')
+            if 'JINA_LOG_NO_COLOR' not in os.environ:
+                print(f'\n{logo_str}\n')
             console.print(f'▶️  {" ".join(sys.argv)}', param_str)
         return args
     else:

--- a/jina/helper.py
+++ b/jina/helper.py
@@ -1529,6 +1529,7 @@ def get_rich_console():
     """
     return Console(
         force_terminal=True,
+        color_system=None if 'JINA_LOG_NO_COLOR' in os.environ else 'auto',
     )  # It forces render in any terminal, especially in PyCharm
 
 


### PR DESCRIPTION
### Goals

- Skips printing `jina.logo` if `JINA_LOG_NO_COLOR` is set.
- Disables rich console colors, if `JINA_LOG_NO_COLOR` is set. 

Both needed for [jcloud logs](https://github.com/jina-ai/jcloud#view-logs).  

#### Default

![image](https://user-images.githubusercontent.com/9050737/165296784-95c2680a-4d92-4865-8afc-154c3898dfe3.png)

#### `JINA_LOG_NO_COLOR` set
![image](https://user-images.githubusercontent.com/9050737/165296859-2a54338d-a3c8-4afd-ab65-8da21c71e418.png)