### PR TITLE
test: add communication test with old jina version

### DIFF
--- a/tests/proto/old_server_version/Dockerfile
+++ b/tests/proto/old_server_version/Dockerfile
@@ -1,0 +1,10 @@
+ARG JINA_VERSION=latest
+
+FROM jinaai/jina:${JINA_VERSION}
+
+WORKDIR /app
+
+ADD flow.yml flow.yml
+ADD exec.py exec.py
+
+ENTRYPOINT ["jina", "flow", "--uses", "flow.yml"]

--- a/tests/proto/old_server_version/exec.py
+++ b/tests/proto/old_server_version/exec.py
@@ -1,0 +1,10 @@
+from docarray import Document, DocumentArray
+
+from jina import Executor, requests
+
+
+class TestExecutor(Executor):
+    @requests
+    def foo(self, docs: DocumentArray, parameters, **kwargs):
+        assert docs is not None
+        assert parameters is not None

--- a/tests/proto/old_server_version/flow.yml
+++ b/tests/proto/old_server_version/flow.yml
@@ -1,0 +1,7 @@
+jtype: Flow
+with:
+  port: 8080
+executors:
+  - name: myexec1
+    uses: TestExecutor
+    py_modules: exec.py

--- a/tests/proto/test_proto.py
+++ b/tests/proto/test_proto.py
@@ -1,0 +1,9 @@
+from docarray import Document, DocumentArray
+
+from jina import Client
+
+
+def test_new_client_old_proto():  # need to build and start old server docker
+    client = Client(port=8080)
+
+    client.index(DocumentArray([Document(text='hello') for _ in range(10)]))


### PR DESCRIPTION
# Context

It could be nice to try to communicate with the old gateway (using latest docker image which should refer to the last release version on pypi)

# What this pr do

add a draft test. 