### PR TITLE
ci: allow release from any branch

### DIFF
--- a/.github/workflows/force-docker-build.yml
+++ b/.github/workflows/force-docker-build.yml
@@ -61,18 +61,24 @@ jobs:
           if [ -n "${PIP_TAG}" ]; then
               PIP_TAG=-${PIP_TAG}
           fi
+          
+          LAST_VER_TAG=$(git tag -l | sort -V | tail -n1)
+          PRE_VERSION=-dev$(git rev-list $LAST_VER_TAG..HEAD --count)
 
           if [[ "${{ github.event.inputs.triggered_by }}" == "CD" ]]; then
 
             if [[ "${{ matrix.py_version }}" == "$DEFAULT_PY_VERSION" ]]; then
               echo "TAG_ALIAS=\
                               jinaai/jina:master${PY_TAG}${PIP_TAG}, \
-                              jinaai/jina:master${PIP_TAG}" \
+                              jinaai/jina:master${PIP_TAG} \
+                              jinaai/jina:${JINA_VERSION}${PRE_VERSION}${PIP_TAG} \
+                              jinaai/jina:${JINA_VERSION}${PRE_VERSION}${PY_TAG}${PIP_TAG}" \
                               >> $GITHUB_ENV
             else
               # on every CD
               echo "TAG_ALIAS=\
-                              jinaai/jina:master${PY_TAG}${PIP_TAG}" \
+                              jinaai/jina:master${PY_TAG}${PIP_TAG} \
+                              jinaai/jina:${JINA_VERSION}${PRE_VERSION}${PY_TAG}${PIP_TAG}" \
                               >> $GITHUB_ENV
             fi
 

--- a/.github/workflows/force-release.yml
+++ b/.github/workflows/force-release.yml
@@ -57,4 +57,4 @@ jobs:
         with:
           github_token: ${{ secrets.JINA_DEV_BOT }}
           tags: true
-          branch: master
+          branch: ${{ github.ref }}

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -62,11 +62,6 @@ function make_release_note {
 
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
 
-if [[ "$BRANCH" != "master" ]]; then
-  printf "You are not at master branch, exit\n";
-  exit 1;
-fi
-
 LAST_UPDATE=`git show --no-notes --format=format:"%H" $BRANCH | head -n 1`
 LAST_COMMIT=`git show --no-notes --format=format:"%H" origin/$BRANCH | head -n 1`
 


### PR DESCRIPTION
# Goals

1. Allow release to be made by any branch in order to enable hot fixes from the past.
2. Push docker images for pre releases

closes: #5266

# 1-  Workflow for hotfix creation and release

1. create a branch "in the past", implement your hotfix on that branch
3. in `jina./__init__.py` set the version number that you wish to release
4. run the action `manual release` from your hotfix branch, using the dropdown menu. A relase will be made, tag will be created, and version will be bumped. 
![image](https://user-images.githubusercontent.com/44071807/195821124-236cc19f-8a03-46b3-9559-2aa6129b04c8.png)

5. merge your hotfix branch back into master.

## Try it out first

This modified action can be tried out (without actually releasing anything) here: https://github.com/jina-ai/jina-test-ci

# 2 - docker push for pre releases

We already push to docker hub for every merge on master, now we also provide a separate tag for every such pre-release.

You can try out the script that produces these tags, by running this locally: https://github.com/jina-ai/jina-test-ci/blob/main/test-docker-push.sh