### PR TITLE
fix: remove tag from save config yaml

### DIFF
--- a/jina/jaml/__init__.py
+++ b/jina/jaml/__init__.py
@@ -554,9 +554,16 @@ class JAMLCompatible(metaclass=JAMLCompatibleType):
         """
         from jina.jaml.parsers import get_parser
 
-        tmp = {'jtype': cls.__name__}
-        tmp.update(get_parser(cls, version=data._version).dump(data))
-        return representer.represent_mapping('!' + cls.__name__, tmp)
+        config_dict = get_parser(cls, version=data._version).dump(data)
+        config_dict_with_jtype = {
+            'jtype': cls.__name__
+        }  # specifies the type of Jina object that is represented
+        config_dict_with_jtype.update(config_dict)
+        # To maintain compatibility with off-the-shelf parsers we don't want any tags ('!...') to show up in the output
+        # Since pyyaml insists on receiving a tag, we need to pass the default map tag. This won't show up in the output
+        return representer.represent_mapping(
+            'tag:yaml.org,2002:map', config_dict_with_jtype
+        )
 
     @classmethod
     def _from_yaml(cls, constructor: FullConstructor, node):

--- a/jina/jaml/__init__.py
+++ b/jina/jaml/__init__.py
@@ -554,7 +554,8 @@ class JAMLCompatible(metaclass=JAMLCompatibleType):
         """
         from jina.jaml.parsers import get_parser
 
-        tmp = get_parser(cls, version=data._version).dump(data)
+        tmp = {'jtype': cls.__name__}
+        tmp.update(get_parser(cls, version=data._version).dump(data))
         return representer.represent_mapping('!' + cls.__name__, tmp)
 
     @classmethod

--- a/jina/jaml/__init__.py
+++ b/jina/jaml/__init__.py
@@ -562,7 +562,7 @@ class JAMLCompatible(metaclass=JAMLCompatibleType):
         # To maintain compatibility with off-the-shelf parsers we don't want any tags ('!...') to show up in the output
         # Since pyyaml insists on receiving a tag, we need to pass the default map tag. This won't show up in the output
         return representer.represent_mapping(
-            'tag:yaml.org,2002:map', config_dict_with_jtype
+            representer.DEFAULT_MAPPING_TAG, config_dict_with_jtype
         )
 
     @classmethod

--- a/tests/unit/jaml/test_type_parse.py
+++ b/tests/unit/jaml/test_type_parse.py
@@ -1,6 +1,7 @@
 import os
 
 import pytest
+import yaml
 
 from jina import Flow, __default_executor__, requests
 from jina.excepts import BadConfigSource
@@ -190,3 +191,25 @@ def test_exception_invalid_yaml():
 
     with pytest.raises(BadConfigSource):
         Flow.load_config(yaml)
+
+
+def test_jtype(tmpdir):
+    flow_path = os.path.join(tmpdir, 'flow.yml')
+    exec_path = os.path.join(tmpdir, 'exec.yml')
+
+    f = Flow()
+    f.save_config(flow_path)
+    with open(flow_path, 'r') as file:
+        conf = yaml.safe_load(file)
+        assert 'jtype' in conf
+        assert conf['jtype'] == 'Flow'
+
+    e = BaseExecutor()
+    e.save_config(exec_path)
+    with open(exec_path, 'r') as file:
+        conf = yaml.safe_load(file)
+        assert 'jtype' in conf
+        assert conf['jtype'] == 'BaseExecutor'
+
+    assert type(BaseExecutor.load_config(exec_path)) == BaseExecutor
+    assert type(Flow.load_config(flow_path)) == Flow


### PR DESCRIPTION
The output of `f.save_config()` should not include `!Flow` since it is deprecated syntax and not compatible with jcloud.