### PR TITLE
fix: fix missing secret when logged-in user  with --force-update and …

### DIFF
--- a/jina/hubble/hubio.py
+++ b/jina/hubble/hubio.py
@@ -859,7 +859,7 @@ metas:
                 elif status == 'failed':
                     error = stream_msg.get('error', {})
                     msg = error.get('message')
-                    message = stream_msg.get('message', {})
+                    message = stream_msg.get('message')
                     raise Exception(
                         f'{ msg or message or "Unknown Error"} session_id: {session_id}'
                     )

--- a/jina/hubble/hubio.py
+++ b/jina/hubble/hubio.py
@@ -424,7 +424,6 @@ metas:
 
                 #new_secret 始终是 None
                 new_uuid8, new_secret = self._prettyprint_result(console, image)
-
                 dump_secret(work_path, new_uuid8, form_data.get('secret'), new_task_id)
 
             else:
@@ -860,9 +859,9 @@ metas:
                 elif status == 'failed':
                     error = stream_msg.get('error', {})
                     msg = error.get('message')
-
+                    message = stream_msg.get('message', {})
                     raise Exception(
-                        f'{ msg or "Unknown Error"} session_id: {session_id}'
+                        f'{ msg or message or "Unknown Error"} session_id: {session_id}'
                     )
 
                 elif status == 'waiting':

--- a/jina/hubble/hubio.py
+++ b/jina/hubble/hubio.py
@@ -364,8 +364,6 @@ metas:
         content,
         form_data,
         work_path,
-        uuid8,
-        secret,
         task_id,
     ):
 
@@ -377,8 +375,6 @@ metas:
 
             if image:
                 new_uuid8 = image['id']
-                # new_secret 始终是 None
-                # new_secret = image.get('secret')
                 form_data['id'] = new_uuid8
 
                 dump_secret(work_path, new_uuid8, form_data.get('secret'), task_id)
@@ -422,7 +418,7 @@ metas:
             image = self._status_with_progress(console, st, new_task_id, False, verbose)
             if image:
 
-                #new_secret 始终是 None
+                #new_secret always None
                 new_uuid8, new_secret = self._prettyprint_result(console, image)
                 dump_secret(work_path, new_uuid8, form_data.get('secret'), new_task_id)
 
@@ -637,8 +633,6 @@ metas:
                         content,
                         form_data,
                         work_path,
-                        uuid8,
-                        secret,
                         task_id,
                     )
 

--- a/jina/hubble/hubio.py
+++ b/jina/hubble/hubio.py
@@ -418,7 +418,7 @@ metas:
             image = self._status_with_progress(console, st, new_task_id, False, verbose)
             if image:
 
-                #new_secret always None
+                # `new_secret` is always None
                 new_uuid8, new_secret = self._prettyprint_result(console, image)
                 if new_uuid8 != form_data.get('id'):
                     dump_secret(work_path, new_uuid8, form_data.get('secret'), new_task_id)

--- a/jina/hubble/hubio.py
+++ b/jina/hubble/hubio.py
@@ -377,11 +377,11 @@ metas:
 
             if image:
                 new_uuid8 = image['id']
-                new_secret = image.get('secret')
+                # new_secret 始终是 None
+                # new_secret = image.get('secret')
                 form_data['id'] = new_uuid8
 
-                if new_uuid8 != uuid8 or new_secret != secret:
-                    dump_secret(work_path, new_uuid8, new_secret or '', task_id)
+                dump_secret(work_path, new_uuid8, form_data.get('secret'), task_id)
             else:
                 raise Exception(f'Unknown Error, session_id: {session_id}')
 
@@ -415,16 +415,17 @@ metas:
         new_task_id = push_task.get('_id')
         if new_task_id:
 
-            dump_secret(work_path, None, None, new_task_id)
+            dump_secret(work_path, None, form_data.get('secret'), new_task_id)
             self._prettyprint_status_usage(console, work_path, new_task_id)
             st.update(f'Async Uploaded!')
 
             image = self._status_with_progress(console, st, new_task_id, False, verbose)
             if image:
+
+                #new_secret 始终是 None
                 new_uuid8, new_secret = self._prettyprint_result(console, image)
 
-                if new_uuid8 != uuid8 or new_secret != secret or task_id != new_task_id:
-                    dump_secret(work_path, new_uuid8, new_secret or '', new_task_id)
+                dump_secret(work_path, new_uuid8, form_data.get('secret'), new_task_id)
 
             else:
                 raise Exception(f'Unknown Error, session_id: {session_id}')
@@ -857,9 +858,11 @@ metas:
                         st.update(f'Cloud pending ... [dim]: {t} ({status})[/dim]')
 
                 elif status == 'failed':
-                    error = stream_msg.get('message')
+                    error = stream_msg.get('error', {})
+                    msg = error.get('message')
+
                     raise Exception(
-                        f'{ error or "Unknown Error"} session_id: {session_id}'
+                        f'{ msg or "Unknown Error"} session_id: {session_id}'
                     )
 
                 elif status == 'waiting':

--- a/jina/hubble/hubio.py
+++ b/jina/hubble/hubio.py
@@ -411,7 +411,7 @@ metas:
         new_task_id = push_task.get('_id')
         if new_task_id:
 
-            dump_secret(work_path, None, form_data.get('secret'), new_task_id)
+            dump_secret(work_path, form_data.get('id'), form_data.get('secret'), new_task_id)
             self._prettyprint_status_usage(console, work_path, new_task_id)
             st.update(f'Async Uploaded!')
 
@@ -420,7 +420,8 @@ metas:
 
                 #new_secret always None
                 new_uuid8, new_secret = self._prettyprint_result(console, image)
-                dump_secret(work_path, new_uuid8, form_data.get('secret'), new_task_id)
+                if new_uuid8 != form_data.get('id'):
+                    dump_secret(work_path, new_uuid8, form_data.get('secret'), new_task_id)
 
             else:
                 raise Exception(f'Unknown Error, session_id: {session_id}')


### PR DESCRIPTION
<!---Decomposing the complex issue into subtasks can help you build it step-by-step. Thanks for your pull request! :rocket: --->
<!---We know that dev life is hectic, but **please provide a (brief) description** of what your PR does, and how it does it. **Otherwise, your PR cannot be reviewed!** --->
<!---This policy was agreed upon in a past company retro, and makes everyone's life a little easier. Thanks for your collaboration!--->

**Goals:**
<!---https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword--->

fix missing secret when the logged-in user  with --force-update and --secret push an executor
- [ ] check and update documentation. See [guide](https://github.com/jina-ai/jina/CONTRIBUTING.md#documentation-guidelines) and ask the team.
