### PR TITLE
refactor(hub): use hubble sdk

### DIFF
--- a/extra-requirements.txt
+++ b/extra-requirements.txt
@@ -33,6 +33,7 @@ grpcio-health-checking>=1.46.0:  core
 pyyaml>=5.3.1:              core
 packaging>=20.0:            core
 docarray>=0.13.14:          core
+jina-hubble-sdk>=0.11.0:    core
 uvloop:                     perf,standard,devel
 prometheus_client:          perf,standard,devel
 fastapi>=0.76.0:            standard,devel

--- a/extra-requirements.txt
+++ b/extra-requirements.txt
@@ -33,7 +33,7 @@ grpcio-health-checking>=1.46.0:  core
 pyyaml>=5.3.1:              core
 packaging>=20.0:            core
 docarray>=0.13.14:          core
-jina-hubble-sdk>=0.11.0:    core
+jina-hubble-sdk>=0.12.1:    core
 uvloop:                     perf,standard,devel
 prometheus_client:          perf,standard,devel
 fastapi>=0.76.0:            standard,devel

--- a/jina/hubble/hubio.py
+++ b/jina/hubble/hubio.py
@@ -8,6 +8,7 @@ import os
 import random
 from pathlib import Path
 from typing import Dict, Optional, Union
+from urllib.parse import urljoin
 
 import hubble
 
@@ -443,9 +444,9 @@ metas:
 
                 st.update(f'Connecting to Jina Hub ...')
                 if form_data.get('id'):
-                    hubble_url = hubble.utils.get_base_url() + '/executor.update'
+                    hubble_url = urljoin(hubble.utils.get_base_url(), 'executor.update')
                 else:
-                    hubble_url = hubble.utils.get_base_url() + '/executor.create'
+                    hubble_url = urljoin(hubble.utils.get_base_url(), 'executor.create')
 
                 # upload the archived executor to Jina Hub
                 st.update(f'Uploading...')
@@ -679,7 +680,7 @@ metas:
 
             return resp
 
-        pull_url = hubble.utils.get_base_url() + f'/executor.getPackage'
+        pull_url = urljoin(hubble.utils.get_base_url(), 'executor.getPackage')
 
         payload = {'id': name, 'include': ['code'], 'rebuildImage': rebuild_image}
         if image_required:
@@ -744,7 +745,7 @@ metas:
         port = None
 
         json_response = requests.post(
-            url=hubble.utils.get_base_url() + '/sandbox.get',
+            url=urljoin(hubble.utils.get_base_url(), 'sandbox.get'),
             json=payload,
             headers=get_request_header(),
         ).json()
@@ -761,7 +762,7 @@ metas:
         ):
             try:
                 json_response = requests.post(
-                    url=hubble.utils.get_base_url() + '/sandbox.create',
+                    url=urljoin(hubble.utils.get_base_url(), 'sandbox.create'),
                     json=payload,
                     headers=get_request_header(),
                 ).json()

--- a/jina/hubble/hubio.py
+++ b/jina/hubble/hubio.py
@@ -9,6 +9,8 @@ import random
 from pathlib import Path
 from typing import Dict, Optional, Union
 
+import hubble
+
 from jina import __resources_path__, __version__
 from jina.helper import ArgNamespace, get_rich_console, retry
 from jina.hubble import HubExecutor
@@ -20,7 +22,6 @@ from jina.hubble.helper import (
     get_cache_db,
     get_download_cache_dir,
     get_hubble_error_message,
-    get_hubble_url_v2,
     get_request_header,
     get_requirements_env_variables,
     parse_hub_uri,
@@ -442,9 +443,9 @@ metas:
 
                 st.update(f'Connecting to Jina Hub ...')
                 if form_data.get('id'):
-                    hubble_url = get_hubble_url_v2() + '/rpc/executor.update'
+                    hubble_url = hubble.utils.get_base_url() + '/executor.update'
                 else:
-                    hubble_url = get_hubble_url_v2() + '/rpc/executor.create'
+                    hubble_url = hubble.utils.get_base_url() + '/executor.create'
 
                 # upload the archived executor to Jina Hub
                 st.update(f'Uploading...')
@@ -619,7 +620,6 @@ metas:
     def _prettyprint_build_env_usage(self, console, build_env, usage_kind=None):
         from rich import box
         from rich.panel import Panel
-        from rich.syntax import Syntax
         from rich.table import Table
 
         param_str = Table(
@@ -679,7 +679,7 @@ metas:
 
             return resp
 
-        pull_url = get_hubble_url_v2() + f'/rpc/executor.getPackage'
+        pull_url = hubble.utils.get_base_url() + f'/executor.getPackage'
 
         payload = {'id': name, 'include': ['code'], 'rebuildImage': rebuild_image}
         if image_required:
@@ -744,7 +744,7 @@ metas:
         port = None
 
         json_response = requests.post(
-            url=get_hubble_url_v2() + '/rpc/sandbox.get',
+            url=hubble.utils.get_base_url() + '/sandbox.get',
             json=payload,
             headers=get_request_header(),
         ).json()
@@ -761,7 +761,7 @@ metas:
         ):
             try:
                 json_response = requests.post(
-                    url=get_hubble_url_v2() + '/rpc/sandbox.create',
+                    url=hubble.utils.get_base_url() + '/sandbox.create',
                     json=payload,
                     headers=get_request_header(),
                 ).json()

--- a/jina/parsers/__init__.py
+++ b/jina/parsers/__init__.py
@@ -279,4 +279,15 @@ def get_main_parser():
         )
     )
 
+    from hubble.parsers import get_main_parser as get_hubble_parser
+
+    get_hubble_parser(
+        sp.add_parser(
+            'auth',
+            description='Login to Jina AI with your GitHub/Google/Email account',
+            formatter_class=_chf,
+            help='Login to Jina AI',
+        )
+    )
+
     return parser

--- a/jina/resources/extra-requirements.txt
+++ b/jina/resources/extra-requirements.txt
@@ -33,7 +33,7 @@ grpcio-health-checking>=1.46.0:  core
 pyyaml>=5.3.1:              core
 packaging>=20.0:            core
 docarray>=0.13.14:          core
-jina-hubble-sdk>=0.11.0:    core
+jina-hubble-sdk>=0.12.1:    core
 uvloop:                     perf,standard,devel
 prometheus_client:          perf,standard,devel
 fastapi>=0.76.0:            standard,devel

--- a/jina_cli/autocomplete.py
+++ b/jina_cli/autocomplete.py
@@ -15,6 +15,7 @@ ac_table = {
         'pod',
         'deployment',
         'client',
+        'auth',
     ],
     'completions': {
         'executor': [
@@ -305,5 +306,12 @@ ac_table = {
             '--return-responses',
             '--protocol',
         ],
+        'auth login': ['--help', '--force'],
+        'auth logout': ['--help'],
+        'auth token create': ['--help', '--expire'],
+        'auth token delete': ['--help'],
+        'auth token list': ['--help'],
+        'auth token': ['--help', 'create', 'delete', 'list'],
+        'auth': ['--help', 'login', 'logout', 'token'],
     },
 }

--- a/tests/unit/hubble/test_hubio.py
+++ b/tests/unit/hubble/test_hubio.py
@@ -13,14 +13,7 @@ import pytest
 import requests
 import yaml
 
-from jina.hubble import hubio
-from jina.hubble.helper import (
-    _get_auth_token,
-    _get_hub_config,
-    _get_hub_root,
-    disk_cache_offline,
-    get_requirements_env_variables,
-)
+from jina.hubble.helper import disk_cache_offline, get_requirements_env_variables
 from jina.hubble.hubapi import get_secret_path
 from jina.hubble.hubio import HubExecutor, HubIO
 from jina.parsers.hubble import (
@@ -32,25 +25,15 @@ from jina.parsers.hubble import (
 cur_dir = os.path.dirname(os.path.abspath(__file__))
 
 
-def clear_function_caches():
-    _get_auth_token.cache_clear()
-    _get_hub_root.cache_clear()
-    _get_hub_config.cache_clear()
-
-
 @pytest.fixture(scope='function')
 def auth_token(tmpdir):
-    clear_function_caches()
-    os.environ['JINA_HUB_ROOT'] = str(tmpdir)
+    from hubble.utils.config import Config
 
+    c = Config()
     token = 'test-auth-token'
-    with open(tmpdir / 'config.json', 'w') as f:
-        json.dump({'auth_token': token}, f)
-
+    c.set('auth_token', token)
     yield token
-
-    clear_function_caches()
-    del os.environ['JINA_HUB_ROOT']
+    c.delete('auth_token')
 
 
 class PostMockResponse:

--- a/tests/unit/test_helper.py
+++ b/tests/unit/test_helper.py
@@ -23,7 +23,6 @@ from jina.helper import (
     retry,
     run_async,
 )
-from jina.hubble.helper import _get_hubble_base_url
 from jina.jaml.helper import complete_path
 from jina.logging.predefined import default_logger
 from jina.proto import jina_pb2
@@ -300,11 +299,6 @@ def test_find_request_binding():
 )
 def test_ci_vendor():
     assert get_ci_vendor() == 'GITHUB_ACTIONS'
-
-
-def test_get_hubble_base_url():
-    for j in range(2):
-        assert _get_hubble_base_url().startswith('http')
 
 
 def test_retry():


### PR DESCRIPTION
Goals:

- refactor the hubble auth part by removing all existing related code and use `jina-hubble-sdk` as the single source of truth
- add `jina auth` to CLI
- add `jina-hubble-sdk` as one of the `core` dependency
