### PR TITLE
test: fix k8s tests return responses params

### DIFF
--- a/tests/k8s/test_graceful_request_handling.py
+++ b/tests/k8s/test_graceful_request_handling.py
@@ -1,4 +1,4 @@
-import asyncio
+/mport asyncio
 import multiprocessing
 import os
 import time

--- a/tests/k8s/test_graceful_request_handling.py
+++ b/tests/k8s/test_graceful_request_handling.py
@@ -1,4 +1,4 @@
-/mport asyncio
+import asyncio
 import multiprocessing
 import os
 import time

--- a/tests/k8s/test_k8s.py
+++ b/tests/k8s/test_k8s.py
@@ -128,7 +128,6 @@ async def run_test(flow, core_client, namespace, endpoint, n_docs=10, request_si
         client_kwargs = dict(
             host='localhost',
             port=flow.port,
-            return_responses=True,
             asyncio=True,
         )
         client_kwargs.update(flow._common_kwargs)
@@ -140,6 +139,7 @@ async def run_test(flow, core_client, namespace, endpoint, n_docs=10, request_si
             endpoint,
             inputs=[Document() for _ in range(n_docs)],
             request_size=request_size,
+            return_responses=True,
         ):
             responses.append(resp)
 

--- a/tests/k8s/test_k8s_failures.py
+++ b/tests/k8s/test_k8s_failures.py
@@ -140,7 +140,6 @@ async def run_test_until_event(
         client_kwargs = dict(
             host='localhost',
             port=flow.port,
-            return_responses=True,
             asyncio=True,
         )
         client_kwargs.update(flow._common_kwargs)
@@ -166,6 +165,7 @@ async def run_test_until_event(
             endpoint,
             inputs=functools.partial(async_inputs, sent_ids, sleep_time),
             request_size=1,
+            return_responses=True
         ):
             responses.append(resp)
 


### PR DESCRIPTION
Fixes CI problems with K8s. When the `return_responses` param was deprecated these tests were not properly adapted