### PR TITLE
docs: add section for exit_on_exceptions argument

### DIFF
--- a/docs/fundamentals/flow/when-things-go-wrong.md
+++ b/docs/fundamentals/flow/when-things-go-wrong.md
@@ -19,6 +19,16 @@ If the gRPC or WebSocket protocols are used, the networking stream is not interr
 
 In all cases, the {ref}`Jina Client <client>` will raise an Exception.
 
+## Exit on exceptions
+
+Some exceptions like network errors or request timeouts can be transient and can recover automatically. In some cases there
+can be fatal errors or user defined errors that can put the Executor in an unuseable state. The executor can be restarted to recover from such a 
+state. Locally the flow must to be re-run manually to restore the Executor availability. On Kubernetes deployments, the process
+can be automated by terminating the Exeuctor process which will cause the pod to terminate. The availability is restored by the autoscaler by
+creating a new pod to replace the terminated pod. The termination can be enabled for one or more errors by using the `exit_on_exception` argument
+when creating the Executor in a Flow. A sample Flow can be `Flow().add(uses=MyExecutor, exit_on_exceptions: ['Exception', 'RuntimeException']). The 
+`exit_on_exception` argument accepts a list of python or user defined custom Exception or Error class names. Upon matching the caught exception, the Executor will perform a gracefull termination.
+
 ## Network errors
 
 When an {ref}`Executor or Head <architecture-overview>` can't be reached by the {class}`~jina.Flow`'s gateway, it attempts to re-connect

--- a/docs/fundamentals/flow/when-things-go-wrong.md
+++ b/docs/fundamentals/flow/when-things-go-wrong.md
@@ -24,7 +24,7 @@ In all cases, the {ref}`Jina Client <client>` will raise an Exception.
 Some exceptions like network errors or request timeouts can be transient and can recover automatically. In some cases there
 can be fatal errors or user defined errors that can put the Executor in an unuseable state. The executor can be restarted to recover from such a 
 state. Locally the flow must to be re-run manually to restore the Executor availability. On Kubernetes deployments, the process
-can be automated by terminating the Exeuctor process which will cause the pod to terminate. The availability is restored by the autoscaler by
+can be automated by terminating the Executor process which will cause the pod to terminate. The availability is restored by the autoscaler by
 creating a new pod to replace the terminated pod. The termination can be enabled for one or more errors by using the `exit_on_exception` argument
 when creating the Executor in a Flow. A sample Flow can be `Flow().add(uses=MyExecutor, exit_on_exceptions: ['Exception', 'RuntimeException']). The 
 `exit_on_exception` argument accepts a list of python or user defined custom Exception or Error class names. Upon matching the caught exception, the Executor will perform a gracefull termination.

--- a/docs/fundamentals/flow/when-things-go-wrong.md
+++ b/docs/fundamentals/flow/when-things-go-wrong.md
@@ -23,11 +23,12 @@ In all cases, the {ref}`Jina Client <client>` will raise an Exception.
 
 Some exceptions like network errors or request timeouts can be transient and can recover automatically. In some cases there
 can be fatal errors or user defined errors that can put the Executor in an unuseable state. The executor can be restarted to recover from such a 
-state. Locally the flow must to be re-run manually to restore the Executor availability. On Kubernetes deployments, the process
-can be automated by terminating the Executor process which will cause the pod to terminate. The availability is restored by the autoscaler by
-creating a new pod to replace the terminated pod. The termination can be enabled for one or more errors by using the `exit_on_exception` argument
-when creating the Executor in a Flow. A sample Flow can be `Flow().add(uses=MyExecutor, exit_on_exceptions: ['Exception', 'RuntimeException']). The 
-`exit_on_exception` argument accepts a list of python or user defined custom Exception or Error class names. Upon matching the caught exception, the Executor will perform a gracefull termination.
+state. Locally the flow must to be re-run manually to restore the Executor availability. 
+
+On Kubernetes deployments, the process can be automated by terminating the Exeuctor process which will cause the pod to terminate. The availability
+ is restored by the autoscaler by creating a new pod to replace the terminated pod. The termination can be enabled for one or more errors by using the `exit_on_exceptions` argument when creating the Executor in a Flow. Upon matching the caught exception, the Executor will perform a gracefull termination.
+ 
+A sample Flow can be `Flow().add(uses=MyExecutor, exit_on_exceptions: ['Exception', 'RuntimeException'])`. The `exit_on_exceptions` argument accepts a list of python or user defined custom Exception or Error class names.
 
 ## Network errors
 


### PR DESCRIPTION
<!---Decomposing the complex issue into subtasks can help you build it step-by-step. Thanks for your pull request! :rocket: --->
<!---We know that dev life is hectic, but **please provide a (brief) description** of what your PR does, and how it does it. **Otherwise, your PR cannot be reviewed!** --->
<!---This policy was agreed upon in a past company retro, and makes everyone's life a little easier. Thanks for your collaboration!--->

**Goals:**
<!---https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword--->

- resolves #5168
- Add section to explain the usage of the `exit_on_exceptions` argument for automatically restarting k8s Executor deployments on exceptions.
- [x] check and update documentation. See [guide](https://github.com/jina-ai/jina/CONTRIBUTING.md#documentation-guidelines) and ask the team.
