### PR TITLE
feat: run dry_run requests as warmup with 5 min max timeout

### DIFF
--- a/jina/serve/gateway.py
+++ b/jina/serve/gateway.py
@@ -176,33 +176,9 @@ class BaseGateway(JAMLCompatible, metaclass=GatewayType):
 
     async def shutdown(self):
         """Shutdown the server and free other allocated resources, e.g, streamer object, health check service, ..."""
+        self.logger.debug(f'Cancelling warmup task {self._warmup_task} if not done.')
         if self._warmup_task and not self._warmup_task.done():
             self._warmup_task.cancel()
-
-    async def warmup(self):
-        '''Run client._is_flow_ready() request to trigger the dry_run endpoint on each executor.
-        This forces the gateway to establish connection and open a gRPC channel to each executor so that the first
-        request doesn't need to experience the penalty of eastablishing a brand new gRPC channel.
-        '''
-        self.logger.debug(f'Running warmup for {self.__class__}')
-        from jina import Client
-
-        timeout = time.time() + 60 * 5  # 5 minutes from now
-
-        while True:
-            dry_run_responses = []
-            for port, protocol in zip(self.ports, self.protocols):
-                client = Client(
-                    host=f'{protocol}://{self.runtime_args.host}:{port}',
-                    asyncio=True,
-                    continue_on_error=True,
-                )
-                dry_run_responses.append(await client.is_flow_ready())
-
-            if time.time() > timeout or all(dry_run_responses):
-                break
-
-            time.sleep(0.2)
 
     def __enter__(self):
         return self

--- a/jina/serve/runtimes/gateway/composite/gateway.py
+++ b/jina/serve/runtimes/gateway/composite/gateway.py
@@ -1,3 +1,4 @@
+import asyncio
 import copy
 from typing import List, Optional
 
@@ -33,18 +34,27 @@ class CompositeGateway(BaseGateway):
         """
         setup GRPC server
         """
+        tasks = []
         for gateway in self.gateways:
-            await gateway.setup_server()
+            tasks.append(asyncio.create_task(gateway.setup_server()))
+
+        await asyncio.gather(*tasks)
 
     async def shutdown(self):
         """Free other resources allocated with the server, e.g, gateway object, ..."""
+        shutdown_tasks = []
         for gateway in self.gateways:
-            await gateway.shutdown()
+            shutdown_tasks.append(asyncio.create_task(gateway.shutdown()))
+
+        await asyncio.gather(*shutdown_tasks)
 
     async def run_server(self):
         """Run GRPC server forever"""
+        run_server_tasks = []
         for gateway in self.gateways:
-            await gateway.run_server()
+            run_server_tasks.append(asyncio.create_task(gateway.run_server()))
+
+        await asyncio.gather(*run_server_tasks)
 
     @property
     def _should_exit(self) -> bool:

--- a/jina/serve/runtimes/gateway/grpc/gateway.py
+++ b/jina/serve/runtimes/gateway/grpc/gateway.py
@@ -1,4 +1,4 @@
-from typing import Optional, AsyncIterator, TYPE_CHECKING
+from typing import TYPE_CHECKING, AsyncIterator, Optional
 
 import grpc
 from grpc_health.v1 import health, health_pb2, health_pb2_grpc
@@ -8,21 +8,22 @@ from jina.helper import get_full_version
 from jina.proto import jina_pb2, jina_pb2_grpc
 from jina.serve.gateway import BaseGateway
 from jina.serve.runtimes.helper import _get_grpc_server_options
-from jina.types.request.status import StatusMessage
 from jina.types.request.data import DataRequest
+from jina.types.request.status import StatusMessage
 
 if TYPE_CHECKING:  # pragma: no cover
     from jina.types.request import Request
+
 
 class GRPCGateway(BaseGateway):
     """GRPC Gateway implementation"""
 
     def __init__(
-            self,
-            grpc_server_options: Optional[dict] = None,
-            ssl_keyfile: Optional[str] = None,
-            ssl_certfile: Optional[str] = None,
-            **kwargs,
+        self,
+        grpc_server_options: Optional[dict] = None,
+        ssl_keyfile: Optional[str] = None,
+        ssl_certfile: Optional[str] = None,
+        **kwargs,
     ):
         """Initialize the gateway
         :param grpc_server_options: Dictionary of kwargs arguments that will be passed to the grpc server as options when starting the server, example : {'grpc.max_send_message_length': -1}
@@ -45,13 +46,9 @@ class GRPCGateway(BaseGateway):
             interceptors=self.grpc_tracing_server_interceptors,
         )
 
-        jina_pb2_grpc.add_JinaRPCServicer_to_server(
-            self, self.server
-        )
+        jina_pb2_grpc.add_JinaRPCServicer_to_server(self, self.server)
 
-        jina_pb2_grpc.add_JinaSingleDataRequestRPCServicer_to_server(
-            self, self.server
-        )
+        jina_pb2_grpc.add_JinaSingleDataRequestRPCServicer_to_server(self, self.server)
 
         jina_pb2_grpc.add_JinaGatewayDryRunRPCServicer_to_server(self, self.server)
         jina_pb2_grpc.add_JinaInfoRPCServicer_to_server(self, self.server)
@@ -86,7 +83,7 @@ class GRPCGateway(BaseGateway):
             )
             self.server.add_secure_port(bind_addr, server_credentials)
         elif (
-                self.ssl_keyfile != self.ssl_certfile
+            self.ssl_keyfile != self.ssl_certfile
         ):  # if we have only ssl_keyfile and not ssl_certfile or vice versa
             raise ValueError(
                 f"you can't pass a ssl_keyfile without a ssl_certfile and vice versa"
@@ -107,6 +104,7 @@ class GRPCGateway(BaseGateway):
 
     async def run_server(self):
         """Run GRPC server forever"""
+        await self.warmup()
         await self.server.wait_for_termination()
 
     async def dry_run(self, empty, context) -> jina_pb2.StatusProto:
@@ -124,7 +122,7 @@ class GRPCGateway(BaseGateway):
         da = DocumentArray([Document()])
         try:
             async for _ in self.streamer.stream_docs(
-                    docs=da, exec_endpoint=__dry_run_endpoint__, request_size=1
+                docs=da, exec_endpoint=__dry_run_endpoint__, request_size=1
             ):
                 pass
             status_message = StatusMessage()
@@ -151,7 +149,9 @@ class GRPCGateway(BaseGateway):
             info_proto.envs[k] = str(v)
         return info_proto
 
-    async def stream(self, request_iterator, context=None, *args, **kwargs) -> AsyncIterator['Request']:
+    async def stream(
+        self, request_iterator, context=None, *args, **kwargs
+    ) -> AsyncIterator['Request']:
         """
         stream requests from client iterator and stream responses back.
 
@@ -161,11 +161,13 @@ class GRPCGateway(BaseGateway):
         :param kwargs: keyword arguments
         :yield: responses to the request after streaming to Executors in Flow
         """
-        async for resp in self.streamer.stream(request_iterator=request_iterator, context=context, *args, **kwargs):
+        async for resp in self.streamer.stream(
+            request_iterator=request_iterator, context=context, *args, **kwargs
+        ):
             yield resp
 
     async def process_single_data(
-            self, request: DataRequest, context=None
+        self, request: DataRequest, context=None
     ) -> DataRequest:
         """Implements request and response handling of a single DataRequest
         :param request: DataRequest from Client

--- a/jina/serve/runtimes/gateway/grpc/gateway.py
+++ b/jina/serve/runtimes/gateway/grpc/gateway.py
@@ -1,3 +1,4 @@
+import asyncio
 from typing import TYPE_CHECKING, AsyncIterator, Optional
 
 import grpc
@@ -99,12 +100,13 @@ class GRPCGateway(BaseGateway):
 
     async def shutdown(self):
         """Free other resources allocated with the server, e.g, gateway object, ..."""
+        await super().shutdown()
         await self.server.stop(0)
         await self.health_servicer.enter_graceful_shutdown()
 
     async def run_server(self):
         """Run GRPC server forever"""
-        await self.warmup()
+        self._warmup_task = asyncio.create_task(self.warmup())
         await self.server.wait_for_termination()
 
     async def dry_run(self, empty, context) -> jina_pb2.StatusProto:

--- a/jina/serve/runtimes/gateway/grpc/gateway.py
+++ b/jina/serve/runtimes/gateway/grpc/gateway.py
@@ -106,7 +106,7 @@ class GRPCGateway(BaseGateway):
 
     async def run_server(self):
         """Run GRPC server forever"""
-        self._warmup_task = asyncio.create_task(self.warmup())
+        self._warmup_task = asyncio.create_task(self.streamer.warmup())
         await self.server.wait_for_termination()
 
     async def dry_run(self, empty, context) -> jina_pb2.StatusProto:

--- a/jina/serve/runtimes/gateway/http/fastapi.py
+++ b/jina/serve/runtimes/gateway/http/fastapi.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import os
 from abc import abstractmethod
@@ -105,13 +106,14 @@ class FastAPIBaseGateway(BaseGateway):
             )
         )
 
+        self._warmup_task = asyncio.create_task(self.warmup())
         await self.server.setup()
-        await self.warmup()
 
     async def shutdown(self):
         """
         Free resources allocated when setting up HTTP server
         """
+        await super().shutdown()
         self.server.should_exit = True
         await self.server.shutdown()
 

--- a/jina/serve/runtimes/gateway/http/fastapi.py
+++ b/jina/serve/runtimes/gateway/http/fastapi.py
@@ -106,6 +106,7 @@ class FastAPIBaseGateway(BaseGateway):
         )
 
         await self.server.setup()
+        await self.warmup()
 
     async def shutdown(self):
         """

--- a/jina/serve/runtimes/gateway/http/fastapi.py
+++ b/jina/serve/runtimes/gateway/http/fastapi.py
@@ -106,7 +106,7 @@ class FastAPIBaseGateway(BaseGateway):
             )
         )
 
-        self._warmup_task = asyncio.create_task(self.warmup())
+        self._warmup_task = asyncio.create_task(self.streamer.warmup())
         await self.server.setup()
 
     async def shutdown(self):

--- a/jina/serve/runtimes/gateway/websocket/gateway.py
+++ b/jina/serve/runtimes/gateway/websocket/gateway.py
@@ -108,6 +108,7 @@ class WebSocketGateway(BaseGateway):
         )
 
         await self.server.setup()
+        await self.warmup()
 
     async def shutdown(self):
         """Free other resources allocated with the server, e.g, gateway object, ..."""

--- a/jina/serve/runtimes/gateway/websocket/gateway.py
+++ b/jina/serve/runtimes/gateway/websocket/gateway.py
@@ -108,7 +108,7 @@ class WebSocketGateway(BaseGateway):
             )
         )
 
-        self._warmup_task = asyncio.create_task(self.warmup())
+        self._warmup_task = asyncio.create_task(self.streamer.warmup())
         await self.server.setup()
 
     async def shutdown(self):

--- a/jina/serve/runtimes/gateway/websocket/gateway.py
+++ b/jina/serve/runtimes/gateway/websocket/gateway.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import os
 from typing import Optional
@@ -107,11 +108,12 @@ class WebSocketGateway(BaseGateway):
             )
         )
 
+        self._warmup_task = asyncio.create_task(self.warmup())
         await self.server.setup()
-        await self.warmup()
 
     async def shutdown(self):
         """Free other resources allocated with the server, e.g, gateway object, ..."""
+        await super().shutdown()
         self.server.should_exit = True
         await self.server.shutdown()
 

--- a/tests/integration/runtimes/test_warmup.py
+++ b/tests/integration/runtimes/test_warmup.py
@@ -1,0 +1,105 @@
+import multiprocessing
+import time
+from dataclasses import dataclass
+
+import pytest
+
+from jina import Executor, requests
+from jina.serve.runtimes.asyncio import AsyncNewLoopRuntime
+from jina.serve.runtimes.worker import WorkerRuntime
+from tests.helper import _generate_pod_args
+
+from .test_runtimes import _create_gateway_runtime
+
+
+class SlowExecutor(Executor):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        time.sleep(4)
+
+
+def _create_worker_runtime(port, name=''):
+    args = _generate_pod_args()
+    args.port = port
+    args.name = name
+    if name == 'slow-executor':
+        args.uses = 'SlowExecutor'
+
+    with WorkerRuntime(args) as runtime:
+        runtime.run_forever()
+
+
+def _setup(worker_port, port, protocol, executor_name=''):
+    graph_description = '{"start-gateway": ["pod0"], "pod0": ["end-gateway"]}'
+    pod_addresses = f'{{"pod0": ["0.0.0.0:{worker_port}"]}}'
+
+    # create a single worker runtime
+    worker_process = multiprocessing.Process(
+        target=_create_worker_runtime, args=(worker_port, executor_name)
+    )
+    worker_process.start()
+
+    # create a single gateway runtime
+    gateway_process = multiprocessing.Process(
+        target=_create_gateway_runtime,
+        args=(graph_description, pod_addresses, port, protocol),
+    )
+    gateway_process.start()
+
+    AsyncNewLoopRuntime.wait_for_ready_or_shutdown(
+        timeout=5.0,
+        ctrl_address=f'0.0.0.0:{worker_port}',
+        ready_or_shutdown_event=multiprocessing.Event(),
+    )
+    AsyncNewLoopRuntime.wait_for_ready_or_shutdown(
+        timeout=5.0,
+        ctrl_address=f'0.0.0.0:{port}',
+        ready_or_shutdown_event=multiprocessing.Event(),
+    )
+    return worker_process, gateway_process
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('protocol', ['grpc', 'http', 'websocket'])
+async def test_gateway_warmup_fast_executor(port_generator, protocol, capfd):
+    worker_port = port_generator()
+    port = port_generator()
+    worker_process, gateway_process = _setup(worker_port, port, protocol)
+
+    time.sleep(1)
+
+    gateway_process.terminate()
+    gateway_process.join()
+    worker_process.terminate()
+    worker_process.join()
+
+    assert gateway_process.exitcode == 0
+    assert worker_process.exitcode == 0
+
+    out, _ = capfd.readouterr()
+    assert 'recv DataRequest at _jina_dry_run_' in out
+    assert not 'ERROR' in out
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('protocol', ['grpc', 'http', 'websocket'])
+async def test_gateway_warmup_slow_executor(port_generator, protocol, capfd):
+    worker_port = port_generator()
+    port = port_generator()
+    worker_process, gateway_process = _setup(
+        worker_port, port, protocol, 'slow-executor'
+    )
+
+    time.sleep(1)
+
+    gateway_process.terminate()
+    gateway_process.join()
+    worker_process.terminate()
+    worker_process.join()
+
+    assert gateway_process.exitcode == 0
+    assert worker_process.exitcode == 0
+
+    out, _ = capfd.readouterr()
+    assert 'recv DataRequest at _jina_dry_run_' in out
+    assert 'ERROR' in out

--- a/tests/integration/runtimes/test_warmup.py
+++ b/tests/integration/runtimes/test_warmup.py
@@ -15,7 +15,7 @@ from .test_runtimes import _create_gateway_runtime
 class SlowExecutor(Executor):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        time.sleep(4)
+        time.sleep(3)
 
 
 def _create_worker_runtime(port, name=''):
@@ -105,7 +105,7 @@ async def test_gateway_warmup_slow_executor(port_generator, protocol, capfd):
 
 
 @pytest.mark.asyncio
-async def test_multi_protocol_gateway_fast_executor(port_generator, capfd):
+async def test_multi_protocol_gateway_warmup_fast_executor(port_generator, capfd):
     http_port = port_generator()
     grpc_port = port_generator()
     websocket_port = port_generator()
@@ -119,26 +119,6 @@ async def test_multi_protocol_gateway_fast_executor(port_generator, capfd):
     )
 
     with flow:
-        out, _ = capfd.readouterr()
-        assert 'recv DataRequest at _jina_dry_run_' in out
-
-
-@pytest.mark.asyncio
-async def test_multi_protocol_gateway_slow_executor(port_generator, capfd):
-    http_port = port_generator()
-    grpc_port = port_generator()
-    websocket_port = port_generator()
-    flow = (
-        Flow()
-        .config_gateway(
-            port=[http_port, grpc_port, websocket_port],
-            protocol=['http', 'grpc', 'websocket'],
-        )
-        .add(uses='SlowExecutor', name='slowExecutor')
-    )
-
-    with flow:
         time.sleep(1)
         out, _ = capfd.readouterr()
-        print(out)
         assert 'recv DataRequest at _jina_dry_run_' in out


### PR DESCRIPTION
**Goals:**
<!---https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword--->

- resolves #5467
- trigger warmup requests using the `client.is_flow_ready()` method from the gateway. 
- this runs the `dry_run` rpc to each exectuor thereby establishing the first connection and gRPC channel. 
- the warmup sequence runs for a max of 5 minutes and exits if all dry_run responses are successful. On failure, the warmup is retried after 0.2 seconds. 
- when debug logging is enabled the gateway will log connections errors until the Flow is ready or the warmup reaches the max timeout of 5 minutes.