### PR TITLE
fix: set workspace in executor init method

### DIFF
--- a/jina/serve/executors/__init__.py
+++ b/jina/serve/executors/__init__.py
@@ -119,6 +119,7 @@ class BaseExecutor(JAMLCompatible, metaclass=ExecutorType):
         metas: Optional[Dict] = None,
         requests: Optional[Dict] = None,
         runtime_args: Optional[Dict] = None,
+        workspace: Optional[str] = None,
         **kwargs,
     ):
         """`metas` and `requests` are always auto-filled with values from YAML config.
@@ -127,11 +128,13 @@ class BaseExecutor(JAMLCompatible, metaclass=ExecutorType):
         :param requests: a dict of endpoint-function mapping
         :param runtime_args: a dict of arguments injected from :class:`Runtime` during runtime
         :param kwargs: additional extra keyword arguments to avoid failing when extra params ara passed that are not expected
+        :param workspace: the workspace of the executor. Only used if a workspace is not already provided in `metas` or `runtime_args`
         """
         self._add_metas(metas)
         self._add_requests(requests)
         self._add_runtime_args(runtime_args)
         self._init_monitoring()
+        self._init_workspace = workspace
         self.logger = JinaLogger(self.__class__.__name__)
         if __dry_run_endpoint__ not in self.requests:
             self.requests[__dry_run_endpoint__] = self._dry_run_func
@@ -321,6 +324,7 @@ class BaseExecutor(JAMLCompatible, metaclass=ExecutorType):
         workspace = (
             getattr(self.runtime_args, 'workspace', None)
             or getattr(self.metas, 'workspace')
+            or self._init_workspace
             or os.environ.get('JINA_DEFAULT_WORKSPACE_BASE')
         )
         if workspace:

--- a/tests/unit/serve/executors/test_executor.py
+++ b/tests/unit/serve/executors/test_executor.py
@@ -9,8 +9,8 @@ from unittest import mock
 
 import pytest
 import yaml
-
 from docarray import Document, DocumentArray
+
 from jina import Client, Executor, Flow, requests
 from jina.clients.request import request_generator
 from jina.parsers import set_pod_parser
@@ -370,6 +370,12 @@ def test_set_workspace(tmpdir):
     with Flow().add(uses=WorkspaceExec, uses_metas={'workspace': str(tmpdir)}) as f:
         resp = f.post(on='/foo', inputs=Document())
     assert resp[0].text == complete_workspace
+    complete_workspace_no_replicas = os.path.abspath(
+        os.path.join(tmpdir, 'WorkspaceExec')
+    )
+    assert (
+        WorkspaceExec(workspace=str(tmpdir)).workspace == complete_workspace_no_replicas
+    )
 
 
 def test_default_workspace(tmpdir):


### PR DESCRIPTION
Goals:

Enable setting of Executor workspace directly in the Executor init:

```python
e = MyExec(workspace='/test')
```
