### PR TITLE
docs: add versioned docs

### DIFF
--- a/.github/workflows/build-old-docs.yml
+++ b/.github/workflows/build-old-docs.yml
@@ -47,7 +47,7 @@ jobs:
         id: get_versions
         run: |
           printf "versions=" >> $GITHUB_OUTPUT
-          curl https://raw.githubusercontent.com/${{ inputs.repo_owner }}/${{ inputs.package }}/main/docs/_versions.json >> $GITHUB_OUTPUT
+          curl https://raw.githubusercontent.com/${{ inputs.repo_owner }}/${{ inputs.package }}/master/docs/_versions.json >> $GITHUB_OUTPUT
     outputs:
       versions: ${{ steps.get_versions.outputs.versions }}
 
@@ -70,7 +70,7 @@ jobs:
         run: |
           git show --summary
           echo "Get latest sidebar brand template"
-          wget https://raw.githubusercontent.com/${{ inputs.repo_owner }}/${{ inputs.package }}/main/docs/_templates/sidebar/brand.html
+          wget https://raw.githubusercontent.com/${{ inputs.repo_owner }}/${{ inputs.package }}/master/docs/_templates/sidebar/brand.html
           mv ./brand.html ./docs/_templates/sidebar/brand.html
       - name: Install dependencies
         run: |
@@ -114,7 +114,7 @@ jobs:
           cd docs
           for i in $(ls /tmp/artifacts); do unzip "/tmp/artifacts/$i/build.zip"; done
           rm _versions.json || true
-          wget https://raw.githubusercontent.com/${{ inputs.repo_owner }}/${{ inputs.package }}/main/docs/_versions.json
+          wget https://raw.githubusercontent.com/${{ inputs.repo_owner }}/${{ inputs.package }}/master/docs/_versions.json
       - name: Push it up!
         run: |
           git config --local user.email "${{ inputs.git_config_email }}"

--- a/.github/workflows/build-old-docs.yml
+++ b/.github/workflows/build-old-docs.yml
@@ -1,0 +1,124 @@
+name: Build old docs
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_token:
+        description: 'Your release token'
+        required: true
+      triggered_by:
+        description: 'CD | TAG | MANUAL'
+        required: false
+        default: MANUAL
+      package:
+        description: The name of the repo to build documentation for.
+        type: string
+        default: jina
+      repo_owner:
+        description: The owner of the repo to build documentation for. Defaults to 'jina-ai'.
+        type: string
+        default: jina-ai
+      pages_branch:
+        description: Branch that Github Pages observes
+        type: string
+        default: gh-pages
+      git_config_name:
+        type: string
+        default: Jina Dev Bot
+      git_config_email:
+        type: string
+        default: dev-bot@jina.ai
+
+jobs:
+  token-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check release token
+        id: token-check
+        run: | 
+          touch SUCCESS
+        if: inputs.release_token == env.release_token
+        env:
+          release_token: ${{ secrets.JINA_CORE_RELEASE_TOKEN }}
+      - name: Fail release token
+        run: |
+          [[ -f SUCCESS ]]
+      - name: Get versions
+        id: get_versions
+        run: |
+          printf "versions=" >> $GITHUB_OUTPUT
+          curl https://raw.githubusercontent.com/${{ inputs.repo_owner }}/${{ inputs.package }}/main/docs/_versions.json >> $GITHUB_OUTPUT
+    outputs:
+      versions: ${{ steps.get_versions.outputs.versions }}
+
+  build-doc:
+    needs: token-check
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.token-check.outputs.versions) }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+          ref: ${{ matrix.version }}
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.7'
+      - name: Get latest templates
+        run: |
+          git show --summary
+          echo "Get latest sidebar brand template"
+          wget https://raw.githubusercontent.com/${{ inputs.repo_owner }}/${{ inputs.package }}/main/docs/_templates/sidebar/brand.html
+          mv ./brand.html ./docs/_templates/sidebar/brand.html
+      - name: Install dependencies
+        run: |
+          pip install .[devel]
+          cd docs
+          pip install -r requirements.txt
+          pip install --pre -U furo
+          pip install sphinx-markdown-tables==0.0.17
+      - name: Sphinx Build
+        run: |
+          cd docs
+          bash makedoc.sh
+      - name: Package build into artifact
+        run: |
+          mv ./docs/_build/dirhtml ./${{ matrix.version }}
+          zip -r /tmp/build.zip ./${{ matrix.version }}/*
+      - name: Upload built html
+        uses: actions/upload-artifact@v3
+        with:
+            name: ${{ matrix.version }}
+            path: /tmp/build.zip
+            retention-days: 1
+  
+  push-docs:
+    runs-on: ubuntu-latest
+    needs: build-doc
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+          ref: ${{ inputs.pages_branch }}
+      - uses: actions/download-artifact@v3
+        with:
+          path: /tmp/artifacts
+      - name: Clear old builds
+        run: |
+          cd docs
+          for i in $(ls /tmp/artifacts); do git rm -rf "$i" || true; done
+      - name: In with new builds
+        run: |
+          cd docs
+          for i in $(ls /tmp/artifacts); do unzip "/tmp/artifacts/$i/build.zip"; done
+          rm _versions.json || true
+          wget https://raw.githubusercontent.com/${{ inputs.repo_owner }}/${{ inputs.package }}/main/docs/_versions.json
+      - name: Push it up!
+        run: |
+          git config --local user.email "${{ inputs.git_config_email }}"
+          git config --local user.name "${{ inputs.git_config_name }}"
+          git show --summary
+          git add . && git commit -m "chore(docs): update old docs due to ${{github.event_name}} on ${{github.repository}}"
+          git push origin

--- a/.github/workflows/build-old-docs.yml
+++ b/.github/workflows/build-old-docs.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Sphinx Build
         run: |
           cd docs
-          bash makedoc.sh
+          bash makedoc.sh local-only
       - name: Package build into artifact
         run: |
           mv ./docs/_build/dirhtml ./${{ matrix.version }}

--- a/.github/workflows/force-docs-build.yml
+++ b/.github/workflows/force-docs-build.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Sphinx Build
         run: |
           cd docs
-          bash makedoc.sh
+          bash makedoc.sh local-only
           mv ./_build/dirhtml /tmp/gen-html
           cd ..
       - name: Checkout to GH pages branch (${{ inputs.pages_branch }})

--- a/.github/workflows/force-docs-build.yml
+++ b/.github/workflows/force-docs-build.yml
@@ -10,6 +10,28 @@ on:
         description: 'CD | TAG | MANUAL'
         required: false
         default: MANUAL
+      build_old_docs:
+        description: 'Whether to build old docs (TRUE | FALSE)'
+        type: string
+        default: 'FALSE'
+      package:
+        description: The name of the repo to build documentation for.
+        type: string
+        default: jina
+      repo_owner:
+        description: The owner of the repo to build documentation for. Defaults to 'jina-ai'.
+        type: string
+        default: jina-ai
+      pages_branch:
+        description: Branch that Github Pages observes
+        type: string
+        default: gh-pages
+      git_config_name:
+        type: string
+        default: Jina Dev Bot
+      git_config_email:
+        type: string
+        default: dev-bot@jina.ai
 
 jobs:
   token-check:
@@ -26,44 +48,66 @@ jobs:
         run: |
           [[ -f SUCCESS ]]
 
-
-  regular-release:
+  build-and-push-latest-docs:
     needs: token-check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.5.0
+      - uses: actions/checkout@v3
         with:
-          fetch-depth: 0
+          fetch-depth: 1
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.7
-      - name: Build doc and push to gh-pages
+          python-version: '3.7'
+      - name: Install Dependencies
         run: |
-          git config --local user.email "dev-bot@jina.ai"
-          git config --local user.name "Jina Dev Bot"
           pip install .[devel]
-          mkdir gen-html
           cd docs
           pip install -r requirements.txt
           pip install --pre -U furo
-          export NUM_RELEASES=2
-          bash makedoc.sh local-only
-          cd ./_build/dirhtml/
-          cp -r ./ ../../../gen-html
-          cd -  # back to ./docs
+          pip install sphinx-markdown-tables==0.0.17
+      - name: Sphinx Build
+        run: |
+          cd docs
+          bash makedoc.sh
+          mv ./_build/dirhtml /tmp/gen-html
           cd ..
-          git checkout -f gh-pages
-          git rm -rf ./docs
-          mkdir -p docs
-          cd gen-html
-          cp -r ./ ../docs
-          cd ../docs
-          ls -la
-          touch .nojekyll
-          cp 404/index.html 404.html
-          sed -i 's/href="\.\./href="/' 404.html # fix asset urls that needs to be updated in 404.html
-          echo docs.jina.ai > CNAME
-          cd ..
-          git status
-          git add docs && git commit -m "chore(docs): update docs due to ${{github.event_name}} on ${{github.repository}}"
-          git push --force origin gh-pages
+      - name: Checkout to GH pages branch (${{ inputs.pages_branch }})
+        run: |
+          git fetch origin ${{ inputs.pages_branch }}:${{ inputs.pages_branch }} --depth 1
+          git checkout -f ${{ inputs.pages_branch }}
+          git reset --hard HEAD
+      - name: Small config stuff
+        run: |
+          touch /tmp/gen-html/.nojekyll
+          cp ./docs/_versions.json /tmp/gen-html/_versions.json
+          cp ./docs/CNAME /tmp/gen-html/CNAME
+          cp /tmp/gen-html/404/index.html /tmp/gen-html/404.html
+          sed -i 's/href="\.\./href="/' /tmp/gen-html/404.html # fix asset urls that needs to be updated in 404.html
+      - name: Moving old doc versions
+        run: |
+          cd docs
+          for i in $(cat _versions.json | jq '.[].version' | tr -d '"'); do mv "$i" /tmp/gen-html; done
+      - name: Swap in new docs
+        run: |
+          rm -rf ./docs
+          mv /tmp/gen-html ./docs
+      - name: Push it up!
+        run: |
+          git config --local user.email "${{ inputs.git_config_email }}"
+          git config --local user.name "${{ inputs.git_config_name }}"
+          git show --summary
+          git add ./docs && git commit -m "chore(docs): update docs due to ${{github.event_name}} on ${{github.repository}}"
+          git push origin ${{ inputs.pages_branch }}
+
+  build-old-docs:
+    needs: build-and-push-latest-docs
+    runs-on: ubuntu-latest
+    if: inputs.build_old_docs == 'TRUE'
+    steps:
+      - uses: benc-uk/workflow-dispatch@v1
+        with:
+          workflow: Build old docs
+          token: ${{ secrets.JINA_DEV_BOT }}
+          inputs: '{ "release_token": "${{ env.release_token }}", "triggered_by": "TAG"}'
+        env:
+          release_token: ${{ secrets.JINA_CORE_RELEASE_TOKEN }}

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -66,7 +66,7 @@ jobs:
         with:
           workflow: Manual Docs Build
           token: ${{ secrets.JINA_DEV_BOT }}
-          inputs: '{ "release_token": "${{ env.release_token }}", "triggered_by": "TAG"}'
+          inputs: '{ "release_token": "${{ env.release_token }}", "triggered_by": "TAG", "build_old_docs": "TRUE"}'
         env:
           release_token: ${{ secrets.JINA_CORE_RELEASE_TOKEN }}
 

--- a/docs/_templates/sidebar/brand.html
+++ b/docs/_templates/sidebar/brand.html
@@ -16,26 +16,33 @@
   {%- endif %}
   {% endblock brand_content %}
 </a>
+<script>
+  function setPrefix(prefix){
+    window.sessionStorage.setItem("version-select-index", document.getElementsByClassName("version-select")[0].selectedIndex);
+    window.location.href = prefix
+  }
+</script>
+<script defer>
+  fetch(`https://${window.location.host}/_versions.json`)
+  .then((resp) => resp.json())
+  .then((data) => {
+    var versionSelector = document.getElementsByClassName("version-select")[0]
+    for(var i = 0; i < data.length; i++){
+      var option = document.createElement("option");
+      option.innerHTML = data[i].version;
+      option.value = "/" + data[i].version;
+      versionSelector.appendChild(option);
+    }
+
+    if(window.sessionStorage.getItem('version-select-index')){
+      versionSelector.selectedIndex = window.sessionStorage.getItem('version-select-index');
+    }
+  })
+  .catch((err) => console.log(err));
+</script>
 <div class="sd-d-flex-row sd-align-major-spaced">
   <a class="github-button" href="https://github.com/jina-ai/jina" data-icon="octicon-star" data-show-count="true" aria-label="Star jina-ai/jina on GitHub" style="opacity: 0;">Star</a>
-  {% if versions %}
-  <select onChange="window.location.href=this.value" class="version-select">
-      {%- for item in versions|reverse %}
-        {% if item.name == latest_jina_version %}
-          {% set new_url = item.url if current_version.name == latest_jina_version else item.url | replace('/' + latest_jina_version, "") %}
-          {% if current_version.version == item.version %}
-            <option value="{{ new_url }}" selected="selected" >latest ({{ item.name }})</option>
-          {% else %}
-            <option value="{{ new_url }}" >latest({{ item.name }})</option>
-          {% endif %}
-        {% else %}
-          {% if current_version.version == item.version %}
-            <option value="{{ item.url }}" selected="selected" >{{ item.name }}</option>
-          {% else %}
-            <option value="{{ item.url }}" >{{ item.name }}</option>
-          {% endif %}
-        {% endif %}
-      {%- endfor %}
+  <select onChange="setPrefix(this.value)" class="version-select">
+    <option value="/">latest</option>
   </select>
-  {% endif %}
 </div>

--- a/docs/_versions.json
+++ b/docs/_versions.json
@@ -1,0 +1,1 @@
+[{"version": "v3.11.0"}, {"version": "v3.10.1"}, {"version": "v3.9.3"}, {"version": "v3.8.4"}, {"version": "v3.7.14"}, {"version": "v3.6.16"}, {"version": "v3.5.0"}, {"version": "v3.4.11"}]

--- a/scripts/prepend_version_json.py
+++ b/scripts/prepend_version_json.py
@@ -1,0 +1,21 @@
+from typing import List
+import argparse
+import json
+
+parser = argparse.ArgumentParser(prog="Prepender docs/_versions.json")
+parser.add_argument(
+    "--version",
+    type=str,
+    help="The version we wish to prepend (e.g. v0.18.0)",
+    required=True,
+)
+args = parser.parse_args()
+
+with open("./docs/_versions.json") as f:
+    versions: List[dict] = json.load(f)
+    element = {k: v for k, v in args._get_kwargs()}
+    if element != versions[0]:
+        versions.insert(0, element)
+
+with open("./docs/_versions.json", "w") as f:
+    json.dump(versions, f)

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -75,6 +75,10 @@ export RELEASE_VER=$(sed -n '/^__version__/p' $INIT_FILE | cut -d \' -f2)
 LAST_VER=$(git tag -l | sort -V | tail -n1)
 printf "last version: \e[1;32m$LAST_VER\e[0m\n"
 
+# Update new _versions.json if necessary
+python ./scripts/prepend_version_json.py --version "v$RELEASE_VER"
+git add ./docs/_versions.json
+
 if [[ $1 == "final" ]]; then
   printf "this will be a final release: \e[1;33m$RELEASE_VER\e[0m\n"
 


### PR DESCRIPTION
Goals:
- [x] Address https://github.com/jina-ai/jina/issues/5283

Docs Changes:
- Added a version selector to the sidebar in `docs/_templates/sidebar/brand.html`.

CI changes:
- Updates the `Manual Docs Build` workflow (`.github/workflows/force-docs-build.yml`).
  - This can be run whenever the docs are updated.
  - Changed some steps to be compatible with the new folder structure introduced by versioned docs
  - Increased modularity of steps to increase separation of concerns as well as increase visibility on time taken for each concern.
  - Decreased time taken to fetch code by changing fetches to shallow (depth 1)
  
- Added the `Build old docs` workflow (`.github/workflows/build-old-docs.yml`)
  - This should be run when a new release is created (because there will be a new old release)
  - The workflow will build the docs for all the versions specified in `docs/_versions.json` of the `main` branch
  - Each version  of the docs is built by checking out to the release, pulling the latest `docs/_templates/sidebar/brand.html` in `main`. Then building with `makedoc.sh`.
  - Each version is then placed in separate folders in `./docs` of the pages_branch.

- Updates the `Release CD` workflow (`.github/workflows/tag.yml`)
  - Add `Build old docs` trigger to dispatch
  
- release.sh
  - Add logic to bump versions in _versions.json. This file is used by the `Build old docs` workflow to know which releases to build docs for