### PR TITLE
feat: add runtime name as label for monitoring

### DIFF
--- a/jina/serve/executors/__init__.py
+++ b/jina/serve/executors/__init__.py
@@ -15,9 +15,8 @@ from jina.jaml import JAML, JAMLCompatible, env_var_regex, internal_var_regex
 from jina.serve.executors.decorators import requests, store_init_kwargs, wrap_func
 
 if TYPE_CHECKING:
-    from prometheus_client import Summary
-
     from docarray import DocumentArray
+    from prometheus_client import Summary
 
 __all__ = ['BaseExecutor', 'ReducerExecutor']
 
@@ -503,7 +502,8 @@ class BaseExecutor(JAMLCompatible, metaclass=ExecutorType):
                     documentation,
                     registry=self.runtime_args.metrics_registry,
                     namespace='jina',
-                )
+                    labelnames=('pod_name',),
+                ).labels(self.runtime_args.name)
             return self._metrics_buffer[name]
         else:
             return None

--- a/jina/serve/executors/__init__.py
+++ b/jina/serve/executors/__init__.py
@@ -131,7 +131,7 @@ class BaseExecutor(JAMLCompatible, metaclass=ExecutorType):
                 'Time spent when calling the executor request method',
                 registry=self.runtime_args.metrics_registry,
                 namespace='jina',
-                labelnames=('executor', 'endpoint', 'pods_name'),
+                labelnames=('executor', 'endpoint', 'pod_name'),
             )
             self._metrics_buffer = {'process_request_seconds': self._summary_method}
 
@@ -256,13 +256,13 @@ class BaseExecutor(JAMLCompatible, metaclass=ExecutorType):
     async def __acall_endpoint__(self, req_endpoint, **kwargs):
         func = self.requests[req_endpoint]
 
-        pods_name = (
+        pod_name = (
             self.runtime_args.name if hasattr(self.runtime_args, 'name') else None
         )
 
         _summary = (
             self._summary_method.labels(
-                self.__class__.__name__, req_endpoint, pods_name
+                self.__class__.__name__, req_endpoint, pod_name
             ).time()
             if self._summary_method
             else contextlib.nullcontext()

--- a/jina/serve/executors/__init__.py
+++ b/jina/serve/executors/__init__.py
@@ -130,7 +130,7 @@ class BaseExecutor(JAMLCompatible, metaclass=ExecutorType):
                 'Time spent when calling the executor request method',
                 registry=self.runtime_args.metrics_registry,
                 namespace='jina',
-                labelnames=('executor', 'endpoint', 'pod_name'),
+                labelnames=('executor', 'endpoint', 'runtime_name'),
             )
             self._metrics_buffer = {'process_request_seconds': self._summary_method}
 
@@ -255,13 +255,13 @@ class BaseExecutor(JAMLCompatible, metaclass=ExecutorType):
     async def __acall_endpoint__(self, req_endpoint, **kwargs):
         func = self.requests[req_endpoint]
 
-        pod_name = (
+        runtime_name = (
             self.runtime_args.name if hasattr(self.runtime_args, 'name') else None
         )
 
         _summary = (
             self._summary_method.labels(
-                self.__class__.__name__, req_endpoint, pod_name
+                self.__class__.__name__, req_endpoint, runtime_name
             ).time()
             if self._summary_method
             else contextlib.nullcontext()
@@ -502,7 +502,7 @@ class BaseExecutor(JAMLCompatible, metaclass=ExecutorType):
                     documentation,
                     registry=self.runtime_args.metrics_registry,
                     namespace='jina',
-                    labelnames=('pod_name',),
+                    labelnames=('runtime_name',),
                 ).labels(self.runtime_args.name)
             return self._metrics_buffer[name]
         else:

--- a/jina/serve/executors/__init__.py
+++ b/jina/serve/executors/__init__.py
@@ -131,7 +131,7 @@ class BaseExecutor(JAMLCompatible, metaclass=ExecutorType):
                 'Time spent when calling the executor request method',
                 registry=self.runtime_args.metrics_registry,
                 namespace='jina',
-                labelnames=('executor', 'endpoint'),
+                labelnames=('executor', 'endpoint', 'pods_name'),
             )
             self._metrics_buffer = {'process_request_seconds': self._summary_method}
 
@@ -256,8 +256,14 @@ class BaseExecutor(JAMLCompatible, metaclass=ExecutorType):
     async def __acall_endpoint__(self, req_endpoint, **kwargs):
         func = self.requests[req_endpoint]
 
+        pods_name = (
+            self.runtime_args.name if hasattr(self.runtime_args, 'name') else None
+        )
+
         _summary = (
-            self._summary_method.labels(self.__class__.__name__, req_endpoint).time()
+            self._summary_method.labels(
+                self.__class__.__name__, req_endpoint, pods_name
+            ).time()
             if self._summary_method
             else contextlib.nullcontext()
         )

--- a/jina/serve/runtimes/gateway/grpc/__init__.py
+++ b/jina/serve/runtimes/gateway/grpc/__init__.py
@@ -46,7 +46,7 @@ class GRPCGatewayRuntime(GatewayRuntime):
 
     async def _async_setup_server(self):
 
-        request_handler = RequestHandler(self.metrics_registry)
+        request_handler = RequestHandler(self.metrics_registry, self.name)
 
         self.streamer = RequestStreamer(
             args=self.args,

--- a/jina/serve/runtimes/gateway/http/app.py
+++ b/jina/serve/runtimes/gateway/http/app.py
@@ -72,7 +72,7 @@ def get_fastapi_app(
     from jina.serve.runtimes.gateway.request_handling import RequestHandler
     from jina.serve.stream import RequestStreamer
 
-    request_handler = RequestHandler(metrics_registry)
+    request_handler = RequestHandler(metrics_registry, args.name)
 
     streamer = RequestStreamer(
         args=args,
@@ -252,14 +252,13 @@ def get_fastapi_app(
             from dataclasses import asdict
 
             import strawberry
+            from docarray import DocumentArray
             from docarray.document.strawberry_type import (
                 JSONScalar,
                 StrawberryDocument,
                 StrawberryDocumentInput,
             )
             from strawberry.fastapi import GraphQLRouter
-
-            from docarray import DocumentArray
 
             async def get_docs_from_endpoint(
                 data, target_executor, parameters, exec_endpoint

--- a/jina/serve/runtimes/gateway/request_handling.py
+++ b/jina/serve/runtimes/gateway/request_handling.py
@@ -20,13 +20,13 @@ class RequestHandler:
     Class that handles the requests arriving to the gateway and the result extracted from the requests future.
 
     :param metrics_registry: optional metrics registry for prometheus used if we need to expose metrics from the executor or from the data request handler
-    :param pods_name: optional pods_name that will be registered during monitoring
+    :param pod_name: optional pod_name that will be registered during monitoring
     """
 
     def __init__(
         self,
         metrics_registry: Optional['CollectorRegistry'] = None,
-        pods_name: Optional[str] = None,
+        pod_name: Optional[str] = None,
     ):
         self.request_init_time = {} if metrics_registry else None
 
@@ -42,8 +42,8 @@ class RequestHandler:
                 'Time spent processing request',
                 registry=metrics_registry,
                 namespace='jina',
-                labelnames=('pods_name',),
-            ).labels(pods_name)
+                labelnames=('pod_name',),
+            ).labels(pod_name)
 
         else:
             self._summary = None

--- a/jina/serve/runtimes/gateway/request_handling.py
+++ b/jina/serve/runtimes/gateway/request_handling.py
@@ -20,9 +20,14 @@ class RequestHandler:
     Class that handles the requests arriving to the gateway and the result extracted from the requests future.
 
     :param metrics_registry: optional metrics registry for prometheus used if we need to expose metrics from the executor or from the data request handler
+    :param pods_name: optional pods_name that will be registered during monitoring
     """
 
-    def __init__(self, metrics_registry: Optional['CollectorRegistry'] = None):
+    def __init__(
+        self,
+        metrics_registry: Optional['CollectorRegistry'] = None,
+        pods_name: Optional[str] = None,
+    ):
         self.request_init_time = {} if metrics_registry else None
 
         if metrics_registry:
@@ -37,7 +42,9 @@ class RequestHandler:
                 'Time spent processing request',
                 registry=metrics_registry,
                 namespace='jina',
-            )
+                labelnames=('pods_name',),
+            ).labels(pods_name)
+
         else:
             self._summary = None
 

--- a/jina/serve/runtimes/gateway/request_handling.py
+++ b/jina/serve/runtimes/gateway/request_handling.py
@@ -20,13 +20,13 @@ class RequestHandler:
     Class that handles the requests arriving to the gateway and the result extracted from the requests future.
 
     :param metrics_registry: optional metrics registry for prometheus used if we need to expose metrics from the executor or from the data request handler
-    :param pod_name: optional pod_name that will be registered during monitoring
+    :param runtime_name: optional runtime_name that will be registered during monitoring
     """
 
     def __init__(
         self,
         metrics_registry: Optional['CollectorRegistry'] = None,
-        pod_name: Optional[str] = None,
+        runtime_name: Optional[str] = None,
     ):
         self.request_init_time = {} if metrics_registry else None
 
@@ -42,8 +42,8 @@ class RequestHandler:
                 'Time spent processing request',
                 registry=metrics_registry,
                 namespace='jina',
-                labelnames=('pod_name',),
-            ).labels(pod_name)
+                labelnames=('runtime_name',),
+            ).labels(runtime_name)
 
         else:
             self._summary = None

--- a/jina/serve/runtimes/gateway/websocket/app.py
+++ b/jina/serve/runtimes/gateway/websocket/app.py
@@ -109,7 +109,7 @@ def get_fastapi_app(
     from jina.serve.runtimes.gateway.request_handling import RequestHandler
     from jina.serve.stream import RequestStreamer
 
-    request_handler = RequestHandler(metrics_registry)
+    request_handler = RequestHandler(metrics_registry, args.name)
 
     streamer = RequestStreamer(
         args=args,

--- a/jina/serve/runtimes/head/__init__.py
+++ b/jina/serve/runtimes/head/__init__.py
@@ -60,7 +60,7 @@ class HeadRuntime(AsyncNewLoopRuntime, ABC):
                     'Time spent processing request',
                     registry=self.metrics_registry,
                     namespace='jina',
-                    labelnames=('pods_name',),
+                    labelnames=('pod_name',),
                 )
                 .labels(self.args.name)
                 .time()

--- a/jina/serve/runtimes/head/__init__.py
+++ b/jina/serve/runtimes/head/__init__.py
@@ -54,12 +54,17 @@ class HeadRuntime(AsyncNewLoopRuntime, ABC):
             ):
                 from prometheus_client import Summary
 
-            self._summary = Summary(
-                'receiving_request_seconds',
-                'Time spent processing request',
-                registry=self.metrics_registry,
-                namespace='jina',
-            ).time()
+            self._summary = (
+                Summary(
+                    'receiving_request_seconds',
+                    'Time spent processing request',
+                    registry=self.metrics_registry,
+                    namespace='jina',
+                    labelnames=('pods_name',),
+                )
+                .labels(self.args.name)
+                .time()
+            )
         else:
             self._summary = contextlib.nullcontext()
 

--- a/jina/serve/runtimes/head/__init__.py
+++ b/jina/serve/runtimes/head/__init__.py
@@ -60,7 +60,7 @@ class HeadRuntime(AsyncNewLoopRuntime, ABC):
                     'Time spent processing request',
                     registry=self.metrics_registry,
                     namespace='jina',
-                    labelnames=('pod_name',),
+                    labelnames=('runtime_name',),
                 )
                 .labels(self.args.name)
                 .time()

--- a/jina/serve/runtimes/request_handlers/data_request_handler.py
+++ b/jina/serve/runtimes/request_handlers/data_request_handler.py
@@ -55,7 +55,7 @@ class DataRequestHandler:
                     'document_processed',
                     'Number of Documents that have been processed by the executor',
                     namespace='jina',
-                    labelnames=('endpoint', 'executor'),
+                    labelnames=('endpoint', 'executor', 'pods_name'),
                     registry=metrics_registry,
                 )
         else:
@@ -159,7 +159,9 @@ class DataRequestHandler:
 
         if self._counter:
             self._counter.labels(
-                requests[0].header.exec_endpoint, self._executor.__class__.__name__
+                requests[0].header.exec_endpoint,
+                self._executor.__class__.__name__,
+                self.args.name,
             ).inc(len(docs))
 
         DataRequestHandler.replace_docs(requests[0], docs, self.args.output_array_type)

--- a/jina/serve/runtimes/request_handlers/data_request_handler.py
+++ b/jina/serve/runtimes/request_handlers/data_request_handler.py
@@ -55,7 +55,7 @@ class DataRequestHandler:
                     'document_processed',
                     'Number of Documents that have been processed by the executor',
                     namespace='jina',
-                    labelnames=('endpoint', 'executor', 'pods_name'),
+                    labelnames=('endpoint', 'executor', 'pod_name'),
                     registry=metrics_registry,
                 )
         else:

--- a/jina/serve/runtimes/request_handlers/data_request_handler.py
+++ b/jina/serve/runtimes/request_handlers/data_request_handler.py
@@ -55,7 +55,7 @@ class DataRequestHandler:
                     'document_processed',
                     'Number of Documents that have been processed by the executor',
                     namespace='jina',
-                    labelnames=('endpoint', 'executor', 'pod_name'),
+                    labelnames=('endpoint', 'executor', 'runtime_name'),
                     registry=metrics_registry,
                 )
         else:

--- a/jina/serve/runtimes/worker/__init__.py
+++ b/jina/serve/runtimes/worker/__init__.py
@@ -47,7 +47,7 @@ class WorkerRuntime(AsyncNewLoopRuntime, ABC):
                     'Time spent processing request',
                     registry=self.metrics_registry,
                     namespace='jina',
-                    labelnames=('pods_name',),
+                    labelnames=('pod_name',),
                 )
                 .labels(self.args.name)
                 .time()

--- a/jina/serve/runtimes/worker/__init__.py
+++ b/jina/serve/runtimes/worker/__init__.py
@@ -41,12 +41,17 @@ class WorkerRuntime(AsyncNewLoopRuntime, ABC):
             ):
                 from prometheus_client import Summary
 
-            self._summary_time = Summary(
-                'receiving_request_seconds',
-                'Time spent processing request',
-                registry=self.metrics_registry,
-                namespace='jina',
-            ).time()
+            self._summary_time = (
+                Summary(
+                    'receiving_request_seconds',
+                    'Time spent processing request',
+                    registry=self.metrics_registry,
+                    namespace='jina',
+                    labelnames=('pods_name',),
+                )
+                .labels(self.args.name)
+                .time()
+            )
         else:
             self._summary_time = contextlib.nullcontext()
 

--- a/jina/serve/runtimes/worker/__init__.py
+++ b/jina/serve/runtimes/worker/__init__.py
@@ -47,7 +47,7 @@ class WorkerRuntime(AsyncNewLoopRuntime, ABC):
                     'Time spent processing request',
                     registry=self.metrics_registry,
                     namespace='jina',
-                    labelnames=('pod_name',),
+                    labelnames=('runtime_name',),
                 )
                 .labels(self.args.name)
                 .time()

--- a/tests/integration/monitoring/test_executor.py
+++ b/tests/integration/monitoring/test_executor.py
@@ -52,9 +52,10 @@ def test_decorator_interface(port_generator):
         f.post('/foo', inputs=DocumentArray.empty(4))
 
         resp = req.get(f'http://localhost:{port}/')
-        assert f'jina_metrics_name_count{{pod_name="executor0/rep-0"}} 1.0' in str(
+        assert f'jina_metrics_name_count{{runtime_name="executor0/rep-0"}} 1.0' in str(
             resp.content
         )
-        assert f'jina_proces_2_seconds_count{{pod_name="executor0/rep-0"}} 1.0' in str(
-            resp.content
+        assert (
+            f'jina_proces_2_seconds_count{{runtime_name="executor0/rep-0"}} 1.0'
+            in str(resp.content)
         )

--- a/tests/integration/monitoring/test_executor.py
+++ b/tests/integration/monitoring/test_executor.py
@@ -52,5 +52,9 @@ def test_decorator_interface(port_generator):
         f.post('/foo', inputs=DocumentArray.empty(4))
 
         resp = req.get(f'http://localhost:{port}/')
-        assert f'jina_metrics_name_count 1.0' in str(resp.content)
-        assert f'jina_proces_2_seconds_count 1.0' in str(resp.content)
+        assert f'jina_metrics_name_count{{pod_name="executor0/rep-0"}} 1.0' in str(
+            resp.content
+        )
+        assert f'jina_proces_2_seconds_count{{pod_name="executor0/rep-0"}} 1.0' in str(
+            resp.content
+        )

--- a/tests/integration/monitoring/test_monitoring.py
+++ b/tests/integration/monitoring/test_monitoring.py
@@ -36,7 +36,7 @@ def test_enable_monitoring_deployment(port_generator, executor):
             f.post(f'/{meth}', inputs=DocumentArray())
             resp = req.get(f'http://localhost:{port2}/')
             assert (
-                f'process_request_seconds_created{{endpoint="/{meth}",executor="DummyExecutor"}}'
+                f'process_request_seconds_created{{endpoint="/{meth}",executor="DummyExecutor",pods_name="executor1/rep-0"}}'
                 in str(resp.content)
             )
 
@@ -67,6 +67,7 @@ def test_monitoring_head(port_generator, executor):
     with Flow(monitoring=True, port_monitoring=port_generator()).add(
         uses=executor, port_monitoring=port1
     ).add(uses=executor, port_monitoring=port2, shards=2) as f:
+
         port3 = f._deployment_nodes['executor0'].pod_args['pods'][0][0].port_monitoring
         port4 = f._deployment_nodes['executor1'].pod_args['pods'][0][0].port_monitoring
 
@@ -97,12 +98,12 @@ def test_document_processed_total(port_generator, executor):
 
         resp = req.get(f'http://localhost:{port1}/')
         assert (
-            f'jina_document_processed_total{{endpoint="/foo",executor="DummyExecutor"}} 4.0'  # check that we count 4 documents on foo
+            f'jina_document_processed_total{{endpoint="/foo",executor="DummyExecutor",pods_name="executor0/rep-0"}} 4.0'  # check that we count 4 documents on foo
             in str(resp.content)
         )
 
         assert not (
-            f'jina_document_processed_total{{endpoint="/bar",executor="DummyExecutor"}}'  # check that we does not start counting documents on bar as it has not been called yet
+            f'jina_document_processed_total{{endpoint="/bar",executor="DummyExecutor",pods_name="executor0/rep-0"}}'  # check that we does not start counting documents on bar as it has not been called yet
             in str(resp.content)
         )
 
@@ -111,12 +112,12 @@ def test_document_processed_total(port_generator, executor):
         )  # process 5 documents on bar
 
         assert not (
-            f'jina_document_processed_total{{endpoint="/bar",executor="DummyExecutor"}} 5.0'  # check that we count 5 documents on foo
+            f'jina_document_processed_total{{endpoint="/bar",executor="DummyExecutor",pods_name="executor0/rep-0"}} 5.0'  # check that we count 5 documents on foo
             in str(resp.content)
         )
 
         assert (
-            f'jina_document_processed_total{{endpoint="/foo",executor="DummyExecutor"}} 4.0'  # check that we nothing change on bar count
+            f'jina_document_processed_total{{endpoint="/foo",executor="DummyExecutor",pods_name="executor0/rep-0"}} 4.0'  # check that we nothing change on bar count
             in str(resp.content)
         )
 

--- a/tests/integration/monitoring/test_monitoring.py
+++ b/tests/integration/monitoring/test_monitoring.py
@@ -36,7 +36,7 @@ def test_enable_monitoring_deployment(port_generator, executor):
             f.post(f'/{meth}', inputs=DocumentArray())
             resp = req.get(f'http://localhost:{port2}/')
             assert (
-                f'process_request_seconds_created{{endpoint="/{meth}",executor="DummyExecutor",pod_name="executor1/rep-0"}}'
+                f'process_request_seconds_created{{endpoint="/{meth}",executor="DummyExecutor",runtime_name="executor1/rep-0"}}'
                 in str(resp.content)
             )
 
@@ -98,12 +98,12 @@ def test_document_processed_total(port_generator, executor):
 
         resp = req.get(f'http://localhost:{port1}/')
         assert (
-            f'jina_document_processed_total{{endpoint="/foo",executor="DummyExecutor",pod_name="executor0/rep-0"}} 4.0'  # check that we count 4 documents on foo
+            f'jina_document_processed_total{{endpoint="/foo",executor="DummyExecutor",runtime_name="executor0/rep-0"}} 4.0'  # check that we count 4 documents on foo
             in str(resp.content)
         )
 
         assert not (
-            f'jina_document_processed_total{{endpoint="/bar",executor="DummyExecutor",pod_name="executor0/rep-0"}}'  # check that we does not start counting documents on bar as it has not been called yet
+            f'jina_document_processed_total{{endpoint="/bar",executor="DummyExecutor",runtime_name="executor0/rep-0"}}'  # check that we does not start counting documents on bar as it has not been called yet
             in str(resp.content)
         )
 
@@ -112,12 +112,12 @@ def test_document_processed_total(port_generator, executor):
         )  # process 5 documents on bar
 
         assert not (
-            f'jina_document_processed_total{{endpoint="/bar",executor="DummyExecutor",pod_name="executor0/rep-0"}} 5.0'  # check that we count 5 documents on foo
+            f'jina_document_processed_total{{endpoint="/bar",executor="DummyExecutor",runtime_name="executor0/rep-0"}} 5.0'  # check that we count 5 documents on foo
             in str(resp.content)
         )
 
         assert (
-            f'jina_document_processed_total{{endpoint="/foo",executor="DummyExecutor",pod_name="executor0/rep-0"}} 4.0'  # check that we nothing change on bar count
+            f'jina_document_processed_total{{endpoint="/foo",executor="DummyExecutor",runtime_name="executor0/rep-0"}} 4.0'  # check that we nothing change on bar count
             in str(resp.content)
         )
 

--- a/tests/integration/monitoring/test_monitoring.py
+++ b/tests/integration/monitoring/test_monitoring.py
@@ -36,7 +36,7 @@ def test_enable_monitoring_deployment(port_generator, executor):
             f.post(f'/{meth}', inputs=DocumentArray())
             resp = req.get(f'http://localhost:{port2}/')
             assert (
-                f'process_request_seconds_created{{endpoint="/{meth}",executor="DummyExecutor",pods_name="executor1/rep-0"}}'
+                f'process_request_seconds_created{{endpoint="/{meth}",executor="DummyExecutor",pod_name="executor1/rep-0"}}'
                 in str(resp.content)
             )
 
@@ -98,12 +98,12 @@ def test_document_processed_total(port_generator, executor):
 
         resp = req.get(f'http://localhost:{port1}/')
         assert (
-            f'jina_document_processed_total{{endpoint="/foo",executor="DummyExecutor",pods_name="executor0/rep-0"}} 4.0'  # check that we count 4 documents on foo
+            f'jina_document_processed_total{{endpoint="/foo",executor="DummyExecutor",pod_name="executor0/rep-0"}} 4.0'  # check that we count 4 documents on foo
             in str(resp.content)
         )
 
         assert not (
-            f'jina_document_processed_total{{endpoint="/bar",executor="DummyExecutor",pods_name="executor0/rep-0"}}'  # check that we does not start counting documents on bar as it has not been called yet
+            f'jina_document_processed_total{{endpoint="/bar",executor="DummyExecutor",pod_name="executor0/rep-0"}}'  # check that we does not start counting documents on bar as it has not been called yet
             in str(resp.content)
         )
 
@@ -112,12 +112,12 @@ def test_document_processed_total(port_generator, executor):
         )  # process 5 documents on bar
 
         assert not (
-            f'jina_document_processed_total{{endpoint="/bar",executor="DummyExecutor",pods_name="executor0/rep-0"}} 5.0'  # check that we count 5 documents on foo
+            f'jina_document_processed_total{{endpoint="/bar",executor="DummyExecutor",pod_name="executor0/rep-0"}} 5.0'  # check that we count 5 documents on foo
             in str(resp.content)
         )
 
         assert (
-            f'jina_document_processed_total{{endpoint="/foo",executor="DummyExecutor",pods_name="executor0/rep-0"}} 4.0'  # check that we nothing change on bar count
+            f'jina_document_processed_total{{endpoint="/foo",executor="DummyExecutor",pod_name="executor0/rep-0"}} 4.0'  # check that we nothing change on bar count
             in str(resp.content)
         )
 

--- a/tests/unit/serve/runtimes/worker/test_worker_runtime.py
+++ b/tests/unit/serve/runtimes/worker/test_worker_runtime.py
@@ -438,7 +438,7 @@ async def test_decorator_monitoring(port_generator):
     )
 
     resp = req.get(f'http://localhost:{port}/')
-    assert f'jina_metrics_name_count{{pod_name="None"}} 1.0' in str(resp.content)
+    assert f'jina_metrics_name_count{{runtime_name="None"}} 1.0' in str(resp.content)
 
     cancel_event.set()
     runtime_thread.join()

--- a/tests/unit/serve/runtimes/worker/test_worker_runtime.py
+++ b/tests/unit/serve/runtimes/worker/test_worker_runtime.py
@@ -433,12 +433,12 @@ async def test_decorator_monitoring(port_generator):
         ready_or_shutdown_event=Event(),
     )
 
-    result = await GrpcConnectionPool.send_request_async(
+    await GrpcConnectionPool.send_request_async(
         _create_test_data_message(), f'{args.host}:{args.port}', timeout=1.0
     )
 
     resp = req.get(f'http://localhost:{port}/')
-    assert f'jina_metrics_name_count 1.0' in str(resp.content)
+    assert f'jina_metrics_name_count{{pod_name="None"}} 1.0' in str(resp.content)
 
     cancel_event.set()
     runtime_thread.join()


### PR DESCRIPTION
We need a specific name on each endpoint so that we can differentiate them. For example we need to differentiate the metrics coming from the executors from the one coming from the gateway.

Therefore we need to add a common label on every endpoint with the name of the pod.#

- [x] Added `runtime_name` to the labels on every metrics
- [x] include metrics from the decorator: https://github.com/jina-ai/jina/pull/4737