### PR TITLE
fix: add proper error message to not-found errors

### DIFF
--- a/jina/clients/base/grpc.py
+++ b/jina/clients/base/grpc.py
@@ -277,6 +277,11 @@ class GRPCBaseClient(BaseClient):
                                     f'{msg}\nThe ongoing request is terminated as the server is not available or closed already.'
                                 )
                                 raise ConnectionError(my_details)
+                            if my_code == grpc.StatusCode.NOT_FOUND:
+                                self.logger.error(
+                                    f'{msg}\nThe ongoing request is terminated as a resource cannot be found.'
+                                )
+                                raise ConnectionError(my_details)
                             elif my_code == grpc.StatusCode.DEADLINE_EXCEEDED:
                                 self.logger.error(
                                     f'{msg}\nThe ongoing request is terminated due to a server-side timeout.'

--- a/jina/serve/networking.py
+++ b/jina/serve/networking.py
@@ -1000,23 +1000,26 @@ class GrpcConnectionPool:
         # connection failures have the code grpc.StatusCode.UNAVAILABLE
         # cancelled requests have the code grpc.StatusCode.CANCELLED
         # timed out requests have the code grpc.StatusCode.DEADLINE_EXCEEDED
+        # if an Executor is down behind an API gateway, grpc.StatusCode.NOT_FOUND is returned
         # requests usually gets cancelled when the server shuts down
         # retries for cancelled requests will hit another replica in K8s
         self._logger.debug(
             f'GRPC call to {current_deployment} errored, with error {format_grpc_error(error)} and for the {retry_i + 1}th time.'
         )
-        if (
-            error.code() != grpc.StatusCode.UNAVAILABLE
-            and error.code() != grpc.StatusCode.CANCELLED
-            and error.code() != grpc.StatusCode.DEADLINE_EXCEEDED
-            and error.code() != grpc.StatusCode.UNKNOWN
-            and error.code() != grpc.StatusCode.INTERNAL
-        ):
+        errors_to_retry = [
+            grpc.StatusCode.UNAVAILABLE,
+            grpc.StatusCode.DEADLINE_EXCEEDED,
+            grpc.StatusCode.NOT_FOUND,
+        ]
+        errors_to_handle = errors_to_retry + [
+            grpc.StatusCode.CANCELLED,
+            grpc.StatusCode.UNKNOWN,
+            grpc.StatusCode.INTERNAL,
+        ]
+
+        if error.code() not in errors_to_handle:
             return error
-        elif (
-            error.code() == grpc.StatusCode.UNAVAILABLE
-            or error.code() == grpc.StatusCode.DEADLINE_EXCEEDED
-        ) and retry_i >= total_num_tries - 1:  # retries exhausted. if we land here it already failed once, therefore -1
+        elif error.code() in errors_to_retry and retry_i >= total_num_tries - 1:
             self._logger.debug(
                 f'GRPC call for {current_deployment} failed, retries exhausted'
             )

--- a/jina/serve/runtimes/gateway/graph/topology_graph.py
+++ b/jina/serve/runtimes/gateway/graph/topology_graph.py
@@ -98,6 +98,14 @@ class TopologyGraph:
                     f' You can increase the allowed time by setting `timeout_send` in your Flow YAML `with` block or Flow `__init__()` method.'
                 )
                 raise err
+            elif err_code == grpc.StatusCode.NOT_FOUND:
+                err._details = (
+                    err.details()
+                    + f'\n|Gateway: Connection error with deployment `{self.name}` at address(es) {err.dest_addr}.'
+                    f' Connection with {err.dest_addr} succeeded, but `{self.name}` was not found.'
+                    f' Possibly `{self.name}` is behind an API gateway but not reachable.'
+                )
+                raise err
             else:
                 raise
 

--- a/jina/serve/runtimes/gateway/http/app.py
+++ b/jina/serve/runtimes/gateway/http/app.py
@@ -48,7 +48,6 @@ def get_fastapi_app(
     with ImportExtensions(required=True):
         from fastapi import FastAPI, Response, status
         from fastapi.middleware.cors import CORSMiddleware
-
         from jina.serve.runtimes.gateway.http.models import (
             JinaEndpointRequestModel,
             JinaRequestModel,
@@ -196,7 +195,10 @@ def get_fastapi_app(
             except InternalNetworkError as err:
                 import grpc
 
-                if err.code() == grpc.StatusCode.UNAVAILABLE:
+                if (
+                    err.code() == grpc.StatusCode.UNAVAILABLE
+                    or err.code() == grpc.StatusCode.NOT_FOUND
+                ):
                     response.status_code = status.HTTP_503_SERVICE_UNAVAILABLE
                 elif err.code() == grpc.StatusCode.DEADLINE_EXCEEDED:
                     response.status_code = status.HTTP_504_GATEWAY_TIMEOUT

--- a/jina/serve/runtimes/head/__init__.py
+++ b/jina/serve/runtimes/head/__init__.py
@@ -212,6 +212,10 @@ class HeadRuntime(AsyncNewLoopRuntime, ABC):
             context.set_details(
                 f'|Head: Connection to worker (Executor) pod at address {err.dest_addr} could be established, but timed out.'
             )
+        elif err_code == grpc.StatusCode.NOT_FOUND:
+            context.set_details(
+                f'|Head: Connection to worker (Executor) pod at address {err.dest_addr} could be established, but resource was not found.'
+            )
         context.set_code(err.code())
         self.logger.error(f'Error while getting responses from Pods: {err.details()}')
         if err.request_id:

--- a/tests/integration/runtimes/test_network_failures.py
+++ b/tests/integration/runtimes/test_network_failures.py
@@ -5,7 +5,7 @@ import uuid
 import pytest
 from docarray import DocumentArray
 
-from jina import Client, Executor, requests
+from jina import Client, Executor, Flow, requests
 from jina.parsers import set_gateway_parser
 from jina.serve.runtimes.asyncio import AsyncNewLoopRuntime
 from jina.serve.runtimes.gateway import GatewayRuntime
@@ -874,3 +874,15 @@ def test_custom_num_retries_headful(port_generator, retries, capfd):
         worker_process.join()
         head_process.terminate()
         head_process.join()
+
+
+def test_not_found_error_message(capfd):
+    depl_name = 'dummyexec'
+    addr = 'https://blah.wolf.jina.ai/'
+    f = Flow().add(host=addr, external=True, name=depl_name)
+    with pytest.raises(ConnectionError) as e:
+        with f:
+            f.post(inputs=[], on='/foo')
+
+    assert 'blah.wolf.jina.ai' in str(e.value)
+    assert depl_name in str(e.value)


### PR DESCRIPTION
Signed-off-by: Johannes Messner <messnerjo@gmail.com>

<!---Decomposing the complex issue into subtasks can help you build it step-by-step. Thanks for your pull request! :rocket: --->
<!---We know that dev life is hectic, but **please provide a (brief) description** of what your PR does, and how it does it. **Otherwise, your PR cannot be reviewed!** --->
<!---This policy was agreed upon in a past company retro, and makes everyone's life a little easier. Thanks for your collaboration!--->

**Goals:**
<!---https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword--->

When an external Executor/Flow is behind an API Gateway (which is the case for JCloud), but is down, then DNS resolution succeeds but a "resource" (the Exec/Flow) cannot be found, resulting in a gRPC error with `NOT_FOUND` code.

This error case was not properly handled **before,** giving output like the following:

![image](https://user-images.githubusercontent.com/44071807/214031911-11c77c7a-3b02-44f9-a319-ba41088a4334.png)

The user had no way of knowing what part of the Flow failed.

**After** this PR, the affected deployment and its address will be displayed:

```console
ERROR  gateway/rep-0/GatewayRuntime@123711 Error while       [01/23/23 12:35:15]
       getting responses from deployments: no Route matched                     
       with those values                                                        
       trailing_metadata=Metadata((('date', 'Mon, 23 Jan                        
       2023 11:35:15 GMT'), ('content-length', '0'),                            
       ('x-kong-response-latency', '0'), ('server',                             
       'kong/3.0.2')))                                                          
       trailing_metadata=Metadata((('date', 'Mon, 23 Jan                        
       2023 11:35:15 GMT'), ('content-length', '0'),                            
       ('x-kong-response-latency', '0'), ('server',                             
       'kong/3.0.2')))                                                          
       |Gateway: Connection error with deployment                               
       `executor0` at address(es) {'blah.wolf.jina.ai'}.                        
       Connection with {'blah.wolf.jina.ai'} succeeded, but                     
       `executor0` was not found. Possibly `executor0` is                       
       behind an API gateway but not reachable.                                 
       trailing_metadata=Metadata((('date', 'Mon, 23 Jan                        
       2023 11:35:15 GMT'), ('content-length', '0'),                            
       ('x-kong-response-latency', '0'), ('server',                             
       'kong/3.0.2')))
```

**TODO:**

- [x] add a test

- resolves #5613 
- [x] check and update documentation. See [guide](https://github.com/jina-ai/jina/blob/master/CONTRIBUTING.md#-contributing-documentation) and ask the team.
