### PR TITLE
chore: allow test to pass even if commit name is not good

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
         run: exit 1
 
   docker-image-test:
-    needs: [commit-lint, code-injection]
+    needs: [code-injection]
     runs-on: ubuntu-latest
     services:
       registry:
@@ -150,7 +150,7 @@ jobs:
 
   hub-test:
     runs-on: ubuntu-latest
-    needs: [commit-lint, lint-flake-8, code-injection]
+    needs: [lint-flake-8, code-injection]
     if: ${{ !github.event.pull_request.head.repo.fork }}
     steps:
 #      - name: Cancel Previous Runs
@@ -171,7 +171,7 @@ jobs:
           JINAHUB_PASSWORD: ${{ secrets.JINAHUB_PASSWORD }}
 
   k8s-test:
-    needs: [commit-lint, lint-flake-8, code-injection]
+    needs: [lint-flake-8, code-injection]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.5.0
@@ -212,7 +212,7 @@ jobs:
           fail_ci_if_error: false
 
   k8s-failures-test:
-    needs: [ commit-lint, lint-flake-8, code-injection ]
+    needs: [ lint-flake-8, code-injection ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.5.0
@@ -254,7 +254,7 @@ jobs:
           fail_ci_if_error: false
 
   docker-compose-test:
-    needs: [commit-lint, lint-flake-8, code-injection]
+    needs: [lint-flake-8, code-injection]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.5.0
@@ -292,7 +292,7 @@ jobs:
 
   prep-testbed:
     runs-on: ubuntu-latest
-    needs: [commit-lint, lint-flake-8, code-injection]
+    needs: [ lint-flake-8, code-injection]
     steps:
       - uses: actions/checkout@v2.5.0
       - id: set-matrix
@@ -353,7 +353,7 @@ jobs:
 
   import-test:
     runs-on: ubuntu-latest
-    needs: [ commit-lint, lint-flake-8, code-injection ]
+    needs: [lint-flake-8, code-injection ]
     strategy:
       fail-fast: false
       matrix:
@@ -385,7 +385,7 @@ jobs:
   # just for blocking the merge until all parallel core-test are successful
   success-all-test:
     runs-on: ubuntu-latest
-    needs: [core-test, import-test, hub-test, k8s-test, k8s-failures-test, docker-compose-test, docker-image-test, check-docstring, check-black, code-injection]
+    needs: [commit-lint, core-test, import-test, hub-test, k8s-test, k8s-failures-test, docker-compose-test, docker-image-test, check-docstring, check-black, code-injection]
     if: always()
     steps:
       - uses: technote-space/workflow-conclusion-action@v2


### PR DESCRIPTION
# Context

we forbid test to be run when commit name are not good. This should not be the good we should run the test in the CI but just mark that the name is not good. External contributors have a hard time in the first contribution