### PR TITLE
fix: pin docarray version for new column syntax

### DIFF
--- a/extra-requirements.txt
+++ b/extra-requirements.txt
@@ -32,7 +32,7 @@ grpcio-reflection>=1.46.0,<1.48.1:  core
 grpcio-health-checking>=1.46.0,<1.48.1:  core
 pyyaml>=5.3.1:              core
 packaging>=20.0:            core
-docarray>=0.16.3:           core
+docarray>=0.16.4:           core
 jina-hubble-sdk>=0.15.1:    core
 jcloud>=0.0.35:             core
 uvloop:                     perf,standard,devel

--- a/jina/resources/extra-requirements.txt
+++ b/jina/resources/extra-requirements.txt
@@ -32,7 +32,7 @@ grpcio-reflection>=1.46.0,<1.48.1:  core
 grpcio-health-checking>=1.46.0,<1.48.1:  core
 pyyaml>=5.3.1:              core
 packaging>=20.0:            core
-docarray>=0.16.3:           core
+docarray>=0.16.4:           core
 jina-hubble-sdk>=0.15.1:    core
 jcloud>=0.0.35:             core
 uvloop:                     perf,standard,devel


### PR DESCRIPTION
Pin docarray version so that new column syntax is accepted by default
