### PR TITLE
test: fix histograms monitoring test

### DIFF
--- a/tests/unit/serve/instrumentation/test_networking_histograms.py
+++ b/tests/unit/serve/instrumentation/test_networking_histograms.py
@@ -1,12 +1,13 @@
+from typing import Dict, List, Tuple
+
 import pytest
-from typing import Tuple, List, Dict
+from opentelemetry.metrics import Meter
 from opentelemetry.sdk.metrics import MeterProvider
 from opentelemetry.sdk.metrics.export import (
+    HistogramDataPoint,
     InMemoryMetricReader,
     Metric,
-    HistogramDataPoint,
 )
-from opentelemetry.metrics import Meter
 
 from jina.serve.networking import _NetworkingHistograms
 
@@ -59,7 +60,7 @@ def test_recording_methods(metrics_setup: Tuple[InMemoryMetricReader, Meter]):
         metric_reader.get_metrics_data().resource_metrics[0].scope_metrics[0].metrics
     )
     data_points_sums: Dict[str, HistogramDataPoint] = {
-        hist.name: next(hist.data.data_points).sum for hist in histogram_metrics
+        hist.name: next(iter(hist.data.data_points)).sum for hist in histogram_metrics
     }
     assert data_points_sums == {
         'request_time': 10,


### PR DESCRIPTION
Recent release (https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.15.0) from open telemetry sdk introduces a small breaking change which breaks our CI.
This PR adapts the existing test.
I believe the test should be just removed