### PR TITLE
fix: gpu dockerfile template include now jina install

### DIFF
--- a/jina/hubble/hubio.py
+++ b/jina/hubble/hubio.py
@@ -212,8 +212,6 @@ Meta information helps other users to identify, search and reuse your Executor o
                         .replace('{{exec_keywords}}', str(exec_keywords.split(',')))
                         .replace('{{exec_url}}', exec_url)
                     )
-
-                    f = [v + '\n' for v in f.split('\n')]
                     fpw.writelines(f)
 
         Path(exec_path).mkdir(parents=True, exist_ok=True)

--- a/jina/hubble/hubio.py
+++ b/jina/hubble/hubio.py
@@ -213,9 +213,7 @@ Meta information helps other users to identify, search and reuse your Executor o
                         .replace('{{exec_url}}', exec_url)
                     )
 
-                    f = [
-                        v + '\n' for v in f.split('\n') if not ('{{' in v or '}}' in v)
-                    ]
+                    f = [v + '\n' for v in f.split('\n')]
                     fpw.writelines(f)
 
         Path(exec_path).mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
# Context

`jina hub new` and selecting `torch-gpu` as Dockerfile template will remove the line that install jina (this [line](https://github.com/jina-ai/jina/blob/1df9b45919b5d24cd0d61dbcaec633c43c2e02bc/jina/resources/executor-template/torch.Dockerfile#L12)) 

This is because of this [line](https://github.com/jina-ai/jina/blob/1df9b45919b5d24cd0d61dbcaec633c43c2e02bc/jina/hubble/hubio.py#L217) in hubble parsing

# what this pro do ?

- [x] remove the useless filtering that remove valid dockerfile code