### PR TITLE
fix: pass tls to the deployment

### DIFF
--- a/cli/autocomplete.py
+++ b/cli/autocomplete.py
@@ -304,6 +304,7 @@ ac_table = {
             '--when',
             '--external',
             '--deployment-role',
+            '--tls',
         ],
         'client': [
             '--help',

--- a/jina/orchestrate/deployments/__init__.py
+++ b/jina/orchestrate/deployments/__init__.py
@@ -293,7 +293,7 @@ class Deployment(BaseDeployment):
         """
         has_cert = getattr(self.args, 'ssl_certfile', None) is not None
         has_key = getattr(self.args, 'ssl_keyfile', None) is not None
-        return self.is_sandbox or (has_cert and has_key)
+        return self.args.tls or self.is_sandbox or (has_cert and has_key)
 
     @property
     def external(self) -> bool:

--- a/jina/orchestrate/deployments/__init__.py
+++ b/jina/orchestrate/deployments/__init__.py
@@ -293,7 +293,8 @@ class Deployment(BaseDeployment):
         """
         has_cert = getattr(self.args, 'ssl_certfile', None) is not None
         has_key = getattr(self.args, 'ssl_keyfile', None) is not None
-        return self.args.tls or self.is_sandbox or (has_cert and has_key)
+        tls = getattr(self.args, 'tls', False)
+        return tls or self.is_sandbox or (has_cert and has_key)
 
     @property
     def external(self) -> bool:

--- a/jina/orchestrate/flow/base.py
+++ b/jina/orchestrate/flow/base.py
@@ -660,6 +660,7 @@ class Flow(PostMixin, JAMLCompatible, ExitStack, metaclass=FlowType):
         timeout_ctrl: Optional[int] = 60,
         timeout_ready: Optional[int] = 600000,
         timeout_send: Optional[int] = None,
+        tls: Optional[bool] = False,
         upload_files: Optional[List[str]] = None,
         uses: Optional[Union[str, Type['BaseExecutor'], dict]] = 'BaseExecutor',
         uses_after: Optional[Union[str, Type['BaseExecutor'], dict]] = None,
@@ -741,6 +742,7 @@ class Flow(PostMixin, JAMLCompatible, ExitStack, metaclass=FlowType):
         :param timeout_ctrl: The timeout in milliseconds of the control request, -1 for waiting forever
         :param timeout_ready: The timeout in milliseconds of a Pod waits for the runtime to be ready, -1 for waiting forever
         :param timeout_send: The timeout in milliseconds used when sending data requests to Executors, -1 means no timeout, disabled by default
+        :param tls: If set, connect to deployment using tls encryption
         :param upload_files: The files on the host to be uploaded to the remote
           workspace. This can be useful when your Deployment has more
           file dependencies beyond a single YAML file, e.g.

--- a/jina/parsers/orchestrate/deployment.py
+++ b/jina/parsers/orchestrate/deployment.py
@@ -52,3 +52,10 @@ def mixin_base_deployment_parser(parser):
         if _SHOW_ALL_ARGS
         else argparse.SUPPRESS,
     )
+
+    gp.add_argument(
+        '--tls',
+        action='store_true',
+        default=False,
+        help='If set, connect to deployment using tls encryption',
+    )


### PR DESCRIPTION
# Adding TLS support to deployment

## Context
Right now tls is ignored without any warning when added the a deployment
```python
from jina import Flow
from docarray import DocumentArray

f = Flow().add(tls=True, host='host.wolf.jina.ai', external=True)
```

It means than no encryption is used when using external executor even if the user thinks it is used.

## Solution

With this pr the `tls` argument is correctly passed to the deployment.

It fix the issue with wolf external deployment https://github.com/jina-ai/jina/issues/4838.