### PR TITLE
fix: use secret if logged in user provided it explicitly

### DIFF
--- a/docs/fundamentals/executor/hub/push-executor.md
+++ b/docs/fundamentals/executor/hub/push-executor.md
@@ -21,16 +21,16 @@ jina hub push [--public/--private] <path_to_executor_folder>
 
 It will return `NAME` & `SECRET`, which you will need to use (if the Executor is private) or update the Executor. **Please keep them carefully.**
 
+````{admonition} Note
+:class: note
+If you are logged in to the Hub using our CLI tools (`jina auth login` or `jcloud login`), you can push and pull your executors without `SECRET`.
+````
+
 You can then visit [the Hub portal](https://hub.jina.ai), click on the "Recent" tab and see your published Executor.
 
 ````{admonition} Note
 :class: note
 If no `--public` or `--private` argument is provided, then it is **public** by default.
-````
-
-````{admonition} Note
-:class: note
-If you are logged in to the Hub using our CLI tools (`jina auth login` or `jcloud login`), you can push and pull your executors without `SECRET`.
 ````
 
 ````{admonition} Important

--- a/docs/fundamentals/executor/hub/push-executor.md
+++ b/docs/fundamentals/executor/hub/push-executor.md
@@ -28,6 +28,11 @@ You can then visit [the Hub portal](https://hub.jina.ai), click on the "Recent" 
 If no `--public` or `--private` argument is provided, then it is **public** by default.
 ````
 
+````{admonition} Note
+:class: note
+If you are logged in to the Hub using our CLI tools (`jina auth login` or `jcloud login`), you can push and pull your executors without `SECRET`.
+````
+
 ````{admonition} Important
 :class: important
 Anyone can use public Executors, but to use a private Executor you must know its `SECRET`.

--- a/jina/hubble/hubio.py
+++ b/jina/hubble/hubio.py
@@ -406,6 +406,7 @@ metas:
                 )
 
                 image = None
+                warning = None
                 session_id = req_header.get('jinameta-session-id')
                 for stream_line in resp.iter_lines():
                     stream_msg = json.loads(stream_line)
@@ -439,6 +440,7 @@ metas:
                         )
                     elif t == 'complete':
                         image = stream_msg['payload']
+                        warning = stream_msg.get('warning')
                         st.update(
                             f'Cloud building ... [dim]{subject}: {t} ({stream_msg["message"]})[/dim]'
                         )
@@ -454,7 +456,9 @@ metas:
                             )
 
                 if image:
-                    new_uuid8, new_secret = self._prettyprint_result(console, image)
+                    new_uuid8, new_secret = self._prettyprint_result(
+                        console, image, warning=warning
+                    )
                     if new_uuid8 != uuid8 or new_secret != secret:
                         dump_secret(work_path, new_uuid8, new_secret or '')
                 else:
@@ -469,7 +473,7 @@ metas:
                 )
                 raise e
 
-    def _prettyprint_result(self, console, image):
+    def _prettyprint_result(self, console, image, *, warning: Optional[str] = None):
         # TODO: only support single executor now
 
         from rich import box
@@ -500,6 +504,12 @@ metas:
             )
 
         table.add_row(':eyes: Visibility', visibility)
+
+        if warning:
+            table.add_row(
+                ':warning: Warning',
+                f':exclamation:️ [bold yellow]{warning}',
+            )
 
         p1 = Panel(
             table,


### PR DESCRIPTION
Goals:

- [x] Show warning message.
   Hubble API changed to respect/use secret if logged in user provided it explicitly.
   And returns warning message if it happens. So with this PR, user will see warning like below:

![Screenshot 2022-06-27 at 17 30 52](https://user-images.githubusercontent.com/492616/175988744-d3a1f472-f245-4c79-a0f3-d3af19bb189d.png)

- [x] ~~Write documentation on integration between user accounts and `jina hub push/pull`.~~
- [x] check and update documentation. See [guide](https://github.com/jina-ai/jina/CONTRIBUTING.md#documentation-guidelines) and ask the team.

Related https://github.com/jina-ai/hubble/pull/476, https://github.com/jina-ai/hubble/issues/431