### PR TITLE
fix: add check that jaml parses to correct class

### DIFF
--- a/jina/jaml/__init__.py
+++ b/jina/jaml/__init__.py
@@ -749,7 +749,12 @@ class JAMLCompatible(metaclass=JAMLCompatibleType):
                 # revert yaml's tag and load again, this time with substitution
                 tag_yml = JAML.unescape(JAML.dump(no_tag_yml))
             # load into object, no more substitute
-            return JAML.load(tag_yml, substitute=False, runtime_args=runtime_args)
+            obj = JAML.load(tag_yml, substitute=False, runtime_args=runtime_args)
+            if not isinstance(obj, cls):
+                raise BadConfigSource(
+                    f'Can not construct {cls} object from {source}. Source might be an invalid configuration.'
+                )
+            return obj
 
     @classmethod
     def _override_yml_params(cls, raw_yaml, field_name, override_field):

--- a/tests/unit/jaml/invalid.yml
+++ b/tests/unit/jaml/invalid.yml
@@ -1,0 +1,1 @@
+invalidkey: hello

--- a/tests/unit/jaml/test_type_parse.py
+++ b/tests/unit/jaml/test_type_parse.py
@@ -2,9 +2,10 @@ import os
 
 import pytest
 
-from jina.serve.executors import BaseExecutor
+from jina import Flow, __default_executor__, requests
+from jina.excepts import BadConfigSource
 from jina.jaml import JAML, JAMLCompatible
-from jina import __default_executor__, requests, Flow
+from jina.serve.executors import BaseExecutor
 
 
 class MyExecutor(BaseExecutor):
@@ -179,3 +180,11 @@ def test_parsing_brackets_in_envvar():
         assert b['executors'][0]['env']['var2'] == 'a'
         assert b['executors'][0]['env']['var3'] == '{"1": "2"}-a'
         assert b['executors'][0]['env']['var4'] == '-{"1": "2"}'
+
+
+def test_exception_invalid_yaml():
+    with pytest.raises(BadConfigSource):
+        BaseExecutor.load_config('./invalid.yml')
+
+    with pytest.raises(BadConfigSource):
+        Flow.load_config('./invalid.yml')

--- a/tests/unit/jaml/test_type_parse.py
+++ b/tests/unit/jaml/test_type_parse.py
@@ -183,8 +183,10 @@ def test_parsing_brackets_in_envvar():
 
 
 def test_exception_invalid_yaml():
+    cur_dir = os.path.dirname(os.path.abspath(__file__))
+    yaml = os.path.join(cur_dir, 'invalid.yml')
     with pytest.raises(BadConfigSource):
-        BaseExecutor.load_config('./invalid.yml')
+        BaseExecutor.load_config(yaml)
 
     with pytest.raises(BadConfigSource):
-        Flow.load_config('./invalid.yml')
+        Flow.load_config(yaml)


### PR DESCRIPTION
Fixes silent error when invalid YAML is passed as an Executor
