### PR TITLE
feat: allow to load parameters from jina data request proto wo loading the full docs

### DIFF
--- a/jina/__init__.py
+++ b/jina/__init__.py
@@ -68,7 +68,7 @@ __version__ = '3.6.5'
 
 # do not change this line manually
 # this is managed by proto/build-proto.sh and updated on every execution
-__proto_version__ = '0.1.12'
+__proto_version__ = '0.1.13'
 
 try:
     __docarray_version__ = _docarray.__version__

--- a/jina/proto/jina.proto
+++ b/jina/proto/jina.proto
@@ -121,6 +121,17 @@ message DataRequestProto {
     DataContentProto data = 4; // container for docs and groundtruths
 }
 
+message DataRequestProtoWoDocs {
+
+    HeaderProto header = 1; // header contains meta info defined by the user
+
+    google.protobuf.Struct parameters = 2; // extra kwargs that will be used in executor
+
+    repeated RouteProto routes = 3; // status info on every routes
+
+}
+
+
 /**
  * Represents a list of data requests
  * This should be replaced by streaming

--- a/jina/proto/jina_pb2.py
+++ b/jina/proto/jina_pb2.py
@@ -18,7 +18,7 @@ from google.protobuf import empty_pb2 as google_dot_protobuf_dot_empty__pb2
 from google.protobuf import struct_pb2 as google_dot_protobuf_dot_struct__pb2
 from google.protobuf import timestamp_pb2 as google_dot_protobuf_dot_timestamp__pb2
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\njina.proto\x12\x04jina\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1cgoogle/protobuf/struct.proto\x1a\x1bgoogle/protobuf/empty.proto\x1a\x0e\x64ocarray.proto\"\x9f\x01\n\nRouteProto\x12\x10\n\x08\x65xecutor\x18\x01 \x01(\t\x12.\n\nstart_time\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12,\n\x08\x65nd_time\x18\x03 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12!\n\x06status\x18\x04 \x01(\x0b\x32\x11.jina.StatusProto\"\xc3\x01\n\rJinaInfoProto\x12+\n\x04jina\x18\x01 \x03(\x0b\x32\x1d.jina.JinaInfoProto.JinaEntry\x12+\n\x04\x65nvs\x18\x02 \x03(\x0b\x32\x1d.jina.JinaInfoProto.EnvsEntry\x1a+\n\tJinaEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\x1a+\n\tEnvsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"\xc6\x01\n\x0bHeaderProto\x12\x12\n\nrequest_id\x18\x01 \x01(\t\x12!\n\x06status\x18\x02 \x01(\x0b\x32\x11.jina.StatusProto\x12\x1a\n\rexec_endpoint\x18\x03 \x01(\tH\x00\x88\x01\x01\x12\x1c\n\x0ftarget_executor\x18\x04 \x01(\tH\x01\x88\x01\x01\x12\x14\n\x07timeout\x18\x05 \x01(\rH\x02\x88\x01\x01\x42\x10\n\x0e_exec_endpointB\x12\n\x10_target_executorB\n\n\x08_timeout\"#\n\x0e\x45ndpointsProto\x12\x11\n\tendpoints\x18\x01 \x03(\t\"\xf9\x01\n\x0bStatusProto\x12*\n\x04\x63ode\x18\x01 \x01(\x0e\x32\x1c.jina.StatusProto.StatusCode\x12\x13\n\x0b\x64\x65scription\x18\x02 \x01(\t\x12\x33\n\texception\x18\x03 \x01(\x0b\x32 .jina.StatusProto.ExceptionProto\x1aN\n\x0e\x45xceptionProto\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0c\n\x04\x61rgs\x18\x02 \x03(\t\x12\x0e\n\x06stacks\x18\x03 \x03(\t\x12\x10\n\x08\x65xecutor\x18\x04 \x01(\t\"$\n\nStatusCode\x12\x0b\n\x07SUCCESS\x10\x00\x12\t\n\x05\x45RROR\x10\x01\"^\n\rRelatedEntity\x12\n\n\x02id\x18\x01 \x01(\t\x12\x0f\n\x07\x61\x64\x64ress\x18\x02 \x01(\t\x12\x0c\n\x04port\x18\x03 \x01(\r\x12\x15\n\x08shard_id\x18\x04 \x01(\rH\x00\x88\x01\x01\x42\x0b\n\t_shard_id\"\xa0\x02\n\x10\x44\x61taRequestProto\x12!\n\x06header\x18\x01 \x01(\x0b\x32\x11.jina.HeaderProto\x12+\n\nparameters\x18\x02 \x01(\x0b\x32\x17.google.protobuf.Struct\x12 \n\x06routes\x18\x03 \x03(\x0b\x32\x10.jina.RouteProto\x12\x35\n\x04\x64\x61ta\x18\x04 \x01(\x0b\x32\'.jina.DataRequestProto.DataContentProto\x1a\x63\n\x10\x44\x61taContentProto\x12,\n\x04\x64ocs\x18\x01 \x01(\x0b\x32\x1c.docarray.DocumentArrayProtoH\x00\x12\x14\n\ndocs_bytes\x18\x02 \x01(\x0cH\x00\x42\x0b\n\tdocuments\"@\n\x14\x44\x61taRequestListProto\x12(\n\x08requests\x18\x01 \x03(\x0b\x32\x16.jina.DataRequestProto2Z\n\x12JinaDataRequestRPC\x12\x44\n\x0cprocess_data\x12\x1a.jina.DataRequestListProto\x1a\x16.jina.DataRequestProto\"\x00\x32\x63\n\x18JinaSingleDataRequestRPC\x12G\n\x13process_single_data\x12\x16.jina.DataRequestProto\x1a\x16.jina.DataRequestProto\"\x00\x32G\n\x07JinaRPC\x12<\n\x04\x43\x61ll\x12\x16.jina.DataRequestProto\x1a\x16.jina.DataRequestProto\"\x00(\x01\x30\x01\x32`\n\x18JinaDiscoverEndpointsRPC\x12\x44\n\x12\x65ndpoint_discovery\x12\x16.google.protobuf.Empty\x1a\x14.jina.EndpointsProto\"\x00\x32N\n\x14JinaGatewayDryRunRPC\x12\x36\n\x07\x64ry_run\x12\x16.google.protobuf.Empty\x1a\x11.jina.StatusProto\"\x00\x32G\n\x0bJinaInfoRPC\x12\x38\n\x07_status\x12\x16.google.protobuf.Empty\x1a\x13.jina.JinaInfoProto\"\x00\x62\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\njina.proto\x12\x04jina\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1cgoogle/protobuf/struct.proto\x1a\x1bgoogle/protobuf/empty.proto\x1a\x0e\x64ocarray.proto\"\x9f\x01\n\nRouteProto\x12\x10\n\x08\x65xecutor\x18\x01 \x01(\t\x12.\n\nstart_time\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12,\n\x08\x65nd_time\x18\x03 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12!\n\x06status\x18\x04 \x01(\x0b\x32\x11.jina.StatusProto\"\xc3\x01\n\rJinaInfoProto\x12+\n\x04jina\x18\x01 \x03(\x0b\x32\x1d.jina.JinaInfoProto.JinaEntry\x12+\n\x04\x65nvs\x18\x02 \x03(\x0b\x32\x1d.jina.JinaInfoProto.EnvsEntry\x1a+\n\tJinaEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\x1a+\n\tEnvsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"\xc6\x01\n\x0bHeaderProto\x12\x12\n\nrequest_id\x18\x01 \x01(\t\x12!\n\x06status\x18\x02 \x01(\x0b\x32\x11.jina.StatusProto\x12\x1a\n\rexec_endpoint\x18\x03 \x01(\tH\x00\x88\x01\x01\x12\x1c\n\x0ftarget_executor\x18\x04 \x01(\tH\x01\x88\x01\x01\x12\x14\n\x07timeout\x18\x05 \x01(\rH\x02\x88\x01\x01\x42\x10\n\x0e_exec_endpointB\x12\n\x10_target_executorB\n\n\x08_timeout\"#\n\x0e\x45ndpointsProto\x12\x11\n\tendpoints\x18\x01 \x03(\t\"\xf9\x01\n\x0bStatusProto\x12*\n\x04\x63ode\x18\x01 \x01(\x0e\x32\x1c.jina.StatusProto.StatusCode\x12\x13\n\x0b\x64\x65scription\x18\x02 \x01(\t\x12\x33\n\texception\x18\x03 \x01(\x0b\x32 .jina.StatusProto.ExceptionProto\x1aN\n\x0e\x45xceptionProto\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0c\n\x04\x61rgs\x18\x02 \x03(\t\x12\x0e\n\x06stacks\x18\x03 \x03(\t\x12\x10\n\x08\x65xecutor\x18\x04 \x01(\t\"$\n\nStatusCode\x12\x0b\n\x07SUCCESS\x10\x00\x12\t\n\x05\x45RROR\x10\x01\"^\n\rRelatedEntity\x12\n\n\x02id\x18\x01 \x01(\t\x12\x0f\n\x07\x61\x64\x64ress\x18\x02 \x01(\t\x12\x0c\n\x04port\x18\x03 \x01(\r\x12\x15\n\x08shard_id\x18\x04 \x01(\rH\x00\x88\x01\x01\x42\x0b\n\t_shard_id\"\xa0\x02\n\x10\x44\x61taRequestProto\x12!\n\x06header\x18\x01 \x01(\x0b\x32\x11.jina.HeaderProto\x12+\n\nparameters\x18\x02 \x01(\x0b\x32\x17.google.protobuf.Struct\x12 \n\x06routes\x18\x03 \x03(\x0b\x32\x10.jina.RouteProto\x12\x35\n\x04\x64\x61ta\x18\x04 \x01(\x0b\x32\'.jina.DataRequestProto.DataContentProto\x1a\x63\n\x10\x44\x61taContentProto\x12,\n\x04\x64ocs\x18\x01 \x01(\x0b\x32\x1c.docarray.DocumentArrayProtoH\x00\x12\x14\n\ndocs_bytes\x18\x02 \x01(\x0cH\x00\x42\x0b\n\tdocuments\"\x8a\x01\n\x16\x44\x61taRequestProtoWoDocs\x12!\n\x06header\x18\x01 \x01(\x0b\x32\x11.jina.HeaderProto\x12+\n\nparameters\x18\x02 \x01(\x0b\x32\x17.google.protobuf.Struct\x12 \n\x06routes\x18\x03 \x03(\x0b\x32\x10.jina.RouteProto\"@\n\x14\x44\x61taRequestListProto\x12(\n\x08requests\x18\x01 \x03(\x0b\x32\x16.jina.DataRequestProto2Z\n\x12JinaDataRequestRPC\x12\x44\n\x0cprocess_data\x12\x1a.jina.DataRequestListProto\x1a\x16.jina.DataRequestProto\"\x00\x32\x63\n\x18JinaSingleDataRequestRPC\x12G\n\x13process_single_data\x12\x16.jina.DataRequestProto\x1a\x16.jina.DataRequestProto\"\x00\x32G\n\x07JinaRPC\x12<\n\x04\x43\x61ll\x12\x16.jina.DataRequestProto\x1a\x16.jina.DataRequestProto\"\x00(\x01\x30\x01\x32`\n\x18JinaDiscoverEndpointsRPC\x12\x44\n\x12\x65ndpoint_discovery\x12\x16.google.protobuf.Empty\x1a\x14.jina.EndpointsProto\"\x00\x32N\n\x14JinaGatewayDryRunRPC\x12\x36\n\x07\x64ry_run\x12\x16.google.protobuf.Empty\x1a\x11.jina.StatusProto\"\x00\x32G\n\x0bJinaInfoRPC\x12\x38\n\x07_status\x12\x16.google.protobuf.Empty\x1a\x13.jina.JinaInfoProto\"\x00\x62\x06proto3')
 
 
 
@@ -33,6 +33,7 @@ _STATUSPROTO_EXCEPTIONPROTO = _STATUSPROTO.nested_types_by_name['ExceptionProto'
 _RELATEDENTITY = DESCRIPTOR.message_types_by_name['RelatedEntity']
 _DATAREQUESTPROTO = DESCRIPTOR.message_types_by_name['DataRequestProto']
 _DATAREQUESTPROTO_DATACONTENTPROTO = _DATAREQUESTPROTO.nested_types_by_name['DataContentProto']
+_DATAREQUESTPROTOWODOCS = DESCRIPTOR.message_types_by_name['DataRequestProtoWoDocs']
 _DATAREQUESTLISTPROTO = DESCRIPTOR.message_types_by_name['DataRequestListProto']
 _STATUSPROTO_STATUSCODE = _STATUSPROTO.enum_types_by_name['StatusCode']
 RouteProto = _reflection.GeneratedProtocolMessageType('RouteProto', (_message.Message,), {
@@ -116,6 +117,13 @@ DataRequestProto = _reflection.GeneratedProtocolMessageType('DataRequestProto', 
 _sym_db.RegisterMessage(DataRequestProto)
 _sym_db.RegisterMessage(DataRequestProto.DataContentProto)
 
+DataRequestProtoWoDocs = _reflection.GeneratedProtocolMessageType('DataRequestProtoWoDocs', (_message.Message,), {
+  'DESCRIPTOR' : _DATAREQUESTPROTOWODOCS,
+  '__module__' : 'jina_pb2'
+  # @@protoc_insertion_point(class_scope:jina.DataRequestProtoWoDocs)
+  })
+_sym_db.RegisterMessage(DataRequestProtoWoDocs)
+
 DataRequestListProto = _reflection.GeneratedProtocolMessageType('DataRequestListProto', (_message.Message,), {
   'DESCRIPTOR' : _DATAREQUESTLISTPROTO,
   '__module__' : 'jina_pb2'
@@ -160,18 +168,20 @@ if _descriptor._USE_C_DESCRIPTORS == False:
   _DATAREQUESTPROTO._serialized_end=1363
   _DATAREQUESTPROTO_DATACONTENTPROTO._serialized_start=1264
   _DATAREQUESTPROTO_DATACONTENTPROTO._serialized_end=1363
-  _DATAREQUESTLISTPROTO._serialized_start=1365
-  _DATAREQUESTLISTPROTO._serialized_end=1429
-  _JINADATAREQUESTRPC._serialized_start=1431
-  _JINADATAREQUESTRPC._serialized_end=1521
-  _JINASINGLEDATAREQUESTRPC._serialized_start=1523
-  _JINASINGLEDATAREQUESTRPC._serialized_end=1622
-  _JINARPC._serialized_start=1624
-  _JINARPC._serialized_end=1695
-  _JINADISCOVERENDPOINTSRPC._serialized_start=1697
-  _JINADISCOVERENDPOINTSRPC._serialized_end=1793
-  _JINAGATEWAYDRYRUNRPC._serialized_start=1795
-  _JINAGATEWAYDRYRUNRPC._serialized_end=1873
-  _JINAINFORPC._serialized_start=1875
-  _JINAINFORPC._serialized_end=1946
+  _DATAREQUESTPROTOWODOCS._serialized_start=1366
+  _DATAREQUESTPROTOWODOCS._serialized_end=1504
+  _DATAREQUESTLISTPROTO._serialized_start=1506
+  _DATAREQUESTLISTPROTO._serialized_end=1570
+  _JINADATAREQUESTRPC._serialized_start=1572
+  _JINADATAREQUESTRPC._serialized_end=1662
+  _JINASINGLEDATAREQUESTRPC._serialized_start=1664
+  _JINASINGLEDATAREQUESTRPC._serialized_end=1763
+  _JINARPC._serialized_start=1765
+  _JINARPC._serialized_end=1836
+  _JINADISCOVERENDPOINTSRPC._serialized_start=1838
+  _JINADISCOVERENDPOINTSRPC._serialized_end=1934
+  _JINAGATEWAYDRYRUNRPC._serialized_start=1936
+  _JINAGATEWAYDRYRUNRPC._serialized_end=2014
+  _JINAINFORPC._serialized_start=2016
+  _JINAINFORPC._serialized_end=2087
 # @@protoc_insertion_point(module_scope)

--- a/jina/types/request/data.py
+++ b/jina/types/request/data.py
@@ -98,6 +98,8 @@ class DataRequest(Request):
         request: Optional[RequestSourceType] = None,
     ):
         self.buffer = None
+        self._buffer_when_load_wo_data = None
+
         try:
             if isinstance(request, jina_pb2.DataRequestProto):
                 self._pb_body = request
@@ -123,27 +125,81 @@ class DataRequest(Request):
     @property
     def is_decompressed(self) -> bool:
         """
-        Checks if the underlying proto object was already deserialized
-
-        :return: True if the proto was deserialized before
+        Checks if the underlying proto object was already deserialized into a :class:`jina.proto.jina_pb2.DataRequestProto`
+        or a :class:`jina.proto.jina_pb2.DataRequestProtoWoDocs`
+           :return: True if the proto was deserialized before
         """
         return self.buffer is None
 
     @property
-    def proto(self) -> 'jina_pb2.DataRequestProto':
+    def is_decompressed_wo_data(self) -> bool:
         """
-        Cast ``self`` to a :class:`jina_pb2.DataRequestProto`. Laziness will be broken and serialization will be recomputed when calling
-        :meth:`SerializeToString`.
-        :return: protobuf instance
+        Checks if the underlying proto object was already deserialized into a :class:`jina.proto.jina_pb2.DataRequestProtoWoDocs` i,e
+         a DataRequest without docs
+
+        :return: True if the proto was deserialized before into a DataRequest without docs
+        """
+        return self.is_decompressed and self._buffer_when_load_wo_data is not None
+
+    @property
+    def proto_wo_data(self) -> 'jina_pb2.DataRequestProtoWoDocs':
+        """
+        Transform the current buffer to a :class:`jina_pb2.DataRequestProtoWoDocs`. Laziness will be broken and
+        serialization will be recomputed when calling :meth:`SerializeToString`. :return: protobuf instance
+        :return: DataRequestProtoWoDocs protobuf instance
         """
         if not self.is_decompressed:
-            self._decompress()
+            self._decompress_wo_data()
         return self._pb_body
 
+    @property
+    def proto(self) -> 'jina_pb2.DataRequestProto':
+        """
+        Cast ``self`` to a :class:`jina_pb2.DataRequestProto`. Laziness will be broken and serialization will be recomputed when calling.
+        Under the hood it is calling :meth:`jina.types.request.data.DataRequest.proto_wo_data`. This method is keep for legacy.
+        :meth:`SerializeToString`.
+        :return: DataRequestProto protobuf instance
+        """
+        return self.proto_data
+
+    @property
+    def proto_data(self) -> 'jina_pb2.DataRequestProto':
+        """
+        Transform the current buffer to a :class:`jina_pb2.DataRequestProto`. Laziness will be broken and
+        serialization will be recomputed when calling :meth:`SerializeToString`. :return: protobuf instance
+        :return: DataRequestProto protobuf instance
+        """
+        if not self.is_decompressed:
+            if self.is_decompressed_wo_data:
+                self._decompress_from_wo_data_buffer()
+            else:
+                self._decompress()
+        return self._pb_body
+
+    def _decompress_wo_data(self):
+        """Decompress the buffer into a DataRequestProto without docs, it is useful if one want to access the parameters
+        or the header of the proto without the cost of deserializing the Docs."""
+
+        # Under the hood it used a different DataRequestProto (the DataRequestProtoWoDocs) that will just ignore the
+        # bytes from the bytes related to the docs that are store at the end of the Proto buffer
+
+        self._pb_body = jina_pb2.DataRequestProtoWoDocs()
+        self._pb_body.ParseFromString(self.buffer)
+        self._buffer_when_load_wo_data = self.buffer
+        self.buffer = None
+
     def _decompress(self):
+        """Decompress the buffer into a DataRequestProto"""
         self._pb_body = jina_pb2.DataRequestProto()
         self._pb_body.ParseFromString(self.buffer)
         self.buffer = None
+
+    def _decompress_from_wo_data_buffer(self):
+        """Decompress the buffer into a DataRequestProto when the buffer has already been deserialized into a
+        DataRequestProtoWoDocs"""
+        self._pb_body = jina_pb2.DataRequestProto()
+        self._pb_body.ParseFromString(self._buffer_when_load_wo_data)
+        self._buffer_when_load_wo_data = None
 
     def to_dict(self) -> Dict:
         """Return the object in Python dictionary.
@@ -173,7 +229,7 @@ class DataRequest(Request):
 
     @cached_property
     def data(self) -> 'DataRequest._DataContent':
-        """Get the data contaned in this data request
+        """Get the data contained in this data request
 
         :return: the data content as an instance of _DataContent wrapping docs
         """
@@ -185,7 +241,7 @@ class DataRequest(Request):
         :return: a Python dict view of the parameters.
         """
         # if u get this u need to have it decompressed
-        return json_format.MessageToDict(self.proto.parameters)
+        return json_format.MessageToDict(self.proto_wo_data.parameters)
 
     @parameters.setter
     def parameters(self, value: Dict):
@@ -211,7 +267,7 @@ class DataRequest(Request):
 
         :return: the status object of this request
         """
-        return self.proto.header.status
+        return self.proto_wo_data.header.status
 
     @property
     def request_id(self):


### PR DESCRIPTION
# Context:

Right now there is no way to access the parameters from a `DataRequest` without deserializing the docs which is costly.

What we have now is the lazy loading of the proto which allow to pass the DataRequest from the Gateway to the Executor without any proto deserialization unless we directly call one of the field in which case the deserialization will be done lazily.

This is not enough and we need to be able to only deserialize the header and the parameters of the proto without paying the cost of the docs deserialization.

This will be useful for this [PR](https://github.com/jina-ai/jina/pull/4939) where we  want to modify the parameters on the fly without touching the docs.

## What this PR do:

- [ ] Add a new proto `DataRequestWoDocs` which will be used when we don't need the docs
- [ ] Parameters/Header access use the `DataRequestWoDocs` at lazy deserialization 
- [ ] tests
- [ ] Documentation

