### PR TITLE
fix: fix specific params problem with branches

### DIFF
--- a/jina/serve/runtimes/gateway/graph/topology_graph.py
+++ b/jina/serve/runtimes/gateway/graph/topology_graph.py
@@ -62,10 +62,7 @@ class TopologyGraph:
                 req = self.parts_to_send[i] if not need_copy else copy.deepcopy(self.parts_to_send[i])
                 filtered_docs = req.docs.find(self._filter_condition)
                 req.data.docs = filtered_docs
-
                 self.parts_to_send[i] = req
-                # filtered_docs = self.parts_to_send[i].docs.find(self._filter_condition)
-                # self.parts_to_send[i].data.docs = filtered_docs
 
         def _update_request_by_params(self, deployment_name: str, request_input_parameters: Dict):
             specific_parameters = _parse_specific_params(

--- a/jina/serve/runtimes/gateway/request_handling.py
+++ b/jina/serve/runtimes/gateway/request_handling.py
@@ -138,6 +138,7 @@ class RequestHandler:
             for key in request_input_parameters:
                 if _is_param_for_specific_executor(key):
                     has_specific_params = True
+                    break
 
             for origin_node in request_graph.origin_nodes:
                 leaf_tasks = origin_node.get_leaf_tasks(

--- a/jina/serve/runtimes/gateway/request_handling.py
+++ b/jina/serve/runtimes/gateway/request_handling.py
@@ -10,6 +10,7 @@ from jina.excepts import InternalNetworkError
 from jina.importer import ImportExtensions
 from jina.serve.networking import GrpcConnectionPool
 from jina.serve.runtimes.gateway.graph.topology_graph import TopologyGraph
+from jina.serve.runtimes.request_handlers.data_request_handler import DataRequestHandler
 
 if TYPE_CHECKING:
     from asyncio import Future
@@ -138,6 +139,7 @@ class RequestHandler:
                     endpoint=endpoint,
                     executor_endpoint_mapping=self._executor_endpoint_mapping,
                     target_executor_pattern=request.header.target_executor,
+                    request_input_parameters=request.parameters
                 )
                 # Every origin node returns a set of tasks that are the ones corresponding to the leafs of each of their
                 # subtrees that unwrap all the previous tasks. It starts like a chain of waiting for tasks from previous
@@ -181,6 +183,9 @@ class RequestHandler:
 
                 if graph.has_filter_conditions:
                     _sort_response_docs(response)
+
+                collect_results = request_graph.collect_all_results()
+                response.parameters[DataRequestHandler._KEY_RESULT] = collect_results
                 return response
 
             # In case of empty topologies

--- a/jina/serve/runtimes/gateway/request_handling.py
+++ b/jina/serve/runtimes/gateway/request_handling.py
@@ -197,8 +197,9 @@ class RequestHandler:
 
                 collect_results = request_graph.collect_all_results()
                 resp_params = response.parameters
-                resp_params[DataRequestHandler._KEY_RESULT] = collect_results
-                response.parameters = resp_params
+                if len(collect_results) > 0:
+                    resp_params[DataRequestHandler._KEY_RESULT] = collect_results
+                    response.parameters = resp_params
                 return response
 
             # In case of empty topologies

--- a/jina/serve/runtimes/helper.py
+++ b/jina/serve/runtimes/helper.py
@@ -36,7 +36,7 @@ def _get_name_from_replicas_name(name: str) -> Tuple[str]:
 def _is_param_for_specific_executor(key_name: str) -> bool:
     """Tell if a key is for a specific Executor
 
-    ex: 'key' is for every Executor whereas 'key__my_executor' is only for 'my_executor'
+    ex: 'key' is for every Executor whereas 'my_executor__key' is only for 'my_executor'
 
     :param key_name: key name of the param
     :return: return True if key_name is for specific Executor, False otherwise

--- a/tests/integration/container_runtime_args/test_container_get_args.py
+++ b/tests/integration/container_runtime_args/test_container_get_args.py
@@ -8,7 +8,6 @@ from jina import Client, Document, DocumentArray, Flow
 cur_dir = os.path.dirname(os.path.abspath(__file__))
 
 img_name = 'jina/replica-exec'
-exposed_port = 12345
 
 
 @pytest.fixture(scope='function')
@@ -26,7 +25,8 @@ def docker_image_built():
 
 @pytest.mark.parametrize('shards', [1, 2])
 @pytest.mark.parametrize('replicas', [1, 3, 4])
-def test_containerruntime_args(docker_image_built, shards, replicas):
+def test_containerruntime_args(docker_image_built, shards, replicas, port_generator):
+    exposed_port = port_generator()
     f = Flow(port=exposed_port).add(
         name='executor_container',
         uses=f'docker://{img_name}',

--- a/tests/integration/high_order_matches/test_document.py
+++ b/tests/integration/high_order_matches/test_document.py
@@ -1,7 +1,5 @@
 from jina import Client, Document, Executor, Flow, requests
 
-exposed_port = 12345
-
 
 def validate_results(results):
     req = results[0]
@@ -25,7 +23,9 @@ class MatchAdder(Executor):
                     doc.matches.append(Document())
 
 
-def test_single_executor():
+def test_single_executor(port_generator):
+
+    exposed_port = port_generator()
 
     f = Flow(port=exposed_port).add(
         uses={'jtype': 'MatchAdder', 'with': {'traversal_paths': 'r,m'}}
@@ -38,7 +38,9 @@ def test_single_executor():
     validate_results(results)
 
 
-def test_multi_executor():
+def test_multi_executor(port_generator):
+
+    exposed_port = port_generator()
 
     f = (
         Flow(port=exposed_port)

--- a/tests/integration/override_config_params/container/test_override_config_params.py
+++ b/tests/integration/override_config_params/container/test_override_config_params.py
@@ -5,7 +5,6 @@ import pytest
 from jina import Flow, Document, Client
 
 cur_dir = os.path.dirname(os.path.abspath(__file__))
-exposed_port = 12345
 
 
 @pytest.fixture()
@@ -23,7 +22,8 @@ def docker_image():
 
 
 @pytest.fixture()
-def flow(request):
+def flow(request, port_generator):
+    exposed_port = port_generator()
     flow_src = request.param
     if flow_src == 'yml':
         return Flow(port=exposed_port).load_config(os.path.join(cur_dir, 'flow.yml'))
@@ -38,8 +38,8 @@ def flow(request):
 @pytest.mark.parametrize('flow', ['yml', 'python'], indirect=['flow'])
 def test_override_config_params(docker_image, flow):
     with flow:
-        resps = Client(port=exposed_port, return_responses=True).search(
-            inputs=[Document()]
+        resps = Client(port=flow.port).search(
+            inputs=[Document()], return_responses=True
         )
     doc = resps[0].docs[0]
     assert doc.tags['param1'] == 50
@@ -49,7 +49,8 @@ def test_override_config_params(docker_image, flow):
     assert doc.tags['workspace'] == 'different_workspace'
 
 
-def test_override_config_params_shards(docker_image):
+def test_override_config_params_shards(docker_image, port_generator):
+    exposed_port = port_generator()
     flow = Flow(port=exposed_port).add(
         uses='docker://override-config-test',
         uses_with={'param1': 50, 'param2': 30},
@@ -57,8 +58,8 @@ def test_override_config_params_shards(docker_image):
         shards=2,
     )
     with flow:
-        resps = Client(port=exposed_port, return_responses=True).search(
-            inputs=[Document()]
+        resps = Client(port=exposed_port).search(
+            inputs=[Document()], return_responses=True
         )
     doc = resps[0].docs[0]
     assert doc.tags['param1'] == 50

--- a/tests/integration/override_executor_specific_params/test_specific_params.py
+++ b/tests/integration/override_executor_specific_params/test_specific_params.py
@@ -8,7 +8,6 @@ OVERRIDEN_EXECUTOR1_PARAMS = {
     'param2': 60,
     'exec_name': {'param1': 'changed'},
 }
-exposed_port = 12345
 
 
 class DummyOverrideParams(Executor):
@@ -32,7 +31,8 @@ class DummyAssertIfParamsCanBeChangedInsidePods(Executor):
         assert parameters == ORIGINAL_PARAMS
 
 
-def test_override_params(mocker):
+def test_override_params(mocker, port_generator):
+    exposed_port = port_generator()
     f = (
         Flow(port=exposed_port)
         .add(

--- a/tests/integration/specific_executor_params/test_specific_params.py
+++ b/tests/integration/specific_executor_params/test_specific_params.py
@@ -1,6 +1,6 @@
-import copy
-
-from docarray import DocumentArray
+import numpy as np
+from docarray import DocumentArray, Document, dataclass
+from docarray.typing import Text
 
 from jina import Executor, Flow, requests
 
@@ -13,12 +13,13 @@ def test_specific_params():
 
         @requests
         def process(self, docs, parameters, **kwargs):
-            docs[0].tags['assert'] = parameters == self.params_awaited
+            for doc in docs:
+                doc.tags['assert'] = parameters == self.params_awaited
 
     flow = (
         Flow()
-        .add(uses=MyExec, name='exec1', uses_with={'params_awaited': {'key_1': True}})
-        .add(
+            .add(uses=MyExec, name='exec1', uses_with={'params_awaited': {'key_1': True}})
+            .add(
             uses=MyExec,
             name='exec2',
             uses_with={'params_awaited': {'key_1': True, 'key_2': False}},
@@ -32,3 +33,65 @@ def test_specific_params():
         )
 
         assert docs[0].tags['assert']
+
+
+def test_specific_params_with_branched_flow():
+    class TextEncoderTestSpecific(Executor):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.model = lambda t: np.random.rand(
+                len(t), 128
+            )  # initialize dummy text embedding model
+
+        @requests(on='/encode')
+        def encode_text(self, docs, parameters, **kwargs):
+            path = parameters.get('access_path', None)
+            text_docs = docs[path]
+            embeddings = self.model(text_docs[:, 'text'])
+            text_docs.embeddings = embeddings
+
+    class EmbeddingCombinerTestSpecific(Executor):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.model = lambda emb1, emb2: np.concatenate(
+                [emb1, emb2], axis=1
+            )  # initialize dummy model to combine embeddings
+
+        @requests(on='/encode')
+        def combine(self, docs, parameters, **kwargs):
+            text1_path = parameters.get('text1_access_path', None)
+            text2_path = parameters.get('text2_access_path', None)
+            text1_docs = docs[text1_path]
+            text2_docs = docs[text2_path]
+            combined_embeddings = self.model(text1_docs.embeddings, text2_docs.embeddings)
+            docs.embeddings = combined_embeddings
+
+    @dataclass
+    class MMDoc:
+        text1: Text
+        text2: Text
+
+    mmdoc_dataclass = MMDoc(text1='text 1', text2='text 2')
+    da = DocumentArray([Document(mmdoc_dataclass)])
+    f = (
+        Flow()
+            .add(uses=TextEncoderTestSpecific, name='Text1Encoder')
+            .add(uses=TextEncoderTestSpecific, name='Text2Encoder', needs='gateway')
+            .add(uses=EmbeddingCombinerTestSpecific, name='Combiner', needs=['Text1Encoder', 'Text2Encoder'])
+    )
+
+    with f:
+        da = f.post(
+            inputs=da,
+            on='/encode',
+            parameters={
+                'Text1Encoder__access_path': '@.[text1]',
+                'Text2Encoder__access_path': '@.[text2]',
+                'Combiner__text1_access_path': '@.[text1]',
+                'Combiner__text2_access_path': '@.[text2]',
+            },
+        )
+
+    assert len(da) == 1
+    for d in da:
+        assert d.embedding.shape == (256, )

--- a/tests/integration/specific_executor_params/test_specific_params.py
+++ b/tests/integration/specific_executor_params/test_specific_params.py
@@ -61,6 +61,8 @@ def test_specific_params_with_branched_flow():
         def combine(self, docs, parameters, **kwargs):
             text1_path = parameters.get('text1_access_path', None)
             text2_path = parameters.get('text2_access_path', None)
+            assert text1_path == '@.[text1]'
+            assert text2_path == '@.[text2]'
             text1_docs = docs[text1_path]
             text2_docs = docs[text2_path]
             combined_embeddings = self.model(text1_docs.embeddings, text2_docs.embeddings)

--- a/tests/unit/orchestrate/flow/flow-orchestrate/test_flow_docarray_return.py
+++ b/tests/unit/orchestrate/flow/flow-orchestrate/test_flow_docarray_return.py
@@ -61,11 +61,11 @@ def test_empty_docarray():
     f = Flow().add(uses=SimplExecutor)
     with pytest.raises(BadServer):
         with f:
-            docs = f.post(on='/')
+            f.post(on='/')
 
 
-def test_flow_client_defaults():
-    exposed_port = 12345
+def test_flow_client_defaults(port_generator):
+    exposed_port = port_generator()
     f = Flow(port=exposed_port).add(uses=SimplExecutor)
     c = Client(port=exposed_port)
     with f:


### PR DESCRIPTION
Solves an issue with `executor specific parameters` per Executor.

Original problem is that `request` is concurrently altered and there are issues on how they are updated before they are sent.

This problem is now solved by deepcopying the request before sending, but we have to analyze if this is the right approach since it can imply performance degradation. To solve this I added some optimizations in the code to detect when it is actually needed

Here I just want to validate this functionality would work, specially if the `__results__` handling is correct

