### PR TITLE
fix: fix multiplier format when using max attempts

### DIFF
--- a/jina/clients/base/grpc.py
+++ b/jina/clients/base/grpc.py
@@ -69,7 +69,8 @@ class GRPCBaseClient(BaseClient):
         max_attempts: int = 1,
         initial_backoff: float = 0.5,
         max_backoff: float = 0.1,
-        backoff_multiplier: float = 1.5,
+        backoff_
+        : float = 1.5,
         **kwargs,
     ):
         try:
@@ -95,7 +96,7 @@ class GRPCBaseClient(BaseClient):
                                     "maxAttempts": max_attempts,
                                     "initialBackoff": f"{initial_backoff}s",
                                     "maxBackoff": f"{max_backoff}s",
-                                    "backoffMultiplier": {backoff_multiplier},
+                                    "backoffMultiplier": backoff_multiplier,
                                     "retryableStatusCodes": [
                                         "UNAVAILABLE",
                                         "DEADLINE_EXCEEDED",

--- a/jina/clients/base/grpc.py
+++ b/jina/clients/base/grpc.py
@@ -12,7 +12,7 @@ from jina.logging.profile import ProgressBar
 from jina.proto import jina_pb2, jina_pb2_grpc
 from jina.serve.networking import GrpcConnectionPool
 
-if TYPE_CHECKING: # pragma: no cover
+if TYPE_CHECKING:  # pragma: no cover
     from jina.clients.base import CallbackFnType, InputType
 
 
@@ -69,8 +69,7 @@ class GRPCBaseClient(BaseClient):
         max_attempts: int = 1,
         initial_backoff: float = 0.5,
         max_backoff: float = 0.1,
-        backoff_
-        : float = 1.5,
+        backoff_multiplier: float = 1.5,
         **kwargs,
     ):
         try:


### PR DESCRIPTION
When using max_attempts parameter in the client, the grpc retry configuration is configured with wthe wrong format of the multiplier parameter.
This PR fixes this behavior.
