### PR TITLE
docs: add jcloud version doc

### DIFF
--- a/docs/fundamentals/jcloud/advanced.md
+++ b/docs/fundamentals/jcloud/advanced.md
@@ -31,7 +31,7 @@ executors:
         memory: 8G
 ```
 
-### `spot` vs `on-demand` capacity
+## `spot` vs `on-demand` capacity
 
 For cost optimization, `jcloud` tries to deploy all Executors on `spot` capacity. These are ideal for stateless Executors, which can withstand interruptions & restarts. It is recommended to use `on-demand` capacity for stateful Executors (e.g.- indexers) though.
 
@@ -77,4 +77,16 @@ executors:
 
 ```{figure} external-executors-multiple.png
 :width: 70%
+```
+## Deploy with specific `jina` version
+
+To manage `jina` version while deploying a Flow to `jcloud`, you can pass `version` arg in the Flow yaml.
+
+```yaml
+jtype: Flow
+jcloud:
+  version: 3.4.11
+executors:
+  - name: custom
+    uses: jinahub+docker://CustomExecutor
 ```


### PR DESCRIPTION
Goals:

- Add jcloud version related docs.

Preview: 
https://github.com/jina-ai/jina/blob/jcloud-version/docs/fundamentals/jcloud/advanced.md
