### PR TITLE
ci: fix move docs that did not exist

### DIFF
--- a/.github/workflows/force-docs-build.yml
+++ b/.github/workflows/force-docs-build.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Moving old doc versions
         run: |
           cd docs
-          for i in $(cat _versions.json | jq '.[].version' | tr -d '"'); do if [ -d "$i" ]; then; mv "$i" /tmp/gen-html; fi; done
+          for i in $(cat _versions.json | jq '.[].version' | tr -d '"'); do if [ -d "$i" ]; then mv "$i" /tmp/gen-html; fi; done
       - name: Swap in new docs
         run: |
           rm -rf ./docs


### PR DESCRIPTION

**Goals:**
- Resolves https://github.com/jina-ai/jina/actions/runs/3330903483/jobs/5509997880#step:8:14
- Bash somehow doesn't evaluate the previous syntax correctly. It works on zsh, just not bash.
