### PR TITLE
feat: expose kwargs to Clients

### DIFF
--- a/jina/clients/base/grpc.py
+++ b/jina/clients/base/grpc.py
@@ -40,7 +40,10 @@ class GRPCBaseClient(BaseClient):
                 stub = jina_pb2_grpc.JinaGatewayDryRunRPCStub(channel)
                 self.logger.debug(f'connected to {self.args.host}:{self.args.port}')
                 call_result = stub.dry_run(
-                    jina_pb2.google_dot_protobuf_dot_empty__pb2.Empty(), **kwargs
+                    jina_pb2.google_dot_protobuf_dot_empty__pb2.Empty(),
+                    metadata=kwargs.get('metadata', None),
+                    credentials=kwargs.get('credentials', None),
+                    timeout=kwargs.get('timeout', None),
                 )
                 metadata, response = (
                     await call_result.trailing_metadata(),
@@ -80,12 +83,14 @@ class GRPCBaseClient(BaseClient):
                 self.logger.debug(f'connected to {self.args.host}:{self.args.port}')
 
                 with ProgressBar(
-                    total_length=self._inputs_length, disable=not (self.show_progress)
+                    total_length=self._inputs_length, disable=not self.show_progress
                 ) as p_bar:
-
                     async for resp in stub.Call(
                         req_iter,
                         compression=self.compression,
+                        metadata=kwargs.get('metadata', None),
+                        credentials=kwargs.get('credentials', None),
+                        timeout=kwargs.get('timeout', None),
                     ):
                         callback_exec(
                             response=resp,

--- a/jina/clients/base/helper.py
+++ b/jina/clients/base/helper.py
@@ -17,26 +17,32 @@ if TYPE_CHECKING:
 class AioHttpClientlet(ABC):
     """aiohttp session manager"""
 
-    def __init__(self, url: str, logger: 'JinaLogger') -> None:
+    def __init__(self, url: str, logger: 'JinaLogger', **kwargs) -> None:
         """HTTP Client to be used with the streamer
 
         :param url: url to send http/websocket request to
         :param logger: jina logger
+        :param kwargs: kwargs  which will be forwarded to the `aiohttp.Session` instance. Used to pass headers to requests
         """
         self.url = url
         self.logger = logger
         self.msg_recv = 0
         self.msg_sent = 0
         self.session = None
+        self._session_kwargs = kwargs
 
     @abstractmethod
-    async def send_message(self):
-        """Send message to Gateway"""
+    async def send_message(self, **kwargs):
+        """Send message to Gateway
+        :param kwargs: kwargs which will be forwarded to the `aiohttp.Session.post` method. Used to pass headers to requests
+        """
         ...
 
     @abstractmethod
-    async def send_dry_run(self):
-        """Query the dry_run endpoint from Gateway"""
+    async def send_dry_run(self, **kwargs):
+        """Query the dry_run endpoint from Gateway
+        :param kwargs: kwargs which will be forwarded to the `aiohttp.Session.post` method. Used to pass headers to requests
+        """
         ...
 
     @abstractmethod
@@ -63,7 +69,7 @@ class AioHttpClientlet(ABC):
         with ImportExtensions(required=True):
             import aiohttp
 
-        self.session = aiohttp.ClientSession()
+        self.session = aiohttp.ClientSession(**self._session_kwargs)
         await self.session.__aenter__()
         return self
 
@@ -206,6 +212,7 @@ class WebsocketClientlet(AioHttpClientlet):
         self.websocket = await self.session.ws_connect(
             url=self.url,
             protocols=(WebsocketSubProtocols.BYTES.value,),
+            **self._session_kwargs,
         ).__aenter__()
         self.response_iter = WsResponseIter(self.websocket)
         return self

--- a/jina/clients/base/helper.py
+++ b/jina/clients/base/helper.py
@@ -29,7 +29,13 @@ class AioHttpClientlet(ABC):
         self.msg_recv = 0
         self.msg_sent = 0
         self.session = None
-        self._session_kwargs = kwargs
+        self._session_kwargs = {}
+        if kwargs.get('headers', None):
+            self._session_kwargs['headers'] = kwargs.get('headers')
+        if kwargs.get('auth', None):
+            self._session_kwargs['auth'] = kwargs.get('auth')
+        if kwargs.get('cookies', None):
+            self._session_kwargs['cookies'] = kwargs.get('cookies')
 
     @abstractmethod
     async def send_message(self, **kwargs):

--- a/jina/clients/base/http.py
+++ b/jina/clients/base/http.py
@@ -44,7 +44,7 @@ class HTTPBaseClient(BaseClient):
     async def _dry_run(self, **kwargs) -> bool:
         """Sends a dry run to the Flow to validate if the Flow is ready to receive requests
 
-        :param kwargs: potential kwargs received passed from the public interface
+        :param kwargs: kwargs coming from the public interface. Includes arguments to be passed to the `HTTPClientlet`
         :return: boolean indicating the health/readiness of the Flow
         """
         from jina.proto import jina_pb2
@@ -54,10 +54,10 @@ class HTTPBaseClient(BaseClient):
                 proto = 'https' if self.args.tls else 'http'
                 url = f'{proto}://{self.args.host}:{self.args.port}/dry_run'
                 iolet = await stack.enter_async_context(
-                    HTTPClientlet(url=url, logger=self.logger)
+                    HTTPClientlet(url=url, logger=self.logger, **kwargs)
                 )
 
-                response = await iolet.send_dry_run()
+                response = await iolet.send_dry_run(**kwargs)
                 r_status = response.status
 
                 r_str = await response.json()
@@ -83,7 +83,7 @@ class HTTPBaseClient(BaseClient):
         :param on_done: the callback for on_done
         :param on_error: the callback for on_error
         :param on_always: the callback for on_always
-        :param kwargs: kwargs for _get_task_name and _get_requests
+        :param kwargs: kwargs coming from the public interface. Includes arguments to be passed to the `HTTPClientlet`
         :yields: generator over results
         """
         with ImportExtensions(required=True):
@@ -102,7 +102,7 @@ class HTTPBaseClient(BaseClient):
                 proto = 'https' if self.args.tls else 'http'
                 url = f'{proto}://{self.args.host}:{self.args.port}/post'
                 iolet = await stack.enter_async_context(
-                    HTTPClientlet(url=url, logger=self.logger)
+                    HTTPClientlet(url=url, logger=self.logger, **kwargs)
                 )
 
                 def _request_handler(request: 'Request') -> 'asyncio.Future':

--- a/jina/clients/base/websocket.py
+++ b/jina/clients/base/websocket.py
@@ -25,7 +25,7 @@ class WebSocketBaseClient(BaseClient):
     async def _dry_run(self, **kwargs) -> bool:
         """Sends a dry run to the Flow to validate if the Flow is ready to receive requests
 
-        :param kwargs: potential kwargs received passed from the public interface
+        :param kwargs: kwargs coming from the public interface. Includes arguments to be passed to the `WebsocketClientlet`
         :return: boolean indicating the readiness of the Flow
         """
         async with AsyncExitStack() as stack:
@@ -33,7 +33,7 @@ class WebSocketBaseClient(BaseClient):
                 proto = 'wss' if self.args.tls else 'ws'
                 url = f'{proto}://{self.args.host}:{self.args.port}/dry_run'
                 iolet = await stack.enter_async_context(
-                    WebsocketClientlet(url=url, logger=self.logger)
+                    WebsocketClientlet(url=url, logger=self.logger, **kwargs)
                 )
 
                 async def _receive():
@@ -84,7 +84,7 @@ class WebSocketBaseClient(BaseClient):
         :param on_done: the callback for on_done
         :param on_error: the callback for on_error
         :param on_always: the callback for on_always
-        :param kwargs: kwargs for _get_task_name and _get_requests
+        :param kwargs: kwargs coming from the public interface. Includes arguments to be passed to the `WebsocketClientlet`
         :yields: generator over results
         """
         with ImportExtensions(required=True):
@@ -103,7 +103,7 @@ class WebSocketBaseClient(BaseClient):
                 proto = 'wss' if self.args.tls else 'ws'
                 url = f'{proto}://{self.args.host}:{self.args.port}/'
                 iolet = await stack.enter_async_context(
-                    WebsocketClientlet(url=url, logger=self.logger)
+                    WebsocketClientlet(url=url, logger=self.logger, **kwargs)
                 )
 
                 request_buffer: Dict[

--- a/jina/clients/mixin.py
+++ b/jina/clients/mixin.py
@@ -7,7 +7,7 @@ from jina.helper import get_or_reuse_loop, run_async
 from jina.importer import ImportExtensions
 
 if TYPE_CHECKING:
-    from jina import DocumentArray
+    from docarray import DocumentArray
     from jina.clients.base import CallbackFnType, InputType
     from jina.types.request import Response
 
@@ -221,7 +221,7 @@ class AsyncPostMixin:
         :param show_progress: if set, client will show a progress bar on receiving every request.
         :param continue_on_error: if set, a Request that causes callback error will be logged only without blocking the further requests.
         :param return_responses: if set to True, the result will come as Response and not as a `DocumentArray`
-        :param kwargs: additional parameters
+        :param kwargs: additional parameters, can be used to pass metadata or authentication information in the server call
         :yield: Response object
 
         .. warning::

--- a/tests/integration/clients_extra_kwargs/test_clients_post_extra_kwargs.py
+++ b/tests/integration/clients_extra_kwargs/test_clients_post_extra_kwargs.py
@@ -1,0 +1,86 @@
+import os
+
+import grpc
+import pytest
+
+from jina import Flow, __default_host__
+from jina.clients import Client
+from jina.excepts import PortAlreadyUsed
+from jina.helper import is_port_free
+from jina.serve.runtimes.gateway.grpc import GRPCGatewayRuntime as _GRPCGatewayRuntime
+from tests import random_docs
+
+
+@pytest.fixture(scope='function')
+def flow_with_grpc(monkeypatch):
+    class AuthInterceptor(grpc.aio.ServerInterceptor):
+        def __init__(self, key):
+            self._valid_metadata = ('rpc-auth-header', key)
+
+            def deny(_, context):
+                context.abort(grpc.StatusCode.UNAUTHENTICATED, 'Invalid key')
+
+            self._deny = grpc.unary_unary_rpc_method_handler(deny)
+
+        async def intercept_service(self, continuation, handler_call_details):
+            meta = handler_call_details.invocation_metadata
+
+            metas_dicts = {m.key: m.value for m in meta}
+            assert 'rpc-auth-header' in metas_dicts
+            assert (
+                metas_dicts['rpc-auth-header'] == 'access_key'
+            ), f'Invalid access key detected, got {metas_dicts["rpc-auth-header"]}'
+
+            for m in meta:
+                if m == self._valid_metadata:
+                    return await continuation(handler_call_details)
+
+            return self._deny
+
+    class AlternativeGRPCGatewayRuntime(_GRPCGatewayRuntime):
+        async def async_setup(self):
+            """
+            The async method to setup.
+            Create the gRPC server and expose the port for communication.
+            """
+            if not self.args.proxy and os.name != 'nt':
+                os.unsetenv('http_proxy')
+                os.unsetenv('https_proxy')
+
+            if not (is_port_free(__default_host__, self.args.port)):
+                raise PortAlreadyUsed(f'port:{self.args.port}')
+
+            self.server = grpc.aio.server(
+                interceptors=(AuthInterceptor('access_key'),),
+                options=[
+                    ('grpc.max_send_message_length', -1),
+                    ('grpc.max_receive_message_length', -1),
+                ],
+            )
+
+            self._set_topology_graph()
+            self._set_connection_pool()
+
+            await self._async_setup_server()
+
+    monkeypatch.setattr(
+        'jina.serve.runtimes.gateway.grpc.GRPCGatewayRuntime',
+        AlternativeGRPCGatewayRuntime,
+    )
+    return Flow(protocol='grpc').add()
+
+
+def test_client_grpc_kwargs(flow_with_grpc):
+    with flow_with_grpc:
+        client = Client(
+            port=flow_with_grpc.port,
+            host='localhost',
+            protocol='grpc',
+        )
+
+        meta_data = (('rpc-auth-header', 'invalid_access_key'),)
+
+        try:
+            client.post('', random_docs(1), request_size=1, metadata=meta_data)
+        except Exception as exc:
+            assert 'Invalid access key detected, got invalid_access_key' in repr(exc)

--- a/tests/unit/clients/python/test_client.py
+++ b/tests/unit/clients/python/test_client.py
@@ -3,12 +3,10 @@ import time
 
 import pytest
 import requests
-from docarray import Document, DocumentArray
 
-from jina import Executor, Flow, __windows__, helper
+from jina import Executor, Flow, helper
 from jina import requests as req
 from jina.clients import Client
-from jina.excepts import BadClientInput
 from jina.orchestrate.pods.factory import PodFactory
 from jina.parsers import set_gateway_parser
 from tests import random_docs

--- a/tests/unit/clients/python/test_on_err.py
+++ b/tests/unit/clients/python/test_on_err.py
@@ -1,12 +1,11 @@
 from typing import Optional
 
 import aiohttp
-import grpc
 import numpy as np
 import pytest
-from docarray import DocumentArray
 from docarray.document.generators import from_ndarray
 
+from docarray import DocumentArray
 from jina import Client, Flow
 from jina.excepts import BadClientCallback
 

--- a/tests/unit/clients/test_helper.py
+++ b/tests/unit/clients/test_helper.py
@@ -1,9 +1,10 @@
 import aiohttp
 import pytest
-from jina import Flow, Executor, requests
-from jina.logging.logger import JinaLogger
-from jina.clients.request.helper import _new_data_request
+
+from jina import Executor, Flow, requests
 from jina.clients.base.helper import HTTPClientlet, WebsocketClientlet
+from jina.clients.request.helper import _new_data_request
+from jina.logging.logger import JinaLogger
 from jina.types.request.data import DataRequest
 
 logger = JinaLogger('clientlet')


### PR DESCRIPTION
Goals:

Allow the Client to send `header` and any other `auth` information to the server to be captured by some Proxy service

- [x] For HTTP
- [x] For Websocket
- [x] For GRPC
- [ ] Add tests
- [ ] Add Documentation