### PR TITLE
fix: add type checksum conversion of the function fetch_meta

### DIFF
--- a/jina/hubble/hubio.py
+++ b/jina/hubble/hubio.py
@@ -698,7 +698,7 @@ metas:
             image_name=image_name,
             archive_url=resp['package']['download'],
             md5sum=resp['package']['md5'],
-            build_env=buildEnv.keys() if buildEnv else []
+            build_env=list(buildEnv.keys()) if buildEnv and isinstance(buildEnv, dict) else []
         )
 
     @staticmethod

--- a/tests/unit/hubble/test_hubio.py
+++ b/tests/unit/hubble/test_hubio.py
@@ -459,7 +459,7 @@ def test_fetch_with_no_image(mocker, monkeypatch):
     assert mock.call_count == 2
 
 
-@pytest.mark.parametrize('build_env', [ { 'TOKEN': 'TEST' }, None])
+@pytest.mark.parametrize('build_env', [ { 'TOKEN': 'TEST' }, None, ['token']])
 def test_fetch_with_buildEnv(mocker, monkeypatch, build_env):
     mock = mocker.Mock()
 
@@ -473,8 +473,10 @@ def test_fetch_with_buildEnv(mocker, monkeypatch, build_env):
     executor, _ = HubIO(args).fetch_meta('dummy_mwu_encoder', '', force=True)
     assert executor.tag == 'v0'
 
-    if build_env: 
+    if build_env and isinstance(build_env, dict): 
         assert executor.build_env == ['TOKEN'];
+    elif build_env and isinstance(build_env, list): 
+        executor.build_env == [];
     else:
         assert executor.build_env == [];
 

--- a/tests/unit/hubble/test_hubio.py
+++ b/tests/unit/hubble/test_hubio.py
@@ -107,7 +107,7 @@ class FetchMetaMockResponse:
                 'id': 'dummy_mwu_encoder',
                 'name': 'alias_dummy',
                 'visibility': 'public',
-                'commit': {'_id': 'commit_id', 'tags': ['v0'], 'commitParams': { 'buildEnv': self.build_env } } if self.build_env  else {'_id': 'commit_id', 'tags': ['v0']},
+                'commit': {'_id': 'commit_id', 'tags': ['v0'], 'commitParams': { 'buildEnv': self.build_env } } if self.build_env  else {'_id': 'commit_id', 'tags': ['v0'], 'commitParams': { } },
                 'package': {
                     'containers': []
                     if self.no_image
@@ -469,16 +469,6 @@ def test_fetch_with_buildEnv(mocker, monkeypatch, build_env):
 
     monkeypatch.setattr(requests, 'post', _mock_post)
     args = set_hub_pull_parser().parse_args(['jinahub://dummy_mwu_encoder'])
-
-    executor, _ = HubIO(args).fetch_meta(
-        'dummy_mwu_encoder', None, force=True
-    )
-
-    assert executor.uuid == 'dummy_mwu_encoder'
-    assert executor.name == 'alias_dummy'
-    assert executor.tag == 'v0'
-    assert executor.image_name == 'jinahub/pod.dummy_mwu_encoder'
-    assert executor.md5sum == 'ecbe3fdd9cbe25dbb85abaaf6c54ec4f'
 
     executor, _ = HubIO(args).fetch_meta('dummy_mwu_encoder', '', force=True)
     assert executor.tag == 'v0'

--- a/tests/unit/hubble/test_hubio.py
+++ b/tests/unit/hubble/test_hubio.py
@@ -90,11 +90,12 @@ class PostMockResponse:
 
 
 class FetchMetaMockResponse:
-    def __init__(self, response_code: int = 200, no_image=False, fail_count=0):
+    def __init__(self, response_code: int = 200, no_image=False, fail_count=0, build_env=None):
         self.response_code = response_code
         self.no_image = no_image
         self._tried_count = 0
         self._fail_count = fail_count
+        self.build_env = build_env
 
     def json(self):
         if self._tried_count <= self._fail_count:
@@ -106,7 +107,7 @@ class FetchMetaMockResponse:
                 'id': 'dummy_mwu_encoder',
                 'name': 'alias_dummy',
                 'visibility': 'public',
-                'commit': {'_id': 'commit_id', 'tags': ['v0']},
+                'commit': {'_id': 'commit_id', 'tags': ['v0'], 'commitParams': { 'buildEnv': self.build_env } } if self.build_env  else {'_id': 'commit_id', 'tags': ['v0']},
                 'package': {
                     'containers': []
                     if self.no_image
@@ -456,6 +457,33 @@ def test_fetch_with_no_image(mocker, monkeypatch):
 
     assert executor.image_name is None
     assert mock.call_count == 2
+
+
+@pytest.mark.parametrize('build_env', [ { 'TOKEN': 'TEST' }])
+def test_fetch_with_buildEnv(mocker, monkeypatch, build_env):
+    mock = mocker.Mock()
+
+    def _mock_post(url, json, headers=None):
+        mock(url=url, json=json)
+        return FetchMetaMockResponse(response_code=200, no_image=False, fail_count=0, build_env=build_env)
+
+    monkeypatch.setattr(requests, 'post', _mock_post)
+    args = set_hub_pull_parser().parse_args(['jinahub://dummy_mwu_encoder'])
+
+    executor, _ = HubIO(args).fetch_meta(
+        'dummy_mwu_encoder', None, force=True
+    )
+
+    assert executor.uuid == 'dummy_mwu_encoder'
+    assert executor.name == 'alias_dummy'
+    assert executor.tag == 'v0'
+    assert executor.image_name == 'jinahub/pod.dummy_mwu_encoder'
+    assert executor.md5sum == 'ecbe3fdd9cbe25dbb85abaaf6c54ec4f'
+
+    executor, _ = HubIO(args).fetch_meta('dummy_mwu_encoder', '', force=True)
+    assert executor.tag == 'v0'
+
+    assert executor.build_env == ['TOKEN'];
 
 
 def test_fetch_with_retry(mocker, monkeypatch):

--- a/tests/unit/hubble/test_hubio.py
+++ b/tests/unit/hubble/test_hubio.py
@@ -459,7 +459,7 @@ def test_fetch_with_no_image(mocker, monkeypatch):
     assert mock.call_count == 2
 
 
-@pytest.mark.parametrize('build_env', [ { 'TOKEN': 'TEST' }])
+@pytest.mark.parametrize('build_env', [ { 'TOKEN': 'TEST' }, None])
 def test_fetch_with_buildEnv(mocker, monkeypatch, build_env):
     mock = mocker.Mock()
 
@@ -483,8 +483,10 @@ def test_fetch_with_buildEnv(mocker, monkeypatch, build_env):
     executor, _ = HubIO(args).fetch_meta('dummy_mwu_encoder', '', force=True)
     assert executor.tag == 'v0'
 
-    assert executor.build_env == ['TOKEN'];
-
+    if build_env: 
+        assert executor.build_env == ['TOKEN'];
+    else:
+        assert executor.build_env == [];
 
 def test_fetch_with_retry(mocker, monkeypatch):
     mock = mocker.Mock()


### PR DESCRIPTION
Goals:

there was a bug where pulling an Executor with build env vars would not work, because it tried to cache the keys of these env vars, but the DictKeys object can't be pickled. This PR converts these keys to a list, thus fixing the bug.

The diffs are large, but that's only because of the black.
The only relevant line is build_env=list(buildEnv.keys()) if buildEnv and isinstance(buildEnv, dict) else [], line 715 in hubio.py (and the added test).
