### PR TITLE
docs: add docs for `grpccurl` readiness check  on mac

### DIFF
--- a/docs/fundamentals/flow/health-check.md
+++ b/docs/fundamentals/flow/health-check.md
@@ -151,10 +151,19 @@ DEBUG  Flow@19059 2 Deployments (i.e. 2 Pods) are running in this Flow
 
 When using grpc, use [grpcurl](https://github.com/fullstorydev/grpcurl) to access the Gateway's gRPC service that is responsible for reporting the Flow status.
 
+````{tab} Linux
 ```shell
 docker pull fullstorydev/grpcurl:latest
-docker run --network='host' fullstorydev/grpcurl -plaintext 127.0.0.1:12345 jina.JinaGatewayDryRunRPC/dry_run
+docker run --rm --network='host' fullstorydev/grpcurl -plaintext 127.0.0.1:12345 jina.JinaGatewayDryRunRPC/dry_run
 ```
+````
+````{tab} Mac
+```shell
+docker pull fullstorydev/grpcurl:latest
+docker run --rm fullstorydev/grpcurl -plaintext host.docker.internal:12345 jina.JinaGatewayDryRunRPC/dry_run
+```
+````
+
 The error-free output below signifies a correctly running Flow:
 ```json
 {}


### PR DESCRIPTION
<!---Decomposing the complex issue into subtasks can help you build it step-by-step. Thanks for your pull request! :rocket: --->
<!---We know that dev life is hectic, but **please provide a (brief) description** of what your PR does, and how it does it. **Otherwise, your PR cannot be reviewed!** --->
<!---This policy was agreed upon in a past company retro, and makes everyone's life a little easier. Thanks for your collaboration!--->

**Goals:**
<!---https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword--->
Add `grpccurl` readiness check for mac.

Reference: https://github.com/fullstorydev/grpcurl#docker

- [x] check and update documentation. See [guide](https://github.com/jina-ai/jina/blob/master/CONTRIBUTING.md#-contributing-documentation) and ask the team.
