### PR TITLE
refactor: simplify get docs from requests

### DIFF
--- a/jina/serve/runtimes/head/request_handling.py
+++ b/jina/serve/runtimes/head/request_handling.py
@@ -164,9 +164,7 @@ class HeaderRequestHandler(MonitoringRequestMixin):
         elif len(worker_results) > 1 and not reduce:
             # worker returned multiple responses, but the head is configured to skip reduction
             # just concatenate the docs in this case
-            response_request.data.docs = WorkerRequestHandler.get_docs_from_request(
-                requests, field='docs'
-            )
+            response_request.data.docs = WorkerRequestHandler.get_docs_from_request(requests)
 
         merged_metadata = self._merge_metadata(
             metadata,

--- a/jina/serve/runtimes/worker/request_handling.py
+++ b/jina/serve/runtimes/worker/request_handling.py
@@ -414,10 +414,7 @@ class WorkerRequestHandler:
             )
             await task
         else:
-            docs = WorkerRequestHandler.get_docs_from_request(
-                requests,
-                field='docs',
-            )
+            docs = WorkerRequestHandler.get_docs_from_request(requests)
 
             docs_matrix, docs_map = WorkerRequestHandler._get_docs_matrix_from_request(
                 requests
@@ -531,26 +528,22 @@ class WorkerRequestHandler:
     @staticmethod
     def get_docs_from_request(
         requests: List['DataRequest'],
-        field: str,
     ) -> 'DocumentArray':
         """
         Gets a field from the message
 
-        :param requests: requests to get the field from
-        :param field: field name to access
+        :param requests: requests to get the docs from
 
         :returns: DocumentArray extracted from the field from all messages
         """
         if len(requests) > 1:
             result = DocumentArray(
-                [
                     d
-                    for r in reversed([request for request in requests])
-                    for d in getattr(r, field)
-                ]
+                    for r in reversed(requests)
+                    for d in getattr(r, 'docs')
             )
         else:
-            result = getattr(requests[0], field)
+            result = getattr(requests[0], 'docs')
 
         return result
 


### PR DESCRIPTION
<!---Decomposing the complex issue into subtasks can help you build it step-by-step. Thanks for your pull request! :rocket: --->
<!---We know that dev life is hectic, but **please provide a (brief) description** of what your PR does, and how it does it. **Otherwise, your PR cannot be reviewed!** --->
<!---This policy was agreed upon in a past company retro, and makes everyone's life a little easier. Thanks for your collaboration!--->

**Goals:**
<!---https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword--->

Why does it need to be reversed?
