### PR TITLE
refactor: make server link to gateway so that custom gateway can inherit

### DIFF
--- a/jina/serve/gateway.py
+++ b/jina/serve/gateway.py
@@ -1,22 +1,12 @@
 import abc
-import argparse
 from types import SimpleNamespace
-from typing import TYPE_CHECKING, Dict, Optional, Sequence
+from typing import Dict, Optional
 
 from jina.jaml import JAMLCompatible
 from jina.logging.logger import JinaLogger
 from jina.serve.helper import store_init_kwargs, wrap_func
 
 __all__ = ['BaseGateway']
-
-if TYPE_CHECKING:  # pragma: no cover
-    from grpc.aio._interceptor import ClientInterceptor, ServerInterceptor
-    from opentelemetry import trace
-    from opentelemetry.instrumentation.grpc._client import (
-        OpenTelemetryClientInterceptor,
-    )
-    from opentelemetry.metrics import Meter
-    from prometheus_client import CollectorRegistry
 
 
 class GatewayType(type(JAMLCompatible), type):


### PR DESCRIPTION
<!---Decomposing the complex issue into subtasks can help you build it step-by-step. Thanks for your pull request! :rocket: --->
<!---We know that dev life is hectic, but **please provide a (brief) description** of what your PR does, and how it does it. **Otherwise, your PR cannot be reviewed!** --->
<!---This policy was agreed upon in a past company retro, and makes everyone's life a little easier. Thanks for your collaboration!--->

**Goals:**
Make the `GRPCGateway` be the one implementing the methods, so that we can have the CustomGateway developer inherit from it