### PR TITLE
feat(websocket): http healthcheck endpoint

### DIFF
--- a/jina/serve/runtimes/gateway/websocket/__init__.py
+++ b/jina/serve/runtimes/gateway/websocket/__init__.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 import os
 
 from jina import __default_host__
@@ -46,6 +47,16 @@ class WebSocketGatewayRuntime(GatewayRuntime):
                 :param kwargs: keyword arguments
                 """
                 await self.main_loop()
+
+        if 'JINA_DISABLE_HEALTHCHECK_LOGS' in os.environ:
+
+            class _EndpointFilter(logging.Filter):
+                def filter(self, record: logging.LogRecord) -> bool:
+                    # NOTE: space is important after `GET /`, else all logs will be disabled.
+                    return record.getMessage().find("GET / ") == -1
+
+            # Filter out healthcheck endpoint `GET /`
+            logging.getLogger("uvicorn.access").addFilter(_EndpointFilter())
 
         from jina.helper import extend_rest_interface
 

--- a/jina/serve/runtimes/gateway/websocket/app.py
+++ b/jina/serve/runtimes/gateway/websocket/app.py
@@ -130,6 +130,18 @@ def get_fastapi_app(
 
     streamer.Call = streamer.stream
 
+    @app.get(
+        path='/',
+        summary='Get the health of Jina service',
+    )
+    async def _health():
+        """
+        Get the health of this Jina service.
+        .. # noqa: DAR201
+
+        """
+        return {}
+
     @app.on_event('shutdown')
     async def _shutdown():
         await connection_pool.close()


### PR DESCRIPTION
**Goal**

Even though AWS ALB supports Websocket traffic, it can't do health checks for WebSocket. It can do health checks with HTTP protocol though -  I'm enabling the same to add WebSocket gateway support in JCloud. Now, it throws bunch of 404s since the endpoint actually doesn't exist.

This PR adds an HTTP endpoint `GET /` for `WebsocketGateway` like for `HTTPGateway` (since both are FastAPI apps on Uvicorn server). I'm not sure whether this would help other load balancers, though.


- [ ] check and update documentation. See [guide](https://github.com/jina-ai/jina/CONTRIBUTING.md#documentation-guidelines) and ask the team.
