### PR TITLE
fix: set minimal docarray dependency

### DIFF
--- a/extra-requirements.txt
+++ b/extra-requirements.txt
@@ -32,14 +32,14 @@ grpcio-reflection>=1.46.0,<1.48.1:  core
 grpcio-health-checking>=1.46.0,<1.48.1:  core
 pyyaml>=5.3.1:              core
 packaging>=20.0:            core
-docarray>=0.16.1:           core
+docarray>=0.16.3:           core
 jina-hubble-sdk>=0.15.1:    core
 jcloud>=0.0.35:             core
 uvloop:                     perf,standard,devel
 prometheus_client:          perf,standard,devel
 fastapi>=0.76.0:            standard,devel
 uvicorn[standard]:          standard,devel
-docarray[common]>=0.16.1:   standard,devel
+docarray[common]>=0.16.3:   standard,devel
 docker:                     standard,devel
 pathspec:                   standard,devel
 cryptography:               standard,devel
@@ -71,7 +71,7 @@ pytest-kind==21.1.3:        test
 pytest-lazy-fixture:        test
 torch:                      cicd
 psutil:                     test
-strawberry-graphql>=0.96.0,<0.128.0: cicd,devel
+strawberry-graphql>=0.96.0: cicd,devel
 sgqlc:                      cicd,devel
 bs4:                        cicd
 jsonschema:                 cicd

--- a/extra-requirements.txt
+++ b/extra-requirements.txt
@@ -71,7 +71,7 @@ pytest-kind==21.1.3:        test
 pytest-lazy-fixture:        test
 torch:                      cicd
 psutil:                     test
-strawberry-graphql>=0.96.0: cicd,devel
+strawberry-graphql>=0.96.0,<0.128.0: cicd,devel
 sgqlc:                      cicd,devel
 bs4:                        cicd
 jsonschema:                 cicd

--- a/jina/resources/extra-requirements.txt
+++ b/jina/resources/extra-requirements.txt
@@ -32,14 +32,14 @@ grpcio-reflection>=1.46.0,<1.48.1:  core
 grpcio-health-checking>=1.46.0,<1.48.1:  core
 pyyaml>=5.3.1:              core
 packaging>=20.0:            core
-docarray>=0.16.1:           core
+docarray>=0.16.3:           core
 jina-hubble-sdk>=0.15.1:    core
 jcloud>=0.0.35:             core
 uvloop:                     perf,standard,devel
 prometheus_client:          perf,standard,devel
 fastapi>=0.76.0:            standard,devel
 uvicorn[standard]:          standard,devel
-docarray[common]>=0.16.1:   standard,devel
+docarray[common]>=0.16.3:   standard,devel
 docker:                     standard,devel
 pathspec:                   standard,devel
 cryptography:               standard,devel
@@ -71,7 +71,7 @@ pytest-kind==21.1.3:        test
 pytest-lazy-fixture:        test
 torch:                      cicd
 psutil:                     test
-strawberry-graphql>=0.96.0,<0.128.0: cicd,devel
+strawberry-graphql>=0.96.0: cicd,devel
 sgqlc:                      cicd,devel
 bs4:                        cicd
 jsonschema:                 cicd

--- a/jina/resources/extra-requirements.txt
+++ b/jina/resources/extra-requirements.txt
@@ -71,7 +71,7 @@ pytest-kind==21.1.3:        test
 pytest-lazy-fixture:        test
 torch:                      cicd
 psutil:                     test
-strawberry-graphql>=0.96.0: cicd,devel
+strawberry-graphql>=0.96.0,<0.128.0: cicd,devel
 sgqlc:                      cicd,devel
 bs4:                        cicd
 jsonschema:                 cicd


### PR DESCRIPTION
Fix docarray version in order to pass `graphql` tests