### PR TITLE
chore: bump hubble sdk

### DIFF
--- a/extra-requirements.txt
+++ b/extra-requirements.txt
@@ -33,7 +33,7 @@ grpcio-health-checking>=1.46.0,<1.48.1:  core
 pyyaml>=5.3.1:              core
 packaging>=20.0:            core
 docarray>=0.16.4:           core
-jina-hubble-sdk==0.23.0:    core
+jina-hubble-sdk==0.23.3:    core
 jcloud>=0.0.35:             core
 opentelemetry-api>=1.12.0:  core
 opentelemetry-instrumentation-grpc>=0.33b0:  core 

--- a/jina/resources/extra-requirements.txt
+++ b/jina/resources/extra-requirements.txt
@@ -33,7 +33,7 @@ grpcio-health-checking>=1.46.0,<1.48.1:  core
 pyyaml>=5.3.1:              core
 packaging>=20.0:            core
 docarray>=0.16.4:           core
-jina-hubble-sdk==0.23.0:    core
+jina-hubble-sdk==0.23.3:    core
 jcloud>=0.0.35:             core
 opentelemetry-api>=1.12.0:  core
 opentelemetry-instrumentation-grpc>=0.33b0:  core 


### PR DESCRIPTION
**Goals:**
Recent changes to `hubble.login()` un-intentionally removed the functionality of automatically opening the browser during the login process. The latest release of hubble sdk fixes that (https://github.com/jina-ai/jina-hubble-sdk/pull/103)

- resolves https://github.com/jina-ai/jina-hubble-sdk/issues/101
- automatically opens the browser during the login process where possible
- [x] check and update documentation -- not applicable
