### PR TITLE
fix: dump uses_with for gateway in k8s and docker compose

### DIFF
--- a/jina/orchestrate/deployments/config/docker_compose.py
+++ b/jina/orchestrate/deployments/config/docker_compose.py
@@ -66,7 +66,6 @@ class DockerComposeConfig:
             from jina.parsers import set_gateway_parser
 
             taboo = {
-                'uses_with',
                 'uses_metas',
                 'volumes',
                 'uses_before',

--- a/jina/orchestrate/deployments/config/k8s.py
+++ b/jina/orchestrate/deployments/config/k8s.py
@@ -55,7 +55,7 @@ class K8sDeploymentConfig:
             self.k8s_deployments_metadata = k8s_deployments_metadata
 
         def get_gateway_yamls(
-                self,
+            self,
         ) -> List[Dict]:
             cargs = copy.copy(self.deployment_args)
             cargs.deployments_addresses = self.k8s_deployments_addresses
@@ -63,7 +63,6 @@ class K8sDeploymentConfig:
             from jina.parsers import set_gateway_parser
 
             taboo = {
-                'uses_with',
                 'uses_metas',
                 'volumes',
                 'uses_before',
@@ -131,7 +130,7 @@ class K8sDeploymentConfig:
             )
 
         def get_runtime_yamls(
-                self,
+            self,
         ) -> List[Dict]:
             cargs = copy.copy(self.deployment_args)
 
@@ -210,7 +209,7 @@ class K8sDeploymentConfig:
                 gpus=cargs.gpus if hasattr(cargs, 'gpus') else None,
                 monitoring=cargs.monitoring,
                 port_monitoring=cargs.port_monitoring,
-                volumes=getattr(cargs, 'volumes', None)
+                volumes=getattr(cargs, 'volumes', None),
             )
 
     def __init__(
@@ -350,7 +349,7 @@ class K8sDeploymentConfig:
         return parsed_args
 
     def to_kubernetes_yaml(
-            self,
+        self,
     ) -> List[Tuple[str, List[Dict]]]:
         """
         Return a list of dictionary configurations. One for each deployment in this Deployment

--- a/tests/docker_compose/test_docker_compose.py
+++ b/tests/docker_compose/test_docker_compose.py
@@ -342,6 +342,7 @@ async def test_flow_with_custom_gateway(logger, docker_images, tmpdir):
             port=9090,
             protocol='http',
             uses=f'docker://{docker_images[0]}',
+            uses_with={'arg1': 'overridden-hello'},
         )
         .add(
             name='test_executor',
@@ -355,7 +356,8 @@ async def test_flow_with_custom_gateway(logger, docker_images, tmpdir):
     with DockerComposeFlow(dump_path):
 
         _validate_dummy_custom_gateway_response(
-            flow.port, {'arg1': 'hello', 'arg2': 'world', 'arg3': 'default-arg3'}
+            flow.port,
+            {'arg1': 'overridden-hello', 'arg2': 'world', 'arg3': 'default-arg3'},
         )
         _validate_custom_gateway_process(
             flow.port,

--- a/tests/k8s/test_k8s.py
+++ b/tests/k8s/test_k8s.py
@@ -882,6 +882,7 @@ async def test_flow_with_custom_gateway(logger, docker_images, tmpdir):
             port=9090,
             protocol='http',
             uses=f'docker://{docker_images[0]}',
+            uses_with={'arg1': 'overridden-hello'},
         )
         .add(
             name='test_executor',
@@ -925,7 +926,8 @@ async def test_flow_with_custom_gateway(logger, docker_images, tmpdir):
         namespace, gateway_pod_name, flow.port, flow.port, config_path
     ):
         _validate_dummy_custom_gateway_response(
-            flow.port, {'arg1': 'hello', 'arg2': 'world', 'arg3': 'default-arg3'}
+            flow.port,
+            {'arg1': 'overridden-hello', 'arg2': 'world', 'arg3': 'default-arg3'},
         )
         import requests
 


### PR DESCRIPTION
When dumping a flow to docker compose or k8s, the uses_with parameter is ignored because it's in the taboo list.
This PR ensures the uses_with param actually is dumped and tests this behavior