### PR TITLE
feat: generate k8s job from Deployment

### DIFF
--- a/jina/orchestrate/deployments/__init__.py
+++ b/jina/orchestrate/deployments/__init__.py
@@ -1562,4 +1562,4 @@ class Deployment(PostMixin, BaseOrchestrator):
         filename = os.path.join(output_base_path, f'{name}.json')
         os.makedirs(output_base_path, exist_ok=True)
         with open(filename, 'w+') as fp:
-            fp.write(job.to_str())
+            fp.write(job.to_str().replace('\'', '"'))


### PR DESCRIPTION
Generate a k8s job resource for running a one time batch job from a Deployment.

```python
from jina import Executor

batch_job = Deployment(name='batch-inference', uses='jinahub+docker://SimpleIndexer')
batch_job.to_kubernetes_job(output_base_path='.')
```

Verbose output json 
```json
{"api_version": "batch/v1",
 "kind": "Job",
 "metadata": {"annotations": None,
              "creation_timestamp": None,
              "deletion_grace_period_seconds": None,
              "deletion_timestamp": None,
              "finalizers": None,
              "generate_name": None,
              "generation": None,
              "labels": None,
              "managed_fields": None,
              "name": "job0",
              "namespace": None,
              "owner_references": None,
              "resource_version": None,
              "self_link": None,
              "uid": None},
 "spec": {"active_deadline_seconds": None,
          "backoff_limit": 0,
          "completion_mode": None,
          "completions": None,
          "manual_selector": None,
          "parallelism": None,
          "pod_failure_policy": None,
          "selector": None,
          "suspend": None,
          "template": {"metadata": {"annotations": None,
                                    "creation_timestamp": None,
                                    "deletion_grace_period_seconds": None,
                                    "deletion_timestamp": None,
                                    "finalizers": None,
                                    "generate_name": None,
                                    "generation": None,
                                    "labels": {"app": "batch-inference"},
                                    "managed_fields": None,
                                    "name": None,
                                    "namespace": None,
                                    "owner_references": None,
                                    "resource_version": None,
                                    "self_link": None,
                                    "uid": None},
                       "spec": {"active_deadline_seconds": None,
                                "affinity": None,
                                "automount_service_account_token": None,
                                "containers": [{"args": ["executor",
                                                         "--name",
                                                         "batch-inference",
                                                         "--uses",
                                                         "config.yml",
                                                         "--port",
                                                         "61751",
                                                         "--port-monitoring",
                                                         "55899",
                                                         "--native"],
                                                "command": ["jina"],
                                                "env": None,
                                                "env_from": None,
                                                "image": "jinahub+docker://SimpleIndexer",
                                                "image_pull_policy": None,
                                                "lifecycle": None,
                                                "liveness_probe": None,
                                                "name": "batch-inference",
                                                "ports": None,
                                                "readiness_probe": None,
                                                "resources": None,
                                                "security_context": None,
                                                "startup_probe": None,
                                                "stdin": None,
                                                "stdin_once": None,
                                                "termination_message_path": None,
                                                "termination_message_policy": None,
                                                "tty": None,
                                                "volume_devices": None,
                                                "volume_mounts": None,
                                                "working_dir": None}],
                                "dns_config": None,
                                "dns_policy": None,
                                "enable_service_links": None,
                                "ephemeral_containers": None,
                                "host_aliases": None,
                                "host_ipc": None,
                                "host_network": None,
                                "host_pid": None,
                                "host_users": None,
                                "hostname": None,
                                "image_pull_secrets": None,
                                "init_containers": None,
                                "node_name": None,
                                "node_selector": None,
                                "os": None,
                                "overhead": None,
                                "preemption_policy": None,
                                "priority": None,
                                "priority_class_name": None,
                                "readiness_gates": None,
                                "restart_policy": "Never",
                                "runtime_class_name": None,
                                "scheduler_name": None,
                                "security_context": None,
                                "service_account": None,
                                "service_account_name": None,
                                "set_hostname_as_fqdn": None,
                                "share_process_namespace": None,
                                "subdomain": None,
                                "termination_grace_period_seconds": None,
                                "tolerations": None,
                                "topology_spread_constraints": None,
                                "volumes": None}},
          "ttl_seconds_after_finished": None},
 "status": None}
```