### PR TITLE
fix: metric timer initialization with bad default

### DIFF
--- a/jina/serve/instrumentation/__init__.py
+++ b/jina/serve/instrumentation/__init__.py
@@ -138,8 +138,10 @@ class MetricsTimer:
         self,
         summary_metric: Optional['Summary'],
         histogram: Optional['Histogram'],
-        histogram_metric_labels: Dict[str, str] = {},
+        histogram_metric_labels: Optional[Dict[str, str]] = None,
     ) -> None:
+        if histogram_metric_labels is None:
+            histogram_metric_labels = {}
         self._summary_metric = summary_metric
         self._histogram = histogram
         self._histogram_metric_labels = histogram_metric_labels


### PR DESCRIPTION
<!---Decomposing the complex issue into subtasks can help you build it step-by-step. Thanks for your pull request! :rocket: --->
<!---We know that dev life is hectic, but **please provide a (brief) description** of what your PR does, and how it does it. **Otherwise, your PR cannot be reviewed!** --->
<!---This policy was agreed upon in a past company retro, and makes everyone's life a little easier. Thanks for your collaboration!--->

**Goals:**
<!---https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword--->

- Fix bad practice when using defaults in function

Non-constants should not be used as defaults in python methods. This is because they are passed by reference, leading to synced mutation of any objects created under the default. The code snippet below illustrates this effect:

Code:
```python
from typing import Dict 

class Meow:
    def __init__(self, arg: Dict[str, str] = {}) -> None:
        self.arg = arg

    def __repr__(self) -> str:
        return f"{self.__class__.__name__}(arg={self.arg})"

a = Meow()
b = Meow()

a.arg['Dog'] = "Woof"
print(a)
print(b)

b.arg['Pig'] = "Oink"
print(a)
print(b)
```
Output:
```terminal
Meow(arg={'Dog': 'Woof'})
Meow(arg={'Dog': 'Woof'})
Meow(arg={'Dog': 'Woof', 'Pig': 'Oink'})
Meow(arg={'Dog': 'Woof', 'Pig': 'Oink'})
```

As you can see, the two objects have their argument synced. This is most likely undesirable behavior.
What we should do instead is to use the None then fill pattern (maybe there's an official name idk).

Code
```python
from typing import Dict, Optional

class Meow:
    def __init__(self, arg: Optional[Dict[str, str]] = None) -> None:
        if arg is None:
            arg = {}
        self.arg = arg

    def __repr__(self) -> str:
        return f"{self.__class__.__name__}(arg={self.arg})"

a = Meow()
b = Meow()

a.arg['Dog'] = "Woof"
print(a)
print(b)

b.arg['Pig'] = "Oink"
print(a)
print(b)
```
Output:
```terminal
Meow(arg={'Dog': 'Woof'})
Meow(arg={})
Meow(arg={'Dog': 'Woof'})
Meow(arg={'Pig': 'Oink'})
```

They are now decoupled as intended.