### PR TITLE
fix: disable rich traceback in logging

### DIFF
--- a/jina/resources/logging.default.yml
+++ b/jina/resources/logging.default.yml
@@ -1,5 +1,5 @@
 handlers:  # enabled handlers, order does not matter
-  - RichHandler
+  - StreamHandler
 level: INFO  # set verbose level
 configs:
   FileHandler:

--- a/jina/resources/logging.default.yml
+++ b/jina/resources/logging.default.yml
@@ -1,5 +1,5 @@
 handlers:  # enabled handlers, order does not matter
-  - StreamHandler
+  - RichHandler
 level: INFO  # set verbose level
 configs:
   FileHandler:
@@ -18,6 +18,6 @@ configs:
   RichHandler:
     format: '{name}@%(process)2d %(message)s'
     markup: false
-    rich_tracebacks: true
+    rich_tracebacks: false
     show_path: false
     log_time_format: '[%x %X]'


### PR DESCRIPTION
# Context

original issue : https://github.com/jina-ai/jina/issues/5241

Atm the rich formatter invoke the rich traceback with a limited width which make it difficult to read traceback coming from Executor:


ex 
<details>

  ```bash
  
  ERROR  executor0/rep-0@183551 ZeroDivisionError('division by [10/05/22 11:26:23]
         zero')                                                                   
          add "--quiet-error" to suppress the exception                           
         details                                                                  
         ╭──────── Traceback (most recent call last) ────────╮                    
         │ /home/sami/Documents/workspace/Jina/jina/jina/se… │                    
         │ in process_data                                   │                    
         │                                                   │                    
         │   179 │   │   │   │   if self.logger.debug_enable │                    
         │   180 │   │   │   │   │   self._log_data_request( │                    
         │   181 │   │   │   │                               │                    
         │ ❱ 182 │   │   │   │   result = await self._data_r │                    
         │   183 │   │   │   │   if self._successful_request │                    
         │   184 │   │   │   │   │   self._successful_reques │                    
         │   185 │   │   │   │   return result               │                    
         │                                                   │                    
         │ /home/sami/Documents/workspace/Jina/jina/jina/se… │                    
         │ in handle                                         │                    
         │                                                   │                    
         │   161 │   │   )                                   │                    
         │   162 │   │                                       │                    
         │   163 │   │   # executor logic                    │                    
         │ ❱ 164 │   │   return_data = await self._executor. │                    
         │   165 │   │   │   req_endpoint=requests[0].header │                    
         │   166 │   │   │   docs=docs,                      │                    
         │   167 │   │   │   parameters=params,              │                    
         │                                                   │                    
         │ /home/sami/Documents/workspace/Jina/jina/jina/se… │                    
         │ in __acall__                                      │                    
         │                                                   │                    
         │   290 │   │   if req_endpoint in self.requests:   │                    
         │   291 │   │   │   return await self.__acall_endpo │                    
         │   292 │   │   elif __default_endpoint__ in self.r │                    
         │ ❱ 293 │   │   │   return await self.__acall_endpo │                    
         │   294 │                                           │                    
         │   295 │   async def __acall_endpoint__(self, req_ │                    
         │   296 │   │   func = self.requests[req_endpoint]  │                    
         │                                                   │                    
         │ /home/sami/Documents/workspace/Jina/jina/jina/se… │                    
         │ in __acall_endpoint__                             │                    
         │                                                   │                    
         │   311 │   │   │   if iscoroutinefunction(func):   │                    
         │   312 │   │   │   │   return await func(self, **k │                    
         │   313 │   │   │   else:                           │                    
         │ ❱ 314 │   │   │   │   return func(self, **kwargs) │                    
         │   315 │                                           │                    
         │   316 │   @property                               │                    
         │   317 │   def workspace(self) -> Optional[str]:   │                    
         │                                                   │                    
         │ /home/sami/Documents/workspace/Jina/jina/jina/se… │                    
         │ in arg_wrapper                                    │                    
         │                                                   │                    
         │   159 │   │   │   │   def arg_wrapper(            │                    
         │   160 │   │   │   │   │   executor_instance, *arg │                    
         │   161 │   │   │   │   ):  # we need to get the su │                    
         │       the self                                    │                    
         │ ❱ 162 │   │   │   │   │   return fn(executor_inst │                    
         │   163 │   │   │   │                               │                    
         │   164 │   │   │   │   self.fn = arg_wrapper       │                    
         │   165                                             │                    
         │                                                   │                    
         │ /home/sami/.config/JetBrains/PyCharmCE2022.2/scr… │                    
         │ in foo                                            │                    
         │                                                   │                    
         │   12 │                                            │                    
         │   13 │   @requests                                │                    
         │   14 │   def foo(self, docs, **kwargs):           │                    
         │ ❱ 15 │   │   1/0                                  │                    
         │   16                                              │                    
         │   17 with Flow().add(uses=MyExec) as f:           │                    
         │   18                                              │                    
         ╰───────────────────────────────────────────────────╯                    
         ZeroDivisionError: division by zero                                      
  Traceback (most recent call last):
    File "/home/sami/.config/JetBrains/PyCharmCE2022.2/scratches/scratch_6.py", line 19, in <module>
      f.search(inputs=[Document()])
    File "/home/sami/Documents/workspace/Jina/jina/jina/clients/mixin.py", line 271, in post
      return run_async(
    File "/home/sami/Documents/workspace/Jina/jina/jina/helper.py", line 1334, in run_async
      return asyncio.run(func(*args, **kwargs))
    File "/home/sami/.pyenv/versions/3.9.10/lib/python3.9/asyncio/runners.py", line 44, in run
      return loop.run_until_complete(main)
    File "/home/sami/.pyenv/versions/3.9.10/lib/python3.9/asyncio/base_events.py", line 642, in run_until_complete
      return future.result()
    File "/home/sami/Documents/workspace/Jina/jina/jina/clients/mixin.py", line 262, in _get_results
      async for resp in c._get_results(*args, **kwargs):
    File "/home/sami/Documents/workspace/Jina/jina/jina/clients/base/grpc.py", line 122, in _get_results
      callback_exec(
    File "/home/sami/Documents/workspace/Jina/jina/jina/clients/helper.py", line 81, in callback_exec
      raise BadServer(response.header)
  jina.excepts.BadServer: request_id: "c50a57014fb948ccbd8065ada487a136"
  status {
    code: ERROR
    description: "ZeroDivisionError(\'division by zero\')"
    exception {
      name: "ZeroDivisionError"
      args: "division by zero"
      stacks: "Traceback (most recent call last):\n"
      stacks: "  File \"/home/sami/Documents/workspace/Jina/jina/jina/serve/runtimes/worker/__init__.py\", line 182, in process_data\n    result = await self._data_request_handler.handle(requests=requests)\n"
      stacks: "  File \"/home/sami/Documents/workspace/Jina/jina/jina/serve/runtimes/request_handlers/data_request_handler.py\", line 164, in handle\n    return_data = await self._executor.__acall__(\n"
      stacks: "  File \"/home/sami/Documents/workspace/Jina/jina/jina/serve/executors/__init__.py\", line 293, in __acall__\n    return await self.__acall_endpoint__(__default_endpoint__, **kwargs)\n"
      stacks: "  File \"/home/sami/Documents/workspace/Jina/jina/jina/serve/executors/__init__.py\", line 314, in __acall_endpoint__\n    return func(self, **kwargs)\n"
      stacks: "  File \"/home/sami/Documents/workspace/Jina/jina/jina/serve/executors/decorators.py\", line 162, in arg_wrapper\n    return fn(executor_instance, *args, **kwargs)\n"
      stacks: "  File \"/home/sami/.config/JetBrains/PyCharmCE2022.2/scratches/scratch_6.py\", line 15, in foo\n    1/0\n"
      stacks: "ZeroDivisionError: division by zero\n"
      executor: "MyExec"
    }
  }
  exec_endpoint: "/search"
  target_executor: ""
  
  
  Process finished with exit code 1
  ```
</details>

# What this pr do:

Disable rich traceback: nothing change on the UI side, just rich does not use the its custom traceback but rich will still beautify the logs

This is the new behavior
<details>

  ```bash
  
ERROR  executor0/rep-0@198650 ZeroDivisionError('division by [10/05/22 11:40:37]
       zero')                                                                   
        add "--quiet-error" to suppress the exception                           
       details                                                                  
       Traceback (most recent call last):                                       
         File                                                                   
       "/home/sami/Documents/workspace/Jina/jina/jina/serve…                    
       line 182, in process_data                                                
           result = await                                                       
       self._data_request_handler.handle(requests=requests)                     
         File                                                                   
       "/home/sami/Documents/workspace/Jina/jina/jina/serve…                    
       line 164, in handle                                                      
           return_data = await self._executor.__acall__(                        
         File                                                                   
       "/home/sami/Documents/workspace/Jina/jina/jina/serve…                    
       line 293, in __acall__                                                   
           return await                                                         
       self.__acall_endpoint__(__default_endpoint__,                            
       **kwargs)                                                                
         File                                                                   
       "/home/sami/Documents/workspace/Jina/jina/jina/serve…                    
       line 314, in __acall_endpoint__                                          
           return func(self, **kwargs)                                          
         File                                                                   
       "/home/sami/Documents/workspace/Jina/jina/jina/serve…                    
       line 162, in arg_wrapper                                                 
           return fn(executor_instance, *args, **kwargs)                        
         File                                                                   
       "/home/sami/.config/JetBrains/PyCharmCE2022.2/scratc…                    
       line 15, in foo                                                          
           1/0                                                                  
       ZeroDivisionError: division by zero                                      
Traceback (most recent call last):
  File "/home/sami/.config/JetBrains/PyCharmCE2022.2/scratches/scratch_6.py", line 19, in <module>
    f.search(inputs=[Document()])
  File "/home/sami/Documents/workspace/Jina/jina/jina/clients/mixin.py", line 271, in post
    return run_async(
  File "/home/sami/Documents/workspace/Jina/jina/jina/helper.py", line 1334, in run_async
    return asyncio.run(func(*args, **kwargs))
  File "/home/sami/.pyenv/versions/3.9.10/lib/python3.9/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/home/sami/.pyenv/versions/3.9.10/lib/python3.9/asyncio/base_events.py", line 642, in run_until_complete
    return future.result()
  File "/home/sami/Documents/workspace/Jina/jina/jina/clients/mixin.py", line 262, in _get_results
    async for resp in c._get_results(*args, **kwargs):
  File "/home/sami/Documents/workspace/Jina/jina/jina/clients/base/grpc.py", line 122, in _get_results
    callback_exec(
  File "/home/sami/Documents/workspace/Jina/jina/jina/clients/helper.py", line 81, in callback_exec
    raise BadServer(response.header)
jina.excepts.BadServer: request_id: "5d5e0338d0cd4bdd89efc430bbaaa74d"
status {
  code: ERROR
  description: "ZeroDivisionError(\'division by zero\')"
  exception {
    name: "ZeroDivisionError"
    args: "division by zero"
    stacks: "Traceback (most recent call last):\n"
    stacks: "  File \"/home/sami/Documents/workspace/Jina/jina/jina/serve/runtimes/worker/__init__.py\", line 182, in process_data\n    result = await self._data_request_handler.handle(requests=requests)\n"
    stacks: "  File \"/home/sami/Documents/workspace/Jina/jina/jina/serve/runtimes/request_handlers/data_request_handler.py\", line 164, in handle\n    return_data = await self._executor.__acall__(\n"
    stacks: "  File \"/home/sami/Documents/workspace/Jina/jina/jina/serve/executors/__init__.py\", line 293, in __acall__\n    return await self.__acall_endpoint__(__default_endpoint__, **kwargs)\n"
    stacks: "  File \"/home/sami/Documents/workspace/Jina/jina/jina/serve/executors/__init__.py\", line 314, in __acall_endpoint__\n    return func(self, **kwargs)\n"
    stacks: "  File \"/home/sami/Documents/workspace/Jina/jina/jina/serve/executors/decorators.py\", line 162, in arg_wrapper\n    return fn(executor_instance, *args, **kwargs)\n"
    stacks: "  File \"/home/sami/.config/JetBrains/PyCharmCE2022.2/scratches/scratch_6.py\", line 15, in foo\n    1/0\n"
    stacks: "ZeroDivisionError: division by zero\n"
    executor: "MyExec"
  }
}
exec_endpoint: "/search"
target_executor: ""


Process finished with exit code 1
  ```
</details>




