### PR TITLE
fix: cap grpc version

### DIFF
--- a/extra-requirements.txt
+++ b/extra-requirements.txt
@@ -27,9 +27,9 @@
 
 numpy:                      core
 protobuf>=3.13.0:           core
-grpcio>=1.46.0:             core
-grpcio-reflection>=1.46.0:  core
-grpcio-health-checking>=1.46.0:  core
+grpcio>=1.46.0,<1.48.1:     core
+grpcio-reflection>=1.46.0,<1.48.1:  core
+grpcio-health-checking>=1.46.0,<1.48.1:  core
 pyyaml>=5.3.1:              core
 packaging>=20.0:            core
 docarray>=0.16.1:           core

--- a/jina/resources/extra-requirements.txt
+++ b/jina/resources/extra-requirements.txt
@@ -27,9 +27,9 @@
 
 numpy:                      core
 protobuf>=3.13.0:           core
-grpcio>=1.46.0:             core
-grpcio-reflection>=1.46.0:  core
-grpcio-health-checking>=1.46.0:  core
+grpcio>=1.46.0,<1.48.1:     core
+grpcio-reflection>=1.46.0,<1.48.1:  core
+grpcio-health-checking>=1.46.0,<1.48.1:  core
 pyyaml>=5.3.1:              core
 packaging>=20.0:            core
 docarray>=0.16.1:           core


### PR DESCRIPTION
Following latest grpc release (1.48.1), [CI tests start to hang forever and fail](https://github.com/grpc/grpc/issues/30843).
This appears to be related with pytest, multiprocessing since the latest release introduces [changes to forking](https://github.com/grpc/grpc/pull/30605).

This PR will cap grpcio version until compatibility is fixed.