### PR TITLE
docs(jcloud): fix jc status link

### DIFF
--- a/docs/fundamentals/jcloud/index.md
+++ b/docs/fundamentals/jcloud/index.md
@@ -186,7 +186,7 @@ the deletion, to make it non-interactive to better suit your use case, set below
 export JCLOUD_NO_INTERACTIVE=1
 ```
 
-(jcloud-flow-status)
+(jcloud-flow-status)=
 ### Get status
 
 To get the status of a Flow:
@@ -201,7 +201,7 @@ jc status 15937a10bd
 ### Monitoring
 Basic monitoring is provided to the Flows deployed on JCloud.
 
-To access the [Grafana](https://grafana.com/) powered dashboard, get `{ref} the status of the Flow <jcloud-flow-status>` first, at the bottom of the pane you should see the `dashboards` link. Visit the URL and you will find some basic metrics such as 'Number of Request Gateway Received' and 'Time elapsed between receiving a request and sending back the response':
+To access the [Grafana](https://grafana.com/) powered dashboard, get {ref}`the status of the Flow<jcloud-flow-status>` first, at the bottom of the pane you should see the `dashboards` link. Visit the URL and you will find some basic metrics such as 'Number of Request Gateway Received' and 'Time elapsed between receiving a request and sending back the response':
 
 ```{figure} monitoring.png
 :width: 70%


### PR DESCRIPTION
## Goal ##
<img width="989" alt="Screen Shot 2022-09-02 at 13 28 40" src="https://user-images.githubusercontent.com/2687065/188065316-818d8706-3e7e-4183-ad4e-191d5e2f95cc.png">
The linking to `jc status` is broken, this PR is to fix it.