### PR TITLE
ci: fix docker build and push

### DIFF
--- a/.github/workflows/force-docker-build.yml
+++ b/.github/workflows/force-docker-build.yml
@@ -77,14 +77,14 @@ jobs:
             if [[ "${{ matrix.py_version }}" == "$DEFAULT_PY_VERSION" ]]; then
               echo "TAG_ALIAS=\
                               jinaai/jina:master${PY_TAG}${PIP_TAG}, \
-                              jinaai/jina:master${PIP_TAG} \
-                              jinaai/jina:${JINA_VERSION}${PRE_VERSION}${PIP_TAG} \
+                              jinaai/jina:master${PIP_TAG}, \
+                              jinaai/jina:${JINA_VERSION}${PRE_VERSION}${PIP_TAG}, \
                               jinaai/jina:${JINA_VERSION}${PRE_VERSION}${PY_TAG}${PIP_TAG}" \
                               >> $GITHUB_ENV
             else
               # on every CD
               echo "TAG_ALIAS=\
-                              jinaai/jina:master${PY_TAG}${PIP_TAG} \
+                              jinaai/jina:master${PY_TAG}${PIP_TAG}, \
                               jinaai/jina:${JINA_VERSION}${PRE_VERSION}${PY_TAG}${PIP_TAG}" \
                               >> $GITHUB_ENV
             fi


### PR DESCRIPTION
Docker build/push is failing right now, this should fix it by properly separating the different tags that we want to push
