### PR TITLE
fix: bootstrap multiprocessing inside main check to support spawn mp method

### DIFF
--- a/jina/orchestrate/pods/__init__.py
+++ b/jina/orchestrate/pods/__init__.py
@@ -4,6 +4,7 @@ import os
 import threading
 import time
 from abc import ABC, abstractmethod
+from multiprocessing import freeze_support
 from typing import Dict, Optional, Type, Union
 
 from jina import __ready_msg__, __stop_msg__, __windows__
@@ -314,28 +315,31 @@ class Pod(BasePod):
     def __init__(self, args: 'argparse.Namespace'):
         super().__init__(args)
         self.runtime_cls = self._get_runtime_cls()
-        self.worker = multiprocessing.Process(
-            target=run,
-            kwargs={
-                'args': args,
-                'name': self.name,
-                'envs': self._envs,
-                'is_started': self.is_started,
-                'is_shutdown': self.is_shutdown,
-                'is_ready': self.is_ready,
-                'runtime_cls': self.runtime_cls,
-                'jaml_classes': JAML.registered_classes(),
-            },
-            name=self.name,
-            daemon=False,
-        )
+        if __name__ == '__main__':
+            freeze_support()
+            self.worker = multiprocessing.Process(
+                target=run,
+                kwargs={
+                    'args': args,
+                    'name': self.name,
+                    'envs': self._envs,
+                    'is_started': self.is_started,
+                    'is_shutdown': self.is_shutdown,
+                    'is_ready': self.is_ready,
+                    'runtime_cls': self.runtime_cls,
+                    'jaml_classes': JAML.registered_classes(),
+                },
+                name=self.name,
+                daemon=False,
+            )
 
     def start(self):
         """Start the Pod.
         This method calls :meth:`start` in :class:`threading.Thread` or :class:`multiprocesssing.Process`.
         .. #noqa: DAR201
         """
-        self.worker.start()
+        if __name__ == '__main__':
+            self.worker.start()
         self.is_forked = multiprocessing.get_start_method().lower() == 'fork'
 
         if not self.args.noblock_on_start:

--- a/jina/orchestrate/pods/__init__.py
+++ b/jina/orchestrate/pods/__init__.py
@@ -354,7 +354,8 @@ class Pod(BasePod):
         :param kwargs: extra keyword arguments to pass to join
         """
         self.logger.debug(f'joining the process')
-        self.worker.join(*args, **kwargs)
+        if __name__ == '__main__':
+            self.worker.join(*args, **kwargs)
         self.logger.debug(f'successfully joined the process')
 
     def _terminate(self):
@@ -362,7 +363,8 @@ class Pod(BasePod):
         This method calls :meth:`terminate` in :class:`threading.Thread` or :class:`multiprocesssing.Process`.
         """
         self.logger.debug(f'terminating the runtime process')
-        self.worker.terminate()
+        if __name__ == '__main__':
+            self.worker.terminate()
         self.logger.debug(f'runtime process properly terminated')
 
     def _get_runtime_cls(self) -> AsyncNewLoopRuntime:

--- a/jina/orchestrate/pods/__init__.py
+++ b/jina/orchestrate/pods/__init__.py
@@ -21,6 +21,12 @@ __all__ = ['BasePod', 'Pod']
 from jina.serve.runtimes.gateway import GatewayRuntime
 
 
+def _is_main_and_spawn():
+    return (
+        multiprocessing.get_start_method().lower() == 'spawn' and __name__ == '__main__'
+    )
+
+
 def run(
     args: 'argparse.Namespace',
     name: str,
@@ -315,7 +321,7 @@ class Pod(BasePod):
     def __init__(self, args: 'argparse.Namespace'):
         super().__init__(args)
         self.runtime_cls = self._get_runtime_cls()
-        if __name__ == '__main__':
+        if _is_main_and_spawn():
             freeze_support()
             self.worker = multiprocessing.Process(
                 target=run,
@@ -338,7 +344,7 @@ class Pod(BasePod):
         This method calls :meth:`start` in :class:`threading.Thread` or :class:`multiprocesssing.Process`.
         .. #noqa: DAR201
         """
-        if __name__ == '__main__':
+        if _is_main_and_spawn():
             self.worker.start()
         self.is_forked = multiprocessing.get_start_method().lower() == 'fork'
 
@@ -354,7 +360,7 @@ class Pod(BasePod):
         :param kwargs: extra keyword arguments to pass to join
         """
         self.logger.debug(f'joining the process')
-        if __name__ == '__main__':
+        if _is_main_and_spawn():
             self.worker.join(*args, **kwargs)
         self.logger.debug(f'successfully joined the process')
 
@@ -363,7 +369,7 @@ class Pod(BasePod):
         This method calls :meth:`terminate` in :class:`threading.Thread` or :class:`multiprocesssing.Process`.
         """
         self.logger.debug(f'terminating the runtime process')
-        if __name__ == '__main__':
+        if _is_main_and_spawn():
             self.worker.terminate()
         self.logger.debug(f'runtime process properly terminated')
 

--- a/jina/orchestrate/pods/__init__.py
+++ b/jina/orchestrate/pods/__init__.py
@@ -23,7 +23,7 @@ from jina.serve.runtimes.gateway import GatewayRuntime
 
 def _is_main_and_spawn():
     return (
-        multiprocessing.get_start_method().lower() == 'spawn' and __name__ == '__main__'
+        multiprocessing.get_start_method().lower() != 'spawn' or __name__ == '__main__'
     )
 
 


### PR DESCRIPTION
It looks like we don't correctly follow [the python guidelines](https://docs.python.org/3/library/multiprocessing.html#the-spawn-and-forkserver-start-methods) when spawning new process for pods when the spawn method is `spawn`.

This means sometimes we still have issues even with `JINA_MP_START_METHOD=spawn` and we will receive:
```text
        An attempt has been made to start a new process before the
        current process has finished its bootstrapping phase.

        This probably means that you are not using fork to start your
        child processes and you have forgotten to use the proper idiom
        in the main module:

            if __name__ == '__main__':
                freeze_support()
                ...
```
For instance, one can reproduce the bug by running the following flow:
```
from jina import Flow

f = Flow().add()

with f:
    f.block()
```
then run
`JINA_MP_START_METHOD=spawn python flow.py`

currently we only support `JINA_MP_START_METHOD=spawn` if the flow is wrapped in
```python
if __name__ == '__main__':
    with f:
        f.block()
```