### PR TITLE
fix: pass extra arguments to gateway runtime with container pod

### DIFF
--- a/jina/orchestrate/pods/container.py
+++ b/jina/orchestrate/pods/container.py
@@ -2,10 +2,10 @@ import argparse
 import asyncio
 import copy
 import multiprocessing
-import threading
 import os
 import re
 import signal
+import threading
 import time
 from typing import TYPE_CHECKING, Dict, Optional, Union
 
@@ -21,6 +21,7 @@ from jina.orchestrate.pods.container_helper import (
     get_docker_network,
     get_gpu_device_requests,
 )
+from jina.parsers import set_gateway_parser
 from jina.serve.runtimes.asyncio import AsyncNewLoopRuntime
 from jina.serve.runtimes.gateway import GatewayRuntime
 
@@ -74,9 +75,15 @@ def _docker_run(
 
     args.native = True
 
+    parser = (
+        set_gateway_parser()
+        if args.pod_role == PodRoleType.GATEWAY
+        else set_pod_parser()
+    )
+
     non_defaults = ArgNamespace.get_non_defaults_args(
         args,
-        set_pod_parser(),
+        parser,
         taboo={
             'uses',
             'entrypoint',

--- a/tests/unit/orchestrate/pods/container/custom-gateway/dummy_gateway.py
+++ b/tests/unit/orchestrate/pods/container/custom-gateway/dummy_gateway.py
@@ -42,6 +42,13 @@ class DummyGateway(Gateway):
                 'arg3': self.arg3,
             }
 
+        @app.get(path='/runtime_info')
+        def _get_info():
+            return {
+                'ports': self.ports,
+                'protocols': self.protocols,
+            }
+
         @app.get(
             path='/stream',
             response_model=ProcessedResponseModel,

--- a/tests/unit/orchestrate/pods/container/test_container_pod.py
+++ b/tests/unit/orchestrate/pods/container/test_container_pod.py
@@ -2,9 +2,11 @@ import os
 import time
 
 import pytest
+import requests
 
 from jina import Flow
 from jina.constants import __cache_path__
+from jina.enums import GatewayProtocolType
 from jina.excepts import RuntimeFailToStart
 from jina.helper import random_port
 from jina.orchestrate.pods.container import ContainerPod
@@ -272,6 +274,11 @@ def test_container_pod_custom_gateway(dummy_custom_gateway_docker_image_built):
         _validate_dummy_custom_gateway_response(
             port, {'arg1': 'hello', 'arg2': 'world', 'arg3': 'default-arg3'}
         )
+
+        # validate protocol inside the gateway
+        resp = requests.get(f'http://127.0.0.1:{port}/runtime_info').json()
+        assert resp['protocols'] == [GatewayProtocolType.HTTP]
+        assert resp['ports'] == [int(port)]
 
         time.sleep(
             2


### PR DESCRIPTION
In case a custom gateway is started using the container pod, Jina will not pass some arguments to the container entrypoint (due to differences between a normal pod and a gateway pod).
This means that if a Gateway implementation needs to know its protocol (for instance, the composite gateway), the overridden protocol will not reach the runtime.
This PR fixes this issue and adds coverage in the tests