### PR TITLE
feat: add a decoratator for monitoring method

### DIFF
--- a/jina/__init__.py
+++ b/jina/__init__.py
@@ -206,7 +206,7 @@ from jina.orchestrate.flow.base import Flow
 
 # Executor
 from jina.serve.executors import BaseExecutor as Executor
-from jina.serve.executors.decorators import requests
+from jina.serve.executors.decorators import monitor, requests
 
 __all__ = [_s for _s in dir() if not _s.startswith('_')]
 __all__.extend(_names_with_underscore)

--- a/jina/serve/executors/__init__.py
+++ b/jina/serve/executors/__init__.py
@@ -132,8 +132,11 @@ class BaseExecutor(JAMLCompatible, metaclass=ExecutorType):
                 namespace='jina',
                 labelnames=('executor', 'endpoint'),
             )
+            self._metrics_buffer = {'process_request_seconds': self._summary_method}
+
         else:
             self._summary_method = None
+            self._metrics_buffer = None
 
     def _add_requests(self, _requests: Optional[Dict]):
         if not hasattr(self, 'requests'):

--- a/jina/serve/executors/__init__.py
+++ b/jina/serve/executors/__init__.py
@@ -502,22 +502,6 @@ class BaseExecutor(JAMLCompatible, metaclass=ExecutorType):
         else:
             return None
 
-    def log(
-        self,
-        value: Any,
-        name: Optional[str] = None,
-        documentation: Optional[str] = None,
-    ):
-        """
-        observe a value to a metric, if the metric does not exist yet, it will create it and store it in a buffer.
-        :param value: value to be observe by the metric,
-        :param name: the name of the metrics
-        :param documentation:  the description of the metrics
-        """
-        metric = self.get_metrics(name, documentation)
-        if metric:
-            metric.observe(value)
-
 
 class ReducerExecutor(BaseExecutor):
     """

--- a/jina/serve/executors/__init__.py
+++ b/jina/serve/executors/__init__.py
@@ -502,6 +502,22 @@ class BaseExecutor(JAMLCompatible, metaclass=ExecutorType):
         else:
             return None
 
+    def log(
+        self,
+        value: Any,
+        name: Optional[str] = None,
+        documentation: Optional[str] = None,
+    ):
+        """
+        observe a value to a metric, if the metric does not exist yet, it will create it and store it in a buffer.
+        :param value: value to be observe by the metric,
+        :param name: the name of the metrics
+        :param documentation:  the description of the metrics
+        """
+        metric = self.get_metrics(name, documentation)
+        if metric:
+            metric.observe(value)
+
 
 class ReducerExecutor(BaseExecutor):
     """

--- a/jina/serve/executors/decorators.py
+++ b/jina/serve/executors/decorators.py
@@ -147,6 +147,8 @@ def monitor(
     monitoring on your Executor. It will track the time spend calling the function and the number of times it has been
     called. Under the hood it will create a prometheus [Summary](https://prometheus.io/docs/practices/histograms/).
 
+    :warning: Don't use this decorator with the @request decorator as it already handle monitoring under the hood
+
     :param name: the name of the metrics, by default it is based on the name of the method it decorates
     :param documentation:  the description of the metrics, by default it is based on the name of the method it decorates
 

--- a/jina/serve/executors/decorators.py
+++ b/jina/serve/executors/decorators.py
@@ -145,7 +145,7 @@ def monitor(
     """
     `@monitor()` allow to monitor internal method of your executor. You can acces these metrics by enabling the
     monitoring on your Executor. It will track the time spend calling the function and the number of times it has been
-    called. Under the hood it will create a prometheus [Summary](https://prometheus.io/docs/practices/histograms/).
+    called. Under the hood it will create a prometheus Summary : https://prometheus.io/docs/practices/histograms/.
 
     :warning: Don't use this decorator with the @request decorator as it already handle monitoring under the hood
 

--- a/jina/serve/executors/decorators.py
+++ b/jina/serve/executors/decorators.py
@@ -172,7 +172,7 @@ def monitor(
             if metric:
                 with metric.time():
                     return func(self, *args, **kwargs)
-            else:  # should raise a warning or log something about the fact the monitoring is disabled
+            else:
                 return func(self, *args, **kwargs)
 
         return _f

--- a/jina/serve/executors/decorators.py
+++ b/jina/serve/executors/decorators.py
@@ -143,7 +143,7 @@ def monitor(
     documentation: Optional[str] = None,
 ):
     """
-    `@monitor()` allow to monitor internal method of your executor. You can acces these metrics by enabling the
+    `@monitor()` allow to monitor internal method of your executor. You can access these metrics by enabling the
     monitoring on your Executor. It will track the time spend calling the function and the number of times it has been
     called. Under the hood it will create a prometheus Summary : https://prometheus.io/docs/practices/histograms/.
 
@@ -166,20 +166,11 @@ def monitor(
 
         @functools.wraps(func)
         def _f(self, *args, **kwargs):
-            if self._metrics_buffer:
-                if name_ not in self._metrics_buffer:
-                    from prometheus_client import Summary
+            metric = self.get_metrics(name_, documentation_)
 
-                    self._metrics_buffer[name_] = Summary(
-                        name_,
-                        documentation_,
-                        registry=self.runtime_args.metrics_registry,
-                        namespace='jina',
-                    )
-
-                with self._metrics_buffer[name_].time():
+            if metric:
+                with metric.time():
                     return func(self, *args, **kwargs)
-
             else:  # should raise a warning or log something about the fact the monitoring is disabled
                 return func(self, *args, **kwargs)
 

--- a/jina/serve/executors/decorators.py
+++ b/jina/serve/executors/decorators.py
@@ -139,6 +139,7 @@ def requests(
 
 
 def monitor(
+    *,
     name: Optional[str] = None,
     documentation: Optional[str] = None,
 ):

--- a/tests/integration/monitoring/test_executor.py
+++ b/tests/integration/monitoring/test_executor.py
@@ -1,0 +1,81 @@
+import requests as req
+from docarray import DocumentArray
+from prometheus_client import Summary
+
+from jina import Executor, Flow, monitor, requests
+
+
+def test_prometheus_interface(port_generator):
+    class DummyExecutor(Executor):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.summary = Summary(
+                'a', 'A', registry=self.runtime_args.metrics_registry
+            )
+
+        @requests(on='/foo')
+        def foo(self, docs, **kwargs):
+            with self.summary.time():
+                ...
+
+    port = port_generator()
+    with Flow(monitoring=True).add(
+        uses=DummyExecutor, monitoring=True, port_monitoring=port
+    ) as f:
+        f.post('/foo', inputs=DocumentArray.empty(4))
+
+        resp = req.get(f'http://localhost:{port}/')
+        assert f'a_count 1.0' in str(  # check that we count 4 documents on foo
+            resp.content
+        )
+
+
+def test_prometheus_interface(port_generator):
+    class DummyExecutor(Executor):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.summary = Summary(
+                'a', 'A', registry=self.runtime_args.metrics_registry
+            )
+
+        @requests(on='/foo')
+        def foo(self, docs, **kwargs):
+            with self.summary.time():
+                ...
+
+    port = port_generator()
+    with Flow(monitoring=True).add(
+        uses=DummyExecutor, monitoring=True, port_monitoring=port
+    ) as f:
+        f.post('/foo', inputs=DocumentArray.empty(4))
+
+        resp = req.get(f'http://localhost:{port}/')
+        assert f'a_count 1.0' in str(  # check that we count 4 documents on foo
+            resp.content
+        )
+
+
+def test_decorator_interface(port_generator):
+    class DummyExecutor(Executor):
+        @requests(on='/foo')
+        def foo(self, docs, **kwargs):
+            self._proces(docs)
+            self.proces_2(docs)
+
+        @monitor('metrics_name', 'metrics description')
+        def _proces(self, docs):
+            ...
+
+        @monitor()
+        def proces_2(self, docs):
+            ...
+
+    port = port_generator()
+    with Flow(monitoring=True).add(
+        uses=DummyExecutor, monitoring=True, port_monitoring=port
+    ) as f:
+        f.post('/foo', inputs=DocumentArray.empty(4))
+
+        resp = req.get(f'http://localhost:{port}/')
+        assert f'jina_metrics_name_count 1.0' in str(resp.content)
+        assert f'jina_proces_2_seconds_count 1.0' in str(resp.content)

--- a/tests/integration/monitoring/test_executor.py
+++ b/tests/integration/monitoring/test_executor.py
@@ -19,32 +19,7 @@ def test_prometheus_interface(port_generator):
                 ...
 
     port = port_generator()
-    with Flow(monitoring=True).add(
-        uses=DummyExecutor, monitoring=True, port_monitoring=port
-    ) as f:
-        f.post('/foo', inputs=DocumentArray.empty(4))
-
-        resp = req.get(f'http://localhost:{port}/')
-        assert f'a_count 1.0' in str(  # check that we count 4 documents on foo
-            resp.content
-        )
-
-
-def test_prometheus_interface(port_generator):
-    class DummyExecutor(Executor):
-        def __init__(self, *args, **kwargs):
-            super().__init__(*args, **kwargs)
-            self.summary = Summary(
-                'a', 'A', registry=self.runtime_args.metrics_registry
-            )
-
-        @requests(on='/foo')
-        def foo(self, docs, **kwargs):
-            with self.summary.time():
-                ...
-
-    port = port_generator()
-    with Flow(monitoring=True).add(
+    with Flow(monitoring=True, port_monitoring=port_generator()).add(
         uses=DummyExecutor, monitoring=True, port_monitoring=port
     ) as f:
         f.post('/foo', inputs=DocumentArray.empty(4))
@@ -71,7 +46,7 @@ def test_decorator_interface(port_generator):
             ...
 
     port = port_generator()
-    with Flow(monitoring=True).add(
+    with Flow(monitoring=True, port_monitoring=port_generator()).add(
         uses=DummyExecutor, monitoring=True, port_monitoring=port
     ) as f:
         f.post('/foo', inputs=DocumentArray.empty(4))

--- a/tests/integration/monitoring/test_executor.py
+++ b/tests/integration/monitoring/test_executor.py
@@ -37,7 +37,7 @@ def test_decorator_interface(port_generator):
             self._proces(docs)
             self.proces_2(docs)
 
-        @monitor('metrics_name', 'metrics description')
+        @monitor(name='metrics_name', documentation='metrics description')
         def _proces(self, docs):
             ...
 

--- a/tests/unit/serve/runtimes/worker/test_worker_runtime.py
+++ b/tests/unit/serve/runtimes/worker/test_worker_runtime.py
@@ -8,8 +8,9 @@ from threading import Event
 
 import grpc
 import pytest
-
+import requests as req
 from docarray import Document
+
 from jina import DocumentArray, Executor, requests
 from jina.clients.request import request_generator
 from jina.parsers import set_pod_parser
@@ -380,3 +381,66 @@ async def test_worker_runtime_reflection():
 
 def _create_test_data_message(counter=0):
     return list(request_generator('/', DocumentArray([Document(text=str(counter))])))[0]
+
+
+@pytest.mark.asyncio
+@pytest.mark.slow
+@pytest.mark.timeout(5)
+async def test_decorator_monitoring(port_generator):
+    from jina import monitor
+
+    class DummyExecutor(Executor):
+        @requests
+        def foo(self, docs, **kwargs):
+            self._proces(docs)
+            self.proces_2(docs)
+
+        @monitor(name='metrics_name', documentation='metrics description')
+        def _proces(self, docs):
+            ...
+
+        @monitor()
+        def proces_2(self, docs):
+            ...
+
+    port = port_generator()
+    args = set_pod_parser().parse_args(
+        ['--monitoring', '--port-monitoring', str(port), '--uses', 'DummyExecutor']
+    )
+
+    cancel_event = multiprocessing.Event()
+
+    def start_runtime(args, cancel_event):
+        with WorkerRuntime(args, cancel_event=cancel_event) as runtime:
+            runtime.run_forever()
+
+    runtime_thread = Process(
+        target=start_runtime,
+        args=(args, cancel_event),
+        daemon=True,
+    )
+    runtime_thread.start()
+
+    assert AsyncNewLoopRuntime.wait_for_ready_or_shutdown(
+        timeout=5.0,
+        ctrl_address=f'{args.host}:{args.port}',
+        ready_or_shutdown_event=Event(),
+    )
+
+    assert AsyncNewLoopRuntime.wait_for_ready_or_shutdown(
+        timeout=5.0,
+        ctrl_address=f'{args.host}:{args.port}',
+        ready_or_shutdown_event=Event(),
+    )
+
+    result = await GrpcConnectionPool.send_request_async(
+        _create_test_data_message(), f'{args.host}:{args.port}', timeout=1.0
+    )
+
+    resp = req.get(f'http://localhost:{port}/')
+    assert f'jina_metrics_name_count 1.0' in str(resp.content)
+
+    cancel_event.set()
+    runtime_thread.join()
+
+    assert not AsyncNewLoopRuntime.is_ready(f'{args.host}:{args.port}')


### PR DESCRIPTION
Follow up of https://github.com/jina-ai/clip-as-service/pull/674

Goal:

Having an decorator to monitor internal method of an Executor


```python
class DummyExecutor(Executor):
    @requests(on='/foo')
    def foo(self, docs, **kwargs):
        self._proces(docs)
        self.proces_2(docs)

    @monitor(name='metrics_name',  documentation='metrics description')
    def _proces(self, docs):
        ...

    @monitor()
    def proces_2(self, docs):
        ...
```

![Screenshot from 2022-05-02 14-44-11](https://user-images.githubusercontent.com/55492238/166235585-4536f2cd-5aa6-43b2-b879-5559fbfc185f.png)