### PR TITLE
docs: clarify __return__ behavior in parameters

### DIFF
--- a/docs/fundamentals/executor/executor-methods.md
+++ b/docs/fundamentals/executor/executor-methods.md
@@ -346,8 +346,8 @@ class DummyExecutor(Executor):
 Every Executor method can `return` in 3 ways: 
 
 - If you return a `DocumentArray` object, then it will be sent over to the next Executor.
-- If you return `None` or if you don't have a `return` in your method, then the original `doc` object (potentially mutated by your function) will be sent over to the next Executor.
-- If you return a `dict` object, then it will be considered as a result and passed on behind `parameters['__results__']`. The original `doc` object (potentially mutated by your function) will be sent over to the next Executor.
+- If you return `None` or if you don't have a `return` in your method, then the original `docs` object (potentially mutated by your function) will be sent over to the next Executor.
+- If you return a `dict` object, then it will be considered as a result and returned on `parameters['__results__']` to the client. `__results__` key will not be available in subsequent Executors. The original `docs` object (potentially mutated by your function) will be sent over to the next Executor.
 
 
 ```python


### PR DESCRIPTION
# Context

ATM the documentation on the __return__ behavior is not clear

# What this pr do:

small documentation improvement