### PR TITLE
fix: pop the init time instead of normal access

### DIFF
--- a/jina/serve/runtimes/gateway/request_handling.py
+++ b/jina/serve/runtimes/gateway/request_handling.py
@@ -195,9 +195,10 @@ class RequestHandler:
                     route.end_time.GetCurrentTime()
 
             if self._summary:
-                self._summary.observe(
-                    time.time() - self.request_init_time[result.request_id]
-                )
+                init_time = self.request_init_time.pop(
+                    result.request_id
+                )  # need to pop otherwise it stay in memory for ever
+                self._summary.observe(time.time() - init_time)
 
             return result
 


### PR DESCRIPTION
The current implementation of the `receiving_request_seconds` metrics on the gateway introduce a memory leak.

We store the time when sending a request in a dict but we never release this info.

This pr fixed it by poping the value instend of accessing it