### PR TITLE
feat(logs): enable json logging

### DIFF
--- a/jina/logging/logger.py
+++ b/jina/logging/logger.py
@@ -120,11 +120,10 @@ class JinaLogger:
         **kwargs,
     ):
 
-        if not log_config:
-            log_config = os.getenv(
-                'JINA_LOG_CONFIG',
-                'default',
-            )
+        log_config = os.getenv(
+            'JINA_LOG_CONFIG',
+            log_config or 'default',
+        )
 
         if quiet or os.getenv('JINA_LOG_CONFIG', None) == 'QUIET':
             log_config = 'quiet'

--- a/jina/resources/logging.json.yml
+++ b/jina/resources/logging.json.yml
@@ -1,0 +1,7 @@
+handlers:
+  - StreamHandler
+level: INFO
+configs:
+  StreamHandler:
+    format: '%(asctime)s:{name:>15}@%(process)2d[%(levelname).1s]:%(message)s'
+    formatter: JsonFormatter


### PR DESCRIPTION
<!---Decomposing the complex issue into subtasks can help you build it step-by-step. Thanks for your pull request! :rocket: --->
<!---We know that dev life is hectic, but **please provide a (brief) description** of what your PR does, and how it does it. **Otherwise, your PR cannot be reviewed!** --->
<!---This policy was agreed upon in a past company retro, and makes everyone's life a little easier. Thanks for your collaboration!--->

**Goals:**

Resolves #5186 - Enable structured logging (JSON) for Executors & Gateway. 

- Since in K8S, we essentially run commands, 1st 2 will be relevant for JCloud. I used the [default keys with `JsonFormatter`](https://github.com/jina-ai/jina/blob/60e9b8de6f5a6f8927ac16ff67d05d66ebf21a23/jina/logging/formatter.py#L26-L40), we should customize them according to the alerting needs @tarrantro. 
- The Flow example demonstrates, stack traces are tracked properly.
- The table with args & values can easily be removed by skipping `console.print(param_str)` if `JINA_LOG_NO_COLOR` is set, but there's no way to check what args are passed.

https://github.com/jina-ai/jina/blob/9c6740ce4dfea5f02233f3455d098233648547a3/jina_cli/__init__.py#L61-L63

#### Command `jina executor ...`

```bash
$ export JINA_LOG_CONFIG=json JINA_LOG_NO_COLOR=true JINA_LOG_LEVEL=DEBUG
$ jina executor --port 12345
home/deepankar/anaconda3/envs/default/bin/jina executor   
--port 12345                                               
╭──────────────────────┬──────────────────────────────────╮
│             Argument │ Value                            │
├──────────────────────┼──────────────────────────────────┤
│                  cli │ executor                         │
│          compression │ None                             │
│      connection-list │ None                             │
│  disable-auto-volume │ False                            │
│       disable-reduce │ False                            │
│        docker-kwargs │ None                             │
│           entrypoint │ None                             │
│                  env │ None                             │
│   exit-on-exceptions │ []                               │
│   extra-search-paths │ []                               │
│             floating │ False                            │
│         force-update │ False                            │
│                 gpus │ None                             │
│  grpc-server-options │ None                             │
│                 host │ 0.0.0.0                          │
│              host-in │ 0.0.0.0                          │
│ install-requirements │ False                            │
│        k8s-namespace │ None                             │
│           log-config │ default                          │
│           monitoring │ False                            │
│                 name │ None                             │
│               native │ False                            │
│     noblock-on-start │ False                            │
│    output-array-type │ None                             │
│             pod-role │ WORKER                           │
│              polling │ ANY                              │
│                 port │ 12345                            │
│      port-monitoring │ 61102                            │
│           py-modules │ None                             │
│                quiet │ False                            │
│          quiet-error │ False                            │
│    quiet-remote-logs │ False                            │
│             replicas │ 1                                │
│              retries │ -1                               │
│          runtime-cls │ WorkerRuntime                    │
│             shard-id │ 0                                │
│               shards │ 1                                │
│         timeout-ctrl │ 60                               │
│        timeout-ready │ 600000                           │
│         timeout-send │ None                             │
│         upload-files │ None                             │
│                 uses │ BaseExecutor                     │
│   uses-after-address │ None                             │
│  uses-before-address │ None                             │
│           uses-metas │ None                             │
│        uses-requests │ None                             │
│            uses-with │ None                             │
│              volumes │ None                             │
│            workspace │ None                             │
│         workspace-id │ fed5647880ff445a8eef7f982f848217 │
╰──────────────────────┴──────────────────────────────────╯
{"created": 1663930387.5850368, "filename": "data_request_handler.py", "funcName": "_load_executor", "levelname": "DEBUG", "lineno": 98, "module": "data_request_handler", "msg": "<jina.serve.executors.BaseExecutor object at 0x7fc1951f78d0> is successfully loaded!", "name": "WorkerRuntime", "pathname": "/home/deepankar/repos/jina/jina/serve/runtimes/request_handlers/data_request_handler.py", "process": 13386, "processName": "Pod", "thread": 140469860276032, "threadName": "MainThread"}
{"created": 1663930387.58619, "filename": "__init__.py", "funcName": "_async_setup_grpc_server", "levelname": "DEBUG", "lineno": 120, "module": "__init__", "msg": "start listening on 0.0.0.0:12345", "name": "WorkerRuntime", "pathname": "/home/deepankar/repos/jina/jina/serve/runtimes/worker/__init__.py", "process": 13386, "processName": "Pod", "thread": 140469860276032, "threadName": "MainThread"}
{"created": 1663930387.66732, "filename": "__init__.py", "funcName": "wait_start_success", "levelname": "DEBUG", "lineno": 238, "module": "__init__", "msg": "ready and listening", "name": "Pod", "pathname": "/home/deepankar/repos/jina/jina/orchestrate/pods/__init__.py", "process": 13359, "processName": "MainProcess", "thread": 140469860276032, "threadName": "MainThread"}
{"created": 1663930387.6676943, "filename": "__init__.py", "funcName": "join", "levelname": "DEBUG", "lineno": 341, "module": "__init__", "msg": "joining the process", "name": "Pod", "pathname": "/home/deepankar/repos/jina/jina/orchestrate/pods/__init__.py", "process": 13359, "processName": "MainProcess", "thread": 140469860276032, "threadName": "MainThread"}
^C{"created": 1663930396.1569917, "filename": "__init__.py", "funcName": "close", "levelname": "DEBUG", "lineno": 144, "module": "__init__", "msg": "waiting for ready or shutdown signal from runtime", "name": "Pod", "pathname": "/home/deepankar/repos/jina/jina/orchestrate/pods/__init__.py", "process": 13359, "processName": "MainProcess", "thread": 140469860276032, "threadName": "MainThread"}
{"created": 1663930396.1572006, "filename": "__init__.py", "funcName": "close", "levelname": "DEBUG", "lineno": 147, "module": "__init__", "msg": "terminate", "name": "Pod", "pathname": "/home/deepankar/repos/jina/jina/orchestrate/pods/__init__.py", "process": 13359, "processName": "MainProcess", "thread": 140469860276032, "threadName": "MainThread"}
{"created": 1663930396.1571696, "filename": "__init__.py", "funcName": "async_cancel", "levelname": "DEBUG", "lineno": 130, "module": "__init__", "msg": "cancel WorkerRuntime", "name": "WorkerRuntime", "pathname": "/home/deepankar/repos/jina/jina/serve/runtimes/worker/__init__.py", "process": 13386, "processName": "Pod", "thread": 140469860276032, "threadName": "MainThread"}
{"created": 1663930396.1572814, "filename": "__init__.py", "funcName": "_terminate", "levelname": "DEBUG", "lineno": 349, "module": "__init__", "msg": "terminating the runtime process", "name": "Pod", "pathname": "/home/deepankar/repos/jina/jina/orchestrate/pods/__init__.py", "process": 13359, "processName": "MainProcess", "thread": 140469860276032, "threadName": "MainThread"}
{"created": 1663930396.1575117, "filename": "__init__.py", "funcName": "_terminate", "levelname": "DEBUG", "lineno": 351, "module": "__init__", "msg": "runtime process properly terminated", "name": "Pod", "pathname": "/home/deepankar/repos/jina/jina/orchestrate/pods/__init__.py", "process": 13359, "processName": "MainProcess", "thread": 140469860276032, "threadName": "MainThread"}
{"created": 1663930396.1577551, "filename": "__init__.py", "funcName": "async_cancel", "levelname": "DEBUG", "lineno": 135, "module": "__init__", "msg": "stopped GRPC Server", "name": "WorkerRuntime", "pathname": "/home/deepankar/repos/jina/jina/serve/runtimes/worker/__init__.py", "process": 13386, "processName": "Pod", "thread": 140469860276032, "threadName": "MainThread"}
{"created": 1663930396.157994, "filename": "__init__.py", "funcName": "async_cancel", "levelname": "DEBUG", "lineno": 130, "module": "__init__", "msg": "cancel WorkerRuntime", "name": "WorkerRuntime", "pathname": "/home/deepankar/repos/jina/jina/serve/runtimes/worker/__init__.py", "process": 13386, "processName": "Pod", "thread": 140469860276032, "threadName": "MainThread"}
{"created": 1663930396.1580925, "filename": "__init__.py", "funcName": "async_cancel", "levelname": "DEBUG", "lineno": 135, "module": "__init__", "msg": "stopped GRPC Server", "name": "WorkerRuntime", "pathname": "/home/deepankar/repos/jina/jina/serve/runtimes/worker/__init__.py", "process": 13386, "processName": "Pod", "thread": 140469860276032, "threadName": "MainThread"}
{"created": 1663930396.1588535, "filename": "__init__.py", "funcName": "run", "levelname": "DEBUG", "lineno": 94, "module": "__init__", "msg": "process terminated", "name": "Pod", "pathname": "/home/deepankar/repos/jina/jina/orchestrate/pods/__init__.py", "process": 13386, "processName": "Pod", "thread": 140469860276032, "threadName": "MainThread"}
{"created": 1663930396.1589046, "filename": "__init__.py", "funcName": "close", "levelname": "DEBUG", "lineno": 175, "module": "__init__", "msg": "terminated", "name": "Pod", "pathname": "/home/deepankar/repos/jina/jina/orchestrate/pods/__init__.py", "process": 13359, "processName": "MainProcess", "thread": 140469860276032, "threadName": "MainThread"}
```


#### Command `jina gateway ...`
```bash
$ export JINA_LOG_CONFIG=json JINA_LOG_NO_COLOR=true JINA_LOG_LEVEL=DEBUG
$ jina gateway --port 12345                                      
/home/deepankar/anaconda3/envs/default/bin/jina gateway --port   
12345                                                            
╭────────────────────────────┬──────────────────────────────────╮
│                   Argument │ Value                            │
├────────────────────────────┼──────────────────────────────────┤
│                        cli │ gateway                          │
│                compression │ None                             │
│                       cors │ False                            │
│            deployment-role │ GATEWAY                          │
│      deployments-addresses │ {}                               │
│ deployments-disable-reduce │ []                               │
│                description │ None                             │
│                        env │ None                             │
│         exit-on-exceptions │ []                               │
│           expose-endpoints │ None                             │
│    expose-graphql-endpoint │ False                            │
│         extra-search-paths │ []                               │
│                   floating │ False                            │
│           graph-conditions │ {}                               │
│          graph-description │ {}                               │
│        grpc-server-options │ None                             │
│                       host │ 0.0.0.0                          │
│                    host-in │ 0.0.0.0                          │
│              k8s-namespace │ None                             │
│                 log-config │ default                          │
│                 monitoring │ False                            │
│                       name │ gateway                          │
│                     native │ False                            │
│          no-crud-endpoints │ False                            │
│         no-debug-endpoints │ False                            │
│           noblock-on-start │ False                            │
│          output-array-type │ None                             │
│                   pod-role │ WORKER                           │
│                    polling │ ANY                              │
│                       port │ 12345                            │
│            port-monitoring │ 57686                            │
│                   prefetch │ 1000                             │
│                   protocol │ GRPC                             │
│                      proxy │ False                            │
│                 py-modules │ None                             │
│                      quiet │ False                            │
│                quiet-error │ False                            │
│                   replicas │ 1                                │
│                    retries │ -1                               │
│                runtime-cls │ GRPCGatewayRuntime               │
│                   shard-id │ 0                                │
│                     shards │ 1                                │
│               ssl-certfile │ None                             │
│                ssl-keyfile │ None                             │
│               timeout-ctrl │ 60                               │
│              timeout-ready │ 600000                           │
│               timeout-send │ None                             │
│                      title │ None                             │
│                       uses │ BaseExecutor                     │
│                 uses-metas │ None                             │
│              uses-requests │ None                             │
│                  uses-with │ None                             │
│             uvicorn-kwargs │ None                             │
│                  workspace │ None                             │
│               workspace-id │ 3ff81974cc794f7a848868bbd5737be1 │
╰────────────────────────────┴──────────────────────────────────╯
{"created": 1663930528.1480644, "filename": "gateway.py", "funcName": "setup_server", "levelname": "DEBUG", "lineno": 93, "module": "gateway", "msg": "start server bound to 0.0.0.0:12345", "name": "gateway/GRPCGatewayRuntime", "pathname": "/home/deepankar/repos/jina/jina/serve/runtimes/gateway/grpc/gateway.py", "process": 13983, "processName": "MainProcess", "thread": 140565279381312, "threadName": "MainThread"}
{"created": 1663930528.1483958, "filename": "api.py", "funcName": "gateway", "levelname": "INFO", "lineno": 114, "module": "api", "msg": "Gateway with protocol GRPCGatewayRuntime started", "name": "gateway/GRPCGatewayRuntime", "pathname": "/home/deepankar/repos/jina/jina_cli/api.py", "process": 13983, "processName": "MainProcess", "thread": 140565279381312, "threadName": "MainThread"}
```

### Client requests with Exceptions in request

```python
# server.py
from jina import Executor, Flow, requests


class MyExecutor(Executor):
    @requests
    def foo(self, docs, **kwargs):
        for i in range(len(docs)):
            self.logger.info(f'{i} is fooed\n\n' * 10)
            if i % 5 == 0:
                raise Exception('foo')

envs = {
    'JINA_LOG_LEVEL': 'DEBUG',
    'JINA_LOG_CONFIG': 'json',
}

f = Flow(port=12345, env=envs).add(uses=MyExecutor, env=envs)
with f:
    f.block()
```

```python
# client.py
from jina import Client, DocumentArray

Client(host='grpc://localhost:12345').post(
    on='/',
    inputs=DocumentArray.empty(10),
    request_size=1,
    continue_on_error=True,
)
```

```bash
# Server logs
⠋ Waiting ... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 0/0 -:--:--{"created": 1663930983.1420138, "filename": "networking.py", "funcName": "_add_connection", "levelname": "DEBUG", "lineno": 480, "module": "networking", "msg": "adding connection for deployment executor0/heads/0 to grpc://0.0.0.0:54855", "name": "gateway/rep-0/GRPCGatewayRuntime", "pathname": "/home/deepankar/repos/jina/jina/serve/networking.py", "process": 16423, "processName": "gateway/rep-0", "thread": 140272063719232, "threadName": "MainThread"}
{"created": 1663930983.1463406, "filename": "gateway.py", "funcName": "setup_server", "levelname": "DEBUG", "lineno": 93, "module": "gateway", "msg": "start server bound to 0.0.0.0:12345", "name": "gateway/rep-0/GRPCGatewayRuntime", "pathname": "/home/deepankar/repos/jina/jina/serve/runtimes/gateway/grpc/gateway.py", "process": 16423, "processName": "gateway/rep-0", "thread": 140272063719232, "threadName": "MainThread"}
{"created": 1663930983.1501126, "filename": "data_request_handler.py", "funcName": "_load_executor", "levelname": "DEBUG", "lineno": 98, "module": "data_request_handler", "msg": "<__main__.MyExecutor object at 0x7f938a425780> is successfully loaded!", "name": "executor0/rep-0/WorkerRuntime", "pathname": "/home/deepankar/repos/jina/jina/serve/runtimes/request_handlers/data_request_handler.py", "process": 16422, "processName": "executor0/rep-0", "thread": 140272063719232, "threadName": "MainThread"}
{"created": 1663930983.1516063, "filename": "__init__.py", "funcName": "_async_setup_grpc_server", "levelname": "DEBUG", "lineno": 120, "module": "__init__", "msg": "start listening on 0.0.0.0:54855", "name": "executor0/rep-0/WorkerRuntime", "pathname": "/home/deepankar/repos/jina/jina/serve/runtimes/worker/__init__.py", "process": 16422, "processName": "executor0/rep-0", "thread": 140272063719232, "threadName": "MainThread"}
⠙ Waiting executor0 gateway summary... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 0/3 0:00:00{"created": 1663930983.2448988, "filename": "__init__.py", "funcName": "wait_start_success", "levelname": "DEBUG", "lineno": 238, "module": "__init__", "msg": "ready and listening", "name": "executor0/rep-0", "pathname": "/home/deepankar/repos/jina/jina/orchestrate/pods/__init__.py", "process": 16394, "processName": "MainProcess", "thread": 140271159609088, "threadName": "Thread-2"}
{"created": 1663930983.2453225, "filename": "__init__.py", "funcName": "wait_start_success", "levelname": "DEBUG", "lineno": 238, "module": "__init__", "msg": "ready and listening", "name": "gateway/rep-0", "pathname": "/home/deepankar/repos/jina/jina/orchestrate/pods/__init__.py", "process": 16394, "processName": "MainProcess", "thread": 140271201556224, "threadName": "Thread-3"}
───────────────────────────────────────── 🎉 Flow is ready to serve! ─────────────────────────────────────────
╭────────────── 🔗 Endpoint ───────────────╮
│  ⛓     Protocol                    GRPC  │
│  🏠       Local           0.0.0.0:12345  │
│  🔒     Private    192.168.29.185:12345  │
╰──────────────────────────────────────────╯
{"created": 1663930983.8521538, "filename": "base.py", "funcName": "_wait_until_all_ready", "levelname": "DEBUG", "lineno": 1592, "module": "base", "msg": "2 Deployments (i.e. 2 Pods) are running in this Flow", "name": "Flow", "pathname": "/home/deepankar/repos/jina/jina/orchestrate/flow/base.py", "process": 16394, "processName": "MainProcess", "thread": 140272063719232, "threadName": "MainThread"}
{"created": 1663931000.3776033, "filename": "asyncio.py", "funcName": "_log_data_request", "levelname": "DEBUG", "lineno": 197, "module": "asyncio", "msg": "recv DataRequest at / with id: 04196b831bb94ae5afc0bf99dfba9af4", "name": "executor0/rep-0/WorkerRuntime", "pathname": "/home/deepankar/repos/jina/jina/serve/runtimes/asyncio.py", "process": 16422, "processName": "executor0/rep-0", "thread": 140272063719232, "threadName": "MainThread"}
{"created": 1663931000.381231, "filename": "server.py", "funcName": "foo", "levelname": "INFO", "lineno": 8, "module": "server", "msg": "0 is fooed\n\n0 is fooed\n\n0 is fooed\n\n0 is fooed\n\n0 is fooed\n\n0 is fooed\n\n0 is fooed\n\n0 is fooed\n\n0 is fooed\n\n0 is fooed\n\n", "name": "MyExecutor", "pathname": "rough_work/json_logging/server.py", "process": 16422, "processName": "executor0/rep-0", "thread": 140272063719232, "threadName": "MainThread"}
{"created": 1663931000.3813252, "filename": "__init__.py", "funcName": "process_data", "levelname": "ERROR", "lineno": 192, "module": "__init__", "msg": "Exception('foo')\n add \"--quiet-error\" to suppress the exception details", "name": "executor0/rep-0/WorkerRuntime", "pathname": "/home/deepankar/repos/jina/jina/serve/runtimes/worker/__init__.py", "process": 16422, "processName": "executor0/rep-0", "thread": 140272063719232, "threadName": "MainThread"}
{"created": 1663931000.3825622, "filename": "asyncio.py", "funcName": "_log_data_request", "levelname": "DEBUG", "lineno": 197, "module": "asyncio", "msg": "recv DataRequest at / with id: dff242c30a624b47bab5adc502ab8ac5", "name": "executor0/rep-0/WorkerRuntime", "pathname": "/home/deepankar/repos/jina/jina/serve/runtimes/asyncio.py", "process": 16422, "processName": "executor0/rep-0", "thread": 140272063719232, "threadName": "MainThread"}
{"created": 1663931000.3827617, "filename": "server.py", "funcName": "foo", "levelname": "INFO", "lineno": 8, "module": "server", "msg": "0 is fooed\n\n0 is fooed\n\n0 is fooed\n\n0 is fooed\n\n0 is fooed\n\n0 is fooed\n\n0 is fooed\n\n0 is fooed\n\n0 is fooed\n\n0 is fooed\n\n", "name": "MyExecutor", "pathname": "rough_work/json_logging/server.py", "process": 16422, "processName": "executor0/rep-0", "thread": 140272063719232, "threadName": "MainThread"}
{"created": 1663931000.3828416, "filename": "__init__.py", "funcName": "process_data", "levelname": "ERROR", "lineno": 192, "module": "__init__", "msg": "Exception('foo')\n add \"--quiet-error\" to suppress the exception details", "name": "executor0/rep-0/WorkerRuntime", "pathname": "/home/deepankar/repos/jina/jina/serve/runtimes/worker/__init__.py", "process": 16422, "processName": "executor0/rep-0", "thread": 140272063719232, "threadName": "MainThread"}
{"created": 1663931000.3831773, "filename": "__init__.py", "funcName": "endpoint_discovery", "levelname": "DEBUG", "lineno": 161, "module": "__init__", "msg": "got an endpoint discovery request", "name": "executor0/rep-0/WorkerRuntime", "pathname": "/home/deepankar/repos/jina/jina/serve/runtimes/worker/__init__.py", "process": 16422, "processName": "executor0/rep-0", "thread": 140272063719232, "threadName": "MainThread"}
{"created": 1663931000.3834329, "filename": "asyncio.py", "funcName": "_log_data_request", "levelname": "DEBUG", "lineno": 197, "module": "asyncio", "msg": "recv DataRequest at / with id: 58b0a9f8c832466793cfcfa6bc90f39f", "name": "executor0/rep-0/WorkerRuntime", "pathname": "/home/deepankar/repos/jina/jina/serve/runtimes/asyncio.py", "process": 16422, "processName": "executor0/rep-0", "thread": 140272063719232, "threadName": "MainThread"}
{"created": 1663931000.3836167, "filename": "server.py", "funcName": "foo", "levelname": "INFO", "lineno": 8, "module": "server", "msg": "0 is fooed\n\n0 is fooed\n\n0 is fooed\n\n0 is fooed\n\n0 is fooed\n\n0 is fooed\n\n0 is fooed\n\n0 is fooed\n\n0 is fooed\n\n0 is fooed\n\n", "name": "MyExecutor", "pathname": "rough_work/json_logging/server.py", "process": 16422, "processName": "executor0/rep-0", "thread": 140272063719232, "threadName": "MainThread"}
{"created": 1663931000.383688, "filename": "__init__.py", "funcName": "process_data", "levelname": "ERROR", "lineno": 192, "module": "__init__", "msg": "Exception('foo')\n add \"--quiet-error\" to suppress the exception details", "name": "executor0/rep-0/WorkerRuntime", "pathname": "/home/deepankar/repos/jina/jina/serve/runtimes/worker/__init__.py", "process": 16422, "processName": "executor0/rep-0", "thread": 140272063719232, "threadName": "MainThread"}
{"created": 1663931000.3840363, "filename": "asyncio.py", "funcName": "_log_data_request", "levelname": "DEBUG", "lineno": 197, "module": "asyncio", "msg": "recv DataRequest at / with id: de0b7f7832294b12903e5b7383b9869d", "name": "executor0/rep-0/WorkerRuntime", "pathname": "/home/deepankar/repos/jina/jina/serve/runtimes/asyncio.py", "process": 16422, "processName": "executor0/rep-0", "thread": 140272063719232, "threadName": "MainThread"}
{"created": 1663931000.3842068, "filename": "server.py", "funcName": "foo", "levelname": "INFO", "lineno": 8, "module": "server", "msg": "0 is fooed\n\n0 is fooed\n\n0 is fooed\n\n0 is fooed\n\n0 is fooed\n\n0 is fooed\n\n0 is fooed\n\n0 is fooed\n\n0 is fooed\n\n0 is fooed\n\n", "name": "MyExecutor", "pathname": "rough_work/json_logging/server.py", "process": 16422, "processName": "executor0/rep-0", "thread": 140272063719232, "threadName": "MainThread"}
{"created": 1663931000.3842747, "filename": "__init__.py", "funcName": "process_data", "levelname": "ERROR", "lineno": 192, "module": "__init__", "msg": "Exception('foo')\n add \"--quiet-error\" to suppress the exception details", "name": "executor0/rep-0/WorkerRuntime", "pathname": "/home/deepankar/repos/jina/jina/serve/runtimes/worker/__init__.py", "process": 16422, "processName": "executor0/rep-0", "thread": 140272063719232, "threadName": "MainThread"}
{"created": 1663931000.3846092, "filename": "asyncio.py", "funcName": "_log_data_request", "levelname": "DEBUG", "lineno": 197, "module": "asyncio", "msg": "recv DataRequest at / with id: 3cccae18b68c4fef8f6ba9e391377e43", "name": "executor0/rep-0/WorkerRuntime", "pathname": "/home/deepankar/repos/jina/jina/serve/runtimes/asyncio.py", "process": 16422, "processName": "executor0/rep-0", "thread": 140272063719232, "threadName": "MainThread"}
{"created": 1663931000.3847888, "filename": "server.py", "funcName": "foo", "levelname": "INFO", "lineno": 8, "module": "server", "msg": "0 is fooed\n\n0 is fooed\n\n0 is fooed\n\n0 is fooed\n\n0 is fooed\n\n0 is fooed\n\n0 is fooed\n\n0 is fooed\n\n0 is fooed\n\n0 is fooed\n\n", "name": "MyExecutor", "pathname": "rough_work/json_logging/server.py", "process": 16422, "processName": "executor0/rep-0", "thread": 140272063719232, "threadName": "MainThread"}
{"created": 1663931000.3848822, "filename": "__init__.py", "funcName": "process_data", "levelname": "ERROR", "lineno": 192, "module": "__init__", "msg": "Exception('foo')\n add \"--quiet-error\" to suppress the exception details", "name": "executor0/rep-0/WorkerRuntime", "pathname": "/home/deepankar/repos/jina/jina/serve/runtimes/worker/__init__.py", "process": 16422, "processName": "executor0/rep-0", "thread": 140272063719232, "threadName": "MainThread"}
{"created": 1663931000.3852289, "filename": "asyncio.py", "funcName": "_log_data_request", "levelname": "DEBUG", "lineno": 197, "module": "asyncio", "msg": "recv DataRequest at / with id: befef9693ee543e6b0b83d54f01f5330", "name": "executor0/rep-0/WorkerRuntime", "pathname": "/home/deepankar/repos/jina/jina/serve/runtimes/asyncio.py", "process": 16422, "processName": "executor0/rep-0", "thread": 140272063719232, "threadName": "MainThread"}
{"created": 1663931000.3853953, "filename": "server.py", "funcName": "foo", "levelname": "INFO", "lineno": 8, "module": "server", "msg": "0 is fooed\n\n0 is fooed\n\n0 is fooed\n\n0 is fooed\n\n0 is fooed\n\n0 is fooed\n\n0 is fooed\n\n0 is fooed\n\n0 is fooed\n\n0 is fooed\n\n", "name": "MyExecutor", "pathname": "rough_work/json_logging/server.py", "process": 16422, "processName": "executor0/rep-0", "thread": 140272063719232, "threadName": "MainThread"}
{"created": 1663931000.385469, "filename": "__init__.py", "funcName": "process_data", "levelname": "ERROR", "lineno": 192, "module": "__init__", "msg": "Exception('foo')\n add \"--quiet-error\" to suppress the exception details", "name": "executor0/rep-0/WorkerRuntime", "pathname": "/home/deepankar/repos/jina/jina/serve/runtimes/worker/__init__.py", "process": 16422, "processName": "executor0/rep-0", "thread": 140272063719232, "threadName": "MainThread"}
{"created": 1663931000.3857343, "filename": "asyncio.py", "funcName": "_log_data_request", "levelname": "DEBUG", "lineno": 197, "module": "asyncio", "msg": "recv DataRequest at / with id: a3736294255d42a6a27ca0f8d91780a9", "name": "executor0/rep-0/WorkerRuntime", "pathname": "/home/deepankar/repos/jina/jina/serve/runtimes/asyncio.py", "process": 16422, "processName": "executor0/rep-0", "thread": 140272063719232, "threadName": "MainThread"}
{"created": 1663931000.385842, "filename": "server.py", "funcName": "foo", "levelname": "INFO", "lineno": 8, "module": "server", "msg": "0 is fooed\n\n0 is fooed\n\n0 is fooed\n\n0 is fooed\n\n0 is fooed\n\n0 is fooed\n\n0 is fooed\n\n0 is fooed\n\n0 is fooed\n\n0 is fooed\n\n", "name": "MyExecutor", "pathname": "rough_work/json_logging/server.py", "process": 16422, "processName": "executor0/rep-0", "thread": 140272063719232, "threadName": "MainThread"}
{"created": 1663931000.3858829, "filename": "__init__.py", "funcName": "process_data", "levelname": "ERROR", "lineno": 192, "module": "__init__", "msg": "Exception('foo')\n add \"--quiet-error\" to suppress the exception details", "name": "executor0/rep-0/WorkerRuntime", "pathname": "/home/deepankar/repos/jina/jina/serve/runtimes/worker/__init__.py", "process": 16422, "processName": "executor0/rep-0", "thread": 140272063719232, "threadName": "MainThread"}
{"created": 1663931000.3860812, "filename": "asyncio.py", "funcName": "_log_data_request", "levelname": "DEBUG", "lineno": 197, "module": "asyncio", "msg": "recv DataRequest at / with id: 8fd880b873d6438c810b984d68658e37", "name": "executor0/rep-0/WorkerRuntime", "pathname": "/home/deepankar/repos/jina/jina/serve/runtimes/asyncio.py", "process": 16422, "processName": "executor0/rep-0", "thread": 140272063719232, "threadName": "MainThread"}
{"created": 1663931000.3861861, "filename": "server.py", "funcName": "foo", "levelname": "INFO", "lineno": 8, "module": "server", "msg": "0 is fooed\n\n0 is fooed\n\n0 is fooed\n\n0 is fooed\n\n0 is fooed\n\n0 is fooed\n\n0 is fooed\n\n0 is fooed\n\n0 is fooed\n\n0 is fooed\n\n", "name": "MyExecutor", "pathname": "rough_work/json_logging/server.py", "process": 16422, "processName": "executor0/rep-0", "thread": 140272063719232, "threadName": "MainThread"}
{"created": 1663931000.3862262, "filename": "__init__.py", "funcName": "process_data", "levelname": "ERROR", "lineno": 192, "module": "__init__", "msg": "Exception('foo')\n add \"--quiet-error\" to suppress the exception details", "name": "executor0/rep-0/WorkerRuntime", "pathname": "/home/deepankar/repos/jina/jina/serve/runtimes/worker/__init__.py", "process": 16422, "processName": "executor0/rep-0", "thread": 140272063719232, "threadName": "MainThread"}
{"created": 1663931000.3864088, "filename": "asyncio.py", "funcName": "_log_data_request", "levelname": "DEBUG", "lineno": 197, "module": "asyncio", "msg": "recv DataRequest at / with id: 37a8c1884ef8490486164a59b3b29154", "name": "executor0/rep-0/WorkerRuntime", "pathname": "/home/deepankar/repos/jina/jina/serve/runtimes/asyncio.py", "process": 16422, "processName": "executor0/rep-0", "thread": 140272063719232, "threadName": "MainThread"}
{"created": 1663931000.3865087, "filename": "server.py", "funcName": "foo", "levelname": "INFO", "lineno": 8, "module": "server", "msg": "0 is fooed\n\n0 is fooed\n\n0 is fooed\n\n0 is fooed\n\n0 is fooed\n\n0 is fooed\n\n0 is fooed\n\n0 is fooed\n\n0 is fooed\n\n0 is fooed\n\n", "name": "MyExecutor", "pathname": "rough_work/json_logging/server.py", "process": 16422, "processName": "executor0/rep-0", "thread": 140272063719232, "threadName": "MainThread"}
{"created": 1663931000.386548, "filename": "__init__.py", "funcName": "process_data", "levelname": "ERROR", "lineno": 192, "module": "__init__", "msg": "Exception('foo')\n add \"--quiet-error\" to suppress the exception details", "name": "executor0/rep-0/WorkerRuntime", "pathname": "/home/deepankar/repos/jina/jina/serve/runtimes/worker/__init__.py", "process": 16422, "processName": "executor0/rep-0", "thread": 140272063719232, "threadName": "MainThread"}
{"created": 1663931000.3867161, "filename": "asyncio.py", "funcName": "_log_data_request", "levelname": "DEBUG", "lineno": 197, "module": "asyncio", "msg": "recv DataRequest at / with id: b82aada41a0a4197969bf248de209390", "name": "executor0/rep-0/WorkerRuntime", "pathname": "/home/deepankar/repos/jina/jina/serve/runtimes/asyncio.py", "process": 16422, "processName": "executor0/rep-0", "thread": 140272063719232, "threadName": "MainThread"}
{"created": 1663931000.3868144, "filename": "server.py", "funcName": "foo", "levelname": "INFO", "lineno": 8, "module": "server", "msg": "0 is fooed\n\n0 is fooed\n\n0 is fooed\n\n0 is fooed\n\n0 is fooed\n\n0 is fooed\n\n0 is fooed\n\n0 is fooed\n\n0 is fooed\n\n0 is fooed\n\n", "name": "MyExecutor", "pathname": "rough_work/json_logging/server.py", "process": 16422, "processName": "executor0/rep-0", "thread": 140272063719232, "threadName": "MainThread"}
{"created": 1663931000.386854, "filename": "__init__.py", "funcName": "process_data", "levelname": "ERROR", "lineno": 192, "module": "__init__", "msg": "Exception('foo')\n add \"--quiet-error\" to suppress the exception details", "name": "executor0/rep-0/WorkerRuntime", "pathname": "/home/deepankar/repos/jina/jina/serve/runtimes/worker/__init__.py", "process": 16422, "processName": "executor0/rep-0", "thread": 140272063719232, "threadName": "MainThread"}
```

- [ ] check and update documentation. See [guide](https://github.com/jina-ai/jina/CONTRIBUTING.md#documentation-guidelines) and ask the team.