### PR TITLE
docs: document grpc client limitation

### DIFF
--- a/docs/fundamentals/client/client.md
+++ b/docs/fundamentals/client/client.md
@@ -148,8 +148,8 @@ Client(host='https://my.awesome.flow:1234', port=4321)
 ```
 ````
 
-````{admonition} Important
-:class: important
+````{admonition} Caution
+:class: caution
 In case you instanciate a `Client` object using the `grpc` protocol, keep in mind that `grpc` clients cannot be used in 
 a multi-threaded environment (check [this gRPC issue](https://github.com/grpc/grpc/issues/25364) for reference).
 What you should do, is to rely on asynchronous programming or multi-processing rather than multi-threading.

--- a/docs/fundamentals/client/client.md
+++ b/docs/fundamentals/client/client.md
@@ -128,7 +128,7 @@ Client(host='my.awesome.flow', port=1234, protocol='grpc', tls=True)
 ````
 
 
-You can also use a mixe of both:
+You can also use a mix of both:
 
 ```python
 from jina import Client
@@ -146,6 +146,15 @@ from jina import Client
 
 Client(host='https://my.awesome.flow:1234', port=4321)
 ```
+````
+
+````{admonition} Important
+:class: important
+In case you instanciate a `Client` object using the `grpc` protocol, keep in mind that `grpc` clients cannot be used in 
+a multi-threaded environment (check [this gRPC issue](https://github.com/grpc/grpc/issues/25364) for reference).
+What you should do, is to rely on asynchronous programming or multi-processing rather than multi-threading.
+For instance, if you're building a web server, you can introduce multi-processing based parallelism to your app using 
+`gunicorn`: `gunicorn main:app --workers 4 --worker-class uvicorn.workers.UvicornWorker ...`
 ````
 
 


### PR DESCRIPTION
closes: https://github.com/jina-ai/jina/issues/5192

Currently it's not clear to users that the GRPC Client cannot be used in multi-threaded environment like http servers or so.
This pr  mentions that the client can only be used in a single thread and users either have to use 1 thread (use multi processing for servers instead) or use another protocol like http.

