### PR TITLE
fix: fix custom gateway container port

### DIFF
--- a/jina/orchestrate/pods/container.py
+++ b/jina/orchestrate/pods/container.py
@@ -130,7 +130,11 @@ def _docker_run(
         del args.gpus
 
     _args = ArgNamespace.kwargs2list(non_defaults)
-    ports = {f'{args.port}/tcp': args.port} if not net_mode else None
+
+    if args.pod_role == PodRoleType.GATEWAY:
+        ports = {f'{_port}/tcp': _port for _port in args.port} if not net_mode else None
+    else:
+        ports = {f'{args.port}/tcp': args.port} if not net_mode else None
 
     docker_kwargs = args.docker_kwargs or {}
     container = client.containers.run(


### PR DESCRIPTION
The port mapping for gateway is wrongly generated. This bug is hidden because net mode host is usually used.
However, under certain environments where the net mode is disabled, the port mapping is generated and the gateway cannot be started.
This PR takes the new multi protocol format in consideration when generating the port mapping for the gateway.