### PR TITLE
fix: more logging in dry run

### DIFF
--- a/jina/clients/base/http.py
+++ b/jina/clients/base/http.py
@@ -64,6 +64,10 @@ class HTTPBaseClient(BaseClient):
                 self._handle_response_status(r_status, r_str, url)
                 if r_str['code'] == jina_pb2.StatusProto.SUCCESS:
                     return True
+                else:
+                    self.logger.debug(
+                        f'Returned code is not expected! Description: {r_str["description"]}'
+                    )
             except Exception as e:
                 self.logger.error(
                     f'Error while fetching response from HTTP server {e!r}'


### PR DESCRIPTION
## Context ##
In JCloud backend we'd like to have more `DEBUG` logs in case we need to trouble shoot some weird issues we have been seeing.

For example when dry run returns below JSON we want to see the `description`:

```
{"code":1,"description":"DNS resolution failed for questionfilterer.jnamespace-None.svc.cluster.local:8080: C-ares status is not ARES_SUCCESS qtype=A name=questionfilterer.jnamespace-None.svc.cluster.local is_balancer=0: Domain name not found |Gateway: Communication error with deployment at address(es) questionfilterer.jnamespace-None.svc.cluster.local:8080. Head or worker(s) may be down.","exception":{"name":"InternalNetworkError","args":["DNS resolution failed for questionfilterer.jnamespace-None.svc.cluster.local:8080: C-ares status is not ARES_SUCCESS qtype=A name=questionfilterer.jnamespace-None.svc.cluster.local is_balancer=0: Domain name not found |Gateway: Communication error with deployment at address(es) questionfilterer.jnamespace-None.svc.cluster.local:8080. Head or worker(s) may be down."],"stacks":["Traceback (most recent call last):\n","  File \"/usr/local/lib/python3.8/site-packages/jina/serve/networking.py\", line 765, in task_wrapper\n    return await connection.send_discover_endpoint(\n","  File \"/usr/local/lib/python3.8/site-packages/jina/serve/networking.py\", line 200, in send_discover_endpoint\n    await self._init_stubs()\n","  File \"/usr/local/lib/python3.8/site-packages/jina/serve/networking.py\", line 176, in _init_stubs\n    available_services = await GrpcConnectionPool.get_available_services(\n","  File \"/usr/local/lib/python3.8/site-packages/jina/serve/networking.py\", line 1017, in get_available_services\n    async for res in response:\n","  File \"/usr/local/lib/python3.8/site-packages/grpc/aio/_call.py\", line 326, in _fetch_stream_responses\n    await self._raise_for_status()\n","  File \"/usr/local/lib/python3.8/site-packages/grpc/aio/_call.py\", line 236, in _raise_for_status\n    raise _create_rpc_error(await self.initial_metadata(), await\n","grpc.aio._call.AioRpcError: <AioRpcError of RPC that terminated with:\n\tstatus = StatusCode.UNAVAILABLE\n\tdetails = \"DNS resolution failed for questionfilterer.jnamespace-None.svc.cluster.local:8080: C-ares status is not ARES_SUCCESS qtype=A name=questionfilterer.jnamespace-None.svc.cluster.local is_balancer=0: Domain name not found\"\n\tdebug_error_string = \"{\"created\":\"@1657701898.923475649\",\"description\":\"DNS resolution failed for questionfilterer.jnamespace-None.svc.cluster.local:8080: C-ares status is not ARES_SUCCESS qtype=A name=questionfilterer.jnamespace-None.svc.cluster.local is_balancer=0: Domain name not found\",\"file\":\"src/core/lib/transport/error_utils.cc\",\"file_line\":167,\"grpc_status\":14}\"\n>\n","\nDuring handling of the above exception, another exception occurred:\n\n","Traceback (most recent call last):\n","  File \"/usr/local/lib/python3.8/site-packages/jina/serve/runtimes/gateway/http/app.py\", line 134, in _flow_health\n    _ = await _get_singleton_result(\n","  File \"/usr/local/lib/python3.8/site-packages/jina/serve/runtimes/gateway/http/app.py\", line 387, in _get_singleton_result\n    async for k in streamer.stream(request_iterator=request_iterator):\n","  File \"/usr/local/lib/python3.8/site-packages/jina/serve/stream/__init__.py\", line 78, in stream\n    async for response in async_iter:\n","  File \"/usr/local/lib/python3.8/site-packages/jina/serve/stream/__init__.py\", line 154, in _stream_requests\n    response = self._result_handler(future.result())\n","  File \"/usr/local/lib/python3.8/site-packages/jina/serve/runtimes/gateway/request_handling.py\", line 146, in _process_results_at_end_gateway\n    await asyncio.gather(gather_endpoints(request_graph))\n","  File \"/usr/local/lib/python3.8/site-packages/jina/serve/runtimes/gateway/request_handling.py\", line 88, in gather_endpoints\n    raise err\n","  File \"/usr/local/lib/python3.8/site-packages/jina/serve/runtimes/gateway/request_handling.py\", line 80, in gather_endpoints\n    endpoints = await asyncio.gather(*tasks_to_get_endpoints)\n","  File \"/usr/local/lib/python3.8/site-packages/jina/serve/networking.py\", line 769, in task_wrapper\n    self._handle_aiorpcerror(\n","  File \"/usr/local/lib/python3.8/site-packages/jina/serve/networking.py\", line 702, in _handle_aiorpcerror\n    raise InternalNetworkError(\n","jina.excepts.InternalNetworkError: DNS resolution failed for questionfilterer.jnamespace-None.svc.cluster.local:8080: C-ares status is not ARES_SUCCESS qtype=A name=questionfilterer.jnamespace-None.svc.cluster.local is_balancer=0: Domain name not found |Gateway: Communication error with deployment at address(es) questionfilterer.jnamespace-None.svc.cluster.local:8080. Head or worker(s) may be down.\n"],"executor":""}}
```

## Tests ## 
With the change the code prints locally if the HTTP returns 200 but the `code` is not `jina_pb2.StatusProto.SUCCESS`:

```
Returned code is not expected! Description: DNS resolution failed for questionfilterer.jnamespace-None.svc.cluster.local:8080: C-ares status is not ARES_SUCCESS qtype=A name=questionfilterer.jnamespace-None.svc.cluster.local is_balancer=0: Domain name not found |Gateway: Communication error with deployment at address(es) questionfilterer.jnamespace-None.svc.cluster.local:8080. Head or worker(s) may be down.
``` 
