### PR TITLE
fix: fix installing build essentials for python 3.11

### DIFF
--- a/Dockerfiles/debianx.Dockerfile
+++ b/Dockerfiles/debianx.Dockerfile
@@ -43,7 +43,7 @@ RUN cd /tmp/ && \
     if [ -n "${APT_PACKAGES}" ]; then apt-get update && apt-get upgrade -y && \
     apt-get --only-upgrade install openssl libssl1.1 -y && \
     apt-get install --no-install-recommends -y ${APT_PACKAGES}; fi && \
-    if [[ $PY_VERSION==3.11 ]]; then apt-get install --no-install-recommends -y build-essential ; fi && \
+    if [ $PY_VERSION==3.11 ]; then apt-get install --no-install-recommends -y build-essential ; fi && \
     if [ -n "${PIP_TAG}" ]; then pip install --default-timeout=1000 --compile --extra-index-url $PIP_EXTRA_INDEX_URL ".[${PIP_TAG}]" ; fi && \
     pip install --default-timeout=1000 --compile --extra-index-url ${PIP_EXTRA_INDEX_URL} . && \
     # now remove apt packages


### PR DESCRIPTION
fix: fix installing build essentials for python 3.11