### PR TITLE
feat: refactor streamer.stream method to yield reponse and executor error

### DIFF
--- a/docs/concepts/gateway/customization.md
+++ b/docs/concepts/gateway/customization.md
@@ -245,7 +245,7 @@ async def get(text: str):
             errors.append(error)
         else:
             results.append(docs[0].text)
-    return {'results': results, errors=[error.name for error in errors]}
+    return {'results': results, 'errors': [error.name for error in errors]}
 ```
 
 (executor-streamer)=

--- a/docs/concepts/gateway/customization.md
+++ b/docs/concepts/gateway/customization.md
@@ -224,7 +224,7 @@ class MyGateway(FastAPIBaseGateway):
         return app
 ```
 
-### Recovering Executor error
+### Recovering Executor errors
 Exceptions raised by an `Executor` are captured in the server object which can be extracted by using the {meth}`jina.serve.streamer.stream()` method. The `stream` method
 returns an `AsyncGenerator` of a tuple of `DocumentArray` and an optional {class}`jina.excepts.ExecutorError` class that be used to check if the `Executor` has issues processing the input request.
 The error can be utilized for retries, handling partial responses or returning default responses.

--- a/docs/concepts/gateway/customization.md
+++ b/docs/concepts/gateway/customization.md
@@ -224,6 +224,30 @@ class MyGateway(FastAPIBaseGateway):
         return app
 ```
 
+### Recovering executor error
+Exceptions raised by an `Executor` are captured in the server object which can be extracted by using the {meth}`jina.serve.streamer.stream()` method. The `stream` method
+returns an `AsyncGenerator` of a tuple of `DocumentArray` and an optional {class}`jina.excepts.ExecutorError` class that be used to check if the `Executor` has issues processing the input request.
+The error can be utilized for retries, handling partial responses or returning default responses.
+
+```{code-block} python
+---
+emphasize-lines: 5, 6, 7, 8, 9, 10, 11, 12
+---
+@app.get("/endpoint")
+async def get(text: str):
+    results = []
+    errors = []
+    async for docs, error in self.streamer.stream(
+        docs=DocumentArray([Document(text=text)]),
+        exec_endpoint='/',
+    ):
+        if error:
+            errors.append(error)
+        else:
+            results.append(docs[0].text)
+    return {'results': results, errors=[error.name for error in errors]}
+```
+
 (executor-streamer)=
 ## Calling an individual Executor
 An `executor` object is injected by Jina to your gateway class which allows you to call individual Executors from the Gateway.

--- a/docs/concepts/gateway/customization.md
+++ b/docs/concepts/gateway/customization.md
@@ -224,7 +224,7 @@ class MyGateway(FastAPIBaseGateway):
         return app
 ```
 
-### Recovering executor error
+### Recovering Executor error
 Exceptions raised by an `Executor` are captured in the server object which can be extracted by using the {meth}`jina.serve.streamer.stream()` method. The `stream` method
 returns an `AsyncGenerator` of a tuple of `DocumentArray` and an optional {class}`jina.excepts.ExecutorError` class that be used to check if the `Executor` has issues processing the input request.
 The error can be utilized for retries, handling partial responses or returning default responses.

--- a/jina/excepts.py
+++ b/jina/excepts.py
@@ -1,5 +1,5 @@
 """This modules defines all kinds of exceptions raised in Jina."""
-from typing import Set, Union
+from typing import List, Optional, Set, Union
 
 import grpc.aio
 
@@ -145,3 +145,56 @@ class InternalNetworkError(grpc.aio.AioRpcError, BaseJinaException):
                 return self._details
 
         return self.og_exception.details()
+
+
+class ExecutorError(RuntimeError, BaseJinaException):
+    """Used to wrap the underlying Executor error that is serialized as a jina_pb2.StatusProto.ExceptionProto.
+    This class is mostly used to propagate the Executor error to the user. The user can decide to act on the error as
+    desired.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        args: List[str],
+        stacks: List[str],
+        executor: Optional[str] = None,
+    ):
+        self._name = name
+        self._args = args
+        self._stacks = stacks
+        self._executor = executor
+
+    @property
+    def name(self) -> str:
+        """
+        :return: the name of the Executor exception
+        """
+        return self._name
+
+    @property
+    def args(self) -> List[str]:
+        """
+        :return: a list of arguments used to construct the exception
+        """
+        return self._args
+
+    @property
+    def stacks(self) -> List[str]:
+        """
+        :return: a list of strings that contains the exception traceback
+        """
+        return self._stacks
+
+    @property
+    def executor(self) -> Optional[str]:
+        """
+        :return: the name of the executor that raised the exception if available
+        """
+        return self._executor
+
+    def __str__(self):
+        return "\n".join(self.stacks)
+
+    def __repr__(self):
+        return self.__str__()

--- a/jina/serve/runtimes/gateway/grpc/gateway.py
+++ b/jina/serve/runtimes/gateway/grpc/gateway.py
@@ -159,7 +159,7 @@ class GRPCGateway(BaseGateway):
         :param kwargs: keyword arguments
         :yield: responses to the request after streaming to Executors in Flow
         """
-        async for resp in self.streamer.stream(
+        async for resp in self.streamer.rpc_stream(
             request_iterator=request_iterator, context=context, *args, **kwargs
         ):
             yield resp

--- a/jina/serve/runtimes/gateway/http/app.py
+++ b/jina/serve/runtimes/gateway/http/app.py
@@ -378,7 +378,7 @@ def get_fastapi_app(
         :param request_iterator: request iterator, with length of 1
         :return: the first result from the request iterator
         """
-        async for result in streamer.stream(request_iterator=request_iterator):
+        async for result in streamer.rpc_stream(request_iterator=request_iterator):
             result_dict = result.to_dict()
             return result_dict
 

--- a/jina/serve/runtimes/gateway/websocket/app.py
+++ b/jina/serve/runtimes/gateway/websocket/app.py
@@ -1,4 +1,3 @@
-import argparse
 from typing import TYPE_CHECKING, Any, AsyncIterator, Dict, List, Optional, Union
 
 from jina.clients.request import request_generator
@@ -185,7 +184,7 @@ def get_fastapi_app(
                         yield DataRequest(request)
 
         try:
-            async for msg in streamer.stream(request_iterator=req_iter()):
+            async for msg in streamer.rpc_stream(request_iterator=req_iter()):
                 await manager.send(websocket, msg)
         except InternalNetworkError as err:
             import grpc
@@ -215,7 +214,7 @@ def get_fastapi_app(
         :param request_iterator: request iterator, with length of 1
         :return: the first result from the request iterator
         """
-        async for k in streamer.stream(request_iterator=request_iterator):
+        async for k in streamer.rpc_stream(request_iterator=request_iterator):
             request_dict = k.to_dict()
             return request_dict
 
@@ -266,7 +265,7 @@ def get_fastapi_app(
 
         da = DocumentArray([])
         try:
-            async for _ in streamer.stream(
+            async for _ in streamer.rpc_stream(
                 request_iterator=request_generator(
                     exec_endpoint=__dry_run_endpoint__,
                     data=da,

--- a/jina/serve/streamer.py
+++ b/jina/serve/streamer.py
@@ -166,16 +166,16 @@ class GatewayStreamer:
         results_in_order: bool = False,
     ) -> AsyncIterator[Tuple[Union[DocumentArray, 'Request'], 'ExecutorError']]:
         """
-        stream documents and yield responses and unpacked executor exception if any.
+        stream Documents and yield Documents or Responses and unpacked Executor error if any.
 
         :param docs: The Documents to be sent to all the Executors
         :param request_size: The amount of Documents to be put inside a single request.
         :param return_results: If set to True, the generator will yield Responses and not `DocumentArrays`
-        :param exec_endpoint: The executor endpoint to which to send the Documents
+        :param exec_endpoint: The Executor endpoint to which to send the Documents
         :param target_executor: A regex expression indicating the Executors that should receive the Request
         :param parameters: Parameters to be attached to the Requests
         :param results_in_order: return the results in the same order as the request_iterator
-        :yield: tuple of response and error from Executors
+        :yield: tuple of Documents or Responses and unpacked error from Executors if any
         """
         async for result in self.stream_docs(
             docs=docs,
@@ -217,7 +217,7 @@ class GatewayStreamer:
         :param docs: The Documents to be sent to all the Executors
         :param request_size: The amount of Documents to be put inside a single request.
         :param return_results: If set to True, the generator will yield Responses and not `DocumentArrays`
-        :param exec_endpoint: The executor endpoint to which to send the Documents
+        :param exec_endpoint: The Executor endpoint to which to send the Documents
         :param target_executor: A regex expression indicating the Executors that should receive the Request
         :param parameters: Parameters to be attached to the Requests
         :param results_in_order: return the results in the same order as the request_iterator

--- a/jina/serve/streamer.py
+++ b/jina/serve/streamer.py
@@ -191,11 +191,11 @@ class GatewayStreamer:
                     stacks=exception.stacks,
                     executor=exception.executor,
                 )
-            if not return_responses:
+            if return_responses:
+                yield result, error
+            else:
                 result.document_array_cls = return_type
                 yield result.data.docs, error
-            else:
-                yield result, error
 
     async def stream_docs(
         self,

--- a/tests/unit/serve/runtimes/gateway/grpc/test_grpc_gateway_runtime.py
+++ b/tests/unit/serve/runtimes/gateway/grpc/test_grpc_gateway_runtime.py
@@ -162,7 +162,7 @@ async def _test(streamer, stream):
     responses = []
     req = request_generator('/', DocumentArray([Document(text='client0-Request')]))
     if stream:
-        async for resp in streamer.stream(request_iterator=req):
+        async for resp in streamer.rpc_stream(request_iterator=req):
             responses.append(resp)
     else:
         for req in request_generator(

--- a/tests/unit/yaml/dummy_fastapi_gateway.py
+++ b/tests/unit/yaml/dummy_fastapi_gateway.py
@@ -57,7 +57,7 @@ class DummyFastAPIGateway(FastAPIBaseGateway):
         )
         async def _process(text: str):
             doc = None
-            async for req in self.streamer.stream(
+            async for req in self.streamer.rpc_stream(
                 request_generator(
                     exec_endpoint='/',
                     data=DocumentArray([Document(text=text)]),


### PR DESCRIPTION
<!---Decomposing the complex issue into subtasks can help you build it step-by-step. Thanks for your pull request! :rocket: --->
<!---We know that dev life is hectic, but **please provide a (brief) description** of what your PR does, and how it does it. **Otherwise, your PR cannot be reviewed!** --->
<!---This policy was agreed upon in a past company retro, and makes everyone's life a little easier. Thanks for your collaboration!--->

**Goals:**
<!---https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword--->

- resolves #5646 
- rename existing `stream` method that implements the gRPC Call stream method to `rpc_stream`.
- create a new `stream` method that accepts an request iterator and yields a tuple of response and the underlying Executor error.
  - The `ExecutorError` class is used to wrap the `jina_pb2.StatusProto.ExceptionProto` information so that the user can raise the exception if necessary.  
- The new `stream` method doesn't catch all types of exceptions. Exceptions from the`stream` method will be raised.
- [ ] check and update documentation. See [guide](https://github.com/jina-ai/jina/blob/master/CONTRIBUTING.md#-contributing-documentation) and ask the team.
