### PR TITLE
fix: new timer should keep labels

### DIFF
--- a/jina/serve/instrumentation/__init__.py
+++ b/jina/serve/instrumentation/__init__.py
@@ -147,7 +147,7 @@ class MetricsTimer:
         self._histogram_metric_labels = histogram_metric_labels
 
     def _new_timer(self):
-        return self.__class__(self._summary_metric, self._histogram)
+        return self.__class__(self._summary_metric, self._histogram, self._histogram_metric_labels)
 
     def __enter__(self):
         self._start = default_timer()

--- a/tests/unit/serve/instrumentation/test_instrumentation.py
+++ b/tests/unit/serve/instrumentation/test_instrumentation.py
@@ -80,3 +80,31 @@ def test_timer_decorator(metrics_setup):
     )
     assert 'time_taken_decorator' == histogram_metric['name']
     assert 1 == histogram_metric['data']['data_points'][0]['count']
+    assert {} == histogram_metric['data']['data_points'][0]['attributes']
+
+    labels = {
+        'cat': 'meow',
+        'dog': 'woof',
+    }
+    @MetricsTimer(summary, histogram, labels)
+    def _sleep():
+        time.sleep(0.1)
+
+    _sleep()
+
+    # Prometheus samples
+    summary_count_sample = [
+        sample.value for sample in list(summary._samples()) if '_count' == sample.name
+    ]
+    assert 2.0 == summary_count_sample[0]
+    # OpenTelemetry samples
+    histogram_metric = json.loads(
+        metric_reader.get_metrics_data()
+        .resource_metrics[0]
+        .scope_metrics[0]
+        .metrics[0]
+        .to_json()
+    )
+    assert 'time_taken_decorator' == histogram_metric['name']
+    assert 1 == histogram_metric['data']['data_points'][0]['count']
+    assert labels == histogram_metric['data']['data_points'][0]['attributes']


### PR DESCRIPTION
<!---Decomposing the complex issue into subtasks can help you build it step-by-step. Thanks for your pull request! :rocket: --->
<!---We know that dev life is hectic, but **please provide a (brief) description** of what your PR does, and how it does it. **Otherwise, your PR cannot be reviewed!** --->
<!---This policy was agreed upon in a past company retro, and makes everyone's life a little easier. Thanks for your collaboration!--->

**Goals:**
<!---https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword--->


- [x] Add tests that would have caught the bug
- [x] Implement fix
<!--- [ ] check and update documentation. See [guide](https://github.com/jina-ai/jina/blob/master/CONTRIBUTING.md#-contributing-documentation) and ask the team.--->

The current decorator behaviour for MetricsTimer does not correctly save the labels assigned to the histogram.
This PR fixes this.
An example of the problem is in the tests.
The previous implementation would fail on the line:
```python
assert labels == histogram_metric['data']['data_points'][0]['attributes']
```
