### PR TITLE
chore: raise warning if port_monitoring is default and already in use

### DIFF
--- a/jina/serve/runtimes/monitoring.py
+++ b/jina/serve/runtimes/monitoring.py
@@ -1,3 +1,6 @@
+from jina import __default_port_monitoring__
+
+
 class MonitoringMixin:
     """The Monitoring Mixin for pods"""
 
@@ -17,4 +20,19 @@ class MonitoringMixin:
 
             from prometheus_client import start_http_server
 
-            start_http_server(self.args.port_monitoring, registry=self.metrics_registry)
+            try:
+                start_http_server(
+                    self.args.port_monitoring, registry=self.metrics_registry
+                )
+            except OSError as e:
+                if (
+                    e.args[0] == 98
+                    and self.args.port_monitoring == __default_port_monitoring__
+                ):
+                    self.logger.warning(
+                        f'The port monitoring {self.args.port_monitoring} is already in use. If you are running Jina '
+                        f'Flow natively, you may have not set different ports for each Executor'
+                    )
+                    raise
+                else:
+                    raise

--- a/jina/serve/runtimes/monitoring.py
+++ b/jina/serve/runtimes/monitoring.py
@@ -33,7 +33,7 @@ class MonitoringMixin:
                 ):
                     self.logger.warning(
                         f'The port monitoring {self.args.port_monitoring} is already in use. If you are running Jina '
-                        f'Flow natively, you may have not set different ports for each Executor'
+                        f'Flow locally, you may have not set different port_monitoring for each Executor'
                     )
                     raise
                 else:

--- a/jina/serve/runtimes/monitoring.py
+++ b/jina/serve/runtimes/monitoring.py
@@ -1,3 +1,5 @@
+import errno
+
 from jina import __default_port_monitoring__
 
 
@@ -26,7 +28,7 @@ class MonitoringMixin:
                 )
             except OSError as e:
                 if (
-                    e.args[0] == 98
+                    e.args[0] == errno.ENOSR
                     and self.args.port_monitoring == __default_port_monitoring__
                 ):
                     self.logger.warning(


### PR DESCRIPTION
chore: raise warning if port_monitoring is default and already in use

When a user tries to setup monitoring locally and he does not change the default monitoring port for executors, raise a warning to give him a hint