### PR TITLE
chore: send telemetry event before starting gateway object

### DIFF
--- a/jina/serve/runtimes/asyncio.py
+++ b/jina/serve/runtimes/asyncio.py
@@ -31,12 +31,12 @@ class AsyncNewLoopRuntime(BaseRuntime, MonitoringMixin, InstrumentationMixin, AB
     """
 
     def __init__(
-            self,
-            args: 'argparse.Namespace',
-            cancel_event: Optional[
-                Union['asyncio.Event', 'multiprocessing.Event', 'threading.Event']
-            ] = None,
-            **kwargs,
+        self,
+        args: 'argparse.Namespace',
+        cancel_event: Optional[
+            Union['asyncio.Event', 'multiprocessing.Event', 'threading.Event']
+        ] = None,
+        **kwargs,
     ):
         super().__init__(args, **kwargs)
         self._loop = asyncio.new_event_loop()
@@ -44,6 +44,7 @@ class AsyncNewLoopRuntime(BaseRuntime, MonitoringMixin, InstrumentationMixin, AB
         self.is_cancel = cancel_event or asyncio.Event()
 
         if not __windows__:
+
             def _cancel(sig):
                 def _inner_cancel(*args, **kwargs):
                     self.logger.debug(f'Received signal {sig.name}')
@@ -54,6 +55,7 @@ class AsyncNewLoopRuntime(BaseRuntime, MonitoringMixin, InstrumentationMixin, AB
             for sig in HANDLED_SIGNALS:
                 self._loop.add_signal_handler(sig, _cancel(sig), sig, None)
         else:
+
             def _cancel(signum, frame):
                 self.logger.debug(f'Received signal {signum}')
                 self.is_cancel.set(),
@@ -71,9 +73,12 @@ class AsyncNewLoopRuntime(BaseRuntime, MonitoringMixin, InstrumentationMixin, AB
             metrics_exporter_host=self.args.metrics_exporter_host,
             metrics_exporter_port=self.args.metrics_exporter_port,
         )
-        send_telemetry_event(event='start', obj=self, entity_id=self._entity_id)
         self._start_time = time.time()
         self._loop.run_until_complete(self.async_setup())
+        self._send_telemetry_event()
+
+    def _send_telemetry_event(self):
+        send_telemetry_event(event='start', obj=self, entity_id=self._entity_id)
 
     def run_forever(self):
         """
@@ -192,11 +197,11 @@ class AsyncNewLoopRuntime(BaseRuntime, MonitoringMixin, InstrumentationMixin, AB
 
     @classmethod
     def wait_for_ready_or_shutdown(
-            cls,
-            timeout: Optional[float],
-            ready_or_shutdown_event: Union['multiprocessing.Event', 'threading.Event'],
-            ctrl_address: str,
-            **kwargs,
+        cls,
+        timeout: Optional[float],
+        ready_or_shutdown_event: Union['multiprocessing.Event', 'threading.Event'],
+        ctrl_address: str,
+        **kwargs,
     ):
         """
         Check if the runtime has successfully started

--- a/jina/serve/runtimes/gateway/__init__.py
+++ b/jina/serve/runtimes/gateway/__init__.py
@@ -104,7 +104,7 @@ class GatewayRuntime(AsyncNewLoopRuntime):
         )
 
         send_telemetry_event(
-            event='start', obj=self.gateway, protocol=self.args.protocol
+            event='start_gateway ', obj=self.gateway, protocol=self.args.protocol
         )
 
         await self.gateway.setup_server()

--- a/jina/serve/runtimes/gateway/__init__.py
+++ b/jina/serve/runtimes/gateway/__init__.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Optional, Union
 from jina import __default_host__
 from jina.enums import GatewayProtocolType
 from jina.excepts import PortAlreadyUsed
-from jina.helper import is_port_free
+from jina.helper import is_port_free, send_telemetry_event
 from jina.parsers.helper import _update_gateway_args
 from jina.serve.gateway import BaseGateway
 from jina.serve.runtimes.asyncio import AsyncNewLoopRuntime
@@ -101,6 +101,10 @@ class GatewayRuntime(AsyncNewLoopRuntime):
             },
             py_modules=self.args.py_modules,
             extra_search_paths=self.args.extra_search_paths,
+        )
+
+        send_telemetry_event(
+            event='start', obj=self.gateway, protocol=self.args.protocol
         )
 
         await self.gateway.setup_server()

--- a/jina/serve/runtimes/gateway/__init__.py
+++ b/jina/serve/runtimes/gateway/__init__.py
@@ -103,11 +103,22 @@ class GatewayRuntime(AsyncNewLoopRuntime):
             extra_search_paths=self.args.extra_search_paths,
         )
 
-        send_telemetry_event(
-            event='start_gateway ', obj=self.gateway, protocol=self.args.protocol
-        )
-
         await self.gateway.setup_server()
+
+    def _send_telemetry_event(self):
+        is_custom_gateway = self.gateway.__class__ not in [
+            CompositeGateway,
+            GRPCGateway,
+            HTTPGateway,
+            WebSocketGateway,
+        ]
+        send_telemetry_event(
+            event='start',
+            obj=self,
+            entity_id=self._entity_id,
+            is_custom_gateway=is_custom_gateway,
+            protocol=self.args.protocol,
+        )
 
     async def _wait_for_cancel(self):
         """Do NOT override this method when inheriting from :class:`GatewayPod`"""


### PR DESCRIPTION
This PR makes the GatewayRuntime send a special telemetry event for gateway.
An event with name `start_gateway` is sent along with the gateway class and the protocol used.

**Note:**
A more efficient way would be to send information from gateway runtime only once but this means moving send_telemetry_event from init to async_setup