### PR TITLE
fix: warn user when calling load config from flow instance

### DIFF
--- a/jina/orchestrate/flow/base.py
+++ b/jina/orchestrate/flow/base.py
@@ -98,11 +98,7 @@ FALLBACK_PARSERS = [
 ]
 
 
-class _BaseClassFlow(PostMixin, JAMLCompatible, ExitStack, metaclass=FlowType):
-    ...
-
-
-class Flow(_BaseClassFlow):
+class Flow(PostMixin, JAMLCompatible, ExitStack, metaclass=FlowType):
     """Flow is how Jina streamlines and distributes Executors."""
 
     # overload_inject_start_client_flow
@@ -2045,7 +2041,7 @@ class Flow(_BaseClassFlow):
         self._common_kwargs.update(kwargs)
 
     def __getattribute__(self, item):
-        obj = super(_BaseClassFlow, self).__getattribute__(item)
+        obj = super().__getattribute__(item)
 
         if (
             item == 'load_config' and inspect.ismethod(obj) and obj.__self__ is Flow

--- a/jina/orchestrate/flow/base.py
+++ b/jina/orchestrate/flow/base.py
@@ -2047,7 +2047,7 @@ class Flow(PostMixin, JAMLCompatible, ExitStack, metaclass=FlowType):
             item == 'load_config' and inspect.ismethod(obj) and obj.__self__ is Flow
         ):  # check if obj load config call from an instance and not the Class
             warnings.warn(
-                'Calling load_config from a Flow instance will override all of the instance's initial parameters. We recommend to use `Flow.load_config(...)` instead'
+                "Calling load_config from a Flow instance will override all of the instance's initial parameters. We recommend to use `Flow.load_config(...)` instead"
             )
 
         return obj

--- a/jina/orchestrate/flow/base.py
+++ b/jina/orchestrate/flow/base.py
@@ -2051,7 +2051,7 @@ class Flow(_BaseClassFlow):
             item == 'load_config' and inspect.ismethod(obj) and obj.__self__ is Flow
         ):  # check if obj load config call from an instance and not the Class
             warnings.warn(
-                'Calling load_config from a Flow instance will overidde all of its initial parameters. You should probably use `Flow.load_config(...)` instead'
+                'Calling load_config from a Flow instance will override all of its initial parameters. You should probably use `Flow.load_config(...)` instead'
             )
 
         return obj

--- a/jina/orchestrate/flow/base.py
+++ b/jina/orchestrate/flow/base.py
@@ -2047,7 +2047,7 @@ class Flow(PostMixin, JAMLCompatible, ExitStack, metaclass=FlowType):
             item == 'load_config' and inspect.ismethod(obj) and obj.__self__ is Flow
         ):  # check if obj load config call from an instance and not the Class
             warnings.warn(
-                'Calling load_config from a Flow instance will override all of its initial parameters. You should probably use `Flow.load_config(...)` instead'
+                'Calling load_config from a Flow instance will override all of the instance's initial parameters. We recommend to use `Flow.load_config(...)` instead'
             )
 
         return obj

--- a/tests/integration/issues/github_4773/config.yaml
+++ b/tests/integration/issues/github_4773/config.yaml
@@ -1,0 +1,1 @@
+jtype: Flow

--- a/tests/integration/issues/github_4773/test_load_config.py
+++ b/tests/integration/issues/github_4773/test_load_config.py
@@ -1,0 +1,19 @@
+import warnings
+
+import pytest
+
+from jina import Flow
+
+
+def test_load_config_instance():
+    with pytest.warns(UserWarning):  # assert that a warning has been emited
+        f = Flow().load_config('config.yaml')
+    f.build()
+
+
+def test_load_config_class():  # assert that no warnings were emited
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        f = Flow.load_config('config.yaml')
+
+    f.build()

--- a/tests/integration/issues/github_4773/test_load_config.py
+++ b/tests/integration/issues/github_4773/test_load_config.py
@@ -8,12 +8,9 @@ from jina import Flow
 def test_load_config_instance():
     with pytest.warns(UserWarning):  # assert that a warning has been emited
         f = Flow().load_config('config.yaml')
-    f.build()
 
 
 def test_load_config_class():  # assert that no warnings were emited
     with warnings.catch_warnings():
         warnings.simplefilter("error")
         f = Flow.load_config('config.yaml')
-
-    f.build()

--- a/tests/integration/override_config_params/worker/test_override_config_params.py
+++ b/tests/integration/override_config_params/worker/test_override_config_params.py
@@ -2,8 +2,7 @@ import os
 
 import pytest
 
-from jina import Executor, Client, requests
-from jina import Flow, Document
+from jina import Client, Document, Executor, Flow, requests
 
 cur_dir = os.path.dirname(os.path.abspath(__file__))
 exposed_port = 12345
@@ -13,7 +12,7 @@ exposed_port = 12345
 def flow(request):
     flow_src = request.param
     if flow_src == 'flow-yml':
-        return Flow().load_config(os.path.join(cur_dir, 'flow.yml'))
+        return Flow.load_config(os.path.join(cur_dir, 'flow.yml'))
     elif flow_src == 'uses-yml':
         return Flow(port=exposed_port).add(
             uses=os.path.join(cur_dir, 'default_config.yml'),

--- a/tests/unit/parsers/test_warnings.py
+++ b/tests/unit/parsers/test_warnings.py
@@ -1,6 +1,6 @@
 import pytest
 
-from jina import Flow, Executor
+from jina import Executor, Flow
 
 
 class MyExecutor(Executor):
@@ -16,7 +16,7 @@ with:
     foo: bar
     '''
     with pytest.warns(UserWarning, match='ignored unknown') as record:
-        Flow().load_config(yaml)
+        Flow.load_config(yaml)
     assert len(record) == 1
     assert record[0].message.args[0].startswith('ignored unknown')
 
@@ -28,7 +28,7 @@ executors:
     - foo: bar
     '''
     with pytest.warns(UserWarning, match='ignored unknown') as record:
-        Flow().load_config(yaml)
+        Flow.load_config(yaml)
     assert len(record) == 1
     assert record[0].message.args[0].startswith('ignored unknown')
 
@@ -41,7 +41,7 @@ executors:
         foo: bar
     '''
     with pytest.warns(UserWarning, match='ignored unknown') as record:
-        Flow().load_config(yaml)
+        Flow.load_config(yaml)
     assert len(record) == 1
     assert record[0].message.args[0].startswith('ignored unknown')
 
@@ -54,7 +54,7 @@ executors:
         foo: bar
     '''
     with pytest.warns(None, match='ignored unknown') as record:
-        Flow().load_config(yaml)
+        Flow.load_config(yaml)
     assert len(record) == 0
 
 
@@ -65,7 +65,7 @@ executors:
     - override_with: 1
     '''
     with pytest.warns(None, match='ignored unknown') as record:
-        Flow().load_config(yaml)
+        Flow.load_config(yaml)
     assert len(record) == 1
 
 
@@ -79,7 +79,7 @@ executors:
             name: MyExecutor
     '''
     with pytest.warns(None, match='ignored unknown') as record:
-        with Flow().load_config(yaml):
+        with Flow.load_config(yaml):
             pass
     assert len(record) == 0
 


### PR DESCRIPTION
fixing https://github.com/jina-ai/jina/issues/4773

Now when doing 

```python
from jina import Flow

Flow().load_config('config.yaml')
```

you got this warning 

```
UserWarning: Calling load_config from a Flow instance will override all of its initial parameters. You should probably use `Flow.load_config(...)` instead
```