### PR TITLE
ci: downgrade linkerd version in CI

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -306,6 +306,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Test k8s
         run: |
+          export LINKERD2_VERSION=stable-2.11.4
           curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/install | sh
           curl --proto '=https' --tlsv1.2 -sSfL https://linkerd.github.io/linkerd-smi/install | sh
           pytest -v -s --suppress-no-test-exit-code --force-flaky --min-passes 1 --max-runs 5 --cov=jina --cov-report=xml ./tests/k8s/test_k8s_failures.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,7 +191,7 @@ jobs:
       - name: Test k8s
         run: |
           curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/install | sh
-          pytest -v -s --suppress-no-test-exit-code --force-flaky --min-passes 1 --max-runs 5 --cov=jina --cov-report=xml ./tests/k8s/test_k8s.py ./tests/k8s/test_graceful_request_handling.py
+          pytest -v -s --suppress-no-test-exit-code --force-flaky --min-passes 1 --max-runs 5 --cov=jina --cov-report=xml ./tests/k8s/test_graceful_request_handling.py::test_no_message_lost_during_kill
         timeout-minutes: 30
         env:
           JINA_K8S_USE_TEST_PIP: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,7 +191,7 @@ jobs:
       - name: Test k8s
         run: |
           curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/install | sh
-          pytest -v -s --suppress-no-test-exit-code --force-flaky --min-passes 1 --max-runs 5 --cov=jina --cov-report=xml ./tests/k8s/test_graceful_request_handling.py::test_no_message_lost_during_kill
+          pytest -v -s --suppress-no-test-exit-code --force-flaky --min-passes 1 --max-runs 5 --cov=jina --cov-report=xml ./tests/k8s/test_k8s.py ./tests/k8s/test_graceful_request_handling.py
         timeout-minutes: 30
         env:
           JINA_K8S_USE_TEST_PIP: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,6 +231,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Test k8s
         run: |
+          export LINKERD2_VERSION=stable-2.11.4
           curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/install | sh
           curl --proto '=https' --tlsv1.2 -sSfL https://linkerd.github.io/linkerd-smi/install | sh
           pytest -v -s --suppress-no-test-exit-code --force-flaky --min-passes 1 --max-runs 5 --cov=jina --cov-report=xml ./tests/k8s/test_k8s_failures.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,6 +190,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Test k8s
         run: |
+          export LINKERD2_VERSION=stable-2.11.4
           curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/install | sh
           pytest -v -s --suppress-no-test-exit-code --force-flaky --min-passes 1 --max-runs 5 --cov=jina --cov-report=xml ./tests/k8s/test_k8s.py ./tests/k8s/test_graceful_request_handling.py
         timeout-minutes: 30

--- a/tests/k8s/conftest.py
+++ b/tests/k8s/conftest.py
@@ -2,7 +2,6 @@ import os
 import subprocess
 import tempfile
 from pathlib import Path
-from time import sleep
 
 import docker
 import pytest
@@ -39,19 +38,12 @@ class KindClusterWrapper:
         # to avoid this, the right mechanism is implemented in subprocess.run and subprocess.check_output, but output
         # must be piped to a file-like object, not to stdout
         proc_stdout = tempfile.TemporaryFile()
-        proc_stderr = tempfile.TemporaryFile()
-        print(f'running command: {" ".join(cmd)}')
         proc = subprocess.run(
             cmd,
             stdout=proc_stdout,
-            stderr=proc_stderr,
             env={"KUBECONFIG": str(kind_cluster.kubeconfig_path)},
         )
 
-        proc_stdout.seek(0)
-        proc_stderr.seek(0)
-        print('first command stdout:', proc_stdout.read())
-        print('first command stderr:', proc_stderr.read())
         proc_stdout.seek(0)
         kube_out = subprocess.check_output(
             (
@@ -72,15 +64,8 @@ class KindClusterWrapper:
             raise Exception(f'Installing {tool_name} failed with {returncode}')
 
     def _install_linkderd(self, kind_cluster):
-        self._linkerd_install_cmd(
-            kind_cluster,
-            [f'{Path.home()}/.linkerd2/bin/linkerd', 'install', '--crds'],
-            'Linkerd CRDs',
-        )
-
-        # wait until resources are ready
-        sleep(10)
-
+        # linkerd < 2.12: only linkerd install is needed
+        # in later versions, linkerd install --crds will be needed
         self._linkerd_install_cmd(
             kind_cluster, [f'{Path.home()}/.linkerd2/bin/linkerd', 'install'], 'Linkerd'
         )

--- a/tests/k8s/conftest.py
+++ b/tests/k8s/conftest.py
@@ -32,6 +32,11 @@ class KindClusterWrapper:
             env={"KUBECONFIG": str(kind_cluster.kubeconfig_path)},
         )
 
+        returncode = proc.poll()
+        self._log.info(f'Installing Linkerd CRDs to Cluster returned code {returncode}')
+        if returncode is not None and returncode != 0:
+            raise Exception(f"Installing linkerd CRDs failed with {returncode}")
+
         self._log.info('Installing Linkerd to Cluster...')
         proc = subprocess.Popen(
             [f'{Path.home()}/.linkerd2/bin/linkerd', 'install'],

--- a/tests/k8s/conftest.py
+++ b/tests/k8s/conftest.py
@@ -40,6 +40,8 @@ class KindClusterWrapper:
         )
 
         proc_stdout.seek(0)
+        print('first command output:', proc_stdout.read())
+        proc_stdout.seek(0)
         kube_out = subprocess.check_output(
             (
                 str(kind_cluster.kubectl_path),

--- a/tests/k8s/conftest.py
+++ b/tests/k8s/conftest.py
@@ -33,14 +33,19 @@ class KindClusterWrapper:
         # to avoid this, the right mechanism is implemented in subprocess.run and subprocess.check_output, but output
         # must be piped to a file-like object, not to stdout
         proc_stdout = tempfile.TemporaryFile()
+        proc_stderr = tempfile.TemporaryFile()
+        print(f'running command: {" ".join(cmd)}')
         proc = subprocess.run(
             cmd,
             stdout=proc_stdout,
+            stderr=proc_stderr,
             env={"KUBECONFIG": str(kind_cluster.kubeconfig_path)},
         )
 
         proc_stdout.seek(0)
-        print('first command output:', proc_stdout.read())
+        proc_stderr.seek(0)
+        print('first command stdout:', proc_stdout.read())
+        print('first command stderr:', proc_stderr.read())
         proc_stdout.seek(0)
         kube_out = subprocess.check_output(
             (

--- a/tests/k8s/conftest.py
+++ b/tests/k8s/conftest.py
@@ -66,7 +66,14 @@ class KindClusterWrapper:
         )
 
         self._linkerd_install_cmd(
-            kind_cluster, [f'{Path.home()}/.linkerd2/bin/linkerd', 'install'], 'Linkerd'
+            kind_cluster,
+            [
+                f'{Path.home()}/.linkerd2/bin/linkerd',
+                'install',
+                '--set',
+                'proxyInit.runAsRoot=true',
+            ],
+            'Linkerd',
         )
 
         self._log.info('check linkerd status')

--- a/tests/k8s/conftest.py
+++ b/tests/k8s/conftest.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+import tempfile
 from pathlib import Path
 
 import docker
@@ -24,54 +25,49 @@ class KindClusterWrapper:
         self._install_linkderd(kind_cluster)
         self._loaded_images = set()
 
+    def _linkerd_install_cmd(self, kind_cluster, cmd, tool_name):
+        self._log.info(f'Installing {tool_name} to Cluster...')
+
+        # since we need to pipe to commands and the linkerd output can bee too long
+        # there is a risk of deadlock and hanging tests: https://docs.python.org/3/library/subprocess.html#popen-objects
+        # to avoid this, the right mechanism is implemented in subprocess.run and subprocess.check_output, but output
+        # must be piped to a file-like object, not to stdout
+        proc_stdout = tempfile.TemporaryFile()
+        proc = subprocess.run(
+            cmd,
+            stdout=proc_stdout,
+            env={"KUBECONFIG": str(kind_cluster.kubeconfig_path)},
+        )
+
+        proc_stdout.seek(0)
+        kube_out = subprocess.check_output(
+            (
+                str(kind_cluster.kubectl_path),
+                'apply',
+                '-f',
+                '-',
+            ),
+            stdin=proc_stdout,
+            env=os.environ,
+        )
+
+        returncode = proc.returncode
+        self._log.info(
+            f'Installing {tool_name} to Cluster returned code {returncode}, kubectl output was {kube_out}'
+        )
+        if returncode is not None and returncode != 0:
+            raise Exception(f'Installing {tool_name} failed with {returncode}')
+
     def _install_linkderd(self, kind_cluster):
-        self._log.info('Installing Linkerd CRDs to Cluster...')
-        proc = subprocess.Popen(
+        self._linkerd_install_cmd(
+            kind_cluster,
             [f'{Path.home()}/.linkerd2/bin/linkerd', 'install', '--crds'],
-            stdout=subprocess.PIPE,
-            env={"KUBECONFIG": str(kind_cluster.kubeconfig_path)},
-        )
-        kube_out = subprocess.check_output(
-            (
-                str(kind_cluster.kubectl_path),
-                'apply',
-                '-f',
-                '-',
-            ),
-            stdin=proc.stdout,
-            env=os.environ,
+            'Linkerd CRDs',
         )
 
-        returncode = proc.poll()
-        self._log.info(
-            f'Installing Linkerd CRDs to Cluster returned code {returncode}, kubectl output was {kube_out}'
+        self._linkerd_install_cmd(
+            kind_cluster, [f'{Path.home()}/.linkerd2/bin/linkerd', 'install'], 'Linkerd'
         )
-        if returncode is not None and returncode != 0:
-            raise Exception(f"Installing linkerd CRDs failed with {returncode}")
-
-        self._log.info('Installing Linkerd to Cluster...')
-        proc = subprocess.Popen(
-            [f'{Path.home()}/.linkerd2/bin/linkerd', 'install'],
-            stdout=subprocess.PIPE,
-            env={"KUBECONFIG": str(kind_cluster.kubeconfig_path)},
-        )
-        kube_out = subprocess.check_output(
-            (
-                str(kind_cluster.kubectl_path),
-                'apply',
-                '-f',
-                '-',
-            ),
-            stdin=proc.stdout,
-            env=os.environ,
-        )
-        self._log.info('Poll status of linkerd install')
-        returncode = proc.poll()
-        self._log.info(
-            f'Installing Linkerd to Cluster returned code {returncode}, kubectl output was {kube_out}'
-        )
-        if returncode is not None and returncode != 0:
-            raise Exception(f"Installing linkerd failed with {returncode}")
 
         self._log.info('check linkerd status')
         out = subprocess.check_output(

--- a/tests/k8s/conftest.py
+++ b/tests/k8s/conftest.py
@@ -25,6 +25,13 @@ class KindClusterWrapper:
         self._loaded_images = set()
 
     def _install_linkderd(self, kind_cluster):
+        self._log.info('Installing Linkerd CRDs to Cluster...')
+        proc = subprocess.Popen(
+            [f'{Path.home()}/.linkerd2/bin/linkerd', 'install', '--crds'],
+            stdout=subprocess.PIPE,
+            env={"KUBECONFIG": str(kind_cluster.kubeconfig_path)},
+        )
+
         self._log.info('Installing Linkerd to Cluster...')
         proc = subprocess.Popen(
             [f'{Path.home()}/.linkerd2/bin/linkerd', 'install'],

--- a/tests/k8s/conftest.py
+++ b/tests/k8s/conftest.py
@@ -2,6 +2,7 @@ import os
 import subprocess
 import tempfile
 from pathlib import Path
+from time import sleep
 
 import docker
 import pytest
@@ -71,6 +72,9 @@ class KindClusterWrapper:
             [f'{Path.home()}/.linkerd2/bin/linkerd', 'install', '--crds'],
             'Linkerd CRDs',
         )
+
+        # wait until resources are ready
+        sleep(10)
 
         self._linkerd_install_cmd(
             kind_cluster,

--- a/tests/k8s/conftest.py
+++ b/tests/k8s/conftest.py
@@ -26,13 +26,12 @@ class KindClusterWrapper:
 
     def _install_linkderd(self, kind_cluster):
         self._log.info('Installing Linkerd CRDs to Cluster...')
-        proc = subprocess.Popen(
+        subprocess.run(
             [f'{Path.home()}/.linkerd2/bin/linkerd', 'install', '--crds'],
             stdout=subprocess.PIPE,
             env={"KUBECONFIG": str(kind_cluster.kubeconfig_path)},
         )
 
-        returncode = proc.poll()
         self._log.info(f'Installing Linkerd CRDs to Cluster returned code {returncode}')
         if returncode is not None and returncode != 0:
             raise Exception(f"Installing linkerd CRDs failed with {returncode}")

--- a/tests/k8s/conftest.py
+++ b/tests/k8s/conftest.py
@@ -28,6 +28,11 @@ class KindClusterWrapper:
 
     def _linkerd_install_cmd(self, kind_cluster, cmd, tool_name):
         self._log.info(f'Installing {tool_name} to Cluster...')
+        kube_out = subprocess.check_output(
+            (str(kind_cluster.kubectl_path), 'version'),
+            env=os.environ,
+        )
+        self._log.info(f'kuberbetes versions: {kube_out}')
 
         # since we need to pipe to commands and the linkerd output can bee too long
         # there is a risk of deadlock and hanging tests: https://docs.python.org/3/library/subprocess.html#popen-objects

--- a/tests/k8s/conftest.py
+++ b/tests/k8s/conftest.py
@@ -82,14 +82,7 @@ class KindClusterWrapper:
         sleep(10)
 
         self._linkerd_install_cmd(
-            kind_cluster,
-            [
-                f'{Path.home()}/.linkerd2/bin/linkerd',
-                'install',
-                '--set',
-                'proxyInit.runAsRoot=true',
-            ],
-            'Linkerd',
+            kind_cluster, [f'{Path.home()}/.linkerd2/bin/linkerd', 'install'], 'Linkerd'
         )
 
         self._log.info('check linkerd status')

--- a/tests/k8s/conftest.py
+++ b/tests/k8s/conftest.py
@@ -32,10 +32,6 @@ class KindClusterWrapper:
             env={"KUBECONFIG": str(kind_cluster.kubeconfig_path)},
         )
 
-        self._log.info(f'Installing Linkerd CRDs to Cluster returned code {returncode}')
-        if returncode is not None and returncode != 0:
-            raise Exception(f"Installing linkerd CRDs failed with {returncode}")
-
         self._log.info('Installing Linkerd to Cluster...')
         proc = subprocess.Popen(
             [f'{Path.home()}/.linkerd2/bin/linkerd', 'install'],

--- a/tests/k8s/test_graceful_request_handling.py
+++ b/tests/k8s/test_graceful_request_handling.py
@@ -20,7 +20,6 @@ async def create_all_flow_deployments_and_wait_ready(
         'kind': 'Namespace',
         'metadata': {'name': f'{namespace}'},
     }
-    print('creating namespace')
     try:
         utils.create_from_dict(api_client, namespace_object)
     except:
@@ -37,8 +36,6 @@ async def create_all_flow_deployments_and_wait_ready(
             }
         for file in file_set:
             try:
-                print(f'creating {os.path.join(flow_dump_path, deployment_name, file)}')
-
                 utils.create_from_yaml(
                     api_client,
                     yaml_file=os.path.join(flow_dump_path, deployment_name, file),
@@ -51,7 +48,6 @@ async def create_all_flow_deployments_and_wait_ready(
     # wait for all the pods to be up
     while True:
         namespaced_pods = core_client.list_namespaced_pod(namespace)
-        print(f'waiting for pods, created: {namespaced_pods.items}')
         if namespaced_pods.items is not None and len(namespaced_pods.items) == 4:
             break
         await asyncio.sleep(1.0)
@@ -67,10 +63,7 @@ async def create_all_flow_deployments_and_wait_ready(
         'gateway': 1,
         'slow-process-executor': 3,
     }
-
-    print('gathering ready deployments')
     while len(deployment_names) > 0:
-        print(f'waiting for deployments: {deployment_names}')
         deployments_ready = []
         for deployment_name in deployment_names:
             api_response = app_client.read_namespaced_deployment(
@@ -253,13 +246,11 @@ async def test_no_message_lost_during_kill(logger, docker_images, tmpdir):
     dump_path = os.path.join(str(tmpdir), 'test_flow_k8s')
     namespace = 'test-flow-slow-process-executor-ns-2'
     flow.to_kubernetes_yaml(dump_path, k8s_namespace=namespace)
-    logger.info(f' finished generating yaml files')
     from kubernetes import client
 
     api_client = client.ApiClient()
     core_client = client.CoreV1Api(api_client=api_client)
     app_client = client.AppsV1Api(api_client=api_client)
-    logger.info(f'creating flow deployments and waiting')
     await create_all_flow_deployments_and_wait_ready(
         dump_path,
         namespace=namespace,
@@ -267,7 +258,6 @@ async def test_no_message_lost_during_kill(logger, docker_images, tmpdir):
         app_client=app_client,
         core_client=core_client,
     )
-    logger.info(f'finished creating flow deployments and waiting')
 
     # start port forwarding
     logger.debug(f' Start port forwarding')


### PR DESCRIPTION
closes: https://github.com/jina-ai/jina/issues/5089

after the new release in linkerd (12.2.0), it is required to do `linkerd install --crds`.
This PR adds this extra step in order to fix the failing CI tests

UPDATE:
according to [linkerd 2.12 upgrade notice](https://linkerd.io/2.12/tasks/upgrade/#upgrade-notice-stable-2-12-0), kubernetes 1.21 is required
Since we depend on pytest-kind and it can only install kuberentes 1.20, we decide to downgrade linkerd instead.