### PR TITLE
fix: add minimum prometheus client version

### DIFF
--- a/extra-requirements.txt
+++ b/extra-requirements.txt
@@ -38,7 +38,7 @@ jcloud>=0.0.35:             core
 opentelemetry-api>=1.12.0:  core
 opentelemetry-instrumentation-grpc>=0.33b0:  core 
 uvloop:                     perf,standard,devel
-prometheus_client:          perf,standard,devel
+prometheus_client>=0.12.0:          perf,standard,devel
 opentelemetry-sdk>=1.12.0:   perf,standard,devel
 opentelemetry-exporter-otlp>=1.12.0:  perf,standard,devel
 opentelemetry-exporter-prometheus>=1.12.0rc1:  perf,standard,devel

--- a/jina/resources/extra-requirements.txt
+++ b/jina/resources/extra-requirements.txt
@@ -38,7 +38,7 @@ jcloud>=0.0.35:             core
 opentelemetry-api>=1.12.0:  core
 opentelemetry-instrumentation-grpc>=0.33b0:  core 
 uvloop:                     perf,standard,devel
-prometheus_client:          perf,standard,devel
+prometheus_client>=0.12.0:          perf,standard,devel
 opentelemetry-sdk>=1.12.0:   perf,standard,devel
 opentelemetry-exporter-otlp>=1.12.0:  perf,standard,devel
 opentelemetry-exporter-prometheus>=1.12.0rc1:  perf,standard,devel


### PR DESCRIPTION
minimum prometheus client version is 0.12.0
prior to that, `pytest tests/integration/monitoring/test_request_size.py::test_request_size_increasing` will fail