### PR TITLE
refactor: avoid run in executor creating threads

### DIFF
--- a/jina/serve/stream/__init__.py
+++ b/jina/serve/stream/__init__.py
@@ -37,6 +37,7 @@ class RequestStreamer:
         request_handler: Callable[['Request'], 'Awaitable[Request]'],
         result_handler: Callable[['Request'], Optional['Request']],
         prefetch: int = 0,
+        iterate_sync_in_thread: bool = True,
         end_of_iter_handler: Optional[Callable[[], None]] = None,
         logger: Optional['JinaLogger'] = None,
         **logger_kwargs,
@@ -46,6 +47,7 @@ class RequestStreamer:
         :param result_handler: The callable responsible for handling the response.
         :param end_of_iter_handler: Optional callable to handle the end of iteration if some special action needs to be taken.
         :param prefetch: How many Requests are processed from the Client at the same time.
+        :param iterate_sync_in_thread: if True, blocking iterators will call __next__ in a Thread.
         :param logger: Optional logger that can be used for logging
         :param logger_kwargs: Extra keyword arguments that may be passed to the internal logger constructor if none is provided
 
@@ -55,6 +57,7 @@ class RequestStreamer:
         self._request_handler = request_handler
         self._result_handler = result_handler
         self._end_of_iter_handler = end_of_iter_handler
+        self._iterate_sync_in_thread = iterate_sync_in_thread
         self.total_num_floating_tasks_alive = 0
 
     async def stream(
@@ -163,6 +166,7 @@ class RequestStreamer:
                 iterator=request_iterator,
                 request_counter=requests_to_handle,
                 prefetch=self._prefetch,
+                iterate_sync_in_thread=self._iterate_sync_in_thread
             ):
                 num_reqs += 1
                 requests_to_handle.count += 1

--- a/jina/serve/stream/helper.py
+++ b/jina/serve/stream/helper.py
@@ -29,20 +29,23 @@ class AsyncRequestsIterator:
     """Iterator to allow async iteration of blocking/non-blocking iterator from the Client"""
 
     def __init__(
-        self,
-        iterator: Union[Iterator, AsyncIterator],
-        request_counter: Optional[_RequestsCounter] = None,
-        prefetch: int = 0,
+            self,
+            iterator: Union[Iterator, AsyncIterator],
+            request_counter: Optional[_RequestsCounter] = None,
+            prefetch: int = 0,
+            iterate_sync_in_thread: bool = True,
     ) -> None:
         """Async request iterator
 
         :param iterator: request iterator
         :param request_counter: counter of the numbers of request being handled at a given moment
         :param prefetch: The max amount of requests to be handled at a given moment (0 disables feature)
+        :param iterate_sync_in_thread: if True, blocking iterators will call __next__ in a Thread.
         """
         self.iterator = iterator
         self._request_counter = request_counter
         self._prefetch = prefetch
+        self._iterate_sync_in_thread = iterate_sync_in_thread
 
     def iterator__next__(self):
         """
@@ -61,14 +64,24 @@ class AsyncRequestsIterator:
 
     async def __anext__(self):
         if isinstance(self.iterator, Iterator):
-
             """
             An `Iterator` indicates "blocking" code, which might block all tasks in the event loop.
             Hence we iterate in the default executor provided by asyncio.
             """
-            request = await get_or_reuse_loop().run_in_executor(
-                None, self.iterator__next__
-            )
+
+            if not self._iterate_sync_in_thread:
+                async def _get_next():
+                    try:
+                        req = self.iterator.__next__()
+                    except StopIteration:
+                        req = None
+                    return req
+
+                request = await asyncio.create_task(_get_next())
+            else:
+                request = await get_or_reuse_loop().run_in_executor(
+                    None, self.iterator__next__
+                )
 
             """
             `iterator.__next__` can be executed directly and that'd raise `StopIteration` in the executor,


### PR DESCRIPTION
<!---Decomposing the complex issue into subtasks can help you build it step-by-step. Thanks for your pull request! :rocket: --->
<!---We know that dev life is hectic, but **please provide a (brief) description** of what your PR does, and how it does it. **Otherwise, your PR cannot be reviewed!** --->
<!---This policy was agreed upon in a past company retro, and makes everyone's life a little easier. Thanks for your collaboration!--->

**Goals:**
Refactor do not use run_in_executor