### PR TITLE
fix: parsing requirements of executor

### DIFF
--- a/jina/hubble/requirements.py
+++ b/jina/hubble/requirements.py
@@ -81,24 +81,21 @@ def parse_requirement(line: str) -> 'Requirement':
 
     if vcs_match is not None:
         groups = vcs_match.groupdict()
-
+        name = os.path.basename(groups['path']).split('.')[0]
+        egg = None
         if groups['fragment']:
             fragment = _parse_fragment(groups['fragment'])
             egg = fragment.get('egg')
-            if egg:
-                line = f'{egg} @ {line}'
-        else:
-            name = os.path.basename(groups['path']).split('.')[0]
-            line = f'{name} @ {line}'
+
+        line = f'{egg or name} @ {line}'
     elif uri_match is not None:
         groups = uri_match.groupdict()
+        name = os.path.basename(groups['path']).split('.')[0]
+        egg = None
         if groups['fragment']:
             fragment = _parse_fragment(groups['fragment'])
             egg = fragment.get('egg')
-            if egg:
-                line = f'{egg} @ {line}'
-        else:
-            name = os.path.basename(groups['path']).split('.')[0]
-            line = f'{name} @ {line}'
+
+        line = f'{egg or name} @ {line}'
 
     return Requirement.parse(line)

--- a/jina/hubble/requirements.py
+++ b/jina/hubble/requirements.py
@@ -1,0 +1,104 @@
+"""Module for helper functions for parsing requirements file."""
+
+import os
+import re
+from typing import Dict, Tuple, cast
+
+from pkg_resources import Requirement
+
+# Adopted from requirements-parser:
+# https://github.com/madpah/requirements-parser
+
+VCS = [
+    'git',
+    'hg',
+    'svn',
+    'bzr',
+]
+
+VCS_SCHEMES = [
+    'git',
+    'git+https',
+    'git+ssh',
+    'git+git',
+    'hg+http',
+    'hg+https',
+    'hg+static-http',
+    'hg+ssh',
+    'svn',
+    'svn+svn',
+    'svn+http',
+    'svn+https',
+    'svn+ssh',
+    'bzr+http',
+    'bzr+https',
+    'bzr+ssh',
+    'bzr+sftp',
+    'bzr+ftp',
+    'bzr+lp',
+]
+
+URI_REGEX = re.compile(
+    r'^(?P<scheme>https?|file|ftps?)://(?P<path>[^#]+)' r'(#(?P<fragment>\S+))?'
+)
+
+VCS_SCHEMES_REGEX = r'|'.join([scheme.replace('+', r'\+') for scheme in VCS_SCHEMES])
+VCS_REGEX = re.compile(
+    rf'^(?P<scheme>{VCS_SCHEMES_REGEX})://((?P<login>[^/@]+)@)?'
+    r'(?P<path>[^#@]+)(@(?P<revision>[^#]+))?(#(?P<fragment>\S+))?'
+)
+
+
+extras_require_search = re.compile(r'(?P<name>.+)\[(?P<extras>[^\]]+)\]')
+
+
+def _parse_fragment(fragment_string: str) -> Dict[str, str]:
+    """Takes a fragment string nd returns a dict of the components
+
+    :param fragment_string: a fragment string
+    :return: a dict of components
+    """
+    fragment_string = fragment_string.lstrip('#')
+
+    try:
+        return dict(
+            cast(Tuple[str, str], tuple(key_value_string.split('=')))
+            for key_value_string in fragment_string.split('&')
+        )
+    except ValueError:
+        raise ValueError(f'Invalid fragment string {fragment_string}')
+
+
+def parse_requirement(line: str) -> 'Requirement':
+    """Parses a Requirement from a line of a requirement file.
+
+    :param line: a line of a requirement file
+    :returns: a Requirement instance for the given line
+    """
+
+    vcs_match = VCS_REGEX.match(line)
+    uri_match = URI_REGEX.match(line)
+
+    if vcs_match is not None:
+        groups = vcs_match.groupdict()
+
+        if groups['fragment']:
+            fragment = _parse_fragment(groups['fragment'])
+            egg = fragment.get('egg')
+            if egg:
+                line = f'{egg} @ {line}'
+        else:
+            name = os.path.basename(groups['path']).split('.')[0]
+            line = f'{name} @ {line}'
+    elif uri_match is not None:
+        groups = uri_match.groupdict()
+        if groups['fragment']:
+            fragment = _parse_fragment(groups['fragment'])
+            egg = fragment.get('egg')
+            if egg:
+                line = f'{egg} @ {line}'
+        else:
+            name = os.path.basename(groups['path']).split('.')[0]
+            line = f'{name} @ {line}'
+
+    return Requirement.parse(line)

--- a/tests/unit/hubble/test_helper.py
+++ b/tests/unit/hubble/test_helper.py
@@ -97,6 +97,7 @@ def test_install_requirements():
             [],
             ['dev'],
         ),
+        ('http://pypi.python.org/packages/source/p/jina/jina.tar.gz', 'jina', [], []),
     ],
 )
 def test_parse_requirements(requirement, name, specs, extras):

--- a/tests/unit/hubble/test_helper.py
+++ b/tests/unit/hubble/test_helper.py
@@ -83,16 +83,30 @@ def test_install_requirements():
     )
 
 
-def test_parse_requirements():
+@pytest.mark.parametrize(
+    'requirement, name, specs, extras',
+    [
+        ('docarray', 'docarray', [], []),
+        ('jina[dev]', 'jina', [], ['dev']),
+        ('clip-server==0.3.0', 'clip-server', [('==', '0.3.0')], []),
+        ('git+https://github.com/jina-ai/jina.git', 'jina', [], []),
+        ('git+https://github.com/jina-ai/jina.git@v0.1', 'jina', [], []),
+        (
+            'git+https://github.com/jina-ai/jina.git@0.1#egg=jina[dev]',
+            'jina',
+            [],
+            ['dev'],
+        ),
+    ],
+)
+def test_parse_requirements(requirement, name, specs, extras):
     from jina.hubble.requirements import parse_requirement
 
-    requirements = [
-        'docarray',
-        'git+https://github.com/jina-ai/jina.git',
-        'git+https://git.myproject.org/MyProject.git@v0.1#egg=MyProject[security]',
-    ]
-    for r in requirements:
-        req_spec = parse_requirement(r)
+    req_spec = parse_requirement(requirement)
+
+    assert req_spec.project_name == name
+    assert list(req_spec.extras) == extras
+    assert req_spec.specs == specs
 
 
 def test_is_requirement_installed(tmpfile):

--- a/tests/unit/hubble/test_helper.py
+++ b/tests/unit/hubble/test_helper.py
@@ -1,8 +1,8 @@
 import urllib
+from pathlib import Path
 
 import pytest
 
-from pathlib import Path
 from jina.hubble import helper
 from jina.hubble.helper import disk_cache_offline
 from jina.parsers.hubble import set_hub_pull_parser
@@ -81,6 +81,18 @@ def test_install_requirements():
     helper.install_requirements(
         Path(__file__).parent / 'dummy_executor' / 'requirements.txt'
     )
+
+
+def test_parse_requirements():
+    from jina.hubble.requirements import parse_requirement
+
+    requirements = [
+        'docarray',
+        'git+https://github.com/jina-ai/jina.git',
+        'git+https://git.myproject.org/MyProject.git@v0.1#egg=MyProject[security]',
+    ]
+    for r in requirements:
+        req_spec = parse_requirement(r)
 
 
 def test_is_requirement_installed(tmpfile):


### PR DESCRIPTION
Goals:
To allow the following URI or VCS requirements can be parsed correctly:
```
git+https://github.com/huggingface/transformers.git
git+https://github.com/patil-suraj/vqgan-jax.git
git+https://github.com/borisdayma/dalle-mini.git
```

