### PR TITLE
fix: fix multi protocol gateway when using ports and protocols aliases

### DIFF
--- a/jina/orchestrate/flow/base.py
+++ b/jina/orchestrate/flow/base.py
@@ -2113,7 +2113,9 @@ class Flow(
         if GATEWAY_NAME in self._deployment_nodes:
             res = self._deployment_nodes[GATEWAY_NAME].port
         else:
-            res = self._gateway_kwargs.get('port', None)
+            res = self._gateway_kwargs.get('port', None) or self._gateway_kwargs.get(
+                'ports', None
+            )
         if not isinstance(res, list):
             return res
         elif len(res) == 1:
@@ -2399,7 +2401,11 @@ class Flow(
 
         :return: the protocol of this Flow, if only 1 protocol is supported otherwise returns the list of protocols
         """
-        v = self._gateway_kwargs.get('protocol', [GatewayProtocolType.GRPC])
+        v = (
+            self._gateway_kwargs.get('protocol', None)
+            or self._gateway_kwargs.get('protocols', None)
+            or [GatewayProtocolType.GRPC]
+        )
         if not isinstance(v, list):
             v = [v]
         v = GatewayProtocolType.from_string_list(v)

--- a/tests/unit/orchestrate/flow/flow-construct/test_flow.py
+++ b/tests/unit/orchestrate/flow/flow-construct/test_flow.py
@@ -620,6 +620,17 @@ def test_load_flow_with_custom_gateway(tmpdir):
         _validate_flow(f)
 
 
+@pytest.mark.slow
+def test_flow_multi_protocol_aliases():
+    f = Flow(ports=[12345, 12345, 12345], protocols=['http', 'grpc', 'websocket'])
+    assert f.port == [12345, 12345, 12345]
+    assert f.protocol == [
+        GatewayProtocolType.HTTP,
+        GatewayProtocolType.GRPC,
+        GatewayProtocolType.WEBSOCKET,
+    ]
+
+
 def _validate_flow(f):
     graph_dict = f._get_graph_representation()
     addresses = f._get_deployments_addresses()

--- a/tests/unit/orchestrate/flow/flow-construct/test_flow_multiprotocol.py
+++ b/tests/unit/orchestrate/flow/flow-construct/test_flow_multiprotocol.py
@@ -46,6 +46,19 @@ def test_flow_multiprotocol(ports, protocols):
                 assert doc.text == 'processed'
 
 
+def test_flow_multiprotocol_aliases():
+    ports = [random_port(), random_port(), random_port()]
+    protocols = PROTOCOLS
+    flow = Flow().config_gateway(ports=ports, protocols=protocols).add(uses=MyExecutor)
+
+    with flow:
+        for port, protocol in zip(ports, protocols):
+            client = Client(port=port, protocol=protocol)
+            docs = client.post('/', inputs=[Document()])
+            for doc in docs:
+                assert doc.text == 'processed'
+
+
 def test_flow_multiprotocol_yaml():
     flow = Flow.load_config(os.path.join(cur_dir, 'yaml/multi-protocol.yml'))
 


### PR DESCRIPTION
Prior to this PR, using plural aliases for port and protocol doesn't work properly (mainly not correctly returned in Flow API)
This PR fixes the behavior and adds tests