### PR TITLE
feat: custom monitoring with context manager

### DIFF
--- a/docs/fundamentals/executor/monitoring-executor.md
+++ b/docs/fundamentals/executor/monitoring-executor.md
@@ -156,21 +156,20 @@ emphasize-lines: 14, 16
 from jina import requests, Executor
 from docarray import DocumentArray
 
+def preprocessing(self, docs: DocumentArray):
+    ...
+
+def model_inference(self, tensor):
+    ...
+
 class MyExecutor(Executor):
-
-    def preprocessing(self, docs: DocumentArray):
-        ...
-
-    @monitor()
-    def model_inference(self, tensor):
-        ...
 
     @requests
     def encode(self, docs: DocumentArray, **kwargs):
         with self.monitor('preprocessing_seconds', 'Time preprocessing the requests'):
-            docs.tensors = self.preprocessing(docs)
+            docs.tensors = preprocessing(docs)
         with self.monitor('model_inference_seconds', 'Time doing inference the requests'):
-            docs.embedding = self.model_inference(docs.tensors)
+            docs.embedding = model_inference(docs.tensors)
 ```
 ````
 

--- a/jina/serve/executors/__init__.py
+++ b/jina/serve/executors/__init__.py
@@ -490,7 +490,7 @@ class BaseExecutor(JAMLCompatible, metaclass=ExecutorType):
             == BaseExecutor.StandaloneExecutorType.EXTERNAL,
         )
 
-    def get_metrics(
+    def monitor(
         self, name: Optional[str] = None, documentation: Optional[str] = None
     ) -> Optional['Summary']:
         """
@@ -512,6 +512,6 @@ class BaseExecutor(JAMLCompatible, metaclass=ExecutorType):
                     namespace='jina',
                     labelnames=('runtime_name',),
                 ).labels(self.runtime_args.name)
-            return self._metrics_buffer[name]
+            return self._metrics_buffer[name].time()
         else:
-            return None
+            return contextlib.nullcontext()

--- a/jina/serve/executors/decorators.py
+++ b/jina/serve/executors/decorators.py
@@ -229,12 +229,7 @@ def monitor(
 
         @functools.wraps(func)
         def _f(self, *args, **kwargs):
-            metric = self.get_metrics(name_, documentation_)
-
-            if metric:
-                with metric.time():
-                    return func(self, *args, **kwargs)
-            else:
+            with self.monitor(name_, documentation_):
                 return func(self, *args, **kwargs)
 
         return _f

--- a/tests/integration/monitoring/test_executor.py
+++ b/tests/integration/monitoring/test_executor.py
@@ -34,15 +34,15 @@ def test_decorator_interface(port_generator):
     class DummyExecutor(Executor):
         @requests(on='/foo')
         def foo(self, docs, **kwargs):
-            self._proces(docs)
-            self.proces_2(docs)
+            self._process(docs)
+            self.process_2(docs)
 
         @monitor(name='metrics_name', documentation='metrics description')
-        def _proces(self, docs):
+        def _process(self, docs):
             ...
 
         @monitor()
-        def proces_2(self, docs):
+        def process_2(self, docs):
             ...
 
     port = port_generator()
@@ -56,7 +56,7 @@ def test_decorator_interface(port_generator):
             resp.content
         )
         assert (
-            f'jina_proces_2_seconds_count{{runtime_name="executor0/rep-0"}} 1.0'
+            f'jina_process_2_seconds_count{{runtime_name="executor0/rep-0"}} 1.0'
             in str(resp.content)
         )
 
@@ -67,19 +67,19 @@ def test_context_manager_interface(port_generator):
         def foo(self, docs, **kwargs):
 
             with self.monitor(
-                name='proces_seconds', documentation='process time in seconds '
+                name='process_seconds', documentation='process time in seconds '
             ):
-                self._proces(docs)
+                self._process(docs)
 
             with self.monitor(
-                name='proces_2_seconds', documentation='process 2 time in seconds '
+                name='process_2_seconds', documentation='process 2 time in seconds '
             ):
-                self.proces_2(docs)
+                self.process_2(docs)
 
-        def _proces(self, docs):
+        def _process(self, docs):
             ...
 
-        def proces_2(self, docs):
+        def process_2(self, docs):
             ...
 
     port = port_generator()
@@ -90,10 +90,10 @@ def test_context_manager_interface(port_generator):
 
         resp = req.get(f'http://localhost:{port}/')
         assert (
-            f'jina_proces_seconds_count{{runtime_name="executor0/rep-0"}} 1.0'
+            f'jina_process_seconds_count{{runtime_name="executor0/rep-0"}} 1.0'
             in str(resp.content)
         )
         assert (
-            f'jina_proces_2_seconds_count{{runtime_name="executor0/rep-0"}} 1.0'
+            f'jina_process_2_seconds_count{{runtime_name="executor0/rep-0"}} 1.0'
             in str(resp.content)
         )

--- a/tests/unit/serve/runtimes/worker/test_worker_runtime.py
+++ b/tests/unit/serve/runtimes/worker/test_worker_runtime.py
@@ -393,14 +393,14 @@ async def test_decorator_monitoring(port_generator):
         @requests
         def foo(self, docs, **kwargs):
             self._proces(docs)
-            self.proces_2(docs)
+            self.process_2(docs)
 
         @monitor(name='metrics_name', documentation='metrics description')
         def _proces(self, docs):
             ...
 
         @monitor()
-        def proces_2(self, docs):
+        def process_2(self, docs):
             ...
 
     port = port_generator()
@@ -455,19 +455,19 @@ async def test_decorator_monitoring(port_generator):
         def foo(self, docs, **kwargs):
 
             with self.monitor(
-                name='proces_seconds', documentation='process time in seconds '
+                name='process_seconds', documentation='process time in seconds '
             ):
                 self._proces(docs)
 
             with self.monitor(
-                name='proces_2_seconds', documentation='process 2 time in seconds '
+                name='process_2_seconds', documentation='process 2 time in seconds '
             ):
-                self.proces_2(docs)
+                self.process_2(docs)
 
         def _proces(self, docs):
             ...
 
-        def proces_2(self, docs):
+        def process_2(self, docs):
             ...
 
     port = port_generator()
@@ -505,7 +505,7 @@ async def test_decorator_monitoring(port_generator):
     )
 
     resp = req.get(f'http://localhost:{port}/')
-    assert f'jina_proces_seconds_count{{runtime_name="None"}} 1.0' in str(resp.content)
+    assert f'jina_process_seconds_count{{runtime_name="None"}} 1.0' in str(resp.content)
 
     cancel_event.set()
     runtime_thread.join()


### PR DESCRIPTION
# Custom monitoring with context manager
## Context

having only the possibility to monitor custom part of Executor with a decorator is a limitation. We need to have a context manager as well. See full issue here : https://github.com/jina-ai/jina/issues/4876

## What this PR do

This pr allow developer of Executor to use custom metrics with a context manager

example:

```python
from jina import requests, Executor
from docarray import DocumentArray

def preprocessing(self, docs: DocumentArray):
    ...

def model_inference(self, tensor):
    ...

class MyExecutor(Executor):

    @requests
    def encode(self, docs: DocumentArray, **kwargs):
        with self.monitor('preprocessing_seconds', 'Time preprocessing the requests'):
            docs.tensors = preprocessing(docs)
        with self.monitor('model_inference_seconds', 'Time doing inference the requests'):
            docs.embedding = model_inference(docs.tensors)
```

