### PR TITLE
refactor: unify temp path to dot cache jina

### DIFF
--- a/jina/__init__.py
+++ b/jina/__init__.py
@@ -13,6 +13,7 @@ import platform as _platform
 import signal as _signal
 import sys as _sys
 import warnings as _warnings
+from pathlib import Path as _Path
 
 import docarray as _docarray
 
@@ -107,7 +108,7 @@ __jina_env__ = (
     'JINA_RANDOM_PORT_MIN',
     'JINA_DISABLE_HEALTHCHECK_LOGS',
     'JINA_LOCKS_ROOT',
-    'JINA_OPTOUT_TELEMETRY'
+    'JINA_OPTOUT_TELEMETRY',
 )
 
 __default_host__ = _os.environ.get(
@@ -128,6 +129,9 @@ __args_executor_init__ = {'metas', 'requests', 'runtime_args'}
 __resources_path__ = _os.path.join(
     _os.path.dirname(_sys.modules['jina'].__file__), 'resources'
 )
+__cache_path__ = f'{_os.path.expanduser("~")}/.cache/{__package__}'
+if not _Path(__cache_path__).exists():
+    _Path(__cache_path__).mkdir(parents=True, exist_ok=True)
 
 _names_with_underscore = [
     '__version__',

--- a/jina/hubble/helper.py
+++ b/jina/hubble/helper.py
@@ -17,22 +17,22 @@ from pathlib import Path
 from typing import Dict, Optional, Tuple
 from urllib.parse import urljoin, urlparse
 
-from jina import __resources_path__
+from jina import __cache_path__, __resources_path__
 from jina.enums import BetterEnum
 from jina.helper import get_request_header as _get_request_header_main
+from jina.hubble.requirements import (
+    check_env_variable,
+    expand_env_variables,
+    get_env_variables,
+    parse_requirement,
+)
 from jina.importer import ImportExtensions
 from jina.logging.predefined import default_logger
-from jina.hubble.requirements import (
-    get_env_variables,
-    check_env_variable,
-    parse_requirement,
-    expand_env_variables
-)
 
 
 @lru_cache()
 def _get_hub_root() -> Path:
-    hub_root = Path(os.environ.get('JINA_HUB_ROOT', Path.home().joinpath('.jina')))
+    hub_root = Path(os.environ.get('JINA_HUB_ROOT', __cache_path__))
 
     if not hub_root.exists():
         hub_root.mkdir(parents=True, exist_ok=True)
@@ -490,6 +490,7 @@ def is_requirements_installed(
         return isinstance(ex, VersionConflict)
     return True
 
+
 def get_requirements_env_variables(requirements_file: 'Path') -> list:
     """get the env variables in requirements.txt
     :param requirements_file: the requirements.txt file
@@ -507,14 +508,16 @@ def get_requirements_env_variables(requirements_file: 'Path') -> list:
 
     return env_variables
 
+
 def check_requirements_env_variable(env_variable: str) -> bool:
-    """ 
+    """
     check the environment variables is limited
     to uppercase letter and number and the `_` (underscore).
     :param env_variable: env_variable in the requirements.txt file
     :return: True or False if not satisfied
     """
     return check_env_variable(env_variable)
+
 
 def replace_requirements_env_variables(requirements_file: 'Path') -> list:
     """replace the environment variables in requirements.txt
@@ -531,7 +534,7 @@ def replace_requirements_env_variables(requirements_file: 'Path') -> list:
                 line = expand_env_variables(line)
                 env_variables.append(line)
     return env_variables
-    
+
 
 def _get_install_options(requirements_file: 'Path', excludes: Tuple[str] = ('jina',)):
     with requirements_file.open() as requirements:

--- a/jina/hubble/hubapi.py
+++ b/jina/hubble/hubapi.py
@@ -15,6 +15,8 @@ from jina.hubble.helper import (
     unpack_package,
 )
 
+SECRET_PATH = 'secrets'
+
 
 def get_dist_path(uuid: str, tag: str) -> Tuple[Path, Path]:
     """Get the package path according ID and TAG
@@ -58,15 +60,22 @@ def get_lockfile() -> str:
     """
     return str(get_hub_packages_dir() / 'LOCK')
 
+def get_secret_path(name: str) ->Path: 
+    """Get the path of secrets
+    :param name: the name of the executor
+    :return: the path of secrets
+    """
+    return Path( f'{__cache_path__}/{SECRET_PATH}/{name}')
 
-def load_secret() -> Tuple[str, str]:
+
+def load_secret(name: str) -> Tuple[str, str]:
     """Get the UUID and Secret from local
-
+    :param name: the name of the executor
     :return: the UUID and secret
     """
+    
     from cryptography.fernet import Fernet
-
-    config = Path(__cache_path__)
+    config = get_secret_path(name);
     config.mkdir(parents=True, exist_ok=True)
 
     local_id_file = config / 'secret.key'
@@ -88,17 +97,18 @@ def load_secret() -> Tuple[str, str]:
     return uuid8, secret
 
 
-def dump_secret(uuid8: str, secret: str):
+def dump_secret(name: str, uuid8: str, secret: str):
     """Dump the UUID and Secret into local file
-
+    :param name: the name of the executor
     :param uuid8: the ID of the executor
     :param secret: the access secret
     """
     from cryptography.fernet import Fernet
 
-    config = Path(__cache_path__)
+    config = get_secret_path(name);
     config.mkdir(parents=True, exist_ok=True)
 
+    print('----dump_secret----',config)
     local_id_file = config / 'secret.key'
     if local_id_file.exists():
         try:

--- a/jina/hubble/hubapi.py
+++ b/jina/hubble/hubapi.py
@@ -108,7 +108,6 @@ def dump_secret(name: str, uuid8: str, secret: str):
     config = get_secret_path(name);
     config.mkdir(parents=True, exist_ok=True)
 
-    print('----dump_secret----',config)
     local_id_file = config / 'secret.key'
     if local_id_file.exists():
         try:

--- a/jina/hubble/hubapi.py
+++ b/jina/hubble/hubapi.py
@@ -62,20 +62,20 @@ def get_lockfile() -> str:
     """
     return str(get_hub_packages_dir() / 'LOCK')
 
-def get_secret_path(name: str) ->Path: 
+def get_secret_path(inode: str) -> 'Path': 
     """Get the path of secrets
-    :param name: the name of the executor
+    :param inode: the inode of the executor path
     :return: the path of secrets
     """
 
-    pre_path = Path( f'{__cache_path__}/{SECRET_PATH}/{name}')
+    pre_path = Path(f'{__cache_path__}/{SECRET_PATH}/{inode}')
 
     return pre_path
 
 
 def load_secret(work_path: 'Path') -> Tuple[str, str]:
     """Get the UUID and Secret from local
-    :param name: the name of the executor
+    :param work_path: the work path of the executor
     :return: the UUID and secret
     """
     
@@ -111,7 +111,7 @@ def load_secret(work_path: 'Path') -> Tuple[str, str]:
 
 def dump_secret(work_path: 'Path', uuid8: str, secret: str):
     """Dump the UUID and Secret into local file
-    :param name: the name of the executor
+    :param work_path: the work path of the executor
     :param uuid8: the ID of the executor
     :param secret: the access secret
     """

--- a/jina/hubble/hubapi.py
+++ b/jina/hubble/hubapi.py
@@ -96,7 +96,7 @@ def dump_secret(uuid8: str, secret: str):
     """
     from cryptography.fernet import Fernet
 
-    config = __cache_path__
+    config = Path(__cache_path__)
     config.mkdir(parents=True, exist_ok=True)
 
     local_id_file = config / 'secret.key'

--- a/jina/hubble/hubapi.py
+++ b/jina/hubble/hubapi.py
@@ -5,6 +5,7 @@ import shutil
 from pathlib import Path
 from typing import Tuple
 
+from jina import __cache_path__
 from jina.helper import random_identity
 from jina.hubble import HubExecutor
 from jina.hubble.helper import (
@@ -58,15 +59,14 @@ def get_lockfile() -> str:
     return str(get_hub_packages_dir() / 'LOCK')
 
 
-def load_secret(work_path: 'Path') -> Tuple[str, str]:
+def load_secret() -> Tuple[str, str]:
     """Get the UUID and Secret from local
 
-    :param work_path: the local package directory
     :return: the UUID and secret
     """
     from cryptography.fernet import Fernet
 
-    config = work_path / '.jina'
+    config = Path(__cache_path__)
     config.mkdir(parents=True, exist_ok=True)
 
     local_id_file = config / 'secret.key'
@@ -88,16 +88,15 @@ def load_secret(work_path: 'Path') -> Tuple[str, str]:
     return uuid8, secret
 
 
-def dump_secret(work_path: 'Path', uuid8: str, secret: str):
+def dump_secret(uuid8: str, secret: str):
     """Dump the UUID and Secret into local file
 
-    :param work_path: the local package directory
     :param uuid8: the ID of the executor
     :param secret: the access secret
     """
     from cryptography.fernet import Fernet
 
-    config = work_path / '.jina'
+    config = __cache_path__
     config.mkdir(parents=True, exist_ok=True)
 
     local_id_file = config / 'secret.key'

--- a/jina/hubble/hubio.py
+++ b/jina/hubble/hubio.py
@@ -434,7 +434,7 @@ metas:
                 if build_env:
                     form_data['buildEnv'] = json.dumps(build_env)
                 
-                uuid8, secret = load_secret(os.path.basename(work_path))
+                uuid8, secret = load_secret(work_path)
                 if self.args.force_update or uuid8:
                     form_data['id'] = self.args.force_update or uuid8
                 if self.args.secret or secret:
@@ -513,7 +513,7 @@ metas:
                         console, image, warning=warning
                     )
                     if new_uuid8 != uuid8 or new_secret != secret:
-                        dump_secret(os.path.basename(work_path) ,new_uuid8, new_secret or '')
+                        dump_secret(work_path, new_uuid8, new_secret or '')
                 else:
                     raise Exception(f'Unknown Error, session_id: {session_id}')
 

--- a/jina/hubble/hubio.py
+++ b/jina/hubble/hubio.py
@@ -14,6 +14,7 @@ from jina.helper import ArgNamespace, get_rich_console, retry
 from jina.hubble import HubExecutor
 from jina.hubble.helper import (
     archive_package,
+    check_requirements_env_variable,
     disk_cache_offline,
     download_with_resume,
     get_cache_db,
@@ -21,10 +22,9 @@ from jina.hubble.helper import (
     get_hubble_error_message,
     get_hubble_url_v2,
     get_request_header,
+    get_requirements_env_variables,
     parse_hub_uri,
     upload_file,
-    get_requirements_env_variables,
-    check_requirements_env_variable
 )
 from jina.hubble.hubapi import (
     dump_secret,
@@ -347,43 +347,53 @@ metas:
                 )
 
             dockerfile = dockerfile.relative_to(work_path)
-        
+
         build_env = None
         if self.args.build_env:
             build_envs = self.args.build_env.strip().split()
             build_env_dict = {}
             for index, env in enumerate(build_envs):
                 env_list = env.split('=')
-                if (len(env_list) != 2):
-                    raise Exception( f'The --build-env parameter: `{env}` is wrong format. you can use: `--build-env {env}=YOUR_VALUE`.')
+                if len(env_list) != 2:
+                    raise Exception(
+                        f'The --build-env parameter: `{env}` is wrong format. you can use: `--build-env {env}=YOUR_VALUE`.'
+                    )
                 if check_requirements_env_variable(env_list[0]) is False:
-                    raise Exception( f'The --build-env parameter key:`{env_list[0]}` can only consist of uppercase letter and number and underline.')
+                    raise Exception(
+                        f'The --build-env parameter key:`{env_list[0]}` can only consist of uppercase letter and number and underline.'
+                    )
                 build_env_dict[env_list[0]] = env_list[1]
-            build_env = build_env_dict if len(list(build_env_dict.keys()))>0 else None
+            build_env = build_env_dict if len(list(build_env_dict.keys())) > 0 else None
 
         requirements_file = work_path / 'requirements.txt'
 
         requirements_env_variables = []
-        if requirements_file.exists(): 
-            requirements_env_variables = get_requirements_env_variables(requirements_file)
+        if requirements_file.exists():
+            requirements_env_variables = get_requirements_env_variables(
+                requirements_file
+            )
             for index, env in enumerate(requirements_env_variables):
                 if check_requirements_env_variable(env) is False:
-                   raise Exception( f'The requirements.txt environment variables:`${env}` can only consist of uppercase letter and number and underline.')
+                    raise Exception(
+                        f'The requirements.txt environment variables:`${env}` can only consist of uppercase letter and number and underline.'
+                    )
 
         if len(requirements_env_variables) and not build_env:
-            env_variables_str = ','.join(requirements_env_variables);
-            error_str= f'The requirements.txt set environment variables as follows:`{env_variables_str}` should use `--build-env';
+            env_variables_str = ','.join(requirements_env_variables)
+            error_str = f'The requirements.txt set environment variables as follows:`{env_variables_str}` should use `--build-env'
             for item in requirements_env_variables:
-                error_str+= f' {item}=YOUR_VALUE'
+                error_str += f' {item}=YOUR_VALUE'
             raise Exception(f'{error_str}` to add it.')
         elif len(requirements_env_variables) and build_env:
             build_env_keys = list(build_env.keys())
-            diff_env_variables = list(set(requirements_env_variables).difference(set(build_env_keys)))
+            diff_env_variables = list(
+                set(requirements_env_variables).difference(set(build_env_keys))
+            )
             if len(diff_env_variables):
                 diff_env_variables_str = ",".join(diff_env_variables)
-                error_str= f'The requirements.txt set environment variables as follows:`{diff_env_variables_str}` should use `--build-env';
+                error_str = f'The requirements.txt set environment variables as follows:`{diff_env_variables_str}` should use `--build-env'
                 for item in diff_env_variables:
-                    error_str+= f' {item}=YOUR_VALUE'
+                    error_str += f' {item}=YOUR_VALUE'
                 raise Exception(f'{error_str}` to add it.')
 
         console = get_rich_console()
@@ -421,10 +431,10 @@ metas:
                 if dockerfile:
                     form_data['dockerfile'] = str(dockerfile)
 
-                if build_env: 
+                if build_env:
                     form_data['buildEnv'] = json.dumps(build_env)
 
-                uuid8, secret = load_secret(work_path)
+                uuid8, secret = load_secret()
                 if self.args.force_update or uuid8:
                     form_data['id'] = self.args.force_update or uuid8
                 if self.args.secret or secret:
@@ -503,7 +513,7 @@ metas:
                         console, image, warning=warning
                     )
                     if new_uuid8 != uuid8 or new_secret != secret:
-                        dump_secret(work_path, new_uuid8, new_secret or '')
+                        dump_secret(new_uuid8, new_secret or '')
                 else:
                     raise Exception(f'Unknown Error, session_id: {session_id}')
 
@@ -606,7 +616,6 @@ metas:
 
         console.print(Panel(param_str, title='Usage', expand=False, width=100))
 
-    
     def _prettyprint_build_env_usage(self, console, build_env, usage_kind=None):
         from rich import box
         from rich.panel import Panel
@@ -620,12 +629,17 @@ metas:
         param_str.add_column('Your value')
 
         for index, item in enumerate(build_env):
-            param_str.add_row(
-                f'{item}',
-                'your value'
-            )
+            param_str.add_row(f'{item}', 'your value')
 
-        console.print(Panel(param_str, title='build_env', subtitle='You have to set the above environment variables', expand=False, width=100))
+        console.print(
+            Panel(
+                param_str,
+                title='build_env',
+                subtitle='You have to set the above environment variables',
+                expand=False,
+                width=100,
+            )
+        )
 
     @staticmethod
     @disk_cache_offline(cache_file=str(get_cache_db()))
@@ -698,7 +712,7 @@ metas:
             image_name=image_name,
             archive_url=resp['package']['download'],
             md5sum=resp['package']['md5'],
-            build_env=buildEnv.keys() if buildEnv else []
+            build_env=buildEnv.keys() if buildEnv else [],
         )
 
     @staticmethod
@@ -854,7 +868,7 @@ metas:
                 )
 
                 build_env = executor.build_env
-   
+
                 presented_id = executor.name if executor.name else executor.uuid
                 executor_name = (
                     f'{presented_id}'
@@ -887,8 +901,8 @@ metas:
                     import filelock
 
                     if build_env:
-                       self._prettyprint_build_env_usage(console,build_env)
-                   
+                        self._prettyprint_build_env_usage(console, build_env)
+
                     with filelock.FileLock(get_lockfile(), timeout=-1):
                         try:
                             pkg_path, pkg_dist_path = get_dist_path_of_executor(

--- a/jina/hubble/hubio.py
+++ b/jina/hubble/hubio.py
@@ -433,8 +433,8 @@ metas:
 
                 if build_env:
                     form_data['buildEnv'] = json.dumps(build_env)
-
-                uuid8, secret = load_secret()
+                
+                uuid8, secret = load_secret(os.path.basename(work_path))
                 if self.args.force_update or uuid8:
                     form_data['id'] = self.args.force_update or uuid8
                 if self.args.secret or secret:
@@ -513,7 +513,7 @@ metas:
                         console, image, warning=warning
                     )
                     if new_uuid8 != uuid8 or new_secret != secret:
-                        dump_secret(new_uuid8, new_secret or '')
+                        dump_secret(os.path.basename(work_path) ,new_uuid8, new_secret or '')
                 else:
                     raise Exception(f'Unknown Error, session_id: {session_id}')
 

--- a/jina/orchestrate/helper.py
+++ b/jina/orchestrate/helper.py
@@ -1,6 +1,8 @@
 import os
 from pathlib import Path
 
+from jina import __cache_path__
+
 
 def generate_default_volume_and_workspace(workspace_id=''):
     """automatically generate a docker volume, and an Executor workspace inside it
@@ -17,7 +19,7 @@ def generate_default_volume_and_workspace(workspace_id=''):
             path=os.path.abspath(default_workspace), start=Path.home()
         )
     else:  # fallback if no custom volume and no default workspace
-        workspace = os.path.join('.jina', 'executor-workspace')
+        workspace = os.path.join(__cache_path__, 'executor-workspace')
         host_addr = os.path.join(
             Path.home(),
             workspace,

--- a/jina/serve/executors/decorators.py
+++ b/jina/serve/executors/decorators.py
@@ -6,6 +6,7 @@ from contextlib import nullcontext
 from pathlib import Path
 from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Sequence, Union
 
+from jina import __cache_path__
 from jina.helper import convert_tuple_to_list, iscoroutinefunction
 from jina.importer import ImportExtensions
 from jina.serve.executors.metas import get_default_metas
@@ -17,9 +18,7 @@ if TYPE_CHECKING:
 @functools.lru_cache()
 def _get_locks_root() -> Path:
     locks_root = Path(
-        os.environ.get(
-            'JINA_LOCKS_ROOT', Path.home().joinpath('.jina').joinpath('locks')
-        )
+        os.environ.get('JINA_LOCKS_ROOT', os.path.join(__cache_path__, 'locks'))
     )
 
     if not locks_root.exists():

--- a/tests/unit/hubble/test_hubapi.py
+++ b/tests/unit/hubble/test_hubapi.py
@@ -40,9 +40,9 @@ def test_load_dump_secret(test_envs):
 
     uuid8 = 'hello'
     secret = 'world'
-    with tempfile.TemporaryDirectory() as tmpdirname:
-        hubapi.dump_secret(Path(tmpdirname), uuid8, secret)
-        new_uuid8, new_secret = hubapi.load_secret(Path(tmpdirname))
+    with tempfile.TemporaryDirectory():
+        hubapi.dump_secret(uuid8, secret)
+        new_uuid8, new_secret = hubapi.load_secret()
     assert new_uuid8 == uuid8
     assert new_secret == secret
 
@@ -54,10 +54,10 @@ def test_load_dump_secret_existing_encryption_key(test_envs):
     secret = 'world'
     with tempfile.TemporaryDirectory() as tmpdirname:
         # creates an encryption key
-        hubapi.dump_secret(Path(tmpdirname), 'dummy', 'dummy')
+        hubapi.dump_secret('dummy', 'dummy')
 
         # dump secret using existing encryption key
-        hubapi.dump_secret(Path(tmpdirname), uuid8, secret)
-        new_uuid8, new_secret = hubapi.load_secret(Path(tmpdirname))
+        hubapi.dump_secret(uuid8, secret)
+        new_uuid8, new_secret = hubapi.load_secret()
     assert new_uuid8 == uuid8
     assert new_secret == secret

--- a/tests/unit/hubble/test_hubapi.py
+++ b/tests/unit/hubble/test_hubapi.py
@@ -41,8 +41,8 @@ def test_load_dump_secret(test_envs):
     uuid8 = 'hello'
     secret = 'world'
     with tempfile.TemporaryDirectory() as tmpdirname:
-        hubapi.dump_secret(os.path.basename(tmpdirname),uuid8, secret)
-        new_uuid8, new_secret = hubapi.load_secret(os.path.basename(tmpdirname))
+        hubapi.dump_secret(Path(tmpdirname), uuid8, secret)
+        new_uuid8, new_secret = hubapi.load_secret(Path(tmpdirname))
     assert new_uuid8 == uuid8
     assert new_secret == secret
 
@@ -54,10 +54,10 @@ def test_load_dump_secret_existing_encryption_key(test_envs):
     secret = 'world'
     with tempfile.TemporaryDirectory() as tmpdirname:
         # creates an encryption key
-        hubapi.dump_secret(os.path.basename(tmpdirname), 'dummy', 'dummy')
+        hubapi.dump_secret(Path(tmpdirname), 'dummy', 'dummy')
 
         # dump secret using existing encryption key
-        hubapi.dump_secret(os.path.basename(tmpdirname), uuid8, secret)
-        new_uuid8, new_secret = hubapi.load_secret(os.path.basename(tmpdirname))
+        hubapi.dump_secret(Path(tmpdirname), uuid8, secret)
+        new_uuid8, new_secret = hubapi.load_secret(Path(tmpdirname))
     assert new_uuid8 == uuid8
     assert new_secret == secret

--- a/tests/unit/hubble/test_hubapi.py
+++ b/tests/unit/hubble/test_hubapi.py
@@ -40,9 +40,9 @@ def test_load_dump_secret(test_envs):
 
     uuid8 = 'hello'
     secret = 'world'
-    with tempfile.TemporaryDirectory():
-        hubapi.dump_secret(uuid8, secret)
-        new_uuid8, new_secret = hubapi.load_secret()
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        hubapi.dump_secret(os.path.basename(tmpdirname),uuid8, secret)
+        new_uuid8, new_secret = hubapi.load_secret(os.path.basename(tmpdirname))
     assert new_uuid8 == uuid8
     assert new_secret == secret
 
@@ -54,10 +54,10 @@ def test_load_dump_secret_existing_encryption_key(test_envs):
     secret = 'world'
     with tempfile.TemporaryDirectory() as tmpdirname:
         # creates an encryption key
-        hubapi.dump_secret('dummy', 'dummy')
+        hubapi.dump_secret(os.path.basename(tmpdirname), 'dummy', 'dummy')
 
         # dump secret using existing encryption key
-        hubapi.dump_secret(uuid8, secret)
-        new_uuid8, new_secret = hubapi.load_secret()
+        hubapi.dump_secret(os.path.basename(tmpdirname), uuid8, secret)
+        new_uuid8, new_secret = hubapi.load_secret(os.path.basename(tmpdirname))
     assert new_uuid8 == uuid8
     assert new_secret == secret

--- a/tests/unit/hubble/test_hubio.py
+++ b/tests/unit/hubble/test_hubio.py
@@ -169,7 +169,7 @@ def test_push(mocker, monkeypatch, path, mode, tmpdir, force, tag, no_cache, bui
 
     result = HubIO(args).push()
 
-    exec_config_path = get_secret_path(path)
+    exec_config_path = get_secret_path(os.stat(path).st_ino)
     shutil.rmtree(exec_config_path)
 
     _, mock_kwargs = mock.call_args_list[0]

--- a/tests/unit/hubble/test_hubio.py
+++ b/tests/unit/hubble/test_hubio.py
@@ -169,7 +169,8 @@ def test_push(mocker, monkeypatch, path, mode, tmpdir, force, tag, no_cache, bui
 
     result = HubIO(args).push()
 
-    exec_config_path = get_secret_path(os.stat(path).st_ino)
+    
+    exec_config_path = get_secret_path(os.stat(exec_path).st_ino)
     shutil.rmtree(exec_config_path)
 
     _, mock_kwargs = mock.call_args_list[0]

--- a/tests/unit/hubble/test_hubio.py
+++ b/tests/unit/hubble/test_hubio.py
@@ -12,14 +12,14 @@ import docker
 import pytest
 import requests
 import yaml
-from jina.hubble import hubio
 
+from jina.hubble import hubio
 from jina.hubble.helper import (
     _get_auth_token,
     _get_hub_config,
     _get_hub_root,
     disk_cache_offline,
-    get_requirements_env_variables
+    get_requirements_env_variables,
 )
 from jina.hubble.hubio import HubExecutor, HubIO
 from jina.parsers.hubble import (
@@ -164,12 +164,7 @@ def test_push(mocker, monkeypatch, path, mode, tmpdir, force, tag, no_cache, bui
 
     args = set_hub_push_parser().parse_args(_args_list)
 
-    result =  HubIO(args).push()
-    
-
-    # remove .jina
-    exec_config_path = os.path.join(exec_path, '.jina')
-    shutil.rmtree(exec_config_path)
+    result = HubIO(args).push()
 
     _, mock_kwargs = mock.call_args_list[0]
 
@@ -187,10 +182,12 @@ def test_push(mocker, monkeypatch, path, mode, tmpdir, force, tag, no_cache, bui
         assert form_data['id'] == ['UUID8']
     else:
         assert form_data.get('id') is None
-    
+
     if build_env:
         print(form_data['buildEnv'])
-        assert form_data['buildEnv'] == ['{"DOMAIN": "github.com", "DOWNLOAD": "download"}']
+        assert form_data['buildEnv'] == [
+            '{"DOMAIN": "github.com", "DOWNLOAD": "download"}'
+        ]
     else:
         assert form_data.get('buildEnv') is None
 
@@ -228,7 +225,14 @@ def test_push(mocker, monkeypatch, path, mode, tmpdir, force, tag, no_cache, bui
 @pytest.mark.parametrize('mode', ['--public', '--private'])
 @pytest.mark.parametrize('build_env', ['TEST_TOKEN_ccc=ghp_I1cCzUY', 'NO123123'])
 def test_push_wrong_build_env(
-    mocker, monkeypatch, path, mode, tmpdir, env_variable_format_error, env_variable_consist_error, build_env
+    mocker,
+    monkeypatch,
+    path,
+    mode,
+    tmpdir,
+    env_variable_format_error,
+    env_variable_consist_error,
+    build_env,
 ):
     mock = mocker.Mock()
 
@@ -246,15 +250,19 @@ def test_push_wrong_build_env(
 
     if build_env:
         _args_list.extend(['--build-env', build_env])
-    
+
     args = set_hub_push_parser().parse_args(_args_list)
 
     with pytest.raises(Exception) as info:
-         result = HubIO(args).push()
-    
-    assert (
-        env_variable_format_error.format(build_env=build_env) in str( info.value ) 
-        or env_variable_consist_error.format(build_env_key=build_env.split('=')[0]) in str( info.value ))
+        result = HubIO(args).push()
+
+    assert env_variable_format_error.format(build_env=build_env) in str(
+        info.value
+    ) or env_variable_consist_error.format(
+        build_env_key=build_env.split('=')[0]
+    ) in str(
+        info.value
+    )
 
 
 @pytest.mark.parametrize(
@@ -267,7 +275,13 @@ def test_push_wrong_build_env(
 @pytest.mark.parametrize('mode', ['--public', '--private'])
 @pytest.mark.parametrize('requirements_file', ['requirements.txt'])
 def test_push_requirements_file_require_set_env_variables(
-    mocker, monkeypatch, path, mode, tmpdir, requirements_file_need_build_env_error, requirements_file
+    mocker,
+    monkeypatch,
+    path,
+    mode,
+    tmpdir,
+    requirements_file_need_build_env_error,
+    requirements_file,
 ):
     mock = mocker.Mock()
 
@@ -285,12 +299,16 @@ def test_push_requirements_file_require_set_env_variables(
 
     args = set_hub_push_parser().parse_args(_args_list)
 
-    requirements_file = os.path.join(exec_path,requirements_file)
-    requirements_file_env_variables = get_requirements_env_variables(Path(requirements_file))
-    
+    requirements_file = os.path.join(exec_path, requirements_file)
+    requirements_file_env_variables = get_requirements_env_variables(
+        Path(requirements_file)
+    )
+
     with pytest.raises(Exception) as info:
-         result = HubIO(args).push()
-    assert requirements_file_need_build_env_error.format(env_variables_str=','.join(requirements_file_env_variables)) in str( info.value ) 
+        result = HubIO(args).push()
+    assert requirements_file_need_build_env_error.format(
+        env_variables_str=','.join(requirements_file_env_variables)
+    ) in str(info.value)
 
 
 @pytest.mark.parametrize(
@@ -323,14 +341,20 @@ def test_push_diff_env_variables(
 
     args = set_hub_push_parser().parse_args(_args_list)
 
-    requirements_file = os.path.join(exec_path,'requirements.txt')
-    requirements_file_env_variables = get_requirements_env_variables(Path(requirements_file))
-    diff_env_variables = list(set(requirements_file_env_variables).difference(set([build_env])))
+    requirements_file = os.path.join(exec_path, 'requirements.txt')
+    requirements_file_env_variables = get_requirements_env_variables(
+        Path(requirements_file)
+    )
+    diff_env_variables = list(
+        set(requirements_file_env_variables).difference(set([build_env]))
+    )
 
     with pytest.raises(Exception) as info:
-         result = HubIO(args).push()
+        result = HubIO(args).push()
 
-    assert diff_env_variables_error.format(env_variables_str=','.join(diff_env_variables)) in str( info.value ) 
+    assert diff_env_variables_error.format(
+        env_variables_str=','.join(diff_env_variables)
+    ) in str(info.value)
 
 
 @pytest.mark.parametrize(
@@ -390,10 +414,6 @@ def test_push_with_authorization(mocker, monkeypatch, auth_token, build_env):
 
     args = set_hub_push_parser().parse_args(_args_list)
     HubIO(args).push()
-
-    # remove .jina
-    exec_config_path = os.path.join(exec_path, '.jina')
-    shutil.rmtree(exec_config_path)
 
     assert mock.call_count == 1
 
@@ -514,8 +534,9 @@ class DownloadMockResponse:
     def status_code(self):
         return self.response_code
 
+
 @pytest.mark.parametrize('executor_name', ['alias_dummy', None])
-@pytest.mark.parametrize('build_env', [['DOWNLOAD','DOMAIN'], None])
+@pytest.mark.parametrize('build_env', [['DOWNLOAD', 'DOMAIN'], None])
 def test_pull(test_envs, mocker, monkeypatch, executor_name, build_env):
     mock = mocker.Mock()
 
@@ -538,7 +559,7 @@ def test_pull(test_envs, mocker, monkeypatch, executor_name, build_env):
                 md5sum=None,
                 visibility=True,
                 archive_url=None,
-                build_env=build_env
+                build_env=build_env,
             ),
             False,
         )
@@ -558,7 +579,7 @@ def test_pull(test_envs, mocker, monkeypatch, executor_name, build_env):
     monkeypatch.setattr(requests, 'get', _mock_download)
     monkeypatch.setattr(requests, 'head', _mock_head)
 
-    def _mock_get_prettyprint_usage(self,console, executor_name, usage_kind=None):
+    def _mock_get_prettyprint_usage(self, console, executor_name, usage_kind=None):
         mock(console=console)
         mock(usage_kind=usage_kind)
         print('_mock_get_prettyprint_usage executor_name:', executor_name)
@@ -898,4 +919,3 @@ def test_deploy_public_sandbox_create_new(mocker, monkeypatch):
     host, port = HubIO.deploy_public_sandbox(args)
     assert host == 'http://test_new_deployment.com'
     assert port == 4322
-

--- a/tests/unit/hubble/test_hubio.py
+++ b/tests/unit/hubble/test_hubio.py
@@ -27,6 +27,9 @@ from jina.parsers.hubble import (
     set_hub_pull_parser,
     set_hub_push_parser,
 )
+from jina.hubble.hubapi import (
+    get_secret_path
+)
 
 cur_dir = os.path.dirname(os.path.abspath(__file__))
 
@@ -165,6 +168,9 @@ def test_push(mocker, monkeypatch, path, mode, tmpdir, force, tag, no_cache, bui
     args = set_hub_push_parser().parse_args(_args_list)
 
     result = HubIO(args).push()
+
+    exec_config_path = get_secret_path(path)
+    shutil.rmtree(exec_config_path)
 
     _, mock_kwargs = mock.call_args_list[0]
 
@@ -306,6 +312,7 @@ def test_push_requirements_file_require_set_env_variables(
 
     with pytest.raises(Exception) as info:
         result = HubIO(args).push()
+        
     assert requirements_file_need_build_env_error.format(
         env_variables_str=','.join(requirements_file_env_variables)
     ) in str(info.value)
@@ -389,8 +396,10 @@ def test_push_wrong_dockerfile(
 
     args = set_hub_push_parser().parse_args(_args_list)
     args.dockerfile = dockerfile
+
     with pytest.raises(Exception) as info:
         HubIO(args).push()
+        
 
     assert expected_error.format(dockerfile=dockerfile, work_path=args.path) in str(
         info.value


### PR DESCRIPTION
Goal:

as https://jina-ai.slack.com/archives/C01UFNWG9E0/p1660213590270149 

we'd like to unify all default jina-specific directory to `~/.cache/jina` 