### PR TITLE
fix: jina ai cloud redirects

### DIFF
--- a/docs/redirects.txt
+++ b/docs/redirects.txt
@@ -51,4 +51,5 @@ fundamentals/clean-code.md concepts/preliminaries/clean-code.md
 fundamentals/preliminaries/coding-in-python-yaml.md concepts/preliminaries/coding-in-python-yaml.md
 fundamentals/architecture-overview.md concepts/preliminaries/index.md
 fundamentals/executor/hub/index.md concepts/executor/hub/index.md
+fundamentals/flow/index.md concepts/flow/index.md
 

--- a/docs/redirects.txt
+++ b/docs/redirects.txt
@@ -50,6 +50,5 @@ fundamentals/jcloud/yaml-spec.md concepts/jcloud/yaml-spec.md
 fundamentals/clean-code.md concepts/preliminaries/clean-code.md
 fundamentals/preliminaries/coding-in-python-yaml.md concepts/preliminaries/coding-in-python-yaml.md
 fundamentals/architecture-overview.md concepts/preliminaries/index.md
-fundamentals/executor/hub/index.md concepts/executor/hub/index.md
-fundamentals/flow/index.md concepts/flow/index.md
-
+fundamentals/executor/hub.md concepts/executor/hub
+fundamentals/flow.md concepts/flow

--- a/docs/redirects.txt
+++ b/docs/redirects.txt
@@ -50,3 +50,5 @@ fundamentals/jcloud/yaml-spec.md concepts/jcloud/yaml-spec.md
 fundamentals/clean-code.md concepts/preliminaries/clean-code.md
 fundamentals/preliminaries/coding-in-python-yaml.md concepts/preliminaries/coding-in-python-yaml.md
 fundamentals/architecture-overview.md concepts/preliminaries/index.md
+fundamentals/executor/hub/index.md concepts/executor/hub/index.md
+


### PR DESCRIPTION

URLs on Jina AI Cloud currently point to deprecated URLs and cause 404s. This adds redirects to fix that.