### PR TITLE
Fix v2 docarray optional

### DIFF
--- a/jina/serve/executors/__init__.py
+++ b/jina/serve/executors/__init__.py
@@ -112,6 +112,7 @@ class _FunctionWithSchema(NamedTuple):
     def get_function_with_schema(fn: Callable) -> T:
 
         docs_annotation = fn.__annotations__.get('docs', None)
+
         if type(docs_annotation) is str:
             warnings.warn(
                 f'`docs` annotation must be a type hint, got {docs_annotation}'
@@ -119,13 +120,28 @@ class _FunctionWithSchema(NamedTuple):
                 'DocumentArray will be used instead.'
             )
             docs_annotation = None
+        elif not isinstance(docs_annotation, type):
+            warnings.warn(
+                f'`docs` annotation must be a class if you want to use it'
+                f'as schema input, got {docs_annotation}, fallback to default behavior'
+                ''
+            )
+            docs_annotation = None
 
         return_annotation = fn.__annotations__.get('return', None)
+
         if type(return_annotation) is str:
             warnings.warn(
-                f'`docs` annotation must be a type hint, got {return_annotation}'
+                f'`return` annotation must be a type hint, got {return_annotation}'
                 ' instead, you should maybe remove the string annotation. Default value'
                 'DocumentArray will be used instead.'
+            )
+            return_annotation = None
+        elif not isinstance(return_annotation, type):
+            warnings.warn(
+                f'`return` annotation must be a class if you want to use it'
+                f'as schema input, got {docs_annotation}, fallback to default behavior'
+                ''
             )
             return_annotation = None
 

--- a/tests/integration/issues/test_5661.py
+++ b/tests/integration/issues/test_5661.py
@@ -1,0 +1,15 @@
+from typing import Optional
+
+from docarray import Document, DocumentArray
+
+from jina import Executor, Flow, requests
+
+
+def test_optional_type_hint():
+    class MyExec(Executor):
+        @requests
+        def foo(self, docs: Optional[DocumentArray], **kwargs):
+            return docs
+
+    with Flow().add(uses=MyExec) as f:
+        f.post('/', inputs=Document())


### PR DESCRIPTION
# Context

This pr adds a default fallback if the type hint of the Executor is not correct.

this fix : https://github.com/jina-ai/jina/issues/5661