### PR TITLE
fix: define metrics in worker before grpc server

### DIFF
--- a/jina/serve/runtimes/worker/__init__.py
+++ b/jina/serve/runtimes/worker/__init__.py
@@ -32,8 +32,6 @@ class WorkerRuntime(AsyncNewLoopRuntime, ABC):
         """
         Start the DataRequestHandler and wait for the GRPC and Monitoring servers to start
         """
-        await self._async_setup_grpc_server()
-
         if self.metrics_registry:
             with ImportExtensions(
                 required=True,
@@ -54,6 +52,8 @@ class WorkerRuntime(AsyncNewLoopRuntime, ABC):
             )
         else:
             self._summary_time = contextlib.nullcontext()
+
+        await self._async_setup_grpc_server()
 
     async def _async_setup_grpc_server(self):
         """


### PR DESCRIPTION
In the worker runtime, some of the monitoring metrics were define **after** starting the grpc server. It should be the other way around the grpc server should be launch at the end when everything is ready.