### PR TITLE
fix: #5055

### DIFF
--- a/jina/orchestrate/flow/base.py
+++ b/jina/orchestrate/flow/base.py
@@ -1098,8 +1098,8 @@ class Flow(PostMixin, HealthCheckMixin, JAMLCompatible, ExitStack, metaclass=Flo
         """
         # implementation_stub_inject_end_add
 
-        needs = kwargs.get('needs', None)
-        copy_flow = kwargs.get('copy_flow', True)
+        needs = kwargs.pop('needs', None)
+        copy_flow = kwargs.pop('copy_flow', True)
         deployment_role = kwargs.get('deployment_role', DeploymentRoleType.DEPLOYMENT)
 
         op_flow = copy.deepcopy(self) if copy_flow else self

--- a/jina/resources/logging.default.yml
+++ b/jina/resources/logging.default.yml
@@ -16,8 +16,8 @@ configs:
     port: # when not given then record it locally,  /dev/log on linux /var/run/syslog on mac
     formatter: PlainFormatter
   RichHandler:
-    format: '[dim]{name}@%(process)2d[/dim] %(message)s'
-    markup: true
+    format: '{name}@%(process)2d %(message)s'
+    markup: false
     rich_tracebacks: true
     show_path: false
     log_time_format: '[%x %X]'

--- a/jina/resources/logging.docker.yml
+++ b/jina/resources/logging.docker.yml
@@ -17,7 +17,7 @@ configs:
     formatter: PlainFormatter
   RichHandler:
     format: '🐳 %(message)s'
-    markup: true
+    markup: false
     show_path: false
     show_level: false
     show_time: false


### PR DESCRIPTION
Goals:

- #5055
- #5044
   - Logger dependent like JCloud should create their own logger YAML config and use it via `--log-config my.yml` to avoid UX change.
   - In general, the user will not expect `logger.info` supports rich markup, hence we should not turn on markup by default
