### PR TITLE
feat: inherit monitoring arg from Flow

### DIFF
--- a/jina/orchestrate/flow/base.py
+++ b/jina/orchestrate/flow/base.py
@@ -832,11 +832,11 @@ class Flow(PostMixin, JAMLCompatible, ExitStack, metaclass=FlowType):
 
         # set the kwargs inherit from `Flow(kwargs1=..., kwargs2=)`
         for key, value in op_flow._common_kwargs.items():
+
             # do not inherit from all the argument from the flow
             if key not in kwargs and key not in [
                 'port',
                 'port_monitoring',
-                'monitoring',
             ]:
                 kwargs[key] = value
 

--- a/tests/integration/monitoring/test_monitoring.py
+++ b/tests/integration/monitoring/test_monitoring.py
@@ -21,8 +21,8 @@ def test_enable_monitoring_deployment(port_generator):
     port1 = port_generator()
     port2 = port_generator()
 
-    with Flow().add(uses=DummyExecutor, monitoring=True, port_monitoring=port1).add(
-        uses=DummyExecutor, monitoring=True, port_monitoring=port2
+    with Flow().add(uses=DummyExecutor, port_monitoring=port1, monitoring=True).add(
+        uses=DummyExecutor, port_monitoring=port2, monitoring=True
     ) as f:
         for port in [port1, port2]:
             resp = req.get(f'http://localhost:{port}/')
@@ -44,8 +44,8 @@ def test_enable_monitoring_gateway(protocol, port_generator):
     port2 = port_generator()
 
     with Flow(protocol=protocol, monitoring=True, port_monitoring=port0).add(
-        uses=DummyExecutor, monitoring=True, port_monitoring=port1
-    ).add(uses=DummyExecutor, monitoring=True, port_monitoring=port2) as f:
+        uses=DummyExecutor, port_monitoring=port1
+    ).add(uses=DummyExecutor, port_monitoring=port2) as f:
         for port in [port0, port1, port2]:
             resp = req.get(f'http://localhost:{port}/')
             assert resp.status_code == 200
@@ -60,8 +60,8 @@ def test_monitoring_head(port_generator):
     port1 = port_generator()
     port2 = port_generator()
 
-    with Flow().add(uses=DummyExecutor, monitoring=True, port_monitoring=port1).add(
-        uses=DummyExecutor, port_monitoring=port2, monitoring=True, shards=2
+    with Flow(monitoring=True).add(uses=DummyExecutor, port_monitoring=port1).add(
+        uses=DummyExecutor, port_monitoring=port2, shards=2
     ) as f:
         port3 = f._deployment_nodes['executor0'].pod_args['pods'][0][0].port_monitoring
         port4 = f._deployment_nodes['executor1'].pod_args['pods'][0][0].port_monitoring
@@ -81,7 +81,7 @@ def test_document_processed_total(port_generator):
     port1 = port_generator()
 
     with Flow(monitoring=True, port_monitoring=port0).add(
-        uses=DummyExecutor, monitoring=True, port_monitoring=port1
+        uses=DummyExecutor, port_monitoring=port1
     ) as f:
 
         resp = req.get(f'http://localhost:{port1}/')
@@ -115,3 +115,35 @@ def test_document_processed_total(port_generator):
             f'jina_document_processed_total{{endpoint="/foo",executor="DummyExecutor"}} 4.0'  # check that we nothing change on bar count
             in str(resp.content)
         )
+
+
+def test_disable_monitoring_on_pods(port_generator):
+    port0 = port_generator()
+    port1 = port_generator()
+
+    with Flow(monitoring=True, port_monitoring=port0).add(
+        uses=DummyExecutor,
+        port_monitoring=port1,
+        monitoring=False,
+    ):
+        with pytest.raises(req.exceptions.ConnectionError):  # disable on port1
+            resp = req.get(f'http://localhost:{port1}/')
+
+        resp = req.get(f'http://localhost:{port0}/')  # enable on port0
+        assert resp.status_code == 200
+
+
+def test_disable_monitoring_on_gatway_only(port_generator):
+    port0 = port_generator()
+    port1 = port_generator()
+
+    with Flow(monitoring=False, port_monitoring=port0).add(
+        uses=DummyExecutor,
+        port_monitoring=port1,
+        monitoring=True,
+    ):
+        with pytest.raises(req.exceptions.ConnectionError):  # disable on port1
+            resp = req.get(f'http://localhost:{port0}/')
+
+        resp = req.get(f'http://localhost:{port1}/')  # enable on port0
+        assert resp.status_code == 200

--- a/tests/unit/orchestrate/flow/flow-construct/test_flow_monitoring.py
+++ b/tests/unit/orchestrate/flow/flow-construct/test_flow_monitoring.py
@@ -1,0 +1,45 @@
+import pytest
+
+from jina import Executor, Flow, requests
+
+
+@pytest.fixture()
+def get_executor():
+    class DummyExecutor(Executor):
+        @requests(on='/foo')
+        def foo(self, docs, **kwargs):
+            ...
+
+    return DummyExecutor
+
+
+def test_disable_monitoring_on_pods(port_generator, get_executor):
+    port0 = port_generator()
+    port1 = port_generator()
+
+    f = Flow(monitoring=True, port_monitoring=port0).add(
+        uses=get_executor(),
+        port_monitoring=port1,
+        monitoring=False,
+    )
+
+    f = f.build()
+
+    assert f._deployment_nodes['gateway'].pod_args['pods'][0][0].monitoring
+    assert not f._deployment_nodes['executor0'].pod_args['pods'][0][0].monitoring
+
+
+def test_disable_monitoring_on_gatway_only(port_generator, get_executor):
+    port0 = port_generator()
+    port1 = port_generator()
+
+    f = Flow(monitoring=False, port_monitoring=port0).add(
+        uses=get_executor(),
+        port_monitoring=port1,
+        monitoring=True,
+    )
+
+    f = f.build()
+
+    assert not f._deployment_nodes['gateway'].pod_args['pods'][0][0].monitoring
+    assert f._deployment_nodes['executor0'].pod_args['pods'][0][0].monitoring


### PR DESCRIPTION


Right  now ( jina 3.3.18) when doing 

```python
from jina import Flow
Flow(monitoring=True).add(uses='jinahub//SimpleIndexer')
```

the monitoring is not enable on the executor

to enable it we need to to :

```python
Flow(monitoring=True).add(uses='jinahub//SimpleIndexer',monitoring=True)
```

it should be the other way around, we monitoring is set to True on the Flow level all of the executor should inherit from it unless we precisely disable it by doing

```python
Flow(monitoring=True).add(uses='jinahub//SimpleIndexer',monitoring=False)
```

