### PR TITLE
fix: clean up open telemetry resources in the Flow context manager exit procedure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -371,6 +371,11 @@ jobs:
         id: test
         run: |
           pytest --suppress-no-test-exit-code --force-flaky --min-passes 1 --max-runs 5 --cov=jina --cov-report=xml --timeout=600 -v -s --ignore-glob='tests/integration/hub_usage/dummyhub*' ${{ matrix.test-path }}
+          if [[ "${{ matrix.test-path }}" == *"tests/integration/instrumentation/" ]]
+          then
+            echo "sleeping to let open telemetry export daemon thread expire by itself"
+            sleep 2
+          fi 
 
           echo "flag it as jina for codeoverage"
           echo "codecov_flag=jina" >> $GITHUB_OUTPUT

--- a/jina/orchestrate/flow/base.py
+++ b/jina/orchestrate/flow/base.py
@@ -1751,6 +1751,7 @@ class Flow(
         super().__exit__(exc_type, exc_val, exc_tb)
         if self._client:
             self._client.teardown_instrumentation()
+            self._client = None
 
         # unset all envs to avoid any side-effect
         if self.args.env:


### PR DESCRIPTION
<!---Decomposing the complex issue into subtasks can help you build it step-by-step. Thanks for your pull request! :rocket: --->
<!---We know that dev life is hectic, but **please provide a (brief) description** of what your PR does, and how it does it. **Otherwise, your PR cannot be reviewed!** --->
<!---This policy was agreed upon in a past company retro, and makes everyone's life a little easier. Thanks for your collaboration!--->

**Goals:**
<!---https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword--->

- resolves #5545 
- Add instrumentation teardown method to `BaseClient` so that the relevant tracer and metrics provider are correctly cleaned up.
  - This is required because the tracer/metrics exporter starts a daemon thread to export metrics data in batches.
  - The daemon thread is cleaned up using the `shutdown` method or if the program exits using the `atexit` module.
  - The client teardown method is required especially for the test suite because every Flow that is started, creates a client on every `post` method which in turn instantiates a unique tracer/meter provider. The Flow context manager is not cleaning up the instrumentation resources created by the client which would leave open a lot of daemon threads until the test execution completes. 
  - The Flow now lazily creates a client and reuses the client which can be cleaned up correctly.
- In addition a sleep time of 2 seconds is added to allow the daemon thread to shutdown which also contains a max 64 second exponential back off retry logic in the shut down phase. 
- The `BaseClient.teardown_instrumentation` method is mostly required if a program is creating a lot of Flows and using `Flow.post` method the Flow context.
