### PR TITLE
feat: add specific executor param

### DIFF
--- a/jina/serve/runtimes/request_handlers/data_request_handler.py
+++ b/jina/serve/runtimes/request_handlers/data_request_handler.py
@@ -112,6 +112,15 @@ class DataRequestHandler:
             raise
 
     @staticmethod
+    def _parse_params(parameters: Dict, executor_name: str):
+        parsed_params = parameters
+        specific_parameters = parameters.get(executor_name, None)
+        if specific_parameters:
+            parsed_params.update(**specific_parameters)
+
+        return parsed_params
+
+    @staticmethod
     def _parse_specific_params(parameters: Dict, executor_name: str):
         """Parse the parameters dictionary to filter executor specific parameters
 
@@ -164,8 +173,9 @@ class DataRequestHandler:
                     self.args.name,
                 ).observe(req.nbytes)
 
+        params = self._parse_params(requests[0].parameters, self._executor.metas.name)
         params = self._parse_specific_params(
-            requests[0].parameters, self._get_name_from_replicas_name(self.args.name)
+            params, self._get_name_from_replicas_name(self.args.name)
         )
 
         docs = DataRequestHandler.get_docs_from_request(

--- a/jina/serve/runtimes/request_handlers/data_request_handler.py
+++ b/jina/serve/runtimes/request_handlers/data_request_handler.py
@@ -413,8 +413,8 @@ class DataRequestHandler:
         """
         key_split = key_name.split(DataRequestHandler._SPECIFIC_EXECUTOR_SEPARATOR)
 
-        executor_name = key_split.pop(-1)
-        new_key_name = ''.join(key_split)
+        new_key_name = key_split.pop(-1)
+        executor_name = ''.join(key_split)
 
         return new_key_name, executor_name
 

--- a/jina/serve/runtimes/request_handlers/data_request_handler.py
+++ b/jina/serve/runtimes/request_handlers/data_request_handler.py
@@ -112,15 +112,6 @@ class DataRequestHandler:
             raise
 
     @staticmethod
-    def _parse_params(parameters: Dict, executor_name: str):
-        parsed_params = parameters
-        specific_parameters = parameters.get(executor_name, None)
-        if specific_parameters:
-            parsed_params.update(**specific_parameters)
-
-        return parsed_params
-
-    @staticmethod
     def _parse_specific_params(parameters: Dict, executor_name: str):
         """Parse the parameters dictionary to filter executor specific parameters
 
@@ -173,9 +164,8 @@ class DataRequestHandler:
                     self.args.name,
                 ).observe(req.nbytes)
 
-        params = self._parse_params(requests[0].parameters, self._executor.metas.name)
         params = self._parse_specific_params(
-            params, self._get_name_from_replicas_name(self.args.name)
+            requests[0].parameters, self._get_name_from_replicas_name(self.args.name)
         )
 
         docs = DataRequestHandler.get_docs_from_request(

--- a/tests/integration/specific_executor_params/test_specific_params.py
+++ b/tests/integration/specific_executor_params/test_specific_params.py
@@ -1,0 +1,35 @@
+import copy
+
+from docarray import DocumentArray
+
+from jina import Executor, Flow, requests
+
+
+def test_specific_params():
+    class MyExec(Executor):
+        @requests
+        def process(self, docs, parameters, **kwargs):
+            return {'received_parameters': parameters}
+
+    flow = Flow().add(uses=MyExec, name='exec1').add(uses=MyExec, name='exec2')
+
+    with flow:
+        response = flow.index(
+            DocumentArray.empty(size=5),
+            parameters={'key_1': True, 'key_2__exec2': False},
+            return_responses=True,
+        )
+
+    assert response[0].parameters['__results__']['exec1/rep-0'][
+        'received_parameters'
+    ] == {'key_1': True}
+
+    exec2_recevied_param = response[0].parameters['__results__']['exec2/rep-0'][
+        'received_parameters'
+    ]
+    exec2_recevied_param.pop('__results__')
+
+    assert exec2_recevied_param == {
+        'key_1': True,
+        'key_2': False,
+    }

--- a/tests/integration/specific_executor_params/test_specific_params.py
+++ b/tests/integration/specific_executor_params/test_specific_params.py
@@ -16,7 +16,7 @@ def test_specific_params():
     with flow:
         response = flow.index(
             DocumentArray.empty(size=5),
-            parameters={'key_1': True, 'key_2__exec2': False},
+            parameters={'key_1': True, 'exec2__key_2': False},
             return_responses=True,
         )
 

--- a/tests/unit/serve/runtimes/request_handlers/test_data_request_handlers.py
+++ b/tests/unit/serve/runtimes/request_handlers/test_data_request_handlers.py
@@ -139,8 +139,8 @@ async def test_data_request_handler_clear_docs(logger):
     [
         ('key', False),
         ('key_1', False),
-        ('key__executor', True),
-        ('key_2__exec2', True),
+        ('executor__key', True),
+        ('exec2__key_2', True),
         ('__results__', False),
     ],
 )
@@ -151,9 +151,9 @@ def test_is_specific_executor(key_name, is_specific):
 @pytest.mark.parametrize(
     'full_key,key , executor',
     [
-        ('key__executor', 'key', 'executor'),
-        ('key_1__executor', 'key_1', 'executor'),
-        ('key__executor_1', 'key', 'executor_1'),
+        ('executor__key', 'key', 'executor'),
+        ('executor__key_1', 'key_1', 'executor'),
+        ('executor_1__key', 'key', 'executor_1'),
     ],
 )
 def test_split_key_executor_name(full_key, key, executor):
@@ -164,21 +164,23 @@ def test_split_key_executor_name(full_key, key, executor):
     'param, parsed_param, executor_name',
     [
         (
-            {'key': 1, 'key__executor': 2, 'key__wrong_executor': 3},
+            {'key': 1, 'executor__key': 2, 'wrong_executor__key': 3},
             {'key': 2},
             'executor',
         ),
-        ({'key__executor': 2, 'key__wrong_executor': 3}, {'key': 2}, 'executor'),
+        ({'executor__key': 2, 'wrong_executor__key': 3}, {'key': 2}, 'executor'),
         (
-            {'a': 1, 'key__executor': 2, 'key__wrong_executor': 3},
+            {'a': 1, 'executor__key': 2, 'wrong_executor__key': 3},
             {'key': 2, 'a': 1},
             'executor',
         ),
-        ({'key_1': 0, 'key_2__exec2': 1}, {'key_1': 0}, 'executor'),
+        ({'key_1': 0, 'exec2__key_2': 1}, {'key_1': 0}, 'executor'),
     ],
 )
-def test_parse_param(param, parsed_param, executor_name):
-    assert DataRequestHandler._parse_params(param, executor_name) == parsed_param
+def test_parse_specific_param(param, parsed_param, executor_name):
+    assert (
+        DataRequestHandler._parse_specific_params(param, executor_name) == parsed_param
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Context

ATM when you pass a parameters to an Executor `client.index(docs, parameters = {...}` every Executor will receive all of them.
Meaning that if you want to pass different parameters to each Executor you will need to change the name.That's problematic because some Executor except the same parameters, like `traversal_path`.

For instance you can't embed on the chunk with one executor and embed on the root with an other one because you can only pass one `traversal_path`.

**We need to be able to send parameters to different Executor.**

original issue here : https://github.com/jina-ai/jina/issues/4919
this PR take over the old proposition which we decide not to go for : https://github.com/jina-ai/jina/pull/4923 

## Proposal for a Solution

Using the `key__executor_name` instead of `key` to precise that it should only be sent to the given Executor.

The `__` operator is use for this kind of things in the python world. We use it in [docarray](https://docarray.jina.ai/fundamentals/documentarray/access-attributes/?highlight=tags__#dunder-syntax-for-nested-attributes) : da[:,'tags__key'].

This is actually the exact same syntax of [scikit-learn pipeline](https://scikit-learn.org/stable/modules/compose.html#nested-parameters
).

`Parameters of the estimators in the pipeline can be accessed using the <estimator>__<parameter> syntax`

```python
from jina import Flow

f = Flow().add(name='exec1').add(name='exec2')

f.post(parameters= {'key1_exec1': val1}' # like this Exec1 will receive {'key1': val1} in their params and exec2 will receive empty.
f.post(parameters= {'key1': val1}' # like this Exec1  and Exec2 will receive {'key1': val1} 
```

Moreover : regarding performance issue of deserialization on the gateway side I suggest to avoid doing any deserialization on the gateway side by sending the full parameters to the Worker and only passing the one relevant to the Executor


## What this PR do:

- [x] Allow to use the `__` syntax to pass executor to one Executor
- [x] tests
- [ ] documentation

## What still need to be fix/done:

- [ ] find a better way to retrieve the original name of the Executor
- [ ] better pasring machanism, something like `__results__` or `__something__` should not be considerate while parsing