### PR TITLE
fix: bind servers to `host` argument isntead of __default_host__

### DIFF
--- a/jina/orchestrate/deployments/__init__.py
+++ b/jina/orchestrate/deployments/__init__.py
@@ -792,9 +792,7 @@ class Deployment(BaseDeployment):
             selected_devices = []
             if device_str[2:]:
 
-                for device in Deployment._parse_devices(
-                    device_str[2:], num_devices
-                ):
+                for device in Deployment._parse_devices(device_str[2:], num_devices):
                     selected_devices.append(device)
             else:
                 selected_devices = range(num_devices)
@@ -880,7 +878,8 @@ class Deployment(BaseDeployment):
 
         _args = copy.deepcopy(args)
         _args.pod_role = PodRoleType.WORKER
-        _args.host = __default_host__
+        if not _args.host:
+            _args.host = __default_host__
         _args.port = helper.random_port()
 
         if _args.name:

--- a/jina/orchestrate/flow/base.py
+++ b/jina/orchestrate/flow/base.py
@@ -1775,7 +1775,7 @@ class Flow(
         port_gateway = self._deployment_nodes[GATEWAY_NAME].args.port
 
         if not (
-            is_port_free(__default_host__, port_gateway)
+            is_port_free(self.args.host, port_gateway)
         ):  # we check if the port is not used at parsing time as well for robustness
             raise PortAlreadyUsed(f'port:{port_gateway}')
 

--- a/jina/serve/runtimes/gateway/__init__.py
+++ b/jina/serve/runtimes/gateway/__init__.py
@@ -12,7 +12,7 @@ from jina.parsers.helper import _set_gateway_uses
 from jina.serve.gateway import BaseGateway
 from jina.serve.runtimes.asyncio import AsyncNewLoopRuntime
 
-if TYPE_CHECKING: # pragma: no cover
+if TYPE_CHECKING:  # pragma: no cover
     import multiprocessing
     import threading
 
@@ -53,7 +53,7 @@ class GatewayRuntime(AsyncNewLoopRuntime):
 
         Setup the uvicorn server.
         """
-        if not (is_port_free(__default_host__, self.args.port)):
+        if not (is_port_free(self.args.host, self.args.port)):
             raise PortAlreadyUsed(f'port:{self.args.port}')
 
         uses_with = self.args.uses_with or {}
@@ -63,6 +63,7 @@ class GatewayRuntime(AsyncNewLoopRuntime):
                 name=self.name,
                 grpc_server_options=self.args.grpc_server_options,
                 port=self.args.port,
+                host=self.args.host,
                 title=self.args.title,
                 description=self.args.description,
                 no_debug_endpoints=self.args.no_debug_endpoints,

--- a/jina/serve/runtimes/gateway/grpc/gateway.py
+++ b/jina/serve/runtimes/gateway/grpc/gateway.py
@@ -18,6 +18,7 @@ class GRPCGateway(BaseGateway):
     def __init__(
         self,
         port: Optional[int] = None,
+        host: Optional[str] = __default_host__,
         grpc_server_options: Optional[dict] = None,
         ssl_keyfile: Optional[str] = None,
         ssl_certfile: Optional[str] = None,
@@ -25,6 +26,7 @@ class GRPCGateway(BaseGateway):
     ):
         """Initialize the gateway
         :param port: The port of the Gateway, which the client should connect to.
+        :param host: The host of the Gateway, to which the server will bind to.
         :param grpc_server_options: Dictionary of kwargs arguments that will be passed to the grpc server as options when starting the server, example : {'grpc.max_send_message_length': -1}
         :param ssl_keyfile: the path to the key file
         :param ssl_certfile: the path to the certificate file
@@ -32,6 +34,7 @@ class GRPCGateway(BaseGateway):
         """
         super().__init__(**kwargs)
         self.port = port
+        self.host = host
         self.grpc_server_options = grpc_server_options
         self.ssl_keyfile = ssl_keyfile
         self.ssl_certfile = ssl_certfile
@@ -68,7 +71,7 @@ class GRPCGateway(BaseGateway):
             )
         reflection.enable_server_reflection(service_names, self.server)
 
-        bind_addr = f'{__default_host__}:{self.port}'
+        bind_addr = f'{self.host}:{self.port}'
 
         if self.ssl_keyfile and self.ssl_certfile:
             with open(self.ssl_keyfile, 'rb') as f:

--- a/jina/serve/runtimes/gateway/http/gateway.py
+++ b/jina/serve/runtimes/gateway/http/gateway.py
@@ -14,6 +14,7 @@ class HTTPGateway(BaseGateway):
     def __init__(
         self,
         port: Optional[int] = None,
+        host: Optional[str] = __default_host__,
         title: Optional[str] = None,
         description: Optional[str] = None,
         no_debug_endpoints: Optional[bool] = False,
@@ -30,6 +31,7 @@ class HTTPGateway(BaseGateway):
         """Initialize the gateway
             Get the app from FastAPI as the REST interface.
         :param port: The port of the Gateway, which the client should connect to.
+        :param host: The host of the Gateway, to which the server will bind to.
         :param title: The title of this HTTP server. It will be used in automatics docs such as Swagger UI.
         :param description: The description of this HTTP server. It will be used in automatics docs such as Swagger UI.
         :param no_debug_endpoints: If set, `/status` `/post` endpoints are removed from HTTP interface.
@@ -48,6 +50,7 @@ class HTTPGateway(BaseGateway):
         """
         super().__init__(**kwargs)
         self.port = port
+        self.host = host
         self.title = title
         self.description = description
         self.no_debug_endpoints = no_debug_endpoints
@@ -135,7 +138,7 @@ class HTTPGateway(BaseGateway):
         self.server = UviServer(
             config=Config(
                 app=self.app,
-                host=__default_host__,
+                host=self.host,
                 port=self.port,
                 log_level=os.getenv('JINA_LOG_LEVEL', 'error').lower(),
                 **uvicorn_kwargs,

--- a/jina/serve/runtimes/gateway/websocket/gateway.py
+++ b/jina/serve/runtimes/gateway/websocket/gateway.py
@@ -14,6 +14,7 @@ class WebSocketGateway(BaseGateway):
     def __init__(
         self,
         port: Optional[int] = None,
+        host: Optional[str] = __default_host__,
         ssl_keyfile: Optional[str] = None,
         ssl_certfile: Optional[str] = None,
         uvicorn_kwargs: Optional[dict] = None,
@@ -22,6 +23,7 @@ class WebSocketGateway(BaseGateway):
     ):
         """Initialize the gateway
         :param port: The port of the Gateway, which the client should connect to.
+        :param host: The host of the Gateway, to which the server will bind to.
         :param ssl_keyfile: the path to the key file
         :param ssl_certfile: the path to the certificate file
         :param uvicorn_kwargs: Dictionary of kwargs arguments that will be passed to Uvicorn server when starting the server
@@ -31,6 +33,7 @@ class WebSocketGateway(BaseGateway):
         """
         super().__init__(**kwargs)
         self.port = port
+        self.host = host
         self.ssl_keyfile = ssl_keyfile
         self.ssl_certfile = ssl_certfile
         self.uvicorn_kwargs = uvicorn_kwargs
@@ -104,7 +107,7 @@ class WebSocketGateway(BaseGateway):
         self.server = UviServer(
             config=Config(
                 app=self.app,
-                host=__default_host__,
+                host=self.host,
                 port=self.port,
                 ws_max_size=1024 * 1024 * 1024,
                 log_level=os.getenv('JINA_LOG_LEVEL', 'error').lower(),

--- a/jina/serve/runtimes/head/__init__.py
+++ b/jina/serve/runtimes/head/__init__.py
@@ -159,7 +159,7 @@ class HeadRuntime(AsyncNewLoopRuntime, ABC):
             )
         reflection.enable_server_reflection(service_names, self._grpc_server)
 
-        bind_addr = f'0.0.0.0:{self.args.port}'
+        bind_addr = f'{self.args.host}:{self.args.port}'
         self._grpc_server.add_insecure_port(bind_addr)
         self.logger.debug(f'start listening on {bind_addr}')
         await self._grpc_server.start()

--- a/jina/serve/runtimes/worker/__init__.py
+++ b/jina/serve/runtimes/worker/__init__.py
@@ -144,7 +144,7 @@ class WorkerRuntime(AsyncNewLoopRuntime, ABC):
                 service, health_pb2.HealthCheckResponse.SERVING
             )
         reflection.enable_server_reflection(service_names, self._grpc_server)
-        bind_addr = f'0.0.0.0:{self.args.port}'
+        bind_addr = f'{self.args.host}:{self.args.port}'
         self.logger.debug(f'start listening on {bind_addr}')
         self._grpc_server.add_insecure_port(bind_addr)
         await self._grpc_server.start()

--- a/tests/docker_compose/custom-gateway/dummy_gateway.py
+++ b/tests/docker_compose/custom-gateway/dummy_gateway.py
@@ -23,6 +23,7 @@ class DummyGateway(Gateway):
     def __init__(
         self,
         port: int = None,
+        host: str = __default_host__,
         arg1: str = None,
         arg2: str = None,
         arg3: str = 'default-arg3',
@@ -64,7 +65,7 @@ class DummyGateway(Gateway):
                 doc = req.to_dict()['data'][0]
             return {'text': doc['text'], 'tags': doc['tags']}
 
-        self.server = Server(Config(app, host=__default_host__, port=self.port))
+        self.server = Server(Config(app, host=self.host, port=self.port))
 
     async def run_server(self):
         await self.server.serve()

--- a/tests/integration/external_deployment/test_external_deployment.py
+++ b/tests/integration/external_deployment/test_external_deployment.py
@@ -424,7 +424,7 @@ def test_external_flow_with_grpc_metadata():
                 )
             reflection.enable_server_reflection(service_names, self.server)
 
-            bind_addr = f'{__default_host__}:{self.port}'
+            bind_addr = f'{self.host}:{self.port}'
 
             if self.ssl_keyfile and self.ssl_certfile:
                 with open(self.ssl_keyfile, 'rb') as f:

--- a/tests/k8s/custom-gateway/dummy_gateway.py
+++ b/tests/k8s/custom-gateway/dummy_gateway.py
@@ -23,6 +23,7 @@ class DummyGateway(Gateway):
     def __init__(
         self,
         port: int = None,
+        host: str = __default_host__,
         arg1: str = None,
         arg2: str = None,
         arg3: str = 'default-arg3',
@@ -64,7 +65,7 @@ class DummyGateway(Gateway):
                 doc = req.to_dict()['data'][0]
             return {'text': doc['text'], 'tags': doc['tags']}
 
-        self.server = Server(Config(app, host=__default_host__, port=self.port))
+        self.server = Server(Config(app, host=self.host, port=self.port))
 
     async def run_server(self):
         await self.server.serve()

--- a/tests/unit/orchestrate/pods/container/custom-gateway/dummy_gateway.py
+++ b/tests/unit/orchestrate/pods/container/custom-gateway/dummy_gateway.py
@@ -23,6 +23,7 @@ class DummyGateway(Gateway):
     def __init__(
         self,
         port: int = None,
+        host: str = __default_host__,
         arg1: str = None,
         arg2: str = None,
         arg3: str = 'default-arg3',
@@ -30,6 +31,7 @@ class DummyGateway(Gateway):
     ):
         super().__init__(**kwargs)
         self.port = port
+        self.host = host
         self.arg1 = arg1
         self.arg2 = arg2
         self.arg3 = arg3
@@ -64,7 +66,7 @@ class DummyGateway(Gateway):
                 doc = req.to_dict()['data'][0]
             return {'text': doc['text'], 'tags': doc['tags']}
 
-        self.server = Server(Config(app, host=__default_host__, port=self.port))
+        self.server = Server(Config(app, host=self.host, port=self.port))
 
     async def run_server(self):
         await self.server.serve()

--- a/tests/unit/yaml/dummy_gateway.py
+++ b/tests/unit/yaml/dummy_gateway.py
@@ -23,6 +23,7 @@ class DummyGateway(Gateway):
     def __init__(
         self,
         port: int = None,
+        host: str = __default_host__,
         arg1: str = None,
         arg2: str = None,
         arg3: str = 'default-arg3',
@@ -30,6 +31,7 @@ class DummyGateway(Gateway):
     ):
         super().__init__(**kwargs)
         self.port = port
+        self.host = host
         self.arg1 = arg1
         self.arg2 = arg2
         self.arg3 = arg3
@@ -64,7 +66,7 @@ class DummyGateway(Gateway):
                 doc = req.to_dict()['data'][0]
             return {'text': doc['text'], 'tags': doc['tags']}
 
-        self.server = Server(Config(app, host=__default_host__, port=self.port))
+        self.server = Server(Config(app, host=self.host, port=self.port))
 
     async def run_server(self):
         await self.server.serve()


### PR DESCRIPTION
Although we have a `host` parameter in pods, we only use `__default_host__` (either 0.0.0.0 or 127.0.0.1) to bind servers (grpc, http, websocket) in all pod types (head, worker, gateway).
This PR makes the runtime respect the user-provided host parameter and use it when binding servers.
Depends on https://github.com/jina-ai/jina/pull/5378 so that we can pass `host` as runtime argument in gateway classes
closes: https://github.com/jina-ai/jina/issues/5402