### PR TITLE
fix(hubio): add default values for metas when using `jina hub new`

### DIFF
--- a/jina/hubble/hubio.py
+++ b/jina/hubble/hubio.py
@@ -208,9 +208,9 @@ Meta information helps other users to identify, search and reuse your Executor o
                     f = (
                         fp.read()
                         .replace('{{exec_name}}', exec_name)
-                        .replace('{{exec_description}}', exec_description)
-                        .replace('{{exec_keywords}}', str(exec_keywords.split(',')))
-                        .replace('{{exec_url}}', exec_url)
+                        .replace('{{exec_description}}', exec_description if exec_description != '{{}}' else '')
+                        .replace('{{exec_keywords}}', str(exec_keywords.split(',')) if exec_keywords != '{{}}' else '[]')
+                        .replace('{{exec_url}}', exec_url if exec_url != '{{}}' else '')
                     )
                     fpw.writelines(f)
 
@@ -259,9 +259,9 @@ py_modules:
   - executor.py
 metas:
   name: {exec_name}
-  description: {exec_description if exec_description != '{{}}' else 'None'}
-  url: {exec_url if exec_url != '{{}}' else 'None'}
-  keywords: {exec_keywords if exec_keywords != '{{}}' else 'None'}
+  description: {exec_description if exec_description != '{{}}' else ''}
+  keywords: {exec_keywords if exec_keywords != '{{}}' else '[]'}
+  url: {exec_url if exec_url != '{{}}' else ''}
 ''',
                     'yaml',
                     theme='monokai',


### PR DESCRIPTION
**Goals:**
- fix `config.yml` displaying wrong values for `metas` when generating executor with `jina hub new ` with default config

- [x] check and update documentation. See [guide](https://github.com/jina-ai/jina/CONTRIBUTING.md#documentation-guidelines) and ask the team.
