### PR TITLE
chore: use hubble pull mixin parser

### DIFF
--- a/jina/parsers/__init__.py
+++ b/jina/parsers/__init__.py
@@ -15,9 +15,10 @@ def set_pod_parser(parser=None):
 
         parser = set_base_parser()
 
-    from jina.parsers.orchestrate.base import mixin_scalable_deployment_parser
-    from jina.parsers.orchestrate.pod import mixin_pod_parser, mixin_hub_pull_options_parser
     from hubble.executor.parsers.pull import mixin_hub_pull_options_parser
+
+    from jina.parsers.orchestrate.base import mixin_scalable_deployment_parser
+    from jina.parsers.orchestrate.pod import mixin_pod_parser
     from jina.parsers.orchestrate.runtimes.container import (
         mixin_container_runtime_parser,
     )
@@ -139,7 +140,10 @@ def set_client_cli_parser(parser=None):
         mixin_client_features_parser,
         mixin_client_protocol_parser,
     )
-    from jina.parsers.orchestrate.runtimes.remote import mixin_client_gateway_parser, mixin_prefetch_parser
+    from jina.parsers.orchestrate.runtimes.remote import (
+        mixin_client_gateway_parser,
+        mixin_prefetch_parser,
+    )
 
     mixin_client_gateway_parser(parser)
     mixin_client_features_parser(parser)
@@ -289,8 +293,8 @@ def get_main_parser():
         sp.add_parser(
             'pod',
             description='Start a Pod. '
-                        'You should rarely use this directly unless you '
-                        'are doing low-level orchestration',
+            'You should rarely use this directly unless you '
+            'are doing low-level orchestration',
             formatter_class=_chf,
             **(dict(help='Start a Pod')) if _SHOW_ALL_ARGS else {},
         )
@@ -300,8 +304,8 @@ def get_main_parser():
         sp.add_parser(
             'deployment',
             description='Start a Deployment. '
-                        'You should rarely use this directly unless you '
-                        'are doing low-level orchestration',
+            'You should rarely use this directly unless you '
+            'are doing low-level orchestration',
             formatter_class=_chf,
             **(dict(help='Start a Deployment')) if _SHOW_ALL_ARGS else {},
         )

--- a/jina/parsers/orchestrate/pod.py
+++ b/jina/parsers/orchestrate/pod.py
@@ -4,8 +4,8 @@ import argparse
 from dataclasses import dataclass
 from typing import Dict
 
-from jina.helper import random_port
 from jina.enums import PodRoleType
+from jina.helper import random_port
 from jina.parsers.helper import (
     _SHOW_ALL_ARGS,
     CastToIntAction,
@@ -51,7 +51,7 @@ def mixin_pod_parser(parser, pod_type: str = 'worker'):
         type=int,
         default=600000,
         help='The timeout in milliseconds of a Pod waits for the runtime to be ready, -1 for waiting '
-             'forever',
+        'forever',
     )
 
     gp.add_argument(
@@ -96,7 +96,7 @@ def mixin_pod_parser(parser, pod_type: str = 'worker'):
         action='store_true',
         default=False,
         help='If set, starting a Pod/Deployment does not block the thread/process. It then relies on '
-             '`wait_start_success` at outer function for the postpone check.'
+        '`wait_start_success` at outer function for the postpone check.'
         if _SHOW_ALL_ARGS
         else argparse.SUPPRESS,
     )
@@ -106,7 +106,7 @@ def mixin_pod_parser(parser, pod_type: str = 'worker'):
         action='store_true',
         default=False,
         help='If set, the current Pod/Deployment can not be further chained, '
-             'and the next `.add()` will chain after the last Pod/Deployment not this current one.',
+        'and the next `.add()` will chain after the last Pod/Deployment not this current one.',
     )
     if pod_type != 'gateway':
         gp.add_argument(
@@ -122,7 +122,7 @@ def mixin_pod_parser(parser, pod_type: str = 'worker'):
             '--install-requirements',
             action='store_true',
             default=False,
-            help='If set, try to install `requirements.txt` from the local Executor if exists in the Executor folder. If using Hub, install `requirements.txt` in the Hub Executor bundle to local.'
+            help='If set, try to install `requirements.txt` from the local Executor if exists in the Executor folder. If using Hub, install `requirements.txt` in the Hub Executor bundle to local.',
         )
     else:
         gp.add_argument(
@@ -203,7 +203,7 @@ def mixin_pod_runtime_args_parser(arg_group, pod_type='worker'):
         action='store_true',
         default=False,
         help='If set, the sdk implementation of the OpenTelemetry tracer will be available and will be enabled for automatic tracing of requests and customer span creation. '
-             'Otherwise a no-op implementation will be provided.',
+        'Otherwise a no-op implementation will be provided.',
     )
 
     arg_group.add_argument(
@@ -225,7 +225,7 @@ def mixin_pod_runtime_args_parser(arg_group, pod_type='worker'):
         action='store_true',
         default=False,
         help='If set, the sdk implementation of the OpenTelemetry metrics will be available for default monitoring and custom measurements. '
-             'Otherwise a no-op implementation will be provided.',
+        'Otherwise a no-op implementation will be provided.',
     )
 
     arg_group.add_argument(
@@ -240,19 +240,4 @@ def mixin_pod_runtime_args_parser(arg_group, pod_type='worker'):
         type=int,
         default=None,
         help='If tracing is enabled, this port will be used to configure the metrics exporter agent.',
-    )
-
-
-def mixin_hub_pull_options_parser(parser):
-    """Add the arguments for hub pull options to the parser
-    :param parser: the parser configure
-    """
-
-    gp = add_arg_group(parser, title='Pull')
-    gp.add_argument(
-        '--force-update',
-        '--force',
-        action='store_true',
-        default=False,
-        help='If set, always pull the latest Hub Executor bundle even it exists on local',
     )


### PR DESCRIPTION
chore: use hubble pull mixin parser
There are 2 imports of `mixin_hub_pull_options_parser` the first comes from jina and the other comes from hubble.
However, as isort's behavior changes from machine to machine, the order might change and therefore the used parser changes. This results in arguments like `prefer_platform` appearing and disappearing from PR to PR.
This PR keeps only one parser mixin