### PR TITLE
fix(performance): preserve lazy loading in worker request handler

### DIFF
--- a/jina/serve/runtimes/worker/request_handling.py
+++ b/jina/serve/runtimes/worker/request_handling.py
@@ -310,20 +310,22 @@ class WorkerRequestHandler:
                 )
                 self._request_size_histogram.record(req.nbytes, attributes=attributes)
 
-    def _record_docs_processed_monitoring(self, requests, docs):
+    def _record_docs_processed_monitoring(self, requests):
         if self._document_processed_metrics:
             self._document_processed_metrics.labels(
                 requests[0].header.exec_endpoint,
                 self._executor.__class__.__name__,
                 self.args.name,
-            ).inc(len(docs))
+            ).inc(len(requests[0].docs))
         if self._document_processed_counter:
             attributes = WorkerRequestHandler._metric_attributes(
                 requests[0].header.exec_endpoint,
                 self._executor.__class__.__name__,
                 self.args.name,
             )
-            self._document_processed_counter.add(len(docs), attributes=attributes)
+            self._document_processed_counter.add(
+                len(requests[0].docs), attributes=attributes
+            )
 
     def _record_response_size_monitoring(self, requests):
         if self._sent_response_size_metrics:
@@ -439,7 +441,7 @@ class WorkerRequestHandler:
         for req in requests:
             req.add_executor(self.deployment_name)
 
-        self._record_docs_processed_monitoring(requests, requests[0].docs)
+        self._record_docs_processed_monitoring(requests)
         self._record_response_size_monitoring(requests)
 
         return requests[0]

--- a/jina/serve/runtimes/worker/request_handling.py
+++ b/jina/serve/runtimes/worker/request_handling.py
@@ -316,7 +316,11 @@ class WorkerRequestHandler:
                 requests[0].header.exec_endpoint,
                 self._executor.__class__.__name__,
                 self.args.name,
-            ).inc(len(requests[0].docs))
+            ).inc(
+                len(requests[0].docs)
+            )  # TODO we can optimize here and access the
+            # lenght of the da without loading the da in memory
+
         if self._document_processed_counter:
             attributes = WorkerRequestHandler._metric_attributes(
                 requests[0].header.exec_endpoint,
@@ -325,7 +329,7 @@ class WorkerRequestHandler:
             )
             self._document_processed_counter.add(
                 len(requests[0].docs), attributes=attributes
-            )
+            )  # TODO same as above
 
     def _record_response_size_monitoring(self, requests):
         if self._sent_response_size_metrics:


### PR DESCRIPTION
# Context

In one of the monitoring function at the `WorkerRequestHandler` we take `docs` as input. Which means that we call `requests[0].docs` even if the monitoring is not enabled. This is a performance problem bc it means that we will never leverage the lazy loading feature of Jina

# What this PR do

refactor the code so that we avoid accessing docs when the monitoring is not enabled