### PR TITLE
fix: suppress warning for http gateway about health check

### DIFF
--- a/jina/serve/runtimes/gateway/http/app.py
+++ b/jina/serve/runtimes/gateway/http/app.py
@@ -93,21 +93,6 @@ def get_fastapi_app(
             }
         )
 
-        from jina.serve.runtimes.gateway.http.models import JinaHealthModel
-
-        @app.get(
-            path='/',
-            summary='Get the health of Jina Gateway service',
-            response_model=JinaHealthModel,
-        )
-        async def _gateway_health():
-            """
-            Get the health of this Gateway service.
-            .. # noqa: DAR201
-
-            """
-            return {}
-
         from docarray import DocumentArray
 
         from jina.proto import jina_pb2

--- a/jina/serve/runtimes/gateway/http/fastapi.py
+++ b/jina/serve/runtimes/gateway/http/fastapi.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING, Optional
 
 from jina.importer import ImportExtensions
 from jina.serve.gateway import BaseGateway
-from jina.serve.runtimes.gateway.http.models import JinaHealthModel
 
 if TYPE_CHECKING:
     from fastapi import FastAPI
@@ -132,6 +131,7 @@ def _install_health_check(app: 'FastAPI', logger):
             )
 
     if not health_check_exists:
+        from jina.serve.runtimes.gateway.http.models import JinaHealthModel
 
         @app.get(
             path='/',

--- a/jina/serve/runtimes/gateway/http/fastapi.py
+++ b/jina/serve/runtimes/gateway/http/fastapi.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Optional
 
 from jina.importer import ImportExtensions
 from jina.serve.gateway import BaseGateway
+from jina.serve.runtimes.gateway.http.models import JinaHealthModel
 
 if TYPE_CHECKING:
     from fastapi import FastAPI
@@ -132,6 +133,15 @@ def _install_health_check(app: 'FastAPI', logger):
 
     if not health_check_exists:
 
-        @app.get('/')
-        def health_check():
+        @app.get(
+            path='/',
+            summary='Get the health of Jina Gateway service',
+            response_model=JinaHealthModel,
+        )
+        async def _gateway_health():
+            """
+            Get the health of this Gateway service.
+            .. # noqa: DAR201
+
+            """
             return {}


### PR DESCRIPTION
fix: suppress warning for http gateway about health check
After introducing automatic health check installation for fast api gateways, we added a warning in case the health check endpoint already exists. The HTTPGateway was not updated to leave the health check for automatic installation. Thus a warning is always raised.
This PR fixes this issue by removing the health check in http gateway