### PR TITLE
fix(qabot): hide the slot elements on the docs page

### DIFF
--- a/docs/_templates/page.html
+++ b/docs/_templates/page.html
@@ -191,13 +191,15 @@
     <qa-bot
         title="Jina Bot"
         description="The cloud-native neural search framework"
-        >
-        <dl>
-            <dt>You can ask questions about our docs. Try:</dt>
-            <dd>Does Jina support Kubernetes?</dd>
-            <dd>What are the basic concepts in Jina?</dd>
-            <dd>How to share my Executor?</dd>
-        </dl>
+    >
+        <template>
+            <dl>
+                <dt>You can ask questions about our docs. Try:</dt>
+                <dd>Does Jina support Kubernetes?</dd>
+                <dd>What are the basic concepts in Jina?</dd>
+                <dd>How to share my Executor?</dd>
+            </dl>
+        </template>
     </qa-bot>
 
 </div>


### PR DESCRIPTION
Goals:
Add a template to prevent the qabot slot elements from showing on the docs pages.
