### PR TITLE
fix: fix protobuf dependency

### DIFF
--- a/extra-requirements.txt
+++ b/extra-requirements.txt
@@ -26,7 +26,7 @@
 # demo: required for the hello world demos
 
 numpy:                      core
-protobuf>=3.19.1:           core
+protobuf>=3.19.1,<=3.20.1:  core
 grpcio>=1.46.0:             core
 grpcio-reflection>=1.46.0:  core
 pyyaml>=5.3.1:              core

--- a/jina/resources/extra-requirements.txt
+++ b/jina/resources/extra-requirements.txt
@@ -26,7 +26,7 @@
 # demo: required for the hello world demos
 
 numpy:                      core
-protobuf>=3.19.1:           core
+protobuf>=3.19.1,<=3.20.1:  core
 grpcio>=1.46.0:             core
 grpcio-reflection>=1.46.0:  core
 pyyaml>=5.3.1:              core


### PR DESCRIPTION
recent release in protobuf causes the following problem:

```text
TypeError: Descriptors cannot not be created directly.
If this call came from a _pb2.py file, your generated code is out of date and must be 
regenerated with protoc >= 3.19.0.
If you cannot immediately regenerate your protos, some other possible workarounds are:
 1. Downgrade the protobuf package to 3.20.x or lower.
```

As a quick fix, we fix the protobuf version to less than 4.21
The best solution would be to regenerate proto with protoc >= 3.19.0