### PR TITLE
feat(hubble): use fixed domain for hubble api

### DIFF
--- a/jina/hubble/helper.py
+++ b/jina/hubble/helper.py
@@ -94,27 +94,14 @@ def get_download_cache_dir() -> Path:
 
 @lru_cache()
 def _get_hubble_base_url() -> str:
-    """Get base Hubble Url from api.jina.ai or os.environ
+    """Get base Hubble Url from os.environ or constants
 
     :return: base Hubble Url
     """
     if 'JINA_HUBBLE_REGISTRY' in os.environ:
-        u = os.environ['JINA_HUBBLE_REGISTRY']
-    else:
-        try:
-            req = Request(
-                'https://api.jina.ai/hub/hubble.json',
-                headers={'User-Agent': 'Mozilla/5.0'},
-            )
-            with urlopen(req) as resp:
-                u = json.load(resp)['url']
-        except:
-            default_logger.critical(
-                'Can not fetch the Url of Hubble from `api.jina.ai`'
-            )
-            raise
+        return os.environ['JINA_HUBBLE_REGISTRY']
 
-    return u
+    return 'https://api.hubble.jina.ai'
 
 
 @lru_cache()

--- a/jina/hubble/helper.py
+++ b/jina/hubble/helper.py
@@ -98,10 +98,7 @@ def _get_hubble_base_url() -> str:
 
     :return: base Hubble Url
     """
-    if 'JINA_HUBBLE_REGISTRY' in os.environ:
-        return os.environ['JINA_HUBBLE_REGISTRY']
-
-    return 'https://api.hubble.jina.ai'
+    return os.environ.get('JINA_HUBBLE_REGISTRY', 'https://api.hubble.jina.ai')
 
 
 @lru_cache()


### PR DESCRIPTION
Goals:

- `api.jina.ai` is unstable sometimes, remove this layer to get better quality. We need to maintain the old domain even we move to new domain anyway, so no worries about writing domain down directly. 

Related to: https://github.com/jina-ai/hubble/issues/434