### PR TITLE
docs: adjust jcloud monitoring docs

### DIFF
--- a/docs/fundamentals/jcloud/index.md
+++ b/docs/fundamentals/jcloud/index.md
@@ -198,9 +198,9 @@ jc status 15937a10bd
 ```
 
 ### Monitoring
-To enable monitoring with the Flow, you can set `monitoring: true` in the Flow yaml and you'd be given access to a [Grafana](https://grafana.com/) dashboard.
+Basic monitoring is provided to the Flows deployed on JCloud.
 
-To access the dashboard, get the status of the Flow first (see above section), at the bottom of the pane you should see the `dashboards` link. Visit the URL and you will find some basic metrics such as 'Number of Request Gateway Received' and 'Time elapsed between receiving a request and sending back the response':
+To access the [Grafana](https://grafana.com/) powered dashboard, get the status of the Flow first (see above section), at the bottom of the pane you should see the `dashboards` link. Visit the URL and you will find some basic metrics such as 'Number of Request Gateway Received' and 'Time elapsed between receiving a request and sending back the response':
 
 ```{figure} monitoring.png
 :width: 70%


### PR DESCRIPTION
**Goals:**

Now that we made `monitoring` enabled by default (and enforced) for JCloud deployed Flows, we need to adjust the docs around that.

Code changes on JCloud side:

https://github.com/jina-ai/wolf/pull/309
