### PR TITLE
fix: increase minimum protobuf version

### DIFF
--- a/extra-requirements.txt
+++ b/extra-requirements.txt
@@ -26,7 +26,7 @@
 
 
 numpy:                      core
-protobuf>=3.13.0:           core
+protobuf>=3.20.0:           core
 grpcio>=1.46.0,<1.48.1:     core
 grpcio-reflection>=1.46.0,<1.48.1:  core
 grpcio-health-checking>=1.46.0,<1.48.1:  core

--- a/jina/resources/extra-requirements.txt
+++ b/jina/resources/extra-requirements.txt
@@ -26,7 +26,7 @@
 
 
 numpy:                      core
-protobuf>=3.13.0:           core
+protobuf>=3.20.0:           core
 grpcio>=1.46.0,<1.48.1:     core
 grpcio-reflection>=1.46.0,<1.48.1:  core
 grpcio-health-checking>=1.46.0,<1.48.1:  core


### PR DESCRIPTION
in protobuf==3.19.5 the following fails:
```shell
python -c "from google.protobuf.pyext.cpp_message import GeneratedProtocolMessageType"
```
```text
ImportError: cannot import name '_message' from 'google.protobuf.pyext'
```

Thus, we increase min protobuf version due to incompatibility