### PR TITLE
docs: add tips for using multiprocessing fork in macos

### DIFF
--- a/docs/fundamentals/flow/remarks.md
+++ b/docs/fundamentals/flow/remarks.md
@@ -105,7 +105,7 @@
 
 
 
-## multiprocessing Spawn
+## Multiprocessing Spawn
 
 Few cases require to use `spawn` start method for multiprocessing. 
 (e.g.- Cannot re-initialize CUDA in forked subprocess. To use CUDA with multiprocessing, you must use the 'spawn' start method)
@@ -131,6 +131,20 @@ Few cases require to use `spawn` start method for multiprocessing.
 
     Inline functions, such as nested or lambda functions are not picklable. Use `functools.partial` instead.
 
+
+## Multiprocessing Fork in MacOS
+
+Apple has changed the rules for using Objective-C between `fork()` and `exec()` since macOS 10.13.
+This may break some codes that use `fork()` in MacOS.
+For example, the Flow may not be able to start properly with error messages similar to:
+
+```bash
+objc[20337]: +[__NSCFConstantString initialize] may have been in progress in another thread when fork() was called.
+objc[20337]: +[__NSCFConstantString initialize] may have been in progress in another thread when fork() was called. We cannot safely call it or ignore it in the fork() child process. Crashing instead. Set a breakpoint on objc_initializeAfterForkError to debug.```
+```
+
+You can define the environment variable `OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES` to get around this issue.
+Read [here](http://sealiesoftware.com/blog/archive/2017/6/5/Objective-C_and_fork_in_macOS_1013.html) for more details.
 
 
 ## Debugging Executor in a Flow


### PR DESCRIPTION
<!---Decomposing the complex issue into subtasks can help you build it step-by-step. Thanks for your pull request! :rocket: --->
<!---We know that dev life is hectic, but **please provide a (brief) description** of what your PR does, and how it does it. **Otherwise, your PR cannot be reviewed!** --->
<!---This policy was agreed upon in a past company retro, and makes everyone's life a little easier. Thanks for your collaboration!--->

**Goals:**
<!---https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword--->

This PR adds tips for using multiprocessing fork in macOS.

Basically, Apple has changed the usage of `fork()` and `exec()` of Objective-C since MacOS 10.13. [Read here](http://sealiesoftware.com/blog/archive/2017/6/5/Objective-C_and_fork_in_macOS_1013.html).
This may cause Flow to hang at starting stage.

This PR add a fix to the issue by setting `OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES`
