### PR TITLE
fix: add egg info post install command for egg info setup mode

### DIFF
--- a/docs/fundamentals/flow/remarks.md
+++ b/docs/fundamentals/flow/remarks.md
@@ -132,21 +132,6 @@ Few cases require to use `spawn` start method for multiprocessing.
     Inline functions, such as nested or lambda functions are not picklable. Use `functools.partial` instead.
 
 
-(flow-macos-multi-processing-fork)=
-## Multiprocessing Fork in MacOS
-
-Apple has changed the rules for using Objective-C between `fork()` and `exec()` since macOS 10.13.
-This may break some codes that use `fork()` in MacOS.
-For example, the Flow may not be able to start properly with error messages similar to:
-
-```bash
-objc[20337]: +[__NSCFConstantString initialize] may have been in progress in another thread when fork() was called.
-objc[20337]: +[__NSCFConstantString initialize] may have been in progress in another thread when fork() was called. We cannot safely call it or ignore it in the fork() child process. Crashing instead. Set a breakpoint on objc_initializeAfterForkError to debug.```
-```
-
-You can define the environment variable `OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES` to get around this issue.
-Read [here](http://sealiesoftware.com/blog/archive/2017/6/5/Objective-C_and_fork_in_macOS_1013.html) for more details.
-
 
 ## Debugging Executor in a Flow
 

--- a/docs/get-started/install/troubleshooting.md
+++ b/docs/get-started/install/troubleshooting.md
@@ -35,19 +35,6 @@ Then you are likely installing Jina on a less-supported system/architecture. For
 
 Unfortunately, `conda install` is not supported on Windows. You can either do `pip install jina` natively on Windows, or use `pip/conda install` under WSL2.
 
-## On MacOS >= 10.13
-{ref}`Multiprocessing with fork in MacOS <flow-macos-multi-processing-fork>` requires setting the environment variable 
-`OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES` for versions higher than 10.13.
-You can set this variable each time you run a python interpreter that uses Jina or configure it by default using the 
-following command:
-```shell
-echo "export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES" >> ~/.zshrc
-```
-
-````{admonition} Caution
-:class: caution
-Be aware that the latter method will apply to all tools that use the underlying Objective-C fork method.
-````
 
 ## Upgrading from Jina 2.x to 3.x
 If you upgraded an existing Jina installation from 2.x to 3.x you may see the following error message:

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ from os import path
 
 from setuptools import find_packages, setup
 from setuptools.command.develop import develop
+from setuptools.command.egg_info import egg_info
 from setuptools.command.install import install
 
 if sys.version_info < (3, 7, 0):
@@ -89,6 +90,14 @@ class PostInstallCommand(install):
         register_ac()
 
 
+class PostEggInfoCommand(egg_info):
+    """Post-installation for egg info mode."""
+
+    def run(self):
+        egg_info.run(self)
+        register_ac()
+
+
 def get_extra_requires(path, add_all=True):
     import re
     from collections import defaultdict
@@ -164,6 +173,7 @@ setup(
     cmdclass={
         'develop': PostDevelopCommand,
         'install': PostInstallCommand,
+        'egg_info': PostEggInfoCommand,
     },
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
Egg info setup mode does not have a post install command associated with it in setup.py (unlike `install` and `develop`).
This means, jina post install commands will not be executed in some cases (includes autocompletes, setting needed environment variables,...).
This PR adds an egg info post install command to handle this case.