### PR TITLE
fix: remove warning when return type hint is none in exec

### DIFF
--- a/jina/serve/executors/__init__.py
+++ b/jina/serve/executors/__init__.py
@@ -113,7 +113,9 @@ class _FunctionWithSchema(NamedTuple):
 
         docs_annotation = fn.__annotations__.get('docs', None)
 
-        if type(docs_annotation) is str:
+        if docs_annotation is None:
+            pass
+        elif type(docs_annotation) is str:
             warnings.warn(
                 f'`docs` annotation must be a type hint, got {docs_annotation}'
                 ' instead, you should maybe remove the string annotation. Default value'
@@ -131,7 +133,9 @@ class _FunctionWithSchema(NamedTuple):
 
         return_annotation = fn.__annotations__.get('return', None)
 
-        if type(return_annotation) is str:
+        if return_annotation is None:
+            pass
+        elif type(return_annotation) is str:
             warnings.warn(
                 f'`return` annotation must be a class if you want to use it'
                 f'as schema input, got {docs_annotation}. try to remove the Optional'


### PR DESCRIPTION
# Context



remove warning with this code :
```python
from typing import Optional

from jina import Executor, Flow, requests
from docarray import DocumentArray, Document


class MyExec(Executor):
    @requests
    def foo(self, docs: DocumentArray, **kwargs):
        return docs


with Flow().add(uses=MyExec) as f:
    f.post('/', inputs=Document())
```

![Screenshot from 2023-02-08 11-44-04](https://user-images.githubusercontent.com/55492238/217507787-f2b70cd1-d43e-4c0a-8567-862fe50a2cb3.png)
