### PR TITLE
ci: build python 3.10 and 3.11 as default jina docker images and make 3.8 the default jina docker image

### DIFF
--- a/.github/workflows/force-docker-build.yml
+++ b/.github/workflows/force-docker-build.yml
@@ -34,14 +34,14 @@ jobs:
       fail-fast: false
       matrix:
         pip_tag: [ "", "perf", "standard", "devel"]  # default: "" = core
-        py_version: [ "3.7", "3.8", "3.9" ]  # default "" = 3.7
+        py_version: [ "3.7", "3.8", "3.9" , "3.10", "3.11"]  # default "" = 3.7
     steps:
       - uses: actions/checkout@v2.5.0
         with:
           fetch-depth: 100
       - name: Set envs and versions
         run: |
-          DEFAULT_PY_VERSION="3.7"
+          DEFAULT_PY_VERSION="3.8"
           VCS_REF=${{ github.ref }}
           echo "VCS_REF=$VCS_REF" >> $GITHUB_ENV
           echo "Will build $VCS_REF"

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -98,9 +98,11 @@ jinaai/jina:{version}{python_version}{extra}
     - `x.y.z`: the release of a particular version;
     - `x.y`: the alias to the last `x.y.z` patch release, i.e. `x.y` = `x.y.max(z)`;
 - `{python_version}`: The Python version of the image. Possible values:
-    - ` `, `-py37`: Python 3.7;
-    - `-py38` for Python 3.8;
+    - `-py37`: Python 3.7;
+    - ` `, `-py38` for Python 3.8;
     - `-py39` for Python 3.9;
+    - `-py310` for Python 3.10;
+    - `-py311` for Python 3.11;
 - `{extra}`: the extra dependency installed along with Jina. Possible values:
     - ` `: Jina is installed inside the image via `pip install jina`;
     - `-standard`: Jina is installed inside the image via `pip install jina`. It includes all recommended dependencies;  

--- a/docs/get-started/install/troubleshooting.md
+++ b/docs/get-started/install/troubleshooting.md
@@ -6,7 +6,7 @@ This article helps you to solve the installation problems of Jina.
 
 The normal installation of Jina takes 10 seconds. If yours takes longer than this, then it is likely you unnecessarily built wheels from scratch. 
 
-Every upstream dependency of Jina has pre-built wheels exhaustively for x86/arm64, macos/Linux and Python 3.7/3.8/3.9, including `numpy`, `protobuf`, `pyzmq`, `grpcio` etc. This means when you install Jina, your `pip` should directly leverage the pre-built wheels instead of building them from scratch locally. For example, you should expect the install log to contain `-cp38-cp38-macosx_10_15_x86_64.whl` when installing Jina on MacOS with Python 3.8.
+Every upstream dependency of Jina has pre-built wheels exhaustively for x86/arm64, macos/Linux and Python 3.7/3.8/3.9, including `numpy`, `protobuf`, `grpcio` etc. This means when you install Jina, your `pip` should directly leverage the pre-built wheels instead of building them from scratch locally. For example, you should expect the install log to contain `-cp38-cp38-macosx_10_15_x86_64.whl` when installing Jina on MacOS with Python 3.8.
 
 If you find you are building wheels during installation (see an example below), then it is a sign that you are installing Jina **wrongly**. 
 


### PR DESCRIPTION
build python 3.10 and 3.11 as default jina docker images and make 3.8 the default jina docker image