### PR TITLE
fix: install build essentials before pip install for python 3.11 docker image

### DIFF
--- a/Dockerfiles/debianx.Dockerfile
+++ b/Dockerfiles/debianx.Dockerfile
@@ -43,9 +43,9 @@ RUN cd /tmp/ && \
     if [ -n "${APT_PACKAGES}" ]; then apt-get update && apt-get upgrade -y && \
     apt-get --only-upgrade install openssl libssl1.1 -y && \
     apt-get install --no-install-recommends -y ${APT_PACKAGES}; fi && \
+    if [[ $PY_VERSION==3.11 ]]; then apt-get install --no-install-recommends -y build-essential ; fi && \
     if [ -n "${PIP_TAG}" ]; then pip install --default-timeout=1000 --compile --extra-index-url $PIP_EXTRA_INDEX_URL ".[${PIP_TAG}]" ; fi && \
     pip install --default-timeout=1000 --compile --extra-index-url ${PIP_EXTRA_INDEX_URL} . && \
-    if [[ $PY_VERSION==3.11 ]]; then apt-get install --no-install-recommends -y build-essential ; fi && \
     # now remove apt packages
     if [ -n "${APT_PACKAGES}" ]; then apt-get remove -y --auto-remove ${APT_PACKAGES} && apt-get autoremove && apt-get clean && rm -rf /var/lib/apt/lists/*; fi && \
     rm -rf /tmp/* && rm -rf /jina


### PR DESCRIPTION
fix: install build essentials before pip install for py 3.11 on docker