### PR TITLE
chore: add install ecosystem latest version test to ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -418,9 +418,6 @@ jobs:
     needs: [lint-flake-8, code-injection ]
     strategy:
       fail-fast: false
-      matrix:
-        core: ['', 'true']
-        perf: ['', 'true']
     steps:
       - uses: actions/checkout@v2.5.0
       - name: Set up Python 3.7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -397,7 +397,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-    steps:
+        core: ['', 'true']
+        perf: ['', 'true']
+        exclude:
+          - core: 'true'
+            perf: 'true'
+      steps:
       - uses: actions/checkout@v2.5.0
       - name: Set up Python 3.7
         uses: actions/setup-python@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -421,35 +421,35 @@ jobs:
       - name: Test import all
         run: python -c 'from jina import *'
 
-#  install-jina-ecosystem-test:
-#    runs-on: ubuntu-latest
-#    needs: [lint-flake-8, code-injection ]
-#    strategy:
-#      fail-fast: false
-#    steps:
-#      - uses: actions/checkout@v2.5.0
-#      - name: Set up Python 3.7
-#        uses: actions/setup-python@v4
-#        with:
-#          python-version: 3.7
-#      - name: Prepare enviroment
-#        run: |
-#          python -m pip install --upgrade pip
-#          python -m pip install wheel
-#
-#          HUBBLE_VERSION=$(curl -L -s "https://pypi.org/pypi/jina-hubble-sdk/json" |  jq  -r '.releases | keys | .[]| select(startswith("0."))'  | sort -V | tail -1)
-#          DOCARRAY_VERSION=$(curl -L -s "https://pypi.org/pypi/docarray/json" |  jq  -r '.releases | keys | .[]| select(startswith("0."))'  | sort -V | tail -1)
-#          JCLOUD_VERSION=$(curl -L -s "https://pypi.org/pypi/jcloud/json" |  jq  -r '.releases | keys | .[]| select(startswith("0."))'  | sort -V | tail -1)
-#
-#          pip install . jcloud==$JCLOUD_VERSION docarray==$DOCARRAY_VERSION jina-hubble-sdk==$HUBBLE_VERSION
-#
-#        env:
-#          JINA_PIP_INSTALL_CORE: ${{ matrix.core }}
-#          JINA_PIP_INSTALL_PERF: ${{ matrix.perf }}
-#      - name: Test basic import
-#        run: python -c 'from jina import Executor,requests'
-#      - name: Test import all
-#        run: python -c 'from jina import *'
+  install-jina-ecosystem-test:
+    runs-on: ubuntu-latest
+    needs: [lint-flake-8, code-injection ]
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v2.5.0
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.7
+      - name: Prepare enviroment
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install wheel
+
+          HUBBLE_VERSION=$(curl -L -s "https://pypi.org/pypi/jina-hubble-sdk/json" |  jq  -r '.releases | keys | .[]| select(startswith("0."))'  | sort -V | tail -1)
+          DOCARRAY_VERSION=$(curl -L -s "https://pypi.org/pypi/docarray/json" |  jq  -r '.releases | keys | .[]| select(startswith("0."))'  | sort -V | tail -1)
+          JCLOUD_VERSION=$(curl -L -s "https://pypi.org/pypi/jcloud/json" |  jq  -r '.releases | keys | .[]| select(startswith("0."))'  | sort -V | tail -1)
+
+          pip install . jcloud==$JCLOUD_VERSION docarray==$DOCARRAY_VERSION jina-hubble-sdk==$HUBBLE_VERSION
+        env:
+          JINA_PIP_INSTALL_CORE: ${{ matrix.core }}
+          JINA_PIP_INSTALL_PERF: ${{ matrix.perf }}
+
+      - name: Test basic import
+        run: python -c 'from jina import Executor,requests'
+      - name: Test import all
+        run: python -c 'from jina import *'
 
 
   # just for blocking the merge until all parallel core-test are successful

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -399,7 +399,7 @@ jobs:
       matrix:
         core: ['', 'true']
         perf: ['', 'true']
-        exclude: 
+        exclude:
           - core: 'true'
             perf: 'true'
     steps:
@@ -413,6 +413,42 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install wheel
           pip install --no-cache-dir .
+        env:
+          JINA_PIP_INSTALL_CORE: ${{ matrix.core }}
+          JINA_PIP_INSTALL_PERF: ${{ matrix.perf }}
+      - name: Test basic import
+        run: python -c 'from jina import Executor,requests'
+      - name: Test import all
+        run: python -c 'from jina import *'
+
+  install-jina-ecosystem-test:
+    runs-on: ubuntu-latest
+    needs: [lint-flake-8, code-injection ]
+    strategy:
+      fail-fast: false
+      matrix:
+        core: ['', 'true']
+        perf: ['', 'true']
+        exclude:
+          - core: 'true'
+            perf: 'true'
+    steps:
+      - uses: actions/checkout@v2.5.0
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.7
+      - name: Prepare enviroment
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install wheel
+        
+          HUBBLE_VERSION = $(curl -L -s "https://pypi.org/pypi/jina-hubble-sdk/json" |  jq  -r '.releases | keys | .[]| select(startswith("0."))'  | sort -V | tail -1)
+          DOCARRAY_VERSION = $(curl -L -s "https://pypi.org/pypi/docarray/json" |  jq  -r '.releases | keys | .[]| select(startswith("0."))'  | sort -V | tail -1)
+          JCLOUD_VERSION = $(curl -L -s "https://pypi.org/pypi/jcloud/json" |  jq  -r '.releases | keys | .[]| select(startswith("0."))'  | sort -V | tail -1)
+
+          pip install . jcloud==$JCLOUD_VERSION docarray==$DOCARRAY_VERSION jina-hubble-sdk==$HUBBLE_VERSION
+
         env:
           JINA_PIP_INSTALL_CORE: ${{ matrix.core }}
           JINA_PIP_INSTALL_PERF: ${{ matrix.perf }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -402,27 +402,6 @@ jobs:
         exclude:
           - core: 'true'
             perf: 'true'
-      steps:
-      - uses: actions/checkout@v2.5.0
-      - name: Set up Python 3.7
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.7
-      - name: Prepare enviroment
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install wheel
-          pip install --no-cache-dir .[standard]
-      - name: Test basic import
-        run: python -c 'from jina import Executor,requests'
-      - name: Test import all
-        run: python -c 'from jina import *'
-
-  install-jina-ecosystem-test:
-    runs-on: ubuntu-latest
-    needs: [lint-flake-8, code-injection ]
-    strategy:
-      fail-fast: false
     steps:
       - uses: actions/checkout@v2.5.0
       - name: Set up Python 3.7
@@ -433,13 +412,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install wheel
-        
-          HUBBLE_VERSION=$(curl -L -s "https://pypi.org/pypi/jina-hubble-sdk/json" |  jq  -r '.releases | keys | .[]| select(startswith("0."))'  | sort -V | tail -1)
-          DOCARRAY_VERSION=$(curl -L -s "https://pypi.org/pypi/docarray/json" |  jq  -r '.releases | keys | .[]| select(startswith("0."))'  | sort -V | tail -1)
-          JCLOUD_VERSION=$(curl -L -s "https://pypi.org/pypi/jcloud/json" |  jq  -r '.releases | keys | .[]| select(startswith("0."))'  | sort -V | tail -1)
-
-          pip install . jcloud==$JCLOUD_VERSION docarray==$DOCARRAY_VERSION jina-hubble-sdk==$HUBBLE_VERSION
-
+          pip install --no-cache-dir .
         env:
           JINA_PIP_INSTALL_CORE: ${{ matrix.core }}
           JINA_PIP_INSTALL_PERF: ${{ matrix.perf }}
@@ -447,6 +420,36 @@ jobs:
         run: python -c 'from jina import Executor,requests'
       - name: Test import all
         run: python -c 'from jina import *'
+
+#  install-jina-ecosystem-test:
+#    runs-on: ubuntu-latest
+#    needs: [lint-flake-8, code-injection ]
+#    strategy:
+#      fail-fast: false
+#    steps:
+#      - uses: actions/checkout@v2.5.0
+#      - name: Set up Python 3.7
+#        uses: actions/setup-python@v4
+#        with:
+#          python-version: 3.7
+#      - name: Prepare enviroment
+#        run: |
+#          python -m pip install --upgrade pip
+#          python -m pip install wheel
+#
+#          HUBBLE_VERSION=$(curl -L -s "https://pypi.org/pypi/jina-hubble-sdk/json" |  jq  -r '.releases | keys | .[]| select(startswith("0."))'  | sort -V | tail -1)
+#          DOCARRAY_VERSION=$(curl -L -s "https://pypi.org/pypi/docarray/json" |  jq  -r '.releases | keys | .[]| select(startswith("0."))'  | sort -V | tail -1)
+#          JCLOUD_VERSION=$(curl -L -s "https://pypi.org/pypi/jcloud/json" |  jq  -r '.releases | keys | .[]| select(startswith("0."))'  | sort -V | tail -1)
+#
+#          pip install . jcloud==$JCLOUD_VERSION docarray==$DOCARRAY_VERSION jina-hubble-sdk==$HUBBLE_VERSION
+#
+#        env:
+#          JINA_PIP_INSTALL_CORE: ${{ matrix.core }}
+#          JINA_PIP_INSTALL_PERF: ${{ matrix.perf }}
+#      - name: Test basic import
+#        run: python -c 'from jina import Executor,requests'
+#      - name: Test import all
+#        run: python -c 'from jina import *'
 
 
   # just for blocking the merge until all parallel core-test are successful

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -443,9 +443,9 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install wheel
         
-          HUBBLE_VERSION = $(curl -L -s "https://pypi.org/pypi/jina-hubble-sdk/json" |  jq  -r '.releases | keys | .[]| select(startswith("0."))'  | sort -V | tail -1)
-          DOCARRAY_VERSION = $(curl -L -s "https://pypi.org/pypi/docarray/json" |  jq  -r '.releases | keys | .[]| select(startswith("0."))'  | sort -V | tail -1)
-          JCLOUD_VERSION = $(curl -L -s "https://pypi.org/pypi/jcloud/json" |  jq  -r '.releases | keys | .[]| select(startswith("0."))'  | sort -V | tail -1)
+          HUBBLE_VERSION=$(curl -L -s "https://pypi.org/pypi/jina-hubble-sdk/json" |  jq  -r '.releases | keys | .[]| select(startswith("0."))'  | sort -V | tail -1)
+          DOCARRAY_VERSION=$(curl -L -s "https://pypi.org/pypi/docarray/json" |  jq  -r '.releases | keys | .[]| select(startswith("0."))'  | sort -V | tail -1)
+          JCLOUD_VERSION=$(curl -L -s "https://pypi.org/pypi/jcloud/json" |  jq  -r '.releases | keys | .[]| select(startswith("0."))'  | sort -V | tail -1)
 
           pip install . jcloud==$JCLOUD_VERSION docarray==$DOCARRAY_VERSION jina-hubble-sdk==$HUBBLE_VERSION
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -397,11 +397,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        core: ['', 'true']
-        perf: ['', 'true']
-        exclude:
-          - core: 'true'
-            perf: 'true'
     steps:
       - uses: actions/checkout@v2.5.0
       - name: Set up Python 3.7
@@ -412,10 +407,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install wheel
-          pip install --no-cache-dir .
-        env:
-          JINA_PIP_INSTALL_CORE: ${{ matrix.core }}
-          JINA_PIP_INSTALL_PERF: ${{ matrix.perf }}
+          pip install --no-cache-dir .[standard]
       - name: Test basic import
         run: python -c 'from jina import Executor,requests'
       - name: Test import all
@@ -429,9 +421,6 @@ jobs:
       matrix:
         core: ['', 'true']
         perf: ['', 'true']
-        exclude:
-          - core: 'true'
-            perf: 'true'
     steps:
       - uses: actions/checkout@v2.5.0
       - name: Set up Python 3.7

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -72,8 +72,38 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_NIGHTLY_TESTS_WEBHOOK }}
           MATRIX_CONTEXT: ${{ toJson(matrix) }}
 
+  install-jina-ecosystem-test:
+    runs-on: ubuntu-latest
+    needs: [lint-flake-8, code-injection ]
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v2.5.0
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.7
+      - name: Prepare enviroment
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install wheel
+
+          HUBBLE_VERSION=$(curl -L -s "https://pypi.org/pypi/jina-hubble-sdk/json" |  jq  -r '.releases | keys | .[]| select(startswith("0."))'  | sort -V | tail -1)
+          DOCARRAY_VERSION=$(curl -L -s "https://pypi.org/pypi/docarray/json" |  jq  -r '.releases | keys | .[]| select(startswith("0."))'  | sort -V | tail -1)
+          JCLOUD_VERSION=$(curl -L -s "https://pypi.org/pypi/jcloud/json" |  jq  -r '.releases | keys | .[]| select(startswith("0."))'  | sort -V | tail -1)
+
+          pip install . jcloud==$JCLOUD_VERSION docarray==$DOCARRAY_VERSION jina-hubble-sdk==$HUBBLE_VERSION
+        env:
+          JINA_PIP_INSTALL_CORE: ${{ matrix.core }}
+          JINA_PIP_INSTALL_PERF: ${{ matrix.perf }}
+
+      - name: Test basic import
+        run: python -c 'from jina import Executor,requests'
+      - name: Test import all
+        run: python -c 'from jina import *'
+
   success-all-test:
-    needs: [prep-testbed, windows-test]
+    needs: [prep-testbed, windows-test, install-jina-ecosystem-test]
     if: always()
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Signed-off-by: Sami Jaghouar <sami.jaghouar@hotmail.fr>

# Context

It might happen that jina docarray hubble-sdk and jcloud are in conflict on the dependency. This is not intended and we should check before it happen

# What this pr do

Add a test in CI to install the current commit with all of the latest version

- [x] add test in ci
- [x] add nightly runs