### PR TITLE
refactor: hide tgraph, cpool and streaming under new usable api

### DIFF
--- a/jina/clients/base/http.py
+++ b/jina/clients/base/http.py
@@ -123,9 +123,11 @@ class HTTPBaseClient(BaseClient):
                 return result
 
             streamer = RequestStreamer(
-                self.args,
                 request_handler=_request_handler,
                 result_handler=_result_handler,
+                prefetch=getattr(self.args, 'prefetch', 0),
+                logger=self.logger,
+                **vars(self.args)
             )
             async for response in streamer.stream(request_iterator):
                 r_status = response.status

--- a/jina/clients/base/websocket.py
+++ b/jina/clients/base/websocket.py
@@ -157,10 +157,12 @@ class WebSocketBaseClient(BaseClient):
                 return future, None
 
             streamer = RequestStreamer(
-                args=self.args,
                 request_handler=_request_handler,
                 result_handler=_result_handler,
                 end_of_iter_handler=_handle_end_of_iter,
+                prefetch=getattr(self.args, 'prefetch', 0),
+                logger=self.logger,
+                **vars(self.args)
             )
 
             receive_task = asyncio.create_task(_receive())

--- a/jina/serve/bff.py
+++ b/jina/serve/bff.py
@@ -1,0 +1,106 @@
+import argparse
+import asyncio
+from typing import (
+    TYPE_CHECKING,
+    AsyncIterator,
+    Awaitable,
+    Callable,
+    Iterator,
+    Optional,
+    Union,
+)
+
+from jina.serve.stream import RequestStreamer
+from jina.serve.runtimes.gateway.graph.topology_graph import TopologyGraph
+from jina.serve.networking import GrpcConnectionPool
+
+from jina.excepts import InternalNetworkError
+from jina.logging.logger import JinaLogger
+from jina.serve.stream.helper import AsyncRequestsIterator, _RequestsCounter
+from jina.serve.runtimes.gateway.request_handling import RequestHandler
+from jina.serve.stream import RequestStreamer
+
+
+
+
+__all__ = ['RequestStreamer']
+
+from jina.types.request.data import Response
+
+if TYPE_CHECKING:
+    from jina.types.request import Request
+
+
+class GatewayBFF:
+    """
+    Wrapper object to be used in a BFF or in the Gateway. Naming to be defined
+    """
+
+    def __init__(
+            self,
+            graph_representation,
+            executor_addresses,
+            graph_conditions,
+            deployments_disable_reduce,
+            timeout_send,
+            retries,
+            compression,
+            runtime_name,
+            logger: Optional['JinaLogger'] = None,
+            metrics_registry = None,
+    ):
+        """
+        :param graph_representation: Graph representation of the Flow
+        :param executor_addresses: Addresses of the Executors
+        :param logger: Optional logger that can be used for logging
+        """
+        self._timeout_send = timeout_send
+        self._retries = retries
+        self.logger = logger
+        self._metrics_registry = metrics_registry
+        self._topology_graph = self._create_topology_graph(graph_representation, graph_conditions, deployments_disable_reduce)
+        self._connection_pool = self._create_connection_pool(executor_addresses, compression)
+        request_handler = RequestHandler(metrics_registry, runtime_name)
+
+        streamer = RequestStreamer(
+            args=args,
+            request_handler=request_handler.handle_request(
+                graph=self._topology_graph, connection_pool=self._connection_pool
+            ),
+            result_handler=request_handler.handle_result(),
+        )
+
+    def _create_topology_graph(self, graph_description, graph_conditions, deployments_disable_reduce):
+        # check if it should be in K8s, maybe ConnectionPoolFactory to be created
+        import json
+
+        graph_description = json.loads(graph_description)
+        graph_conditions = json.loads(graph_conditions)
+        deployments_disable_reduce = json.loads(deployments_disable_reduce)
+        return TopologyGraph(
+            graph_description,
+            graph_conditions,
+            deployments_disable_reduce,
+            timeout_send=self._timeout_send,
+            retries=self._retries,
+        )
+
+    def _create_connection_pool(self, deployments_addresses, compression):
+        import json
+
+        deployments_addresses = json.loads(deployments_addresses)
+        # add the connections needed
+        connection_pool = GrpcConnectionPool(
+            logger=self.logger,
+            compression=compression,
+            metrics_registry=self._metrics_registry,
+        )
+        for deployment_name, addresses in deployments_addresses.items():
+            for address in addresses:
+                connection_pool.add_connection(
+                    deployment=deployment_name, address=address, head=True
+                )
+
+        return connection_pool
+
+

--- a/jina/serve/bff.py
+++ b/jina/serve/bff.py
@@ -24,8 +24,8 @@ class GatewayBFF:
             self,
             graph_representation: Dict,
             executor_addresses: Dict[str, Union[str, List[str]]],
-            graph_conditions: Dict,
-            deployments_disable_reduce: List[str],
+            graph_conditions: Dict = {},
+            deployments_disable_reduce: List[str] = [],
             timeout_send: Optional[float] = None,
             retries: int = 0,
             compression: Optional[str] = None,
@@ -67,11 +67,6 @@ class GatewayBFF:
     def _create_topology_graph(self, graph_description, graph_conditions, deployments_disable_reduce, timeout_send,
                                retries):
         # check if it should be in K8s, maybe ConnectionPoolFactory to be created
-        import json
-
-        graph_description = json.loads(graph_description)
-        graph_conditions = json.loads(graph_conditions)
-        deployments_disable_reduce = json.loads(deployments_disable_reduce)
         return TopologyGraph(
             graph_representation=graph_description,
             graph_conditions=graph_conditions,
@@ -81,9 +76,6 @@ class GatewayBFF:
         )
 
     def _create_connection_pool(self, deployments_addresses, compression, metrics_registry, logger):
-        import json
-
-        deployments_addresses = json.loads(deployments_addresses)
         # add the connections needed
         connection_pool = GrpcConnectionPool(
             logger=logger,
@@ -108,7 +100,7 @@ class GatewayBFF:
         """
         return self._streamer.stream(*args, **kwargs)
 
-    def stream_docs(self, docs: DocumentArray, exec_endpoint: str, request_size: int,
+    def stream_docs(self, docs: DocumentArray, request_size: int, exec_endpoint: Optional[str] = None,
                     target_executor: Optional[str] = None, parameters: Optional[Dict] = None):
         """
         stream documents and stream responses back.

--- a/jina/serve/bff.py
+++ b/jina/serve/bff.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, Dict
 
 from jina.serve.runtimes.gateway.graph.topology_graph import TopologyGraph
 from jina.serve.networking import GrpcConnectionPool
@@ -6,6 +6,8 @@ from jina.serve.networking import GrpcConnectionPool
 from jina.logging.logger import JinaLogger
 from jina.serve.runtimes.gateway.request_handling import RequestHandler
 from jina.serve.stream import RequestStreamer
+
+from docarray import DocumentArray
 
 __all__ = ['GatewayBFF']
 
@@ -88,6 +90,11 @@ class GatewayBFF:
 
     def stream(self, *args, **kwargs):
         return self._streamer.stream(*args, **kwargs)
+
+    def stream_docs(self, da: DocumentArray, exec_endpoint: str, request_size: int, target_executor: Optional[str] = None, parameters: Optional[Dict] = None, *args, **kwargs):
+        from jina.clients.request import request_generator # move request_generator to another module
+        from jina.enums import DataInputType
+        return self._streamer.stream(request_generator(data=da, data_type=DataInputType.DOCUMENT, exec_endpoint=exec_endpoint, request_size=request_size, target_executor=target_executor, parameters=parameters))
 
     async def close(self):
         await self._streamer.wait_floating_requests_end()

--- a/jina/serve/bff.py
+++ b/jina/serve/bff.py
@@ -94,6 +94,7 @@ class GatewayBFF:
     def stream_docs(self, da: DocumentArray, exec_endpoint: str, request_size: int, target_executor: Optional[str] = None, parameters: Optional[Dict] = None, *args, **kwargs):
         from jina.clients.request import request_generator # move request_generator to another module
         from jina.enums import DataInputType
+        # this request_generator thing can be easily changed by private methods
         return self._streamer.stream(request_generator(data=da, data_type=DataInputType.DOCUMENT, exec_endpoint=exec_endpoint, request_size=request_size, target_executor=target_executor, parameters=parameters))
 
     async def close(self):

--- a/jina/serve/bff.py
+++ b/jina/serve/bff.py
@@ -63,9 +63,9 @@ class GatewayBFF:
         graph_conditions = json.loads(graph_conditions)
         deployments_disable_reduce = json.loads(deployments_disable_reduce)
         return TopologyGraph(
-            graph_description,
-            graph_conditions,
-            deployments_disable_reduce,
+            graph_representation=graph_description,
+            graph_conditions=graph_conditions,
+            deployments_disable_reduce=deployments_disable_reduce,
             timeout_send=self._timeout_send,
             retries=self._retries,
         )

--- a/jina/serve/runtimes/gateway/__init__.py
+++ b/jina/serve/runtimes/gateway/__init__.py
@@ -2,9 +2,7 @@ import argparse
 from abc import ABC
 from typing import TYPE_CHECKING, Optional, Union
 
-from jina.serve.networking import GrpcConnectionPool
 from jina.serve.runtimes.asyncio import AsyncNewLoopRuntime
-from jina.serve.runtimes.gateway.graph.topology_graph import TopologyGraph
 
 if TYPE_CHECKING:
     import asyncio
@@ -25,39 +23,9 @@ class GatewayRuntime(AsyncNewLoopRuntime, ABC):
         ] = None,
         **kwargs,
     ):
-        # this order is intentional: The timeout is needed in _set_topology_graph(), called by super
+        # this order is intentional: The timeout is needed in _create_topology_graph(), called by super
         self.timeout_send = args.timeout_send
         if self.timeout_send:
             self.timeout_send /= 1e3  # convert ms to seconds
         super().__init__(args, cancel_event, **kwargs)
 
-    def _set_topology_graph(self):
-        # check if it should be in K8s, maybe ConnectionPoolFactory to be created
-        import json
-
-        graph_description = json.loads(self.args.graph_description)
-        graph_conditions = json.loads(self.args.graph_conditions)
-        deployments_disable_reduce = json.loads(self.args.deployments_disable_reduce)
-        self._topology_graph = TopologyGraph(
-            graph_description,
-            graph_conditions,
-            deployments_disable_reduce,
-            timeout_send=self.timeout_send,
-            retries=self.args.retries,
-        )
-
-    def _set_connection_pool(self):
-        import json
-
-        deployments_addresses = json.loads(self.args.deployments_addresses)
-        # add the connections needed
-        self._connection_pool = GrpcConnectionPool(
-            logger=self.logger,
-            compression=self.args.compression,
-            metrics_registry=self.metrics_registry,
-        )
-        for deployment_name, addresses in deployments_addresses.items():
-            for address in addresses:
-                self._connection_pool.add_connection(
-                    deployment=deployment_name, address=address, head=True
-                )

--- a/jina/serve/runtimes/gateway/grpc/__init__.py
+++ b/jina/serve/runtimes/gateway/grpc/__init__.py
@@ -10,8 +10,7 @@ from jina.excepts import PortAlreadyUsed
 from jina.helper import get_full_version, is_port_free
 from jina.proto import jina_pb2, jina_pb2_grpc
 from jina.serve.runtimes.gateway import GatewayRuntime
-from jina.serve.runtimes.gateway.request_handling import RequestHandler
-from jina.serve.stream import RequestStreamer
+from jina.serve.bff import GatewayBFF
 from jina.types.request.status import StatusMessage
 
 __all__ = ['GRPCGatewayRuntime']
@@ -21,9 +20,9 @@ class GRPCGatewayRuntime(GatewayRuntime):
     """Gateway Runtime for gRPC."""
 
     def __init__(
-        self,
-        args: argparse.Namespace,
-        **kwargs,
+            self,
+            args: argparse.Namespace,
+            **kwargs,
     ):
         """Initialize the runtime
         :param args: args from CLI
@@ -59,21 +58,16 @@ class GRPCGatewayRuntime(GatewayRuntime):
 
     async def _async_setup_server(self):
 
-        request_handler = RequestHandler(self.metrics_registry, self.name)
+        self.bff = GatewayBFF(graph_representation=self.args.graph_description,
+                              executor_addresses=self.args.deployments_addresses,
+                              graph_conditions=self.args.graph_conditions,
+                              deployments_disable_reduce=self.args.deployments_disable_reduce,
+                              timeout_send=self.args.timeout_send,
+                              retries=self.args.retries, compression=self.args.compression,
+                              runtime_name=self.name, prefetch=self.args.prefetch, logger=self.logger,
+                              metrics_registry=self.metrics_registry)
 
-        self.streamer = RequestStreamer(
-            request_handler=request_handler.handle_request(
-                graph=self._topology_graph, connection_pool=self._connection_pool
-            ),
-            result_handler=request_handler.handle_result(),
-            prefetch=getattr(self.args, 'prefetch', 0),
-            logger=self.logger,
-            **vars(self.args)
-        )
-
-        self.streamer.Call = self.streamer.stream
-
-        jina_pb2_grpc.add_JinaRPCServicer_to_server(self.streamer, self.server)
+        jina_pb2_grpc.add_JinaRPCServicer_to_server(self.bff, self.server)
         jina_pb2_grpc.add_JinaGatewayDryRunRPCServicer_to_server(self, self.server)
         jina_pb2_grpc.add_JinaInfoRPCServicer_to_server(self, self.server)
 
@@ -108,7 +102,7 @@ class GRPCGatewayRuntime(GatewayRuntime):
             )
             self.server.add_secure_port(bind_addr, server_credentials)
         elif (
-            self.args.ssl_keyfile != self.args.ssl_certfile
+                self.args.ssl_keyfile != self.args.ssl_certfile
         ):  # if we have only ssl_keyfile and not ssl_certfile or vice versa
             raise ValueError(
                 f"you can't pass a ssl_keyfile without a ssl_certfile and vice versa"
@@ -123,9 +117,8 @@ class GRPCGatewayRuntime(GatewayRuntime):
         # usually async_cancel should already have been called, but then its a noop
         # if the runtime is stopped without a sigterm (e.g. as a context manager, this can happen)
         self._health_servicer.enter_graceful_shutdown()
-        await self.streamer.wait_floating_requests_end()
+        await self.bff.close()
         await self.async_cancel()
-        await self._connection_pool.close()
 
     async def async_cancel(self):
         """The async method to stop server."""
@@ -157,7 +150,7 @@ class GRPCGatewayRuntime(GatewayRuntime):
                 data=da,
                 data_type=DataInputType.DOCUMENT,
             )
-            async for _ in self.streamer.stream(request_iterator=req_iterator):
+            async for _ in self.bff.stream(request_iterator=req_iterator):
                 pass
             status_message = StatusMessage()
             status_message.set_code(jina_pb2.StatusProto.SUCCESS)

--- a/jina/serve/runtimes/gateway/grpc/__init__.py
+++ b/jina/serve/runtimes/gateway/grpc/__init__.py
@@ -59,9 +59,12 @@ class GRPCGatewayRuntime(GatewayRuntime):
                               executor_addresses=self.args.deployments_addresses,
                               graph_conditions=self.args.graph_conditions,
                               deployments_disable_reduce=self.args.deployments_disable_reduce,
-                              timeout_send=self.args.timeout_send,
-                              retries=self.args.retries, compression=self.args.compression,
-                              runtime_name=self.name, prefetch=self.args.prefetch, logger=self.logger,
+                              timeout_send=self.timeout_send,
+                              retries=self.args.retries,
+                              compression=self.args.compression,
+                              runtime_name=self.name,
+                              prefetch=self.args.prefetch,
+                              logger=self.logger,
                               metrics_registry=self.metrics_registry)
 
         jina_pb2_grpc.add_JinaRPCServicer_to_server(self.bff._streamer, self.server)

--- a/jina/serve/runtimes/gateway/grpc/__init__.py
+++ b/jina/serve/runtimes/gateway/grpc/__init__.py
@@ -51,9 +51,6 @@ class GRPCGatewayRuntime(GatewayRuntime):
             ]
         )
 
-        self._set_topology_graph()
-        self._set_connection_pool()
-
         await self._async_setup_server()
 
     async def _async_setup_server(self):

--- a/jina/serve/runtimes/gateway/grpc/__init__.py
+++ b/jina/serve/runtimes/gateway/grpc/__init__.py
@@ -55,10 +55,17 @@ class GRPCGatewayRuntime(GatewayRuntime):
 
     async def _async_setup_server(self):
 
-        self.gateway_bff = GatewayBFF(graph_representation=self.args.graph_description,
-                                      executor_addresses=self.args.deployments_addresses,
-                                      graph_conditions=self.args.graph_conditions,
-                                      deployments_disable_reduce=self.args.deployments_disable_reduce,
+        import json
+
+        graph_description = json.loads(self.args.graph_description)
+        graph_conditions = json.loads(self.args.graph_conditions)
+        deployments_addresses = json.loads(self.args.deployments_addresses)
+        deployments_disable_reduce = json.loads(self.args.deployments_disable_reduce)
+
+        self.gateway_bff = GatewayBFF(graph_representation=graph_description,
+                                      executor_addresses=deployments_addresses,
+                                      graph_conditions=graph_conditions,
+                                      deployments_disable_reduce=deployments_disable_reduce,
                                       timeout_send=self.timeout_send,
                                       retries=self.args.retries,
                                       compression=self.args.compression,

--- a/jina/serve/runtimes/gateway/grpc/__init__.py
+++ b/jina/serve/runtimes/gateway/grpc/__init__.py
@@ -62,11 +62,13 @@ class GRPCGatewayRuntime(GatewayRuntime):
         request_handler = RequestHandler(self.metrics_registry, self.name)
 
         self.streamer = RequestStreamer(
-            args=self.args,
             request_handler=request_handler.handle_request(
                 graph=self._topology_graph, connection_pool=self._connection_pool
             ),
             result_handler=request_handler.handle_result(),
+            prefetch=getattr(self.args, 'prefetch', 0),
+            logger=self.logger,
+            **vars(self.args)
         )
 
         self.streamer.Call = self.streamer.stream

--- a/jina/serve/runtimes/gateway/grpc/__init__.py
+++ b/jina/serve/runtimes/gateway/grpc/__init__.py
@@ -67,7 +67,7 @@ class GRPCGatewayRuntime(GatewayRuntime):
                               runtime_name=self.name, prefetch=self.args.prefetch, logger=self.logger,
                               metrics_registry=self.metrics_registry)
 
-        jina_pb2_grpc.add_JinaRPCServicer_to_server(self.bff, self.server)
+        jina_pb2_grpc.add_JinaRPCServicer_to_server(self.bff._streamer, self.server)
         jina_pb2_grpc.add_JinaGatewayDryRunRPCServicer_to_server(self, self.server)
         jina_pb2_grpc.add_JinaInfoRPCServicer_to_server(self, self.server)
 

--- a/jina/serve/runtimes/gateway/grpc/__init__.py
+++ b/jina/serve/runtimes/gateway/grpc/__init__.py
@@ -55,19 +55,19 @@ class GRPCGatewayRuntime(GatewayRuntime):
 
     async def _async_setup_server(self):
 
-        self.bff = GatewayBFF(graph_representation=self.args.graph_description,
-                              executor_addresses=self.args.deployments_addresses,
-                              graph_conditions=self.args.graph_conditions,
-                              deployments_disable_reduce=self.args.deployments_disable_reduce,
-                              timeout_send=self.timeout_send,
-                              retries=self.args.retries,
-                              compression=self.args.compression,
-                              runtime_name=self.name,
-                              prefetch=self.args.prefetch,
-                              logger=self.logger,
-                              metrics_registry=self.metrics_registry)
+        self.gateway_bff = GatewayBFF(graph_representation=self.args.graph_description,
+                                      executor_addresses=self.args.deployments_addresses,
+                                      graph_conditions=self.args.graph_conditions,
+                                      deployments_disable_reduce=self.args.deployments_disable_reduce,
+                                      timeout_send=self.timeout_send,
+                                      retries=self.args.retries,
+                                      compression=self.args.compression,
+                                      runtime_name=self.name,
+                                      prefetch=self.args.prefetch,
+                                      logger=self.logger,
+                                      metrics_registry=self.metrics_registry)
 
-        jina_pb2_grpc.add_JinaRPCServicer_to_server(self.bff._streamer, self.server)
+        jina_pb2_grpc.add_JinaRPCServicer_to_server(self.gateway_bff._streamer, self.server)
         jina_pb2_grpc.add_JinaGatewayDryRunRPCServicer_to_server(self, self.server)
         jina_pb2_grpc.add_JinaInfoRPCServicer_to_server(self, self.server)
 
@@ -117,7 +117,7 @@ class GRPCGatewayRuntime(GatewayRuntime):
         # usually async_cancel should already have been called, but then its a noop
         # if the runtime is stopped without a sigterm (e.g. as a context manager, this can happen)
         self._health_servicer.enter_graceful_shutdown()
-        await self.bff.close()
+        await self.gateway_bff.close()
         await self.async_cancel()
 
     async def async_cancel(self):
@@ -149,7 +149,7 @@ class GRPCGatewayRuntime(GatewayRuntime):
                 data=da,
                 data_type=DataInputType.DOCUMENT,
             )
-            async for _ in self.bff.stream(request_iterator=req_iterator):
+            async for _ in self.gateway_bff.stream(request_iterator=req_iterator):
                 pass
             status_message = StatusMessage()
             status_message.set_code(jina_pb2.StatusProto.SUCCESS)

--- a/jina/serve/runtimes/gateway/http/__init__.py
+++ b/jina/serve/runtimes/gateway/http/__init__.py
@@ -67,15 +67,12 @@ class HTTPGatewayRuntime(GatewayRuntime):
                 if ssl_file not in uvicorn_kwargs.keys():
                     uvicorn_kwargs[ssl_file] = getattr(self.args, ssl_file)
 
-        self._set_topology_graph()
-        self._set_connection_pool()
         self._server = UviServer(
             config=Config(
                 app=extend_rest_interface(
                     get_fastapi_app(
-                        self.args,
-                        topology_graph=self._topology_graph,
-                        connection_pool=self._connection_pool,
+                        args=self.args,
+                        name=self.name,
                         logger=self.logger,
                         metrics_registry=self.metrics_registry,
                     )

--- a/jina/serve/runtimes/gateway/http/__init__.py
+++ b/jina/serve/runtimes/gateway/http/__init__.py
@@ -74,6 +74,7 @@ class HTTPGatewayRuntime(GatewayRuntime):
                         args=self.args,
                         name=self.name,
                         logger=self.logger,
+                        timeout_send=self.timeout_send,
                         metrics_registry=self.metrics_registry,
                     )
                 ),

--- a/jina/serve/runtimes/gateway/http/__init__.py
+++ b/jina/serve/runtimes/gateway/http/__init__.py
@@ -100,7 +100,6 @@ class HTTPGatewayRuntime(GatewayRuntime):
     async def async_teardown(self):
         """Shutdown the server."""
         await self._server.shutdown()
-        await self._connection_pool.close()
 
     async def async_cancel(self):
         """Stop the server."""

--- a/jina/serve/runtimes/gateway/http/__init__.py
+++ b/jina/serve/runtimes/gateway/http/__init__.py
@@ -72,7 +72,6 @@ class HTTPGatewayRuntime(GatewayRuntime):
                 app=extend_rest_interface(
                     get_fastapi_app(
                         args=self.args,
-                        name=self.name,
                         logger=self.logger,
                         timeout_send=self.timeout_send,
                         metrics_registry=self.metrics_registry,

--- a/jina/serve/runtimes/gateway/http/app.py
+++ b/jina/serve/runtimes/gateway/http/app.py
@@ -18,11 +18,11 @@ if TYPE_CHECKING:
 
 
 def get_fastapi_app(
-    args: 'argparse.Namespace',
-    topology_graph: 'TopologyGraph',
-    connection_pool: 'GrpcConnectionPool',
-    logger: 'JinaLogger',
-    metrics_registry: Optional['CollectorRegistry'] = None,
+        args: 'argparse.Namespace',
+        topology_graph: 'TopologyGraph',
+        connection_pool: 'GrpcConnectionPool',
+        logger: 'JinaLogger',
+        metrics_registry: Optional['CollectorRegistry'] = None,
 ):
     """
     Get the app from FastAPI as the REST interface.
@@ -47,8 +47,8 @@ def get_fastapi_app(
     app = FastAPI(
         title=args.title or 'My Jina Service',
         description=args.description
-        or 'This is my awesome service. You can set `title` and `description` in your `Flow` or `Gateway` '
-        'to customize the title and description.',
+                    or 'This is my awesome service. You can set `title` and `description` in your `Flow` or `Gateway` '
+                       'to customize the title and description.',
         version=__version__,
     )
 
@@ -66,7 +66,6 @@ def get_fastapi_app(
     from jina.serve.stream import RequestStreamer
 
     request_handler = RequestHandler(metrics_registry, args.name)
-
 
     streamer = RequestStreamer(
         request_handler=request_handler.handle_request(
@@ -90,7 +89,7 @@ def get_fastapi_app(
             {
                 'name': 'Debug',
                 'description': 'Debugging interface. In production, you should hide them by setting '
-                '`--no-debug-endpoints` in `Flow`/`Gateway`.',
+                               '`--no-debug-endpoints` in `Flow`/`Gateway`.',
             }
         )
 
@@ -121,7 +120,7 @@ def get_fastapi_app(
         @app.get(
             path='/dry_run',
             summary='Get the readiness of Jina Flow service, sends an empty DocumentArray to the complete Flow to '
-            'validate connectivity',
+                    'validate connectivity',
             response_model=PROTO_TO_PYDANTIC_MODELS.StatusProto,
         )
         async def _flow_health():
@@ -178,7 +177,7 @@ def get_fastapi_app(
             # do not add response_model here, this debug endpoint should not restricts the response model
         )
         async def post(
-            body: JinaEndpointRequestModel, response: Response
+                body: JinaEndpointRequestModel, response: Response
         ):  # 'response' is a FastAPI response, not a Jina response
             """
             Post a data request to some endpoint.
@@ -285,7 +284,7 @@ def get_fastapi_app(
             {
                 'name': 'CRUD',
                 'description': 'CRUD interface. If your service does not implement those interfaces, you can should '
-                'hide them by setting `--no-crud-endpoints` in `Flow`/`Gateway`.',
+                               'hide them by setting `--no-crud-endpoints` in `Flow`/`Gateway`.',
             }
         )
         crud = {
@@ -324,7 +323,7 @@ def get_fastapi_app(
             from docarray import DocumentArray
 
             async def get_docs_from_endpoint(
-                data, target_executor, parameters, exec_endpoint
+                    data, target_executor, parameters, exec_endpoint
             ):
                 req_generator_input = {
                     'data': [asdict(d) for d in data],
@@ -335,8 +334,8 @@ def get_fastapi_app(
                 }
 
                 if (
-                    req_generator_input['data'] is not None
-                    and 'docs' in req_generator_input['data']
+                        req_generator_input['data'] is not None
+                        and 'docs' in req_generator_input['data']
                 ):
                     req_generator_input['data'] = req_generator_input['data']['docs']
                 try:
@@ -354,11 +353,11 @@ def get_fastapi_app(
             class Mutation:
                 @strawberry.mutation
                 async def docs(
-                    self,
-                    data: Optional[List[StrawberryDocumentInput]] = None,
-                    target_executor: Optional[str] = None,
-                    parameters: Optional[JSONScalar] = None,
-                    exec_endpoint: str = '/search',
+                        self,
+                        data: Optional[List[StrawberryDocumentInput]] = None,
+                        target_executor: Optional[str] = None,
+                        parameters: Optional[JSONScalar] = None,
+                        exec_endpoint: str = '/search',
                 ) -> List[StrawberryDocument]:
                     return await get_docs_from_endpoint(
                         data, target_executor, parameters, exec_endpoint
@@ -368,11 +367,11 @@ def get_fastapi_app(
             class Query:
                 @strawberry.field
                 async def docs(
-                    self,
-                    data: Optional[List[StrawberryDocumentInput]] = None,
-                    target_executor: Optional[str] = None,
-                    parameters: Optional[JSONScalar] = None,
-                    exec_endpoint: str = '/search',
+                        self,
+                        data: Optional[List[StrawberryDocumentInput]] = None,
+                        target_executor: Optional[str] = None,
+                        parameters: Optional[JSONScalar] = None,
+                        exec_endpoint: str = '/search',
                 ) -> List[StrawberryDocument]:
                     return await get_docs_from_endpoint(
                         data, target_executor, parameters, exec_endpoint

--- a/jina/serve/runtimes/gateway/http/app.py
+++ b/jina/serve/runtimes/gateway/http/app.py
@@ -18,6 +18,7 @@ def get_fastapi_app(
         args: 'argparse.Namespace',
         logger: 'JinaLogger',
         name: str,
+        timeout_send: Optional[float] = None,
         metrics_registry: Optional['CollectorRegistry'] = None,
 ):
     """
@@ -26,6 +27,7 @@ def get_fastapi_app(
     :param args: passed arguments.
     :param logger: Jina logger.
     :param name: the name to use in the monitoring
+    :param timeout_send: Timeout to be used when sending to Executors
     :param metrics_registry: optional metrics registry for prometheus used if we need to expose metrics from the executor or from the data request handler
     :return: fastapi app
     """
@@ -59,11 +61,16 @@ def get_fastapi_app(
 
     from jina.serve.bff import GatewayBFF
 
-    gateway_bff = GatewayBFF(graph_representation=args.graph_description, executor_addresses=args.deployments_addresses,
+    gateway_bff = GatewayBFF(graph_representation=args.graph_description,
+                             executor_addresses=args.deployments_addresses,
                              graph_conditions=args.graph_conditions,
-                             deployments_disable_reduce=args.deployments_disable_reduce, timeout_send=args.timeout_send,
-                             retries=args.retries, compression=args.compression,
-                             runtime_name=name, prefetch=args.prefetch, logger=logger,
+                             deployments_disable_reduce=args.deployments_disable_reduce,
+                             timeout_send=timeout_send,
+                             retries=args.retries,
+                             compression=args.compression,
+                             runtime_name=name,
+                             prefetch=args.prefetch,
+                             logger=logger,
                              metrics_registry=metrics_registry)
 
     @app.on_event('shutdown')

--- a/jina/serve/runtimes/gateway/http/app.py
+++ b/jina/serve/runtimes/gateway/http/app.py
@@ -17,7 +17,6 @@ if TYPE_CHECKING:
 def get_fastapi_app(
         args: 'argparse.Namespace',
         logger: 'JinaLogger',
-        name: str,
         timeout_send: Optional[float] = None,
         metrics_registry: Optional['CollectorRegistry'] = None,
 ):
@@ -26,7 +25,6 @@ def get_fastapi_app(
 
     :param args: passed arguments.
     :param logger: Jina logger.
-    :param name: the name to use in the monitoring
     :param timeout_send: Timeout to be used when sending to Executors
     :param metrics_registry: optional metrics registry for prometheus used if we need to expose metrics from the executor or from the data request handler
     :return: fastapi app
@@ -68,7 +66,7 @@ def get_fastapi_app(
                              timeout_send=timeout_send,
                              retries=args.retries,
                              compression=args.compression,
-                             runtime_name=name,
+                             runtime_name=args.name,
                              prefetch=args.prefetch,
                              logger=logger,
                              metrics_registry=metrics_registry)

--- a/jina/serve/runtimes/gateway/http/app.py
+++ b/jina/serve/runtimes/gateway/http/app.py
@@ -67,12 +67,15 @@ def get_fastapi_app(
 
     request_handler = RequestHandler(metrics_registry, args.name)
 
+
     streamer = RequestStreamer(
-        args=args,
         request_handler=request_handler.handle_request(
             graph=topology_graph, connection_pool=connection_pool
         ),
         result_handler=request_handler.handle_result(),
+        prefetch=getattr(args, 'prefetch', 0),
+        logger=logger,
+        **vars(args)
     )
     streamer.Call = streamer.stream
 

--- a/jina/serve/runtimes/gateway/http/app.py
+++ b/jina/serve/runtimes/gateway/http/app.py
@@ -59,10 +59,17 @@ def get_fastapi_app(
 
     from jina.serve.bff import GatewayBFF
 
-    gateway_bff = GatewayBFF(graph_representation=args.graph_description,
-                             executor_addresses=args.deployments_addresses,
-                             graph_conditions=args.graph_conditions,
-                             deployments_disable_reduce=args.deployments_disable_reduce,
+    import json
+
+    graph_description = json.loads(args.graph_description)
+    graph_conditions = json.loads(args.graph_conditions)
+    deployments_addresses = json.loads(args.deployments_addresses)
+    deployments_disable_reduce = json.loads(args.deployments_disable_reduce)
+
+    gateway_bff = GatewayBFF(graph_representation=graph_description,
+                             executor_addresses=deployments_addresses,
+                             graph_conditions=graph_conditions,
+                             deployments_disable_reduce=deployments_disable_reduce,
                              timeout_send=timeout_send,
                              retries=args.retries,
                              compression=args.compression,

--- a/jina/serve/runtimes/gateway/websocket/__init__.py
+++ b/jina/serve/runtimes/gateway/websocket/__init__.py
@@ -71,7 +71,6 @@ class WebSocketGatewayRuntime(GatewayRuntime):
                 app=extend_rest_interface(
                     get_fastapi_app(
                         args=self.args,
-                        name=self.name,
                         logger=self.logger,
                         timeout_send=self.timeout_send,
                         metrics_registry=self.metrics_registry,

--- a/jina/serve/runtimes/gateway/websocket/__init__.py
+++ b/jina/serve/runtimes/gateway/websocket/__init__.py
@@ -73,6 +73,7 @@ class WebSocketGatewayRuntime(GatewayRuntime):
                         args=self.args,
                         name=self.name,
                         logger=self.logger,
+                        timeout_send=self.timeout_send,
                         metrics_registry=self.metrics_registry,
                     )
                 ),

--- a/jina/serve/runtimes/gateway/websocket/__init__.py
+++ b/jina/serve/runtimes/gateway/websocket/__init__.py
@@ -66,15 +66,12 @@ class WebSocketGatewayRuntime(GatewayRuntime):
                 if ssl_file not in uvicorn_kwargs.keys():
                     uvicorn_kwargs[ssl_file] = getattr(self.args, ssl_file)
 
-        self._set_topology_graph()
-        self._set_connection_pool()
         self._server = UviServer(
             config=Config(
                 app=extend_rest_interface(
                     get_fastapi_app(
-                        self.args,
-                        topology_graph=self._topology_graph,
-                        connection_pool=self._connection_pool,
+                        args=self.args,
+                        name=self.name,
                         logger=self.logger,
                         metrics_registry=self.metrics_registry,
                     )

--- a/jina/serve/runtimes/gateway/websocket/__init__.py
+++ b/jina/serve/runtimes/gateway/websocket/__init__.py
@@ -100,7 +100,6 @@ class WebSocketGatewayRuntime(GatewayRuntime):
     async def async_teardown(self):
         """Shutdown the server."""
         await self._server.shutdown()
-        await self._connection_pool.close()
 
     async def async_cancel(self):
         """Stop the server."""

--- a/jina/serve/runtimes/gateway/websocket/app.py
+++ b/jina/serve/runtimes/gateway/websocket/app.py
@@ -114,11 +114,17 @@ def get_fastapi_app(
     app = FastAPI()
 
     from jina.serve.bff import GatewayBFF
+    import json
 
-    gateway_bff = GatewayBFF(graph_representation=args.graph_description,
-                             executor_addresses=args.deployments_addresses,
-                             graph_conditions=args.graph_conditions,
-                             deployments_disable_reduce=args.deployments_disable_reduce,
+    graph_description = json.loads(args.graph_description)
+    graph_conditions = json.loads(args.graph_conditions)
+    deployments_addresses = json.loads(args.deployments_addresses)
+    deployments_disable_reduce = json.loads(args.deployments_disable_reduce)
+
+    gateway_bff = GatewayBFF(graph_representation=graph_description,
+                             executor_addresses=deployments_addresses,
+                             graph_conditions=graph_conditions,
+                             deployments_disable_reduce=deployments_disable_reduce,
                              timeout_send=timeout_send,
                              retries=args.retries,
                              compression=args.compression,

--- a/jina/serve/runtimes/gateway/websocket/app.py
+++ b/jina/serve/runtimes/gateway/websocket/app.py
@@ -13,9 +13,6 @@ from jina.types.request.status import StatusMessage
 if TYPE_CHECKING:
     from prometheus_client import CollectorRegistry
 
-    from jina.serve.networking import GrpcConnectionPool
-    from jina.serve.runtimes.gateway.graph.topology_graph import TopologyGraph
-
 
 def _fits_ws_close_msg(msg: str):
     # Websocket close messages ('reasons') can't exceed 123 bytes:
@@ -25,19 +22,17 @@ def _fits_ws_close_msg(msg: str):
 
 
 def get_fastapi_app(
-    args: 'argparse.Namespace',
-    topology_graph: 'TopologyGraph',
-    connection_pool: 'GrpcConnectionPool',
-    logger: 'JinaLogger',
-    metrics_registry: Optional['CollectorRegistry'] = None,
+        args: 'argparse.Namespace',
+        logger: 'JinaLogger',
+        name: str,
+        metrics_registry: Optional['CollectorRegistry'] = None,
 ):
     """
     Get the app from FastAPI as the Websocket interface.
 
     :param args: passed arguments.
-    :param topology_graph: topology graph that manages the logic of sending to the proper executors.
-    :param connection_pool: Connection Pool to handle multiple replicas and sending to different of them
     :param logger: Jina logger.
+    :param name: the name to use in the monitoring
     :param metrics_registry: optional metrics registry for prometheus used if we need to expose metrics from the executor or from the data request handler
     :return: fastapi app
     """
@@ -106,7 +101,7 @@ def get_fastapi_app(
                 pass
 
         async def send(
-            self, websocket: WebSocket, data: Union[DataRequest, StatusMessage]
+                self, websocket: WebSocket, data: Union[DataRequest, StatusMessage]
         ) -> None:
             subprotocol = self.protocol_dict[self.get_client(websocket)]
             if subprotocol == WebsocketSubProtocols.JSON:
@@ -118,22 +113,14 @@ def get_fastapi_app(
 
     app = FastAPI()
 
-    from jina.serve.runtimes.gateway.request_handling import RequestHandler
-    from jina.serve.stream import RequestStreamer
+    from jina.serve.bff import GatewayBFF
 
-    request_handler = RequestHandler(metrics_registry, args.name)
-
-    streamer = RequestStreamer(
-        request_handler=request_handler.handle_request(
-            graph=topology_graph, connection_pool=connection_pool
-        ),
-        result_handler=request_handler.handle_result(),
-        prefetch=getattr(args, 'prefetch', 0),
-        logger=logger,
-        **vars(args)
-    )
-
-    streamer.Call = streamer.stream
+    gateway_bff = GatewayBFF(graph_representation=args.graph_description, executor_addresses=args.deployments_addresses,
+                             graph_conditions=args.graph_conditions,
+                             deployments_disable_reduce=args.deployments_disable_reduce, timeout_send=args.timeout_send,
+                             retries=args.retries, compression=args.compression,
+                             runtime_name=name, prefetch=args.prefetch, logger=logger,
+                             metrics_registry=metrics_registry)
 
     @app.get(
         path='/',
@@ -168,12 +155,11 @@ def get_fastapi_app(
 
     @app.on_event('shutdown')
     async def _shutdown():
-        await streamer.wait_floating_requests_end()
-        await connection_pool.close()
+        await gateway_bff.close()
 
     @app.websocket('/')
     async def websocket_endpoint(
-        websocket: WebSocket, response: Response
+            websocket: WebSocket, response: Response
     ):  # 'response' is a FastAPI response, not a Jina response
         await manager.connect(websocket)
 
@@ -201,7 +187,7 @@ def get_fastapi_app(
                         yield DataRequest(request)
 
         try:
-            async for msg in streamer.stream(request_iterator=req_iter()):
+            async for msg in gateway_bff.stream(request_iterator=req_iter()):
                 await manager.send(websocket, msg)
         except InternalNetworkError as err:
             import grpc
@@ -231,7 +217,7 @@ def get_fastapi_app(
         :param request_iterator: request iterator, with length of 1
         :return: the first result from the request iterator
         """
-        async for k in streamer.stream(request_iterator=request_iterator):
+        async for k in gateway_bff.stream(request_iterator=request_iterator):
             request_dict = k.to_dict()
             return request_dict
 
@@ -243,7 +229,7 @@ def get_fastapi_app(
     @app.get(
         path='/dry_run',
         summary='Get the readiness of Jina Flow service, sends an empty DocumentArray to the complete Flow to '
-        'validate connectivity',
+                'validate connectivity',
         response_model=PROTO_TO_PYDANTIC_MODELS.StatusProto,
     )
     async def _dry_run_http():
@@ -273,7 +259,7 @@ def get_fastapi_app(
 
     @app.websocket('/dry_run')
     async def websocket_endpoint(
-        websocket: WebSocket, response: Response
+            websocket: WebSocket, response: Response
     ):  # 'response' is a FastAPI response, not a Jina response
         from jina.proto import jina_pb2
         from jina.serve.executors import __dry_run_endpoint__
@@ -282,12 +268,12 @@ def get_fastapi_app(
 
         da = DocumentArray()
         try:
-            async for _ in streamer.stream(
-                request_iterator=request_generator(
-                    exec_endpoint=__dry_run_endpoint__,
-                    data=da,
-                    data_type=DataInputType.DOCUMENT,
-                )
+            async for _ in gateway_bff.stream(
+                    request_iterator=request_generator(
+                        exec_endpoint=__dry_run_endpoint__,
+                        data=da,
+                        data_type=DataInputType.DOCUMENT,
+                    )
             ):
                 pass
             status_message = StatusMessage()

--- a/jina/serve/runtimes/gateway/websocket/app.py
+++ b/jina/serve/runtimes/gateway/websocket/app.py
@@ -25,6 +25,7 @@ def get_fastapi_app(
         args: 'argparse.Namespace',
         logger: 'JinaLogger',
         name: str,
+        timeout_send: Optional[float] = None,
         metrics_registry: Optional['CollectorRegistry'] = None,
 ):
     """
@@ -33,6 +34,7 @@ def get_fastapi_app(
     :param args: passed arguments.
     :param logger: Jina logger.
     :param name: the name to use in the monitoring
+    :param timeout_send: Timeout to be used when sending to Executors
     :param metrics_registry: optional metrics registry for prometheus used if we need to expose metrics from the executor or from the data request handler
     :return: fastapi app
     """
@@ -115,11 +117,16 @@ def get_fastapi_app(
 
     from jina.serve.bff import GatewayBFF
 
-    gateway_bff = GatewayBFF(graph_representation=args.graph_description, executor_addresses=args.deployments_addresses,
+    gateway_bff = GatewayBFF(graph_representation=args.graph_description,
+                             executor_addresses=args.deployments_addresses,
                              graph_conditions=args.graph_conditions,
-                             deployments_disable_reduce=args.deployments_disable_reduce, timeout_send=args.timeout_send,
-                             retries=args.retries, compression=args.compression,
-                             runtime_name=name, prefetch=args.prefetch, logger=logger,
+                             deployments_disable_reduce=args.deployments_disable_reduce,
+                             timeout_send=timeout_send,
+                             retries=args.retries,
+                             compression=args.compression,
+                             runtime_name=name,
+                             prefetch=args.prefetch,
+                             logger=logger,
                              metrics_registry=metrics_registry)
 
     @app.get(

--- a/jina/serve/runtimes/gateway/websocket/app.py
+++ b/jina/serve/runtimes/gateway/websocket/app.py
@@ -124,11 +124,13 @@ def get_fastapi_app(
     request_handler = RequestHandler(metrics_registry, args.name)
 
     streamer = RequestStreamer(
-        args=args,
         request_handler=request_handler.handle_request(
             graph=topology_graph, connection_pool=connection_pool
         ),
         result_handler=request_handler.handle_result(),
+        prefetch=getattr(args, 'prefetch', 0),
+        logger=logger,
+        **vars(args)
     )
 
     streamer.Call = streamer.stream

--- a/jina/serve/runtimes/gateway/websocket/app.py
+++ b/jina/serve/runtimes/gateway/websocket/app.py
@@ -24,7 +24,6 @@ def _fits_ws_close_msg(msg: str):
 def get_fastapi_app(
         args: 'argparse.Namespace',
         logger: 'JinaLogger',
-        name: str,
         timeout_send: Optional[float] = None,
         metrics_registry: Optional['CollectorRegistry'] = None,
 ):
@@ -33,7 +32,6 @@ def get_fastapi_app(
 
     :param args: passed arguments.
     :param logger: Jina logger.
-    :param name: the name to use in the monitoring
     :param timeout_send: Timeout to be used when sending to Executors
     :param metrics_registry: optional metrics registry for prometheus used if we need to expose metrics from the executor or from the data request handler
     :return: fastapi app
@@ -124,7 +122,7 @@ def get_fastapi_app(
                              timeout_send=timeout_send,
                              retries=args.retries,
                              compression=args.compression,
-                             runtime_name=name,
+                             runtime_name=args.name,
                              prefetch=args.prefetch,
                              logger=logger,
                              metrics_registry=metrics_registry)

--- a/jina/serve/stream/__init__.py
+++ b/jina/serve/stream/__init__.py
@@ -40,11 +40,12 @@ class RequestStreamer:
         **logger_kwargs
     ):
         """
-        :param args: args from CLI
         :param request_handler: The callable responsible for handling the request. It should handle a request as input and return a Future to be awaited
         :param result_handler: The callable responsible for handling the response.
         :param end_of_iter_handler: Optional callable to handle the end of iteration if some special action needs to be taken.
+        :param prefetch: How many Requests are processed from the Client at the same time.
         :param logger: Optional logger that can be used for logging
+        :param logger_kwargs: Extra keyword arguments that may be passed to the internal logger constructor if none is provided
 
         """
         self.logger = logger or JinaLogger(self.__class__.__name__, **logger_kwargs)

--- a/jina/serve/stream/__init__.py
+++ b/jina/serve/stream/__init__.py
@@ -32,11 +32,12 @@ class RequestStreamer:
 
     def __init__(
         self,
-        args: argparse.Namespace,
         request_handler: Callable[['Request'], 'Awaitable[Request]'],
         result_handler: Callable[['Request'], Optional['Request']],
+        prefetch: int = 0,
         end_of_iter_handler: Optional[Callable[[], None]] = None,
         logger: Optional['JinaLogger'] = None,
+        **logger_kwargs
     ):
         """
         :param args: args from CLI
@@ -46,9 +47,8 @@ class RequestStreamer:
         :param logger: Optional logger that can be used for logging
 
         """
-        self.args = args
-        self.logger = logger or JinaLogger(self.__class__.__name__, **vars(args))
-        self._prefetch = getattr(self.args, 'prefetch', 0)
+        self.logger = logger or JinaLogger(self.__class__.__name__, **logger_kwargs)
+        self._prefetch = prefetch
         self._request_handler = request_handler
         self._result_handler = result_handler
         self._end_of_iter_handler = end_of_iter_handler

--- a/tests/integration/bff/test_gateway_bff.py
+++ b/tests/integration/bff/test_gateway_bff.py
@@ -1,0 +1,88 @@
+import multiprocessing
+
+import pytest
+
+from jina.parsers import set_pod_parser
+from jina.serve.runtimes.asyncio import AsyncNewLoopRuntime
+from jina.serve.runtimes.worker import WorkerRuntime
+from jina.serve.bff import GatewayBFF
+from jina import Executor, requests
+from jina import DocumentArray
+
+
+class BffTestExecutor(Executor):
+
+    @requests
+    def foo(self, docs, parameters, **kwargs):
+        text_to_add = parameters.get('text_to_add', 'default ')
+        for doc in docs:
+            doc.text += text_to_add
+
+
+def _create_worker_runtime(port, name=''):
+    args = set_pod_parser().parse_args([])
+    args.port = port
+    args.name = name
+    args.uses = 'BffTestExecutor'
+    with WorkerRuntime(args) as runtime:
+        runtime.run_forever()
+
+
+def _setup(pod0_port, pod1_port):
+    pod0_process = multiprocessing.Process(
+        target=_create_worker_runtime, args=(pod0_port,)
+    )
+    pod0_process.start()
+
+    pod1_process = multiprocessing.Process(
+        target=_create_worker_runtime, args=(pod1_port,)
+    )
+    pod1_process.start()
+
+    AsyncNewLoopRuntime.wait_for_ready_or_shutdown(
+        timeout=5.0,
+        ctrl_address=f'0.0.0.0:{pod0_port}',
+        ready_or_shutdown_event=multiprocessing.Event(),
+    )
+    AsyncNewLoopRuntime.wait_for_ready_or_shutdown(
+        timeout=5.0,
+        ctrl_address=f'0.0.0.0:{pod1_port}',
+        ready_or_shutdown_event=multiprocessing.Event(),
+    )
+    return pod0_process, pod1_process
+
+
+@pytest.mark.asyncio
+async def test_gateway_bdd(port_generator):
+    pod0_port = port_generator()
+    pod1_port = port_generator()
+    pod0_process, pod1_process = _setup(pod0_port, pod1_port)
+
+    try:
+        graph_description = {"start-gateway": ["pod0"], "pod0": ["pod1"], "pod1": ["end-gateway"]}
+        pod_addresses = {"pod0": ["0.0.0.0:{pod0_port}"], "pod1": ["0.0.0.0:{pod1_port}"]}
+        # send requests to the gateway
+        gateway_bff = GatewayBFF(graph_representation=graph_description, executor_addresses=pod_addresses)
+
+        input_da = DocumentArray.empty(60)
+
+        resp = DocumentArray.empty(0)
+        num_resp = 0
+        async for r in gateway_bff.stream_docs(docs=input_da, request_size=10):
+            num_resp += 1
+            resp.extend(r)
+
+        assert num_resp == 6
+        assert len(resp) == 60
+        for doc in resp:
+            assert doc.text == 'default default '
+    except Exception:
+        assert False
+    finally:  # clean up runtimes
+        pod0_process.terminate()
+        pod1_process.terminate()
+        pod0_process.join()
+        pod1_process.join()
+
+
+

--- a/tests/integration/clients_extra_kwargs/test_clients_post_extra_kwargs.py
+++ b/tests/integration/clients_extra_kwargs/test_clients_post_extra_kwargs.py
@@ -58,8 +58,6 @@ def flow_with_grpc(monkeypatch):
                 ],
             )
 
-            self._set_topology_graph()
-            self._set_connection_pool()
 
             await self._async_setup_server()
 

--- a/tests/unit/serve/runtimes/gateway/grpc/test_grpc_gateway_runtime.py
+++ b/tests/unit/serve/runtimes/gateway/grpc/test_grpc_gateway_runtime.py
@@ -185,13 +185,13 @@ def test_grpc_gateway_runtime_handle_messages_linear(linear_graph_dict, monkeypa
         ) as runtime:
 
             async def _test():
-                responses = []
+                r = []
                 req = request_generator(
                     '/', DocumentArray([Document(text='client0-Request')])
                 )
-                async for resp in runtime.streamer.Call(request_iterator=req):
-                    responses.append(resp)
-                return responses
+                async for resp in runtime.gateway_bff.stream(request_iterator=req):
+                    r.append(resp)
+                return r
 
             responses = asyncio.run(_test())
         assert len(responses) > 0
@@ -241,7 +241,7 @@ def test_grpc_gateway_runtime_handle_messages_bifurcation(
                 req = request_generator(
                     '/', DocumentArray([Document(text='client0-Request')])
                 )
-                async for resp in runtime.streamer.Call(request_iterator=req):
+                async for resp in runtime.gateway_bff.stream(request_iterator=req):
                     responses.append(resp)
                 return responses
 
@@ -295,7 +295,7 @@ def test_grpc_gateway_runtime_handle_messages_merge_in_gateway(
                 req = request_generator(
                     '/', DocumentArray([Document(text='client0-Request')])
                 )
-                async for resp in runtime.streamer.Call(request_iterator=req):
+                async for resp in runtime.gateway_bff.stream(request_iterator=req):
                     responses.append(resp)
                 return responses
 
@@ -352,7 +352,7 @@ def test_grpc_gateway_runtime_handle_messages_merge_in_last_deployment(
                 req = request_generator(
                     '/', DocumentArray([Document(text='client0-Request')])
                 )
-                async for resp in runtime.streamer.Call(request_iterator=req):
+                async for resp in runtime.gateway_bff.stream(request_iterator=req):
                     responses.append(resp)
                 return responses
 
@@ -409,7 +409,7 @@ def test_grpc_gateway_runtime_handle_messages_complete_graph_dict(
                 req = request_generator(
                     '/', DocumentArray([Document(text='client0-Request')])
                 )
-                async for resp in runtime.streamer.Call(request_iterator=req):
+                async for resp in runtime.gateway_bff.stream(request_iterator=req):
                     responses.append(resp)
                 return responses
 
@@ -459,7 +459,7 @@ def test_grpc_gateway_runtime_handle_empty_graph():
                 req = request_generator(
                     '/', DocumentArray([Document(text='client0-Request')])
                 )
-                async for resp in runtime.streamer.Call(request_iterator=req):
+                async for resp in runtime.gateway_bff.stream(request_iterator=req):
                     responses.append(resp)
                 return responses
 

--- a/tests/unit/serve/runtimes/gateway/http/test_app.py
+++ b/tests/unit/serve/runtimes/gateway/http/test_app.py
@@ -5,16 +5,12 @@ from tempfile import NamedTemporaryFile
 import aiohttp
 import pytest
 import requests as req
-from fastapi.testclient import TestClient
 
 from docarray import Document, DocumentArray
 from jina import Client, Executor, Flow, requests
 from jina.helper import random_port
-from jina.logging.logger import JinaLogger
 from jina.parsers import set_gateway_parser
-from jina.serve.networking import GrpcConnectionPool
-from jina.serve.runtimes.gateway import TopologyGraph
-from jina.serve.runtimes.gateway.http import HTTPGatewayRuntime, get_fastapi_app
+from jina.serve.runtimes.gateway.http import HTTPGatewayRuntime
 from jina.serve.runtimes.gateway.websocket import WebSocketGatewayRuntime
 
 

--- a/tests/unit/serve/stream/test_stream.py
+++ b/tests/unit/serve/stream/test_stream.py
@@ -66,7 +66,6 @@ async def test_request_streamer(prefetch, num_requests, async_iterator):
         result_handler=result_handle_fn,
         end_of_iter_handler=end_of_iter_fn,
         prefetch=getattr(args, 'prefetch', 0),
-        **vars(args)
     )
 
     it = (

--- a/tests/unit/serve/stream/test_stream.py
+++ b/tests/unit/serve/stream/test_stream.py
@@ -62,10 +62,11 @@ async def test_request_streamer(prefetch, num_requests, async_iterator):
     args = Namespace()
     args.prefetch = prefetch
     streamer = RequestStreamer(
-        args=args,
         request_handler=request_handler_fn,
         result_handler=result_handle_fn,
         end_of_iter_handler=end_of_iter_fn,
+        prefetch=getattr(args, 'prefetch', 0),
+        **vars(args)
     )
 
     it = (


### PR DESCRIPTION
Goals:

First conversation starter to have an `object` that can be used by community that hides the `complexity` from `TopologyGraph` and `ConnectionPool`.

Conditions of the design:

- [x] Simple interface. (__init__, stream (as send), and close)
- [x] Do not receive `args` but specific arguments mapping to concepts/features

Things to do:

- [ ] Proper concept naming
- [ ] Naming of arguments and methods
- [x] DocStrings
- [ ] Decision of interface
- [x] Refactor the request_generator part, do not import client code from server