### PR TITLE
feat: smart replica retry

### DIFF
--- a/jina/excepts.py
+++ b/jina/excepts.py
@@ -1,4 +1,6 @@
 """This modules defines all kinds of exceptions raised in Jina."""
+from typing import Set, Union
+
 import grpc.aio
 
 
@@ -84,13 +86,13 @@ class InternalNetworkError(grpc.aio.AioRpcError, BaseJinaException):
         self,
         og_exception: grpc.aio.AioRpcError,
         request_id: str = '',
-        dest_addr: str = '',
+        dest_addr: Union[str, Set[str]] = {''},
         details: str = '',
     ):
         """
         :param og_exception: the original exception that caused the network error
         :param request_id: id of the request that caused the error
-        :param dest_addr: destination (microservice) address of the problematic network call
+        :param dest_addr: destination (microservice) address(es) of the problematic network call(s)
         :param details: details of the error
         """
         self.og_exception = og_exception

--- a/jina/serve/networking.py
+++ b/jina/serve/networking.py
@@ -310,7 +310,7 @@ class GrpcConnectionPool:
             entity_id: Optional[int] = None,
             increase_access_count: bool = True,
         ) -> ReplicaList:
-            # returns all replicas of a given deployment, using a "random" shard
+            # returns all replicas of a given deployment, using a given shard
             if deployment in self._deployments:
                 type_ = 'heads' if head else 'shards'
                 if entity_id is None and head:
@@ -730,10 +730,10 @@ class GrpcConnectionPool:
             tried_addresses = set()
             num_retries = max(3, len(connections.get_all_connections()))
             for i in range(num_retries):
-                connection = connections.get_next_connection()
-                tried_addresses.add(connection.address)
+                current_connection = connections.get_next_connection()
+                tried_addresses.add(current_connection.address)
                 try:
-                    return await connection.send_requests(
+                    return await current_connection.send_requests(
                         requests=requests,
                         metadata=metadata,
                         compression=self.compression,

--- a/jina/serve/networking.py
+++ b/jina/serve/networking.py
@@ -725,7 +725,7 @@ class GrpcConnectionPool:
         # the grpc call function is not a coroutine but some _AioCall
         async def task_wrapper():
             metadata = (('endpoint', endpoint),) if endpoint else None
-            for i in range(3):
+            for i in range(min(3, len(connections.get_all_connections()))):
                 connection = connections.get_next_connection()
                 try:
                     return await connection.send_requests(

--- a/jina/serve/runtimes/gateway/graph/topology_graph.py
+++ b/jina/serve/runtimes/gateway/graph/topology_graph.py
@@ -65,7 +65,7 @@ class TopologyGraph:
             if err_code == grpc.StatusCode.UNAVAILABLE:
                 err._details = (
                     err.details()
-                    + f' |Gateway: Communication error with deployment {self.name} at address {err.dest_addr}. Head or worker may be down.'
+                    + f' |Gateway: Communication error with deployment {self.name} at address(es) {err.dest_addr}. Head or worker(s) may be down.'
                 )
                 raise err
             else:

--- a/jina/serve/runtimes/gateway/request_handling.py
+++ b/jina/serve/runtimes/gateway/request_handling.py
@@ -89,7 +89,7 @@ class RequestHandler:
                 if err_code == grpc.StatusCode.UNAVAILABLE:
                     err._details = (
                         err.details()
-                        + f' |Gateway: Communication error with deployment at address {err.dest_addr}. Head or worker may be down.'
+                        + f' |Gateway: Communication error with deployment at address(es) {err.dest_addr}. Head or worker(s) may be down.'
                     )
                     raise err
                 else:

--- a/tests/integration/runtimes/test_network_failures.py
+++ b/tests/integration/runtimes/test_network_failures.py
@@ -411,3 +411,58 @@ async def test_runtimes_graphql(port_generator):
         worker_process.terminate()
         gateway_process.join()
         worker_process.join()
+
+
+@pytest.mark.asyncio
+async def test_replica_retry(port_generator):
+    # test that if one replica is down, the other replica(s) will be used
+    # create gateway and workers manually, then terminate worker process to provoke an error
+    worker_ports = [port_generator() for _ in range(3)]
+    worker0_port, worker1_port, worker2_port = worker_ports
+    gateway_port = port_generator()
+    graph_description = '{"start-gateway": ["pod0"], "pod0": ["end-gateway"]}'
+    pod_addresses = f'{{"pod0": ["0.0.0.0:{worker0_port}", "0.0.0.0:{worker1_port}", "0.0.0.0:{worker2_port}"]}}'
+
+    worker_processes = []
+    for p in worker_ports:
+        worker_processes.append(_create_worker(p))
+        time.sleep(0.1)
+        AsyncNewLoopRuntime.wait_for_ready_or_shutdown(
+            timeout=5.0,
+            ctrl_address=f'0.0.0.0:{p}',
+            ready_or_shutdown_event=multiprocessing.Event(),
+        )
+
+    gateway_process = _create_gateway(
+        gateway_port, graph_description, pod_addresses, 'grpc'
+    )
+    AsyncNewLoopRuntime.wait_for_ready_or_shutdown(
+        timeout=5.0,
+        ctrl_address=f'0.0.0.0:{gateway_port}',
+        ready_or_shutdown_event=multiprocessing.Event(),
+    )
+
+    try:
+        # ----------- 1. ping Flow once to trigger endpoint discovery -----------
+        # we have to do this in a new process because otherwise grpc will be sad and everything will crash :(
+        p = multiprocessing.Process(target=_send_request, args=(gateway_port, 'grpc'))
+        p.start()
+        p.join()
+        assert p.exitcode == 0
+        # kill second worker, which would be responsible for the second call (round robin)
+        worker_processes[1].terminate()
+        worker_processes[1].join()
+        # ----------- 2. test that redundant replicas take over -----------
+        # we have to do this in a new process because otherwise grpc will be sad and everything will crash :(
+        p = multiprocessing.Process(target=_send_request, args=(gateway_port, 'grpc'))
+        p.start()
+        p.join()
+        assert p.exitcode == 0
+    except Exception:
+        assert False
+    finally:  # clean up runtimes
+        gateway_process.terminate()
+        gateway_process.join()
+        for p in worker_processes:
+            p.terminate()
+            p.join()

--- a/tests/integration/runtimes/test_network_failures.py
+++ b/tests/integration/runtimes/test_network_failures.py
@@ -144,7 +144,6 @@ async def test_runtimes_headless_topology(
             # so in this case, the actual request will fail, not the discovery, which is handled differently by Gateway
             worker_process.terminate()  # kill worker
             worker_process.join()
-            print(f'worker is alive: {worker_process.is_alive()}')
             assert not worker_process.is_alive()
         # ----------- 2. test that gateways remain alive -----------
         # just do the same again, expecting the same failure

--- a/tests/integration/runtimes/test_network_failures.py
+++ b/tests/integration/runtimes/test_network_failures.py
@@ -71,11 +71,14 @@ def _send_request(gateway_port, protocol):
     )
 
 
-def _test_error(gateway_port, error_port, protocol):
+def _test_error(gateway_port, error_ports, protocol):
+    if not isinstance(error_ports, list):
+        error_ports = [error_ports]
     with pytest.raises(ConnectionError) as err_info:  # assert correct error is thrown
         _send_request(gateway_port, protocol)
-    # assert error message contains the port of the broken executor
-    assert str(error_port) in err_info.value.args[0]
+    # assert error message contains the port(s) of the broken executor(s)
+    for port in error_ports:
+        assert str(port) in err_info.value.args[0]
 
 
 @pytest.mark.parametrize(
@@ -455,6 +458,64 @@ async def test_replica_retry(port_generator):
         # ----------- 2. test that redundant replicas take over -----------
         # we have to do this in a new process because otherwise grpc will be sad and everything will crash :(
         p = multiprocessing.Process(target=_send_request, args=(gateway_port, 'grpc'))
+        p.start()
+        p.join()
+        assert p.exitcode == 0
+    except Exception:
+        assert False
+    finally:  # clean up runtimes
+        gateway_process.terminate()
+        gateway_process.join()
+        for p in worker_processes:
+            p.terminate()
+            p.join()
+
+
+@pytest.mark.asyncio
+async def test_replica_retry_all_fail(port_generator):
+    # test that if one replica is down, the other replica(s) will be used
+    # create gateway and workers manually, then terminate worker process to provoke an error
+    worker_ports = [port_generator() for _ in range(3)]
+    worker0_port, worker1_port, worker2_port = worker_ports
+    gateway_port = port_generator()
+    graph_description = '{"start-gateway": ["pod0"], "pod0": ["end-gateway"]}'
+    pod_addresses = f'{{"pod0": ["0.0.0.0:{worker0_port}", "0.0.0.0:{worker1_port}", "0.0.0.0:{worker2_port}"]}}'
+
+    worker_processes = []
+    for p in worker_ports:
+        worker_processes.append(_create_worker(p))
+        time.sleep(0.1)
+        AsyncNewLoopRuntime.wait_for_ready_or_shutdown(
+            timeout=5.0,
+            ctrl_address=f'0.0.0.0:{p}',
+            ready_or_shutdown_event=multiprocessing.Event(),
+        )
+
+    gateway_process = _create_gateway(
+        gateway_port, graph_description, pod_addresses, 'grpc'
+    )
+    AsyncNewLoopRuntime.wait_for_ready_or_shutdown(
+        timeout=5.0,
+        ctrl_address=f'0.0.0.0:{gateway_port}',
+        ready_or_shutdown_event=multiprocessing.Event(),
+    )
+
+    try:
+        # ----------- 1. ping Flow once to trigger endpoint discovery -----------
+        # we have to do this in a new process because otherwise grpc will be sad and everything will crash :(
+        p = multiprocessing.Process(target=_send_request, args=(gateway_port, 'grpc'))
+        p.start()
+        p.join()
+        assert p.exitcode == 0
+        # kill all workers
+        for p in worker_processes:
+            p.terminate()
+            p.join()
+        # ----------- 2. test that call fails with informative error message -----------
+        # we have to do this in a new process because otherwise grpc will be sad and everything will crash :(
+        p = multiprocessing.Process(
+            target=_test_error, args=(gateway_port, worker_ports, 'grpc')
+        )
         p.start()
         p.join()
         assert p.exitcode == 0


### PR DESCRIPTION
Right now, when a replica fails (on local), the gateway will stubbornly retry to connect to that same replica, instead of trying its luck with one of the other replicas. This PR changes that, applying round robing scheduling also for retries, not just successful calls.

**ToDo:**

- [x] smart retry mechanism
- [x] test for retry mechanism
- [x] appropriate error message if all replicas fail
- [x] test for this failure case