### PR TITLE
fix: fix usage with CUDA_VISIBLE_DEVICES

### DIFF
--- a/jina/orchestrate/deployments/__init__.py
+++ b/jina/orchestrate/deployments/__init__.py
@@ -1075,7 +1075,11 @@ class Deployment(PostMixin, BaseOrchestrator):
 
         cuda_device_map = None
         if self.args.env or os.environ.get('CUDA_VISIBLE_DEVICES', '').startswith('RR'):
-            cuda_visible_devices = self.args.env.get('CUDA_VISIBLE_DEVICES') if self.args.env and 'CUDA_VISIBLE_DEVICES' in self.args.env else os.environ.get('CUDA_VISIBLE_DEVICES', None)
+            cuda_visible_devices = (
+                self.args.env.get('CUDA_VISIBLE_DEVICES')
+                if self.args.env and 'CUDA_VISIBLE_DEVICES' in self.args.env
+                else os.environ.get('CUDA_VISIBLE_DEVICES', None)
+            )
             cuda_device_map = Deployment._roundrobin_cuda_device(
                 cuda_visible_devices, replicas
             )

--- a/jina/orchestrate/deployments/__init__.py
+++ b/jina/orchestrate/deployments/__init__.py
@@ -1035,7 +1035,7 @@ class Deployment(PostMixin, BaseOrchestrator):
         return all_devices[slice(*[int(p) if p else None for p in parts])]
 
     @staticmethod
-    def _roundrobin_cuda_device(device_str: str, replicas: int):
+    def _roundrobin_cuda_device(device_str: Optional[str], replicas: int):
         """Parse cuda device string with RR prefix
 
         :param device_str: `RRm:n`, where `RR` is the prefix, m:n is python slice format
@@ -1074,9 +1074,10 @@ class Deployment(PostMixin, BaseOrchestrator):
         sharding_enabled = shards and shards > 1
 
         cuda_device_map = None
-        if self.args.env:
+        if self.args.env or os.environ.get('CUDA_VISIBLE_DEVICES', '').startswith('RR'):
+            cuda_visible_devices = self.args.env.get('CUDA_VISIBLE_DEVICES') if self.args.env and 'CUDA_VISIBLE_DEVICES' in self.args.env else os.environ.get('CUDA_VISIBLE_DEVICES', None)
             cuda_device_map = Deployment._roundrobin_cuda_device(
-                self.args.env.get('CUDA_VISIBLE_DEVICES'), replicas
+                cuda_visible_devices, replicas
             )
 
         for shard_id in range(shards):
@@ -1095,6 +1096,7 @@ class Deployment(PostMixin, BaseOrchestrator):
                     _args.host = self.args.host
 
                 if cuda_device_map:
+                    _args.env = _args.env or {}
                     _args.env['CUDA_VISIBLE_DEVICES'] = str(cuda_device_map[replica_id])
 
                 if _args.name:

--- a/jina_cli/autocomplete.py
+++ b/jina_cli/autocomplete.py
@@ -221,7 +221,7 @@ ac_table = {
         'cloud login': ['--help'],
         'cloud logout': ['--help'],
         'cloud deploy': ['--help'],
-        'cloud normalize': ['--help'],
+        'cloud normalize': ['--help', '--output', '--verbose'],
         'cloud list': ['--help', '--phase', '--name'],
         'cloud status': ['--help', '--verbose'],
         'cloud remove': ['--help'],

--- a/tests/integration/rr_cuda/test_rr_cuda.py
+++ b/tests/integration/rr_cuda/test_rr_cuda.py
@@ -1,0 +1,56 @@
+import os
+
+import pytest
+
+from jina import Flow, Executor, requests, DocumentArray, Document
+
+
+@pytest.fixture()
+def cuda_total_devices(request):
+    old_cuda_total_devices = os.environ.get('CUDA_TOTAL_DEVICES', None)
+    os.environ['CUDA_TOTAL_DEVICES'] = str(request.param)
+    yield
+    if old_cuda_total_devices is not None:
+        os.environ['CUDA_TOTAL_DEVICES'] = old_cuda_total_devices
+    else:
+        os.unsetenv('CUDA_TOTAL_DEVICES')
+
+
+@pytest.fixture()
+def cuda_visible_devices(request):
+    old_cuda_total_devices = os.environ.get('CUDA_VISIBLE_DEVICES', None)
+    if request.param is not None:
+        os.environ['CUDA_VISIBLE_DEVICES'] = str(request.param)
+    yield
+    if old_cuda_total_devices is not None:
+        os.environ['CUDA_VISIBLE_DEVICES'] = old_cuda_total_devices
+    else:
+        os.unsetenv('CUDA_VISIBLE_DEVICES')
+
+
+@pytest.mark.parametrize(
+    'cuda_total_devices, cuda_visible_devices, env',
+    [
+        [3, 'RR', None], [3, None, {'CUDA_VISIBLE_DEVICES': 'RR'}]
+    ],
+    indirect=['cuda_total_devices', 'cuda_visible_devices'],
+)
+def test_cuda_assignment(cuda_total_devices, cuda_visible_devices, env):
+    class MyCUDAUserExecutor(Executor):
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+            self.cuda_visible_devices = os.environ['CUDA_VISIBLE_DEVICES']
+
+        @requests
+        def foo(self, **kwargs):
+            return DocumentArray([Document(tags={'cuda_visible_devices': str(self.cuda_visible_devices)})])
+
+    f = Flow().add(uses=MyCUDAUserExecutor, env=env or {}, replicas=3)
+    with f:
+        ret = f.post(on='/', inputs=DocumentArray.empty(50), request_size=1)
+        cuda_visible_devices = set([doc.tags['cuda_visible_devices'] for doc in ret])
+
+    assert cuda_visible_devices == {'0', '1', '2'}
+
+
+


### PR DESCRIPTION
**Goals:**
What is promised in this documentation section (https://docs.jina.ai/concepts/flow/scale-out/#replicate-on-multiple-gpus) does not work when CUDA_VISIBLE_DEVICES env var is not provided in env args

Should solve #5653  and perhaps #5652


