### PR TITLE
fix: unpin hubble sdk version

### DIFF
--- a/extra-requirements.txt
+++ b/extra-requirements.txt
@@ -33,7 +33,7 @@ grpcio-health-checking>=1.46.0,<1.48.1:  core
 pyyaml>=5.3.1:              core
 packaging>=20.0:            core
 docarray>=0.16.4:           core
-jina-hubble-sdk==0.24.1:    core
+jina-hubble-sdk>=0.24.1:    core
 jcloud>=0.0.35:             core
 opentelemetry-api>=1.12.0:  core
 opentelemetry-instrumentation-grpc>=0.33b0:  core 

--- a/jina/resources/extra-requirements.txt
+++ b/jina/resources/extra-requirements.txt
@@ -33,7 +33,7 @@ grpcio-health-checking>=1.46.0,<1.48.1:  core
 pyyaml>=5.3.1:              core
 packaging>=20.0:            core
 docarray>=0.16.4:           core
-jina-hubble-sdk==0.24.1:    core
+jina-hubble-sdk>=0.24.1:    core
 jcloud>=0.0.35:             core
 opentelemetry-api>=1.12.0:  core
 opentelemetry-instrumentation-grpc>=0.33b0:  core 


### PR DESCRIPTION
# Context

Docarray 0.19.0 need hubble sdk >= 0.24 and jina neeed ==0.24 lets unpin it.

This pr followed up the PR that was merge to do the hotfix https://github.com/jina-ai/jina/pull/5411