### PR TITLE
CI: Add Docker build caching on GHA

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -219,6 +219,8 @@ jobs:
           push: true
           tags: localhost:5000/jina/multiarch:latest
           target: jina
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
       - run: |
           docker run --platform ${{ matrix.test-arch }} localhost:5000/jina/multiarch:latest -v
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,8 @@ jobs:
           push: true
           tags: localhost:5000/jina/multiarch:latest
           target: jina
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
       - run: |
           docker run --platform ${{ matrix.test-arch }} localhost:5000/jina/multiarch:latest -v
 

--- a/.github/workflows/force-docker-build.yml
+++ b/.github/workflows/force-docker-build.yml
@@ -149,3 +149,5 @@ jobs:
             PY_VERSION=${{matrix.py_version}}
             PIP_TAG=${{matrix.pip_tag}}
           target: ${{env.BUILD_TARGET}}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
Goals:

- Add Docker Build caching on GHA
- Refer: https://github.com/docker/build-push-action/blob/master/docs/advanced/cache.md#cache-backend-api

