### PR TITLE
fix: add more logging in grpc dry run

### DIFF
--- a/jina/clients/base/grpc.py
+++ b/jina/clients/base/grpc.py
@@ -46,6 +46,10 @@ class GRPCBaseClient(BaseClient):
                 )
                 if response.code == jina_pb2.StatusProto.SUCCESS:
                     return True
+                else:
+                    self.logger.error(
+                        f'Returned code is not expected! Exception: {response.exception}'
+                    )
         except Exception as e:
             self.logger.error(f'Error while getting response from grpc server {e!r}')
 

--- a/jina/clients/base/http.py
+++ b/jina/clients/base/http.py
@@ -65,7 +65,7 @@ class HTTPBaseClient(BaseClient):
                 if r_str['code'] == jina_pb2.StatusProto.SUCCESS:
                     return True
                 else:
-                    self.logger.debug(
+                    self.logger.error(
                         f'Returned code is not expected! Description: {r_str["description"]}'
                     )
             except Exception as e:


### PR DESCRIPTION
## Context ## 

Similar to https://github.com/jina-ai/jina/pull/5008, I'm adding the logging also for GRPC dry run. 

Also I'm changing the two logs from `DEBUG` to `ERROR` as they contain information that reveals non-transient issue (see below screenshot) which is critical for debugging. I figured it's more appropriate.

## Tests ## 
With log line used:

<img width="1538" alt="Screen Shot 2022-07-28 at 10 01 24" src="https://user-images.githubusercontent.com/2687065/181433571-49467be2-97d6-4ee2-88f1-6bce3c12d03e.png">

