### PR TITLE
docs(flow-switch): fix broken restructuredtext syntax

### DIFF
--- a/docs/how-to/flow-switch.md
+++ b/docs/how-to/flow-switch.md
@@ -1,7 +1,7 @@
 (flow-switch)=
 # Conditional route request inside a Flow
 
-This tutorial gives a deeper insight into the {class}`~jina.Flow 's {ref}`filter condition feature<flow-filter>`.
+This tutorial gives a deeper insight into the {class}`~jina.Flow`'s {ref}`filter condition feature<flow-filter>`.
 
 In a nutshell, this lets any {class}`~jina.Executor` filter Documents that fulfill a specified `condition`, letting you build *selection control* into your Flow.
 


### PR DESCRIPTION
In #5287 I mangled some restructuredtext syntax. This PR fixes that

**Goals:**
- Fix my past mistake and beg forgiveness

- [X] check and update documentation. See [guide](https://github.com/jina-ai/jina/blob/master/CONTRIBUTING.md#-contributing-documentation) and ask the team.
