### PR TITLE
docs: improve grpc third party client documentation

### DIFF
--- a/docs/fundamentals/client/client.md
+++ b/docs/fundamentals/client/client.md
@@ -6,7 +6,7 @@ Clients support four different networking protocols: **HTTP**, **gRPC**, **WebSo
 
 For each of them, you first connect your Client to the API Gateway, before you can send requests to it.
 
-```{hint
+```{hint}
 You want to connect to your Flow from an other programming language that Python ? Please follow the third party 
 client {ref}`documentation <third-party-client>`
 ```

--- a/docs/fundamentals/client/client.md
+++ b/docs/fundamentals/client/client.md
@@ -7,7 +7,7 @@ Clients support four different networking protocols: **HTTP**, **gRPC**, **WebSo
 For each of them, you first connect your Client to the API Gateway, before you can send requests to it.
 
 ```{hint}
-You want to connect to your Flow from an other programming language that Python ? Please follow the third party 
+You want to connect to your Flow from an other programming language than Python ? Please follow the third party 
 client {ref}`documentation <third-party-client>`
 ```
 

--- a/docs/fundamentals/client/client.md
+++ b/docs/fundamentals/client/client.md
@@ -539,5 +539,5 @@ For details on the allowed mutation arguments and response fields, see {ref}`her
 ```{toctree}
 :hidden:
 
-access-flow-api
+third-party-client
 ```

--- a/docs/fundamentals/client/client.md
+++ b/docs/fundamentals/client/client.md
@@ -6,6 +6,12 @@ Clients support four different networking protocols: **HTTP**, **gRPC**, **WebSo
 
 For each of them, you first connect your Client to the API Gateway, before you can send requests to it.
 
+```{hint
+You want to connect to your Flow from an other programming language that Python ? Please follow the third party 
+client {ref}`documentation <third-party-client>`
+```
+
+
 ## Connect
 
 If there is not already a Flow running in the background or on the network, you can start one:

--- a/docs/fundamentals/client/client.md
+++ b/docs/fundamentals/client/client.md
@@ -7,8 +7,8 @@ Clients support four different networking protocols: **HTTP**, **gRPC**, **WebSo
 For each of them, you first connect your Client to the API Gateway, before you can send requests to it.
 
 ```{hint}
-You want to connect to your Flow from an other programming language than Python ? Please follow the third party 
-client {ref}`documentation <third-party-client>`
+If you want to connect to your Flow from a programming language other than Python, please follow the third party 
+client {ref}`documentation <third-party-client>`.
 ```
 
 

--- a/docs/fundamentals/client/third-party-client.md
+++ b/docs/fundamentals/client/third-party-client.md
@@ -230,6 +230,23 @@ We provide a suite of templates for the Jina Flow, in this [collection](https://
 
 This contribution was made by [Jonathan Rowley](https://jina-ai.slack.com/archives/C0169V26ATY/p1649689443888779?thread_ts=1649428823.420879&cid=C0169V26ATY), in our [community Slack](slack.jina.ai). 
 
+## gRPC
+
+To use the gRPC protocol with another language that python you will need to :
+
+* Download the two proto definition files : `jina.proto` and `docarray.proto`
+* Compile them with [protoc](https://grpc.io/docs/protoc-installation/) and precise to which programming language you want to compile them.
+* Add the generated files to your project and import them in your code. 
+
+you should finally be able to communicate with your Flow using the gRPC protocol. You can find more information on the gRPC
+`message` and `service` that you can use to communicate in the  [Protobuf documentation](../../proto/docs.md).
+
+
+If you want to create a gRPC client in another language, you will need to compile the
+You can find the `jina.proto`
+
+
+
 (flow-graphql)=
 ## GraphQL
 
@@ -288,10 +305,6 @@ The available fields in the GraphQL API are defined by the [Document Strawberry 
 
 Essentially, you can ask for any property of a Document, including `embedding`, `text`, `tensor`, `id`, `matches`, `tags`,
 and more.
-
-## gRPC
-
-If you want to create a gRPC client in another language, you will need to compile the [Protobuf definition](../../proto/docs.md). In Python, you can use our {ref}`own client <client>`.
 
 ## Websocket
 

--- a/docs/fundamentals/client/third-party-client.md
+++ b/docs/fundamentals/client/third-party-client.md
@@ -1,4 +1,4 @@
-(access-flow-api)=
+(third-party-client)=
 # Third-party clients
 
 This page is about accessing the Flow with other clients, e.g. `curl`.

--- a/docs/fundamentals/client/third-party-client.md
+++ b/docs/fundamentals/client/third-party-client.md
@@ -234,7 +234,7 @@ This contribution was made by [Jonathan Rowley](https://jina-ai.slack.com/archiv
 
 To use the gRPC protocol with another language that python you will need to :
 
-* Download the two proto definition files : `jina.proto` and `docarray.proto`
+* Download the two proto definition files : `jina.proto` and `docarray.proto` from [github](https://github.com/jina-ai/jina/tree/master/jina/proto) (be sure to use the latest release branch)
 * Compile them with [protoc](https://grpc.io/docs/protoc-installation/) and precise to which programming language you want to compile them.
 * Add the generated files to your project and import them in your code. 
 

--- a/docs/fundamentals/client/third-party-client.md
+++ b/docs/fundamentals/client/third-party-client.md
@@ -234,7 +234,7 @@ This contribution was made by [Jonathan Rowley](https://jina-ai.slack.com/archiv
 
 To use the gRPC protocol with a language other than Python you will need to :
 
-* Download the two proto definition files : `jina.proto` and `docarray.proto` from [github](https://github.com/jina-ai/jina/tree/master/jina/proto) (be sure to use the latest release branch)
+* Download the two proto definition files: `jina.proto` and `docarray.proto` from [github](https://github.com/jina-ai/jina/tree/master/jina/proto) (be sure to use the latest release branch)
 * Compile them with [protoc](https://grpc.io/docs/protoc-installation/) and precise to which programming language you want to compile them.
 * Add the generated files to your project and import them in your code. 
 

--- a/docs/fundamentals/client/third-party-client.md
+++ b/docs/fundamentals/client/third-party-client.md
@@ -1,7 +1,7 @@
 (third-party-client)=
 # Third-party clients
 
-This page is about accessing the Flow with other clients, e.g. `curl`.
+This page is about accessing the Flow with other clients, e.g. `curl` and other programming language than python.
 
 ## HTTP
 
@@ -238,14 +238,8 @@ To use the gRPC protocol with another language that python you will need to :
 * Compile them with [protoc](https://grpc.io/docs/protoc-installation/) and precise to which programming language you want to compile them.
 * Add the generated files to your project and import them in your code. 
 
-you should finally be able to communicate with your Flow using the gRPC protocol. You can find more information on the gRPC
+You should finally be able to communicate with your Flow using the gRPC protocol. You can find more information on the gRPC
 `message` and `service` that you can use to communicate in the  [Protobuf documentation](../../proto/docs.md).
-
-
-If you want to create a gRPC client in another language, you will need to compile the
-You can find the `jina.proto`
-
-
 
 (flow-graphql)=
 ## GraphQL

--- a/docs/fundamentals/client/third-party-client.md
+++ b/docs/fundamentals/client/third-party-client.md
@@ -232,7 +232,7 @@ This contribution was made by [Jonathan Rowley](https://jina-ai.slack.com/archiv
 
 ## gRPC
 
-To use the gRPC protocol with another language that python you will need to :
+To use the gRPC protocol with a language other than Python you will need to :
 
 * Download the two proto definition files : `jina.proto` and `docarray.proto` from [github](https://github.com/jina-ai/jina/tree/master/jina/proto) (be sure to use the latest release branch)
 * Compile them with [protoc](https://grpc.io/docs/protoc-installation/) and precise to which programming language you want to compile them.

--- a/docs/fundamentals/client/third-party-client.md
+++ b/docs/fundamentals/client/third-party-client.md
@@ -1,7 +1,7 @@
 (third-party-client)=
 # Third-party clients
 
-This page is about accessing the Flow with other clients, e.g. `curl` and other programming language than python.
+This page is about accessing the Flow with other clients, e.g. `curl`, or programming languages other than python.
 
 ## HTTP
 

--- a/docs/fundamentals/flow/client.md
+++ b/docs/fundamentals/flow/client.md
@@ -2,7 +2,7 @@
 # Client
 {class}`~jina.Client` enables you to send Documents to a running {class}`~jina.Flow` in a number of different ways, as shown below.
 
-Clients support three different networking protocols: HTTP, gRPC, WebSocket and GraphQL
+Clients support four different networking protocols: **HTTP**, **gRPC**, **WebSocket** and **GraphQL**
 
 For each of them, you first connect your Client to the API Gateway, before you can send requests to it.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -67,7 +67,7 @@ fundamentals/architecture-overview
 fundamentals/executor/index
 fundamentals/flow/index
 fundamentals/gateway/index
-fundamentals/flow/client
+fundamentals/client
 fundamentals/executor/hub/index
 fundamentals/jcloud/index
 how-to/index

--- a/docs/index.md
+++ b/docs/index.md
@@ -67,7 +67,7 @@ fundamentals/architecture-overview
 fundamentals/executor/index
 fundamentals/flow/index
 fundamentals/gateway/index
-fundamentals/client
+fundamentals/client/client
 fundamentals/executor/hub/index
 fundamentals/jcloud/index
 how-to/index

--- a/docs/proto/docs.md
+++ b/docs/proto/docs.md
@@ -10,6 +10,7 @@
     - [DataRequestListProto](#jina-DataRequestListProto)
     - [DataRequestProto](#jina-DataRequestProto)
     - [DataRequestProto.DataContentProto](#jina-DataRequestProto-DataContentProto)
+    - [DataRequestProtoWoData](#jina-DataRequestProtoWoData)
     - [EndpointsProto](#jina-EndpointsProto)
     - [HeaderProto](#jina-HeaderProto)
     - [JinaInfoProto](#jina-JinaInfoProto)
@@ -110,6 +111,23 @@ Represents a DataRequest
 | ----- | ---- | ----- | ----------- |
 | docs | [docarray.DocumentArrayProto](#docarray-DocumentArrayProto) |  | the docs in this request |
 | docs_bytes | [bytes](#bytes) |  | the docs in this request as bytes |
+
+
+
+
+
+
+<a name="jina-DataRequestProtoWoData"></a>
+
+### DataRequestProtoWoData
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| header | [HeaderProto](#jina-HeaderProto) |  | header contains meta info defined by the user |
+| parameters | [google.protobuf.Struct](#google-protobuf-Struct) |  | extra kwargs that will be used in executor |
+| routes | [RouteProto](#jina-RouteProto) | repeated | status info on every routes |
 
 
 


### PR DESCRIPTION
# Context

Right now the docs to use grpc from an other language are really shallow. 

docs to check for review : 
* https://docs-improve-client--jina-docs.netlify.app/fundamentals/client/client/ 
* https://docs-improve-client--jina-docs.netlify.app/fundamentals/client/third-party-client/

## What this pr do

- [x] explain how to communicate to the gateway with gRPC outside a python in a abstract way
- [ ] TODO LATER add an example with an external language
