### PR TITLE
fix: map multiple endpoints to same func

### DIFF
--- a/docs/fundamentals/flow/add-executors.md
+++ b/docs/fundamentals/flow/add-executors.md
@@ -292,7 +292,9 @@ param3: 30
 ```
 
 ### Set `requests` via `uses_requests`
-You can set/override the `requests` configuration of an executor and bind methods to endpoints that you provide. In the following codes, we replace the endpoint `/foo` binded to the `foo()` function with `/non_foo` and add a new endpoint `/bar` for binding `bar()`. Note the `all_req()` function is binded to **all** the endpoints except those explicitly bound to other functions, i.e. `/non_foo` and `/bar`.
+You can set/override the `requests` configuration of an executor and bind methods to endpoints that you provide. 
+In the following codes, we replace the endpoint `/foo` binded to the `foo()` function with both `/non_foo` and `/alias_foo`. 
+And add a new endpoint `/bar` for binding `bar()`. Note the `all_req()` function is binded to **all** the endpoints except those explicitly bound to other functions, i.e. `/non_foo`, `/alias_foo` and `/bar`.
 
 ```python
 from jina import Executor, requests, Flow
@@ -316,12 +318,14 @@ flow = Flow().add(
     uses_requests={
         '/bar': 'bar',
         '/non_foo': 'foo',
+        '/alias_foo': 'foo',
     },
 )
 with flow as f:
     f.post('/bar', parameters={'recipient': 'bar()'})
     f.post('/non_foo', parameters={'recipient': 'foo()'})
     f.post('/foo', parameters={'recipient': 'all_req()'})
+    f.post('/alias_foo', parameters={'recipient': 'foo()'})
 ```
 
 ```text
@@ -332,8 +336,10 @@ with flow as f:
 	🏠 Local access:	0.0.0.0:36507
 	🔒 Private network:	192.168.1.101:36507
 	🌐 Public address:	197.28.82.165:36507
-bar
-foo
+bar bar()
+foo foo()
+all req all_req()
+foo foo()
 ```
 
 ## Unify NDArray types

--- a/jina/serve/executors/__init__.py
+++ b/jina/serve/executors/__init__.py
@@ -7,6 +7,8 @@ import warnings
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, Dict, Optional, Type, Union
 
+import catch as catch
+
 from jina import __args_executor_init__, __default_endpoint__
 from jina.enums import BetterEnum
 from jina.helper import ArgNamespace, T, iscoroutinefunction, typename
@@ -179,14 +181,14 @@ class BaseExecutor(JAMLCompatible, metaclass=ExecutorType):
     def _add_requests(self, _requests: Optional[Dict]):
         if not hasattr(self, 'requests'):
             self.requests = {}
-
         if _requests:
             func_names = {f.__name__: e for e, f in self.requests.items()}
             for endpoint, func in _requests.items():
                 # the following line must be `getattr(self.__class__, func)` NOT `getattr(self, func)`
                 # this to ensure we always have `_func` as unbound method
                 if func in func_names:
-                    del self.requests[func_names[func]]
+                    if func_names[func] in self.requests:
+                        del self.requests[func_names[func]]
 
                 _func = getattr(self.__class__, func)
                 if callable(_func):

--- a/jina/serve/executors/__init__.py
+++ b/jina/serve/executors/__init__.py
@@ -7,8 +7,6 @@ import warnings
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, Dict, Optional, Type, Union
 
-import catch as catch
-
 from jina import __args_executor_init__, __default_endpoint__
 from jina.enums import BetterEnum
 from jina.helper import ArgNamespace, T, iscoroutinefunction, typename

--- a/tests/integration/v2_api/test_override_requests.py
+++ b/tests/integration/v2_api/test_override_requests.py
@@ -11,7 +11,9 @@ def test_override_requests():
             for doc in docs:
                 doc.text = 'foo called'
 
-    with Flow(port=port).add(uses=FooExecutor, uses_requests={'/non_foo': 'foo'}) as f:
+    with Flow(port=port).add(
+        uses=FooExecutor, uses_requests={'/non_foo': 'foo', '/another_foo': 'foo'}
+    ) as f:
         c = Client(port=f.port)
         resp1 = c.post(
             on='/foo', inputs=DocumentArray([Document(text='')]), return_responses=True
@@ -21,9 +23,15 @@ def test_override_requests():
             inputs=DocumentArray([Document(text='')]),
             return_responses=True,
         )
+        resp3 = c.post(
+            on='/another_foo',
+            inputs=DocumentArray([Document(text='')]),
+            return_responses=True,
+        )
 
     assert resp1[0].docs[0].text == ''
     assert resp2[0].docs[0].text == 'foo called'
+    assert resp3[0].docs[0].text == 'foo called'
 
 
 def test_override_requests_uses_after():


### PR DESCRIPTION
Goals: enable mapping different endpoints to the same executor func. 

```python
from jina import Flow, requests, Executor, Document, DocumentArray, Client

class MyExec(Executor):
    @requests(on='/foo')
    def foo(self, docs, **kwargs):
        for d in docs:
            d.text = 'foo'


# change bind to bar()
f = Flow().add(uses=MyExec, uses_requests={'/index': 'foo', '/search': 'foo'})
with f:
    req = Client(port=f.port).post(
        '/index', Document()
    )

    print(req[0].text)
```

raises:
```
CRITI… executor0/rep-0@76726 can not load the executor from  [07/14/22 15:35:16]
       MyExec                                                                   
ERROR  executor0/rep-0@76726 KeyError('/foo') during <class  [07/14/22 15:35:16]
       'jina.serve.runtimes.worker.WorkerRuntime'>                              
       initialization                                                           
        add "--quiet-error" to suppress the exception                           
       details                                                                  
       ╭──────── Traceback (most recent call last) ────────╮                    
       │                                                   │                    
       │ /Users/fengwang/Jina/workspace/jina/jina/orchest… │                    
       │ in run                                            │                    
       │                                                   │                    
       │    71 │                                           │                    
       │    72 │   try:                                    │                    
       │    73 │   │   _set_envs()                         │                    
       │ ❱  74 │   │   runtime = runtime_cls(              │                    
       │    75 │   │   │   args=args,                      │                    
       │    76 │   │   )                                   │                    
       │    77 │   except Exception as ex:                 │                    
       │ /Users/fengwang/Jina/workspace/jina/jina/serve/r… │                    
       │ in __init__                                       │                    
       │                                                   │                    
       │    28 │   │   :param kwargs: keyword args         │                    
       │    29 │   │   """                                 │                    
       │    30 │   │   self._health_servicer = health.Heal │                    
       │ ❱  31 │   │   super().__init__(args, **kwargs)    │                    
       │    32 │                                           │                    
       │    33 │   async def async_setup(self):            │                    
       │    34 │   │   """                                 │                    
       │                                                   │                    
       │ /Users/fengwang/Jina/workspace/jina/jina/serve/r… │                    
       │ in __init__                                       │                    
       │                                                   │                    
       │    63 │   │   │   )                               │                    
       │    64 │   │                                       │                    
       │    65 │   │   self._setup_monitoring()            │                    
       │ ❱  66 │   │   self._loop.run_until_complete(self. │                    
       │    67 │                                           │                    
       │    68 │   def run_forever(self):                  │                    
       │    69 │   │   """                                 │                    
       │                                                   │                    
       │ /Users/fengwang/.pyenv/versions/3.8.6/Library/Fr… │                    
       │ in run_until_complete                             │                    
       │                                                   │                    
       │    613 │   │   if not future.done():              │                    
       │    614 │   │   │   raise RuntimeError('Event loop │                    
       │    615 │   │                                      │                    
       │ ❱  616 │   │   return future.result()             │                    
       │    617 │                                          │                    
       │    618 │   def stop(self):                        │                    
       │    619 │   │   """Stop running the event loop.    │                    
       │                                                   │                    
       │ /Users/fengwang/Jina/workspace/jina/jina/serve/r… │                    
       │ in async_setup                                    │                    
       │                                                   │                    
       │    55 │   │   else:                               │                    
       │    56 │   │   │   self._summary_time = contextlib │                    
       │    57 │   │                                       │                    
       │ ❱  58 │   │   await self._async_setup_grpc_server │                    
       │    59 │                                           │                    
       │    60 │   async def _async_setup_grpc_server(self │                    
       │    61 │   │   """                                 │                    
       │                                                   │                    
       │ /Users/fengwang/Jina/workspace/jina/jina/serve/r… │                    
       │ in _async_setup_grpc_server                       │                    
       │                                                   │                    
       │    65 │   │   # Keep this initialization order    │                    
       │    66 │   │   # otherwise readiness check is not  │                    
       │    67 │   │   # The DataRequestHandler needs to b │                    
       │ ❱  68 │   │   self._data_request_handler = DataRe │                    
       │    69 │   │   │   self.args, self.logger, self.me │                    
       │    70 │   │   )                                   │                    
       │    71                                             │                    
       │                                                   │                    
       │ /Users/fengwang/Jina/workspace/jina/jina/serve/r… │                    
       │ in __init__                                       │                    
       │                                                   │                    
       │    41 │   │   self.args.parallel = self.args.shar │                    
       │    42 │   │   self.logger = logger                │                    
       │    43 │   │   self._is_closed = False             │                    
       │ ❱  44 │   │   self._load_executor(metrics_registr │                    
       │    45 │   │   self._init_monitoring(metrics_regis │                    
       │    46 │                                           │                    
       │    47 │   def _init_monitoring(self, metrics_regi │                    
       │                                                   │                    
       │ /Users/fengwang/Jina/workspace/jina/jina/serve/r… │                    
       │ in _load_executor                                 │                    
       │                                                   │                    
       │    79 │   │   :param metrics_registry: Optional p │                    
       │       passed to the executor so that it can expos │                    
       │    80 │   │   """                                 │                    
       │    81 │   │   try:                                │                    
       │ ❱  82 │   │   │   self._executor: BaseExecutor =  │                    
       │    83 │   │   │   │   self.args.uses,             │                    
       │    84 │   │   │   │   uses_with=self.args.uses_wi │                    
       │    85 │   │   │   │   uses_metas=self.args.uses_m │                    
       │                                                   │                    
       │ /Users/fengwang/Jina/workspace/jina/jina/jaml/__… │                    
       │ in load_config                                    │                    
       │                                                   │                    
       │   757 │   │   │   │   # revert yaml's tag and loa │                    
       │   758 │   │   │   │   tag_yml = JAML.unescape(JAM │                    
       │   759 │   │   │   # load into object, no more sub │                    
       │ ❱ 760 │   │   │   obj = JAML.load(tag_yml, substi │                    
       │   761 │   │   │   if not isinstance(obj, cls):    │                    
       │   762 │   │   │   │   raise BadConfigSource(      │                    
       │   763 │   │   │   │   │   f'Can not construct {cl │                    
       │       invalid configuration.'                     │                    
       │                                                   │                    
       │ /Users/fengwang/Jina/workspace/jina/jina/jaml/__… │                    
       │ in load                                           │                    
       │                                                   │                    
       │   171 │   │   :return: the Python object          │                    
       │   172 │   │                                       │                    
       │   173 │   │   """                                 │                    
       │ ❱ 174 │   │   r = yaml.load(stream, Loader=get_ji │                    
       │   175 │   │                                       │                    
       │   176 │   │   if substitute:                      │                    
       │   177 │   │   │   r = JAML.expand_dict(r, context │                    
       │                                                   │                    
       │ /Users/fengwang/.pyenv/versions/3.8.6/Library/Fr… │                    
       │ in load                                           │                    
       │                                                   │                    
       │    78 │   """                                     │                    
       │    79 │   loader = Loader(stream)                 │                    
       │    80 │   try:                                    │                    
       │ ❱  81 │   │   return loader.get_single_data()     │                    
       │    82 │   finally:                                │                    
       │    83 │   │   loader.dispose()                    │                    
       │    84                                             │                    
       │                                                   │                    
       │ /Users/fengwang/.pyenv/versions/3.8.6/Library/Fr… │                    
       │ in get_single_data                                │                    
       │                                                   │                    
       │    48 │   │   # Ensure that the stream contains a │                    
       │    49 │   │   node = self.get_single_node()       │                    
       │    50 │   │   if node is not None:                │                    
       │ ❱  51 │   │   │   return self.construct_document( │                    
       │    52 │   │   return None                         │                    
       │    53 │                                           │                    
       │    54 │   def construct_document(self, node):     │                    
       │                                                   │                    
       │ /Users/fengwang/.pyenv/versions/3.8.6/Library/Fr… │                    
       │ in construct_document                             │                    
       │                                                   │                    
       │    52 │   │   return None                         │                    
       │    53 │                                           │                    
       │    54 │   def construct_document(self, node):     │                    
       │ ❱  55 │   │   data = self.construct_object(node)  │                    
       │    56 │   │   while self.state_generators:        │                    
       │    57 │   │   │   state_generators = self.state_g │                    
       │    58 │   │   │   self.state_generators = []      │                    
       │                                                   │                    
       │ /Users/fengwang/.pyenv/versions/3.8.6/Library/Fr… │                    
       │ in construct_object                               │                    
       │                                                   │                    
       │    97 │   │   │   │   elif isinstance(node, Mappi │                    
       │    98 │   │   │   │   │   constructor = self.__cl │                    
       │    99 │   │   if tag_suffix is None:              │                    
       │ ❱ 100 │   │   │   data = constructor(self, node)  │                    
       │   101 │   │   else:                               │                    
       │   102 │   │   │   data = constructor(self, tag_su │                    
       │   103 │   │   if isinstance(data, types.Generator │                    
       │                                                   │                    
       │ /Users/fengwang/Jina/workspace/jina/jina/jaml/__… │                    
       │ in _from_yaml                                     │                    
       │                                                   │                    
       │   579 │   │   data = constructor.construct_mappin │                    
       │   580 │   │   from jina.jaml.parsers import get_p │                    
       │   581 │   │                                       │                    
       │ ❱ 582 │   │   return get_parser(cls, version=data │                    
       │   583 │   │   │   cls, data, runtime_args=constru │                    
       │   584 │   │   )                                   │                    
       │   585                                             │                    
       │                                                   │                    
       │ /Users/fengwang/Jina/workspace/jina/jina/jaml/pa… │                    
       │ in parse                                          │                    
       │                                                   │                    
       │    85 │   │   │   │   runtime_args=runtime_args,  │                    
       │    86 │   │   │   )                               │                    
       │    87 │   │   else:                               │                    
       │ ❱  88 │   │   │   obj = cls(                      │                    
       │    89 │   │   │   │   **data.get('with', {}),     │                    
       │    90 │   │   │   │   metas=data.get('metas', {}) │                    
       │    91 │   │   │   │   requests=data.get('requests │                    
       │                                                   │                    
       │ /Users/fengwang/Jina/workspace/jina/jina/serve/e… │                    
       │ in arg_wrapper                                    │                    
       │                                                   │                    
       │   117 │   │   │   │   │   f = func(self, *args, * │                    
       │   118 │   │   │   │   return f                    │                    
       │   119 │   │   │   else:                           │                    
       │ ❱ 120 │   │   │   │   return func(self, *args, ** │                    
       │   121 │   │                                       │                    
       │   122 │   │   return arg_wrapper                  │                    
       │   123                                             │                    
       │                                                   │                    
       │ /Users/fengwang/Jina/workspace/jina/jina/serve/e… │                    
       │ in arg_wrapper                                    │                    
       │                                                   │                    
       │    73 │   │   else:                               │                    
       │    74 │   │   │   self._init_kwargs_dict = tmp    │                    
       │    75 │   │   convert_tuple_to_list(self._init_kw │                    
       │ ❱  76 │   │   f = func(self, *args, **kwargs)     │                    
       │    77 │   │   return f                            │                    
       │    78 │                                           │                    
       │    79 │   return arg_wrapper                      │                    
       │                                                   │                    
       │ /Users/fengwang/Jina/workspace/jina/jina/serve/e… │                    
       │ in __init__                                       │                    
       │                                                   │                    
       │   129 │   │   :param kwargs: additional extra key │                    
       │       params ara passed that are not expected     │                    
       │   130 │   │   """                                 │                    
       │   131 │   │   self._add_metas(metas)              │                    
       │ ❱ 132 │   │   self._add_requests(requests)        │                    
       │   133 │   │   self._add_runtime_args(runtime_args │                    
       │   134 │   │   self._init_monitoring()             │                    
       │   135 │   │   self.logger = JinaLogger(self.__cla │                    
       │                                                   │                    
       │ /Users/fengwang/Jina/workspace/jina/jina/serve/e… │                    
       │ in _add_requests                                  │                    
       │                                                   │                    
       │   186 │   │   │   │   # the following line must b │                    
       │       `getattr(self, func)`                       │                    
       │   187 │   │   │   │   # this to ensure we always  │                    
       │   188 │   │   │   │   if func in func_names:      │                    
       │ ❱ 189 │   │   │   │   │   del self.requests[func_ │                    
       │   190 │   │   │   │                               │                    
       │   191 │   │   │   │   _func = getattr(self.__clas │                    
       │   192 │   │   │   │   if callable(_func):         │                    
       ╰───────────────────────────────────────────────────╯                    
       KeyError: '/foo'                                                         
ERROR  Flow@76690 Flow is aborted due to ['executor0'] can   [07/14/22 15:35:16]
       not be started.                                                          

```

- ...
- ...
- [ ] check and update documentation. See [guide](https://github.com/jina-ai/jina/CONTRIBUTING.md#documentation-guidelines) and ask the team.
