### PR TITLE
fix(hubble): fix the way to generate executor name of the func hub pull

### DIFF
--- a/jina/hubble/hubio.py
+++ b/jina/hubble/hubio.py
@@ -787,7 +787,7 @@ metas:
                     force=need_pull,
                 )
 
-                presented_id = getattr(executor, 'name') if getattr(executor, 'name') is not None else executor.uuid
+                presented_id = executor.name if executor.name else executor.uuid
                 executor_name = (
                     f'{presented_id}'
                     if executor.visibility == 'public' or not secret

--- a/jina/hubble/hubio.py
+++ b/jina/hubble/hubio.py
@@ -787,7 +787,7 @@ metas:
                     force=need_pull,
                 )
 
-                presented_id = getattr(executor, 'name', executor.uuid)
+                presented_id = getattr(executor, 'name') if getattr(executor, 'name') is not None else executor.uuid
                 executor_name = (
                     f'{presented_id}'
                     if executor.visibility == 'public' or not secret

--- a/tests/unit/hubble/test_hubio.py
+++ b/tests/unit/hubble/test_hubio.py
@@ -375,8 +375,8 @@ class DownloadMockResponse:
     def status_code(self):
         return self.response_code
 
-@pytest.mark.parametrize('executer_name', ['alias_dummy',None])
-def test_pull(test_envs, mocker, monkeypatch, executer_name):
+@pytest.mark.parametrize('executor_name', ['alias_dummy', None])
+def test_pull(test_envs, mocker, monkeypatch, executor_name):
     mock = mocker.Mock()
 
     def _mock_fetch(
@@ -391,7 +391,7 @@ def test_pull(test_envs, mocker, monkeypatch, executer_name):
         return (
             HubExecutor(
                 uuid='dummy_mwu_encoder',
-                name=executer_name,
+                name=executor_name,
                 tag='v0',
                 image_name='jinahub/pod.dummy_mwu_encoder',
                 md5sum=None,
@@ -419,8 +419,9 @@ def test_pull(test_envs, mocker, monkeypatch, executer_name):
     def _mock_get_prettyprint_usage(self,console, executor_name, usage_kind=None):
         mock(console=console)
         mock(usage_kind=usage_kind)
-        print('executor_name:', executor_name)
+        print('_mock_get_prettyprint_usage executor_name:', executor_name)
         assert executor_name != 'None'
+        assert print('executor_name:', executor_name)
 
     monkeypatch.setattr(HubIO, '_get_prettyprint_usage', _mock_get_prettyprint_usage)
 

--- a/tests/unit/hubble/test_hubio.py
+++ b/tests/unit/hubble/test_hubio.py
@@ -421,7 +421,6 @@ def test_pull(test_envs, mocker, monkeypatch, executor_name):
         mock(usage_kind=usage_kind)
         print('_mock_get_prettyprint_usage executor_name:', executor_name)
         assert executor_name != 'None'
-        assert print('executor_name:', executor_name)
 
     monkeypatch.setattr(HubIO, '_get_prettyprint_usage', _mock_get_prettyprint_usage)
 

--- a/tests/unit/hubble/test_hubio.py
+++ b/tests/unit/hubble/test_hubio.py
@@ -375,8 +375,8 @@ class DownloadMockResponse:
     def status_code(self):
         return self.response_code
 
-
-def test_pull(test_envs, mocker, monkeypatch):
+@pytest.mark.parametrize('executer_name', ['alias_dummy',None])
+def test_pull(test_envs, mocker, monkeypatch, executer_name):
     mock = mocker.Mock()
 
     def _mock_fetch(
@@ -391,54 +391,7 @@ def test_pull(test_envs, mocker, monkeypatch):
         return (
             HubExecutor(
                 uuid='dummy_mwu_encoder',
-                name='alias_dummy',
-                tag='v0',
-                image_name='jinahub/pod.dummy_mwu_encoder',
-                md5sum=None,
-                visibility=True,
-                archive_url=None,
-            ),
-            False,
-        )
-
-    monkeypatch.setattr(HubIO, 'fetch_meta', _mock_fetch)
-
-    def _mock_download(url, stream=True, headers=None):
-        mock(url=url)
-        return DownloadMockResponse(response_code=200)
-
-    def _mock_head(url):
-        from collections import namedtuple
-
-        HeadInfo = namedtuple('HeadInfo', ['headers'])
-        return HeadInfo(headers={})
-
-    monkeypatch.setattr(requests, 'get', _mock_download)
-    monkeypatch.setattr(requests, 'head', _mock_head)
-
-    args = set_hub_pull_parser().parse_args(['jinahub://dummy_mwu_encoder'])
-    HubIO(args).pull()
-
-    args = set_hub_pull_parser().parse_args(['jinahub://dummy_mwu_encoder:secret'])
-    HubIO(args).pull()
-
-
-def test_pull_with_no_name(test_envs, mocker, monkeypatch):
-    mock = mocker.Mock()
-
-    def _mock_fetch(
-        name,
-        tag=None,
-        secret=None,
-        image_required=True,
-        rebuild_image=True,
-        force=False,
-    ):
-        mock(name=name)
-        return (
-            HubExecutor(
-                uuid='dummy_mwu_encoder',
-                name=None,
+                name=executer_name,
                 tag='v0',
                 image_name='jinahub/pod.dummy_mwu_encoder',
                 md5sum=None,
@@ -472,6 +425,9 @@ def test_pull_with_no_name(test_envs, mocker, monkeypatch):
     monkeypatch.setattr(HubIO, '_get_prettyprint_usage', _mock_get_prettyprint_usage)
 
     args = set_hub_pull_parser().parse_args(['jinahub://dummy_mwu_encoder'])
+    HubIO(args).pull()
+
+    args = set_hub_pull_parser().parse_args(['jinahub://dummy_mwu_encoder:secret'])
     HubIO(args).pull()
 
 

--- a/tests/unit/hubble/test_hubio.py
+++ b/tests/unit/hubble/test_hubio.py
@@ -464,7 +464,6 @@ def test_pull_with_no_name(test_envs, mocker, monkeypatch):
     monkeypatch.setattr(requests, 'head', _mock_head)
 
     def _mock_get_prettyprint_usage(self,console, executor_name, usage_kind=None):
-        mock(self=self)
         mock(console=console)
         mock(usage_kind=usage_kind)
         print('executor_name:', executor_name)

--- a/tests/unit/hubble/test_hubio.py
+++ b/tests/unit/hubble/test_hubio.py
@@ -463,10 +463,16 @@ def test_pull_with_no_name(test_envs, mocker, monkeypatch):
     monkeypatch.setattr(requests, 'get', _mock_download)
     monkeypatch.setattr(requests, 'head', _mock_head)
 
-    args = set_hub_pull_parser().parse_args(['jinahub://dummy_mwu_encoder'])
-    HubIO(args).pull()
+    def _mock_get_prettyprint_usage(self,console, executor_name, usage_kind=None):
+        mock(self=self)
+        mock(console=console)
+        mock(usage_kind=usage_kind)
+        print('executor_name:', executor_name)
+        assert executor_name != 'None'
 
-    args = set_hub_pull_parser().parse_args(['jinahub://dummy_mwu_encoder:secret'])
+    monkeypatch.setattr(HubIO, '_get_prettyprint_usage', _mock_get_prettyprint_usage)
+
+    args = set_hub_pull_parser().parse_args(['jinahub://dummy_mwu_encoder'])
     HubIO(args).pull()
 
 


### PR DESCRIPTION
Fix the way to generate executor name of the func hub pull

Close: https://github.com/jina-ai/hubble/issues/475