### PR TITLE
feat: capture shard failures in the head runtime

### DIFF
--- a/jina/serve/networking.py
+++ b/jina/serve/networking.py
@@ -11,6 +11,7 @@ from grpc.aio import AioRpcError
 from grpc_health.v1 import health_pb2, health_pb2_grpc
 from grpc_reflection.v1alpha.reflection_pb2 import ServerReflectionRequest
 from grpc_reflection.v1alpha.reflection_pb2_grpc import ServerReflectionStub
+
 from jina import __default_endpoint__
 from jina.enums import PollingType
 from jina.excepts import EstablishGrpcConnectionError, InternalNetworkError
@@ -852,10 +853,7 @@ class GrpcConnectionPool:
                 timeout=timeout,
                 retries=retries,
             )
-            if isinstance(result, (AioRpcError, InternalNetworkError)):
-                raise result
-            else:
-                return result
+            return result
         else:
             self._logger.debug(
                 f'no available connections for deployment {deployment} and shard {shard_id}'
@@ -1015,6 +1013,7 @@ class GrpcConnectionPool:
                         connection_list=connections,
                     )
                     if error:
+                        print(f'--->returning error: {type(error)}')
                         return error
 
         return asyncio.create_task(task_wrapper())

--- a/jina/serve/networking.py
+++ b/jina/serve/networking.py
@@ -972,7 +972,7 @@ class GrpcConnectionPool:
         metadata: Optional[Dict[str, str]] = None,
         timeout: Optional[float] = None,
         retries: Optional[int] = -1,
-    ) -> asyncio.Task:
+    ) -> asyncio.Task[Union[Tuple, AioRpcError, InternalNetworkError]]:
         # this wraps the awaitable object from grpc as a coroutine so it can be used as a task
         # the grpc call function is not a coroutine but some _AioCall
 

--- a/jina/serve/networking.py
+++ b/jina/serve/networking.py
@@ -925,7 +925,7 @@ class GrpcConnectionPool:
         total_num_tries: int = 1,  # number of retries + 1
         current_address: str = '',  # the specific address that was contacted during this attempt
         connection_list: Optional[ReplicaList] = None,
-    ) -> Optional[Union[AioRpcError, InternalNetworkError]]:
+    ) -> 'Optional[Union[AioRpcError, InternalNetworkError]]':
         # connection failures, cancelled requests, and timed out requests should be retried
         # all other cases should not be retried and will be raised immediately
         # connection failures have the code grpc.StatusCode.UNAVAILABLE
@@ -972,7 +972,7 @@ class GrpcConnectionPool:
         metadata: Optional[Dict[str, str]] = None,
         timeout: Optional[float] = None,
         retries: Optional[int] = -1,
-    ) -> asyncio.Task[Union[Tuple, AioRpcError, InternalNetworkError]]:
+    ) -> 'asyncio.Task[Union[Tuple, AioRpcError, InternalNetworkError]]':
         # this wraps the awaitable object from grpc as a coroutine so it can be used as a task
         # the grpc call function is not a coroutine but some _AioCall
 

--- a/jina/serve/networking.py
+++ b/jina/serve/networking.py
@@ -1013,7 +1013,6 @@ class GrpcConnectionPool:
                         connection_list=connections,
                     )
                     if error:
-                        print(f'--->returning error: {type(error)}')
                         return error
 
         return asyncio.create_task(task_wrapper())

--- a/jina/serve/networking.py
+++ b/jina/serve/networking.py
@@ -14,7 +14,7 @@ from grpc_reflection.v1alpha.reflection_pb2_grpc import ServerReflectionStub
 
 from jina import __default_endpoint__
 from jina.enums import PollingType
-from jina.excepts import EstablishGrpcConnectionError
+from jina.excepts import EstablishGrpcConnectionError, InternalNetworkError
 from jina.importer import ImportExtensions
 from jina.logging.logger import JinaLogger
 from jina.proto import jina_pb2, jina_pb2_grpc
@@ -952,7 +952,7 @@ class GrpcConnectionPool:
         total_num_tries: int = 1,  # number of retries + 1
         current_address: str = '',  # the specific address that was contacted during this attempt
         connection_list: Optional[ReplicaList] = None,
-    ) -> Optional[BaseException]:
+    ) -> Optional[Union[AioRpcError, InternalNetworkError]]:
         # connection failures, cancelled requests, and timed out requests should be retried
         # all other cases should not be retried and will be raised immediately
         # connection failures have the code grpc.StatusCode.UNAVAILABLE

--- a/jina/serve/runtimes/gateway/graph/topology_graph.py
+++ b/jina/serve/runtimes/gateway/graph/topology_graph.py
@@ -140,9 +140,7 @@ class TopologyGraph:
                             need_copy=not copy_request_at_send
                         )
                     if self._reduce and len(self.parts_to_send) > 1:
-                        self.parts_to_send = [
-                            WorkerRequestHandler.reduce_requests(self.parts_to_send)
-                        ]
+                        WorkerRequestHandler.reduce_requests(self.parts_to_send)
 
                     # avoid sending to executor which does not bind to this endpoint
                     if endpoint is not None and executor_endpoint_mapping is not None:

--- a/jina/serve/runtimes/gateway/graph/topology_graph.py
+++ b/jina/serve/runtimes/gateway/graph/topology_graph.py
@@ -6,12 +6,15 @@ from datetime import datetime
 from typing import Dict, List, Optional, Tuple
 
 import grpc.aio
+from grpc.aio import AioRpcError
 
 from jina import __default_endpoint__
 from jina.excepts import InternalNetworkError
 from jina.serve.networking import GrpcConnectionPool
 from jina.serve.runtimes.helper import _parse_specific_params
-from jina.serve.runtimes.request_handlers.worker_request_handler import WorkerRequestHandler
+from jina.serve.runtimes.request_handlers.worker_request_handler import (
+    WorkerRequestHandler,
+)
 from jina.types.request.data import DataRequest
 
 
@@ -157,7 +160,7 @@ class TopologyGraph:
                         return request, metadata
                     # otherwise, send to executor and get response
                     try:
-                        resp, metadata = await connection_pool.send_requests_once(
+                        result = await connection_pool.send_requests_once(
                             requests=self.parts_to_send,
                             deployment=self.name,
                             metadata=self._metadata,
@@ -166,6 +169,10 @@ class TopologyGraph:
                             timeout=self._timeout_send,
                             retries=self._retries,
                         )
+                        if isinstance(result, (AioRpcError, InternalNetworkError)):
+                            raise result
+                        else:
+                            resp, metadata = result
                         if WorkerRequestHandler._KEY_RESULT in resp.parameters:
                             # Accumulate results from each Node and then add them to the original
                             self.result_in_params_returned = resp.parameters[

--- a/jina/serve/runtimes/gateway/graph/topology_graph.py
+++ b/jina/serve/runtimes/gateway/graph/topology_graph.py
@@ -140,7 +140,9 @@ class TopologyGraph:
                             need_copy=not copy_request_at_send
                         )
                     if self._reduce and len(self.parts_to_send) > 1:
-                        WorkerRequestHandler.reduce_requests(self.parts_to_send)
+                        self.parts_to_send = [
+                            WorkerRequestHandler.reduce_requests(self.parts_to_send)
+                        ]
 
                     # avoid sending to executor which does not bind to this endpoint
                     if endpoint is not None and executor_endpoint_mapping is not None:

--- a/jina/serve/runtimes/gateway/graph/topology_graph.py
+++ b/jina/serve/runtimes/gateway/graph/topology_graph.py
@@ -7,6 +7,7 @@ from typing import Dict, List, Optional, Tuple
 
 import grpc.aio
 from grpc.aio import AioRpcError
+
 from jina import __default_endpoint__
 from jina.excepts import InternalNetworkError
 from jina.serve.networking import GrpcConnectionPool
@@ -159,7 +160,7 @@ class TopologyGraph:
                         return request, metadata
                     # otherwise, send to executor and get response
                     try:
-                        resp, metadata = await connection_pool.send_requests_once(
+                        result = await connection_pool.send_requests_once(
                             requests=self.parts_to_send,
                             deployment=self.name,
                             metadata=self._metadata,
@@ -168,6 +169,10 @@ class TopologyGraph:
                             timeout=self._timeout_send,
                             retries=self._retries,
                         )
+                        if issubclass(type(result), BaseException):
+                            raise result
+                        else:
+                            resp, metadata = result
                         if WorkerRequestHandler._KEY_RESULT in resp.parameters:
                             # Accumulate results from each Node and then add them to the original
                             self.result_in_params_returned = resp.parameters[

--- a/jina/serve/runtimes/gateway/graph/topology_graph.py
+++ b/jina/serve/runtimes/gateway/graph/topology_graph.py
@@ -7,7 +7,6 @@ from typing import Dict, List, Optional, Tuple
 
 import grpc.aio
 from grpc.aio import AioRpcError
-
 from jina import __default_endpoint__
 from jina.excepts import InternalNetworkError
 from jina.serve.networking import GrpcConnectionPool
@@ -160,7 +159,7 @@ class TopologyGraph:
                         return request, metadata
                     # otherwise, send to executor and get response
                     try:
-                        result = await connection_pool.send_requests_once(
+                        resp, metadata = await connection_pool.send_requests_once(
                             requests=self.parts_to_send,
                             deployment=self.name,
                             metadata=self._metadata,
@@ -169,10 +168,6 @@ class TopologyGraph:
                             timeout=self._timeout_send,
                             retries=self._retries,
                         )
-                        if isinstance(result, (AioRpcError, InternalNetworkError)):
-                            raise result
-                        else:
-                            resp, metadata = result
                         if WorkerRequestHandler._KEY_RESULT in resp.parameters:
                             # Accumulate results from each Node and then add them to the original
                             self.result_in_params_returned = resp.parameters[

--- a/jina/serve/runtimes/head/__init__.py
+++ b/jina/serve/runtimes/head/__init__.py
@@ -379,7 +379,7 @@ class HeadRuntime(AsyncNewLoopRuntime, ABC):
                 retries=self._retries,
             )
         elif len(worker_results) > 1 and self._reduce:
-            response_request = WorkerRequestHandler.reduce_requests(worker_results)
+            WorkerRequestHandler.reduce_requests(worker_results)
         elif len(worker_results) > 1 and not self._reduce:
             # worker returned multiple responses, but the head is configured to skip reduction
             # just concatenate the docs in this case

--- a/jina/serve/runtimes/head/__init__.py
+++ b/jina/serve/runtimes/head/__init__.py
@@ -379,7 +379,7 @@ class HeadRuntime(AsyncNewLoopRuntime, ABC):
                 retries=self._retries,
             )
         elif len(worker_results) > 1 and self._reduce:
-            WorkerRequestHandler.reduce_requests(worker_results)
+            response_request = WorkerRequestHandler.reduce_requests(worker_results)
         elif len(worker_results) > 1 and not self._reduce:
             # worker returned multiple responses, but the head is configured to skip reduction
             # just concatenate the docs in this case

--- a/jina/serve/runtimes/head/__init__.py
+++ b/jina/serve/runtimes/head/__init__.py
@@ -10,7 +10,6 @@ import grpc
 from grpc.aio import AioRpcError
 from grpc_health.v1 import health, health_pb2, health_pb2_grpc
 from grpc_reflection.v1alpha import reflection
-
 from jina.enums import PollingType
 from jina.excepts import InternalNetworkError
 from jina.helper import get_full_version
@@ -348,6 +347,9 @@ class HeadRuntime(AsyncNewLoopRuntime, ABC):
         failed_shards = len(exceptions)
 
         if len(worker_results) == 0:
+            if exceptions:
+                # raise the underlying error first
+                raise exceptions[0]
             raise RuntimeError(
                 f'Head {self.name} did not receive a response when sending message to worker pods'
             )

--- a/jina/serve/runtimes/head/__init__.py
+++ b/jina/serve/runtimes/head/__init__.py
@@ -345,6 +345,8 @@ class HeadRuntime(AsyncNewLoopRuntime, ABC):
             )
         )
         failed_shards = len(exceptions)
+        if failed_shards:
+            self.logger.warning(f'{failed_shards} shards out of {total_shards} failed.')
 
         if len(worker_results) == 0:
             if exceptions:

--- a/jina/serve/runtimes/request_handlers/worker_request_handler.py
+++ b/jina/serve/runtimes/request_handlers/worker_request_handler.py
@@ -432,7 +432,7 @@ class WorkerRequestHandler:
     @staticmethod
     def reduce_requests(requests: List['DataRequest']) -> 'DataRequest':
         """
-        Reduces a list of requests containing DocumentArrays inton one request object. Changes are applied to the first
+        Reduces a list of requests containing DocumentArrays into one request object. Changes are applied to the first
         request object in-place.
 
         Reduction consists in reducing every DocumentArray in `requests` sequentially using

--- a/jina/serve/runtimes/request_handlers/worker_request_handler.py
+++ b/jina/serve/runtimes/request_handlers/worker_request_handler.py
@@ -452,6 +452,7 @@ class WorkerRequestHandler:
         The resulting DataRequest object contains Documents of all DocumentArrays inside requests.
 
         :param requests: List of DataRequest objects
+        :return: the resulting DataRequest
         """
         docs_matrix = WorkerRequestHandler.get_docs_matrix_from_request(
             requests, field='docs'

--- a/jina/serve/runtimes/request_handlers/worker_request_handler.py
+++ b/jina/serve/runtimes/request_handlers/worker_request_handler.py
@@ -437,7 +437,6 @@ class WorkerRequestHandler:
         The resulting DataRequest object contains Documents of all DocumentArrays inside requests.
 
         :param requests: List of DataRequest objects
-        :return: the resulting DataRequest
         """
         docs_matrix = WorkerRequestHandler.get_docs_matrix_from_request(
             requests, field='docs'

--- a/jina/serve/runtimes/request_handlers/worker_request_handler.py
+++ b/jina/serve/runtimes/request_handlers/worker_request_handler.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING, Dict, List, Optional
 
 from docarray import DocumentArray
+
 from jina import __default_endpoint__
 from jina.excepts import BadConfigSource
 from jina.importer import ImportExtensions
@@ -10,10 +11,11 @@ from jina.types.request.data import DataRequest
 if TYPE_CHECKING:  # pragma: no cover
     import argparse
 
-    from jina.logging.logger import JinaLogger
     from opentelemetry import metrics, trace
     from opentelemetry.context.context import Context
     from prometheus_client import CollectorRegistry
+
+    from jina.logging.logger import JinaLogger
 
 
 class WorkerRequestHandler:
@@ -68,8 +70,9 @@ class WorkerRequestHandler:
                 required=True,
                 help_text='You need to install the `prometheus_client` to use the montitoring functionality of jina',
             ):
-                from jina.serve.monitoring import _SummaryDeprecated
                 from prometheus_client import Counter, Summary
+
+                from jina.serve.monitoring import _SummaryDeprecated
 
                 self._document_processed_metrics = Counter(
                     'document_processed',
@@ -448,3 +451,5 @@ class WorkerRequestHandler:
 
         params = WorkerRequestHandler.get_parameters_dict_from_request(requests)
         WorkerRequestHandler.replace_parameters(requests[0], params)
+
+        return requests[0]

--- a/jina/serve/runtimes/request_handlers/worker_request_handler.py
+++ b/jina/serve/runtimes/request_handlers/worker_request_handler.py
@@ -1,7 +1,6 @@
 from typing import TYPE_CHECKING, Dict, List, Optional
 
 from docarray import DocumentArray
-
 from jina import __default_endpoint__
 from jina.excepts import BadConfigSource
 from jina.importer import ImportExtensions
@@ -11,11 +10,10 @@ from jina.types.request.data import DataRequest
 if TYPE_CHECKING:  # pragma: no cover
     import argparse
 
+    from jina.logging.logger import JinaLogger
     from opentelemetry import metrics, trace
     from opentelemetry.context.context import Context
     from prometheus_client import CollectorRegistry
-
-    from jina.logging.logger import JinaLogger
 
 
 class WorkerRequestHandler:
@@ -70,9 +68,8 @@ class WorkerRequestHandler:
                 required=True,
                 help_text='You need to install the `prometheus_client` to use the montitoring functionality of jina',
             ):
-                from prometheus_client import Counter, Summary
-
                 from jina.serve.monitoring import _SummaryDeprecated
+                from prometheus_client import Counter, Summary
 
                 self._document_processed_metrics = Counter(
                     'document_processed',
@@ -452,5 +449,3 @@ class WorkerRequestHandler:
 
         params = WorkerRequestHandler.get_parameters_dict_from_request(requests)
         WorkerRequestHandler.replace_parameters(requests[0], params)
-
-        return requests[0]


### PR DESCRIPTION
<!---Decomposing the complex issue into subtasks can help you build it step-by-step. Thanks for your pull request! :rocket: --->
<!---We know that dev life is hectic, but **please provide a (brief) description** of what your PR does, and how it does it. **Otherwise, your PR cannot be reviewed!** --->
<!---This policy was agreed upon in a past company retro, and makes everyone's life a little easier. Thanks for your collaboration!--->

**Goals:**
<!---https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword--->

- resolves #5336
- [x] capture (`AioRpcError` and `InternalNetworkError`) errors as results when sending requests to the shards
  - [x] raise error only if all shards failed or the `uses_before` and `uses_after` requests fail. 
- ~[ ] add the total number of shards and the number of failed shards to the metadata~. Client side communication needs to be implemented as part of https://github.com/jina-ai/jina/issues/5349.
