### PR TITLE
docs: add links to go and kotlin clients

### DIFF
--- a/docs/fundamentals/client/third-party-client.md
+++ b/docs/fundamentals/client/third-party-client.md
@@ -3,6 +3,16 @@
 
 This page is about accessing the Flow with other clients, e.g. `curl`, or programming languages other than python.
 
+## Golang
+
+We have developed a [Jina Go Client](https://github.com/jina-ai/client-go) that supports `grpc`, `http` and `websocket` protocol that will allow you to connect to Jina from your Go applications.
+
+
+## Kotlin
+
+Our community has developed a [Jina Kotlin Client](https://github.com/jina-ai/client-go) # TODO Put proper link
+
+
 ## HTTP
 
 ```{admonition} Available Protocols


### PR DESCRIPTION
**Goals:**
Show the existence of these external clients to the community