### PR TITLE
chore: correct template link to github

### DIFF
--- a/docs/_templates/page.html
+++ b/docs/_templates/page.html
@@ -189,7 +189,7 @@
                     </div>
                     <div class="right-details">
                         <div class="social-btns">
-                            <a class='social-btn' href="https://github.com/jina-ai/docarray/" aria-label="GitHub"
+                            <a class='social-btn' href="https://github.com/jina-ai/jina" aria-label="GitHub"
                                target="_blank" rel="noreferrer"> <i class="fab fa-github"></i></a>
                             <a class='social-btn' href="https://slack.jina.ai" aria-label="Slack" target="_blank"
                                rel="noreferrer"> <i class="fab fa-slack"></i></a>


### PR DESCRIPTION
The github social icon leads to docarray right now. It should lead to the jina repository instead.

This PR corrects the link.
