### PR TITLE
docs: fix metrics names

### DIFF
--- a/docs/fundamentals/flow/monitoring-flow.md
+++ b/docs/fundamentals/flow/monitoring-flow.md
@@ -156,13 +156,13 @@ Because not all Pods have the same role, they expose different kinds of metrics:
 
 ### Gateway Pods
 
-| Metrics name                        | Metrics type                                                         | Description                                                                                                         |
-|-------------------------------------|----------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------|
-| `jina_receiving_request_seconds`    | [Summary](https://prometheus.io/docs/concepts/metric_types/#summary) | Measures the time elapsed between receiving a request from the client and sending back the response.                |
-| `jina_sending_request_seconds`      | [Summary](https://prometheus.io/docs/concepts/metric_types/#summary) | Measures the time elapsed between sending a downstream request to an Executor/Head and receiving the response back. |
-| `jina_number_of_pending_requests`   | [Gauge](https://prometheus.io/docs/concepts/metric_types/#gauge)     | Counts the number of pending requests                                                                               |
-| `jina_successful_requests`          | [Counter](https://prometheus.io/docs/concepts/metric_types/#counter) | Counts the number of successful requests returned by the gateway                                                    |
-| `jina_failed_requests`              | [Counter](https://prometheus.io/docs/concepts/metric_types/#counter) | Counts the number of failed requests returned by the gateway                                                        |
+| Metrics name                           | Metrics type                                                         | Description                                                                                                         |
+|----------------------------------------|----------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------|
+| `jina_receiving_request_seconds`       | [Summary](https://prometheus.io/docs/concepts/metric_types/#summary) | Measures the time elapsed between receiving a request from the client and sending back the response.                |
+| `jina_sending_request_seconds`         | [Summary](https://prometheus.io/docs/concepts/metric_types/#summary) | Measures the time elapsed between sending a downstream request to an Executor/Head and receiving the response back. |
+| `jina_number_of_pending_requests`      | [Gauge](https://prometheus.io/docs/concepts/metric_types/#gauge)     | Counts the number of pending requests                                                                               |
+| `jina_successful_requests_total`       | [Counter](https://prometheus.io/docs/concepts/metric_types/#counter) | Counts the number of successful requests returned by the gateway                                                    |
+| `jina_failed_requests_total`           | [Counter](https://prometheus.io/docs/concepts/metric_types/#counter) | Counts the number of failed requests returned by the gateway                                                        |
 
 ```{seealso} 
 You can find more information on the different type of metrics in Prometheus [here](https://prometheus.io/docs/concepts/metric_types/#metric-types)


### PR DESCRIPTION
Fix failed and successful request count metric names in the documentation