### PR TITLE
fix: use python module path in pymodules

### DIFF
--- a/jina/jaml/helper.py
+++ b/jina/jaml/helper.py
@@ -216,6 +216,8 @@ def complete_path(
         return os.path.abspath(_p)
     elif raise_nonexist:
         raise FileNotFoundError(f'can not find {path}')
+    else:
+        return path
 
 
 def _search_file_in_paths(path, extra_search_paths: Optional[List[str]] = None):

--- a/tests/unit/serve/executors/dummy_executor.py
+++ b/tests/unit/serve/executors/dummy_executor.py
@@ -1,0 +1,13 @@
+from jina import Executor, requests
+
+
+class MyExecutor(Executor):
+    def __init__(self, bar, **kwargs):
+        super().__init__(**kwargs)
+        self.bar = bar
+
+    @requests
+    def process(self, docs, **kwargs):
+        for d in docs:
+            d.text = 'hello world'
+        return docs

--- a/tests/unit/serve/executors/metas_executors.py
+++ b/tests/unit/serve/executors/metas_executors.py
@@ -2,10 +2,6 @@ from jina import DocumentArray, Executor, requests
 
 
 class TestExecutor(Executor):
-    def __init__(self, bar, **kwargs):
-        super().__init__(**kwargs)
-        self.bar = bar
-
     @requests
     def process(self, docs: DocumentArray, **kwargs):
         return docs

--- a/tests/unit/serve/executors/metas_executors.py
+++ b/tests/unit/serve/executors/metas_executors.py
@@ -1,7 +1,11 @@
-from jina import Executor, requests, DocumentArray
+from jina import DocumentArray, Executor, requests
 
 
 class TestExecutor(Executor):
+    def __init__(self, bar, **kwargs):
+        super().__init__(**kwargs)
+        self.bar = bar
+
     @requests
     def process(self, docs: DocumentArray, **kwargs):
         return docs

--- a/tests/unit/serve/executors/test_executor.py
+++ b/tests/unit/serve/executors/test_executor.py
@@ -88,9 +88,6 @@ def test_executor_with_pymodule_path():
         '''
         )
 
-    import sys
-
-    sys.path.append(cur_dir)
     ex = Executor.load_config(
         '''
     jtype: TestExecutor
@@ -98,7 +95,7 @@ def test_executor_with_pymodule_path():
         bar: 123
     metas:
         py_modules:
-            - metas_executors
+            - unit.serve.executors.metas_executors
     '''
     )
     assert ex.bar == 123

--- a/tests/unit/serve/executors/test_executor.py
+++ b/tests/unit/serve/executors/test_executor.py
@@ -19,6 +19,8 @@ from jina.serve.networking import GrpcConnectionPool
 from jina.serve.runtimes.asyncio import AsyncNewLoopRuntime
 from jina.serve.runtimes.worker import WorkerRuntime
 
+cur_dir = os.path.dirname(os.path.abspath(__file__))
+
 PORT = 12350
 
 
@@ -82,19 +84,25 @@ def test_executor_with_pymodule_path():
         jtype: BaseExecutor
         metas:
             py_modules:
-                - jina.serve.executor
+                - jina.no_valide.executor
         '''
         )
 
+    import sys
+
+    sys.path.append(cur_dir)
     ex = Executor.load_config(
         '''
-    jtype: BaseExecutor
+    jtype: TestExecutor
+    with:
+        bar: 123
     metas:
         py_modules:
-            - jina.serve.executors
+            - metas_executors
     '''
     )
-    assert ex.metas.py_modules == ['jina.serve.executors']
+    assert ex.bar == 123
+    assert ex.process(None) is None
 
 
 @property

--- a/tests/unit/serve/executors/test_executor.py
+++ b/tests/unit/serve/executors/test_executor.py
@@ -88,16 +88,16 @@ def test_executor_with_pymodule_path():
 
     ex = Executor.load_config(
         '''
-    jtype: TestExecutor
+    jtype: MyExecutor
     with:
         bar: 123
     metas:
         py_modules:
-            - unit.serve.executors.metas_executors
+            - unit.serve.executors.dummy_executor
     '''
     )
     assert ex.bar == 123
-    assert ex.process(None) is None
+    assert ex.process(DocumentArray([Document()]))[0].text == 'hello world'
 
 
 @property

--- a/tests/unit/serve/executors/test_executor.py
+++ b/tests/unit/serve/executors/test_executor.py
@@ -75,6 +75,28 @@ def test_executor_import_with_external_dependencies(capsys):
     assert 'hello' in out
 
 
+def test_executor_with_pymodule_path():
+    with pytest.raises(FileNotFoundError):
+        ex = Executor.load_config(
+            '''
+        jtype: BaseExecutor
+        metas:
+            py_modules:
+                - jina.serve.executor
+        '''
+        )
+
+    ex = Executor.load_config(
+        '''
+    jtype: BaseExecutor
+    metas:
+        py_modules:
+            - jina.serve.executors
+    '''
+    )
+    assert ex.metas.py_modules == ['jina.serve.executors']
+
+
 @property
 def workspace(self) -> str:
     """

--- a/tests/unit/serve/executors/test_executor.py
+++ b/tests/unit/serve/executors/test_executor.py
@@ -19,8 +19,6 @@ from jina.serve.networking import GrpcConnectionPool
 from jina.serve.runtimes.asyncio import AsyncNewLoopRuntime
 from jina.serve.runtimes.worker import WorkerRuntime
 
-cur_dir = os.path.dirname(os.path.abspath(__file__))
-
 PORT = 12350
 
 

--- a/tests/unit/serve/executors/test_set_metas.py
+++ b/tests/unit/serve/executors/test_set_metas.py
@@ -73,3 +73,6 @@ def test_name_python_jaml_identical():
     # Make sure that the executor meta name is equal to only the class name
     assert jaml_metas_name == 'TestExecutor'
     assert py_metas_name == 'TestExecutor'
+
+    # Make sure that the executor can be loaded from a native python module path as well
+    load_py_modules({'py_modules': ['metas_executors']})


### PR DESCRIPTION
Goals:

To fix the issue when using python module path in the meta `py_modules`, such as:

```python
from jina import Flow, Document

f = Flow().add(uses='!CLIPEncoder', uses_meta={'py_modules': ['clip_server.executors.clip_torch']})

with f:
    r = f.post(on='/', inputs=Document(text='hello world'))
    print(r.embeddings)
```
raise the following error:
```
CRITI… executor0/rep-0@26144 can not load the executor from  [07/15/22 16:09:18]
       CLIPEncoder                                                              
ERROR  executor0/rep-0@26144 TypeError('stat: path should be [07/15/22 16:09:18]
       string, bytes, os.PathLike or integer, not NoneType')                    
       during <class                                                            
       'jina.serve.runtimes.worker.WorkerRuntime'>                              
       initialization                                                           
        add "--quiet-error" to suppress the exception                           
       details                                                                  
       ╭──────── Traceback (most recent call last) ────────╮                    
       │                                                   │                    
       │ /Users/fengwang/Jina/workspace/jina/jina/orchest… │                    
       │ in run                                            │                    
       │                                                   │                    
       │    71 │                                           │                    
       │    72 │   try:                                    │                    
       │    73 │   │   _set_envs()                         │                    
       │ ❱  74 │   │   runtime = runtime_cls(              │                    
       │    75 │   │   │   args=args,                      │                    
       │    76 │   │   )                                   │                    
       │    77 │   except Exception as ex:                 │                    
       │ /Users/fengwang/Jina/workspace/jina/jina/serve/r… │                    
       │ in __init__                                       │                    
       │                                                   │                    
       │    28 │   │   :param kwargs: keyword args         │                    
       │    29 │   │   """                                 │                    
       │    30 │   │   self._health_servicer = health.Heal │                    
       │ ❱  31 │   │   super().__init__(args, **kwargs)    │                    
       │    32 │                                           │                    
       │    33 │   async def async_setup(self):            │                    
       │    34 │   │   """                                 │                    
       │                                                   │                    
       │ /Users/fengwang/Jina/workspace/jina/jina/serve/r… │                    
       │ in __init__                                       │                    
       │                                                   │                    
       │    63 │   │   │   )                               │                    
       │    64 │   │                                       │                    
       │    65 │   │   self._setup_monitoring()            │                    
       │ ❱  66 │   │   self._loop.run_until_complete(self. │                    
       │    67 │                                           │                    
       │    68 │   def run_forever(self):                  │                    
       │    69 │   │   """                                 │                    
       │                                                   │                    
       │ /Users/fengwang/.pyenv/versions/3.8.6/Library/Fr… │                    
       │ in run_until_complete                             │                    
       │                                                   │                    
       │    613 │   │   if not future.done():              │                    
       │    614 │   │   │   raise RuntimeError('Event loop │                    
       │    615 │   │                                      │                    
       │ ❱  616 │   │   return future.result()             │                    
       │    617 │                                          │                    
       │    618 │   def stop(self):                        │                    
       │    619 │   │   """Stop running the event loop.    │                    
       │                                                   │                    
       │ /Users/fengwang/Jina/workspace/jina/jina/serve/r… │                    
       │ in async_setup                                    │                    
       │                                                   │                    
       │    55 │   │   else:                               │                    
       │    56 │   │   │   self._summary_time = contextlib │                    
       │    57 │   │                                       │                    
       │ ❱  58 │   │   await self._async_setup_grpc_server │                    
       │    59 │                                           │                    
       │    60 │   async def _async_setup_grpc_server(self │                    
       │    61 │   │   """                                 │                    
       │                                                   │                    
       │ /Users/fengwang/Jina/workspace/jina/jina/serve/r… │                    
       │ in _async_setup_grpc_server                       │                    
       │                                                   │                    
       │    65 │   │   # Keep this initialization order    │                    
       │    66 │   │   # otherwise readiness check is not  │                    
       │    67 │   │   # The DataRequestHandler needs to b │                    
       │ ❱  68 │   │   self._data_request_handler = DataRe │                    
       │    69 │   │   │   self.args, self.logger, self.me │                    
       │    70 │   │   )                                   │                    
       │    71                                             │                    
       │                                                   │                    
       │ /Users/fengwang/Jina/workspace/jina/jina/serve/r… │                    
       │ in __init__                                       │                    
       │                                                   │                    
       │    41 │   │   self.args.parallel = self.args.shar │                    
       │    42 │   │   self.logger = logger                │                    
       │    43 │   │   self._is_closed = False             │                    
       │ ❱  44 │   │   self._load_executor(metrics_registr │                    
       │    45 │   │   self._init_monitoring(metrics_regis │                    
       │    46 │                                           │                    
       │    47 │   def _init_monitoring(self, metrics_regi │                    
       │                                                   │                    
       │ /Users/fengwang/Jina/workspace/jina/jina/serve/r… │                    
       │ in _load_executor                                 │                    
       │                                                   │                    
       │    79 │   │   :param metrics_registry: Optional p │                    
       │       passed to the executor so that it can expos │                    
       │    80 │   │   """                                 │                    
       │    81 │   │   try:                                │                    
       │ ❱  82 │   │   │   self._executor: BaseExecutor =  │                    
       │    83 │   │   │   │   self.args.uses,             │                    
       │    84 │   │   │   │   uses_with=self.args.uses_wi │                    
       │    85 │   │   │   │   uses_metas=self.args.uses_m │                    
       │                                                   │                    
       │ /Users/fengwang/Jina/workspace/jina/jina/jaml/__… │                    
       │ in load_config                                    │                    
       │                                                   │                    
       │   727 │   │   │                                   │                    
       │   728 │   │   │   if allow_py_modules:            │                    
       │   729 │   │   │   │   _extra_search_paths = extra │                    
       │ ❱ 730 │   │   │   │   load_py_modules(            │                    
       │   731 │   │   │   │   │   no_tag_yml,             │                    
       │   732 │   │   │   │   │   extra_search_paths=(_ex │                    
       │   733 │   │   │   │   │   if s_path               │                    
       │                                                   │                    
       │ /Users/fengwang/Jina/workspace/jina/jina/jaml/he… │                    
       │ in load_py_modules                                │                    
       │                                                   │                    
       │   269 │   _finditem(d)                            │                    
       │   270 │   if mod:                                 │                    
       │   271 │   │   mod = [complete_path(m, extra_searc │                    
       │ ❱ 272 │   │   PathImporter.add_modules(*mod)      │                    
       │   273                                             │                    
       │                                                   │                    
       │ /Users/fengwang/Jina/workspace/jina/jina/importe… │                    
       │ in add_modules                                    │                    
       │                                                   │                    
       │   144 │   │   # assume paths are Python module na │                    
       │   145 │   │   not_python_module_paths = []        │                    
       │   146 │   │   for path in paths:                  │                    
       │ ❱ 147 │   │   │   if not os.path.isfile(path):    │                    
       │   148 │   │   │   │   try:                        │                    
       │   149 │   │   │   │   │   importlib.import_module │                    
       │   150 │   │   │   │   except:                     │                    
       │                                                   │                    
       │ /Users/fengwang/.pyenv/versions/3.8.6/Library/Fr… │                    
       │ in isfile                                         │                    
       │                                                   │                    
       │    27 def isfile(path):                           │                    
       │    28 │   """Test whether a path is a regular fil │                    
       │    29 │   try:                                    │                    
       │ ❱  30 │   │   st = os.stat(path)                  │                    
       │    31 │   except (OSError, ValueError):           │                    
       │    32 │   │   return False                        │                    
       │    33 │   return stat.S_ISREG(st.st_mode)         │                    
       ╰───────────────────────────────────────────────────╯                    
       TypeError: stat: path should be string, bytes,                           
       os.PathLike or integer, not NoneType                                     
ERROR  Flow@26027 Flow is aborted due to ['executor0'] can   [07/15/22 16:09:18]
       not be started.                              
```
- ...
- ...
- [ ] check and update documentation. See [guide](https://github.com/jina-ai/jina/CONTRIBUTING.md#documentation-guidelines) and ask the team.
