### PR TITLE
feat: add tests for disable external exec

### DIFF
--- a/tests/integration/external_deployment/test_external_deployment.py
+++ b/tests/integration/external_deployment/test_external_deployment.py
@@ -58,7 +58,7 @@ class MyExternalExecutor(Executor):
 
 @pytest.mark.parametrize('num_shards', [1, 2], indirect=True)
 def test_flow_with_external_deployment(
-        external_deployment, external_deployment_args, input_docs, num_shards
+    external_deployment, external_deployment_args, input_docs, num_shards
 ):
     with external_deployment:
         external_args = vars(external_deployment_args)
@@ -78,9 +78,30 @@ def test_flow_with_external_deployment(
         validate_response(resp, 50)
 
 
+def test_disable_external(input_docs):
+    class MyExecutor(Executor):
+        @requests
+        def foo(self, docs, *args, **kwargs):
+            for doc in docs:
+                doc.tags['id'] = 'not_external'
+
+    flow = Flow().add(
+        host='somewhere',
+        port='12345',
+        name='external_fake',
+        external=False,
+        uses=MyExecutor,
+    )
+    with flow as f:
+        resp = flow.index(inputs=input_docs)
+
+    for doc in resp:
+        assert doc.tags['id'] == 'not_external'
+
+
 @pytest.mark.parametrize('num_shards', [2], indirect=True)
 def test_two_flow_with_shared_external_deployment(
-        external_deployment, external_deployment_args, input_docs, num_shards
+    external_deployment, external_deployment_args, input_docs, num_shards
 ):
     external_deployment.head_args.disable_reduce = True
     with external_deployment:
@@ -96,8 +117,8 @@ def test_two_flow_with_shared_external_deployment(
 
         flow2 = (
             Flow()
-                .add(name='foo')
-                .add(
+            .add(name='foo')
+            .add(
                 **external_args,
                 name='external_fake',
                 external=True,
@@ -161,12 +182,12 @@ def external_deployment_shards_2(external_deployment_shards_2_args):
 
 @pytest.mark.parametrize('num_shards', [1, 2], indirect=True)
 def test_flow_with_external_deployment_shards(
-        external_deployment_shards_1,
-        external_deployment_shards_2,
-        external_deployment_shards_1_args,
-        external_deployment_shards_2_args,
-        input_docs,
-        num_shards,
+    external_deployment_shards_1,
+    external_deployment_shards_2,
+    external_deployment_shards_1_args,
+    external_deployment_shards_2_args,
+    input_docs,
+    num_shards,
 ):
     with external_deployment_shards_1, external_deployment_shards_2:
         external_args_1 = vars(external_deployment_shards_1_args)
@@ -179,20 +200,20 @@ def test_flow_with_external_deployment_shards(
         del external_args_2['deployment_role']
         flow = (
             Flow()
-                .add(name='executor1')
-                .add(
+            .add(name='executor1')
+            .add(
                 **external_args_1,
                 name='external_fake_1',
                 external=True,
                 needs=['executor1'],
             )
-                .add(
+            .add(
                 **external_args_2,
                 name='external_fake_2',
                 external=True,
                 needs=['executor1'],
             )
-                .needs(needs=['external_fake_1', 'external_fake_2'], port=random_port())
+            .needs(needs=['external_fake_1', 'external_fake_2'], port=random_port())
         )
 
         with flow:
@@ -226,10 +247,10 @@ def external_deployment_pre_shards(external_deployment_pre_shards_args):
 
 @pytest.mark.parametrize('num_shards', [1, 2], indirect=True)
 def test_flow_with_external_deployment_pre_shards(
-        external_deployment_pre_shards,
-        external_deployment_pre_shards_args,
-        input_docs,
-        num_shards,
+    external_deployment_pre_shards,
+    external_deployment_pre_shards_args,
+    input_docs,
+    num_shards,
 ):
     with external_deployment_pre_shards:
         external_args = vars(external_deployment_pre_shards_args)
@@ -238,20 +259,20 @@ def test_flow_with_external_deployment_pre_shards(
         del external_args['deployment_role']
         flow = (
             Flow()
-                .add(
+            .add(
                 **external_args,
                 name='external_fake',
                 external=True,
             )
-                .add(
+            .add(
                 name='executor1',
                 needs=['external_fake'],
             )
-                .add(
+            .add(
                 name='executor2',
                 needs=['external_fake'],
             )
-                .needs(['executor1', 'executor2'])
+            .needs(['executor1', 'executor2'])
         )
         with flow:
             resp = flow.index(inputs=input_docs)
@@ -286,10 +307,10 @@ def external_deployment_join(external_deployment_join_args):
 
 @pytest.mark.parametrize('num_shards', [1, 2], indirect=True)
 def test_flow_with_external_deployment_join(
-        external_deployment_join,
-        external_deployment_join_args,
-        input_docs,
-        num_shards,
+    external_deployment_join,
+    external_deployment_join_args,
+    input_docs,
+    num_shards,
 ):
     with external_deployment_join:
         external_args = vars(external_deployment_join_args)
@@ -298,19 +319,19 @@ def test_flow_with_external_deployment_join(
         del external_args['deployment_role']
         flow = (
             Flow()
-                .add(
+            .add(
                 **external_args,
                 external=True,
             )
-                .add(
+            .add(
                 name='executor1',
                 needs=['executor0'],
             )
-                .add(
+            .add(
                 name='executor2',
                 needs=['executor0'],
             )
-                .needs(
+            .needs(
                 **external_args,
                 external=True,
                 needs=['executor1', 'executor2'],
@@ -325,7 +346,6 @@ def test_flow_with_external_deployment_join(
 
 def test_external_flow_with_target_executor():
     class ExtExecutor(Executor):
-
         @requests
         def foo(self, docs, **kwargs):
             for doc in docs:
@@ -338,6 +358,5 @@ def test_external_flow_with_target_executor():
         f = Flow().add(port=external_flow.port, external=True, name='external_executor')
         with f:
             response = f.post(on='/', inputs=d, target_executor='external_executor')
-
 
     assert response[0].text == 'external'


### PR DESCRIPTION
# context

fix some issue when saying `external=False` but still having `host` 

## What this pr do :

```python
Flow().add(host='grpc://localhost:12345', external=False, use=MyExec)
```

this will not use the external Executor anymore as intended