### PR TITLE
docs: remove broken api sidebar

### DIFF
--- a/docs/api-rst.rst
+++ b/docs/api-rst.rst
@@ -14,7 +14,6 @@ For further details, please refer to the full :ref:`user guide <executor-cookboo
 
 .. autosummary::
    :nosignatures:
-   :toctree: stubs/flow
    :template: class.rst
 
    base.Flow
@@ -28,7 +27,6 @@ For further details, please refer to the full :ref:`user guide <executor-cookboo
 
 .. autosummary::
    :nosignatures:
-   :toctree: stubs/executor
    :template: class.rst
 
    Executor
@@ -44,7 +42,6 @@ For further details, please refer to the full :ref:`user guide <executor-cookboo
 
 .. autosummary::
    :nosignatures:
-   :toctree: stubs/clients
    :template: class.rst
 
    Client
@@ -64,7 +61,6 @@ For further details, please refer to the full :ref:`user guide <executor-cookboo
 
 .. autosummary::
    :nosignatures:
-   :toctree: stubs/internals
    :template: class.rst
 
    asyncio.AsyncNewLoopRuntime


### PR DESCRIPTION
Goals:

The links in the sidebar of the API reference page were broken. This removes the sidebar until we figure out a way to fix it properly.
