### PR TITLE
feat: interoperability docarray v2 

### DIFF
--- a/docs/concepts/flow/deployment-args.md
+++ b/docs/concepts/flow/deployment-args.md
@@ -56,3 +56,4 @@
 | `external` | The Deployment will be considered an external Deployment that has been started independently from the Flow.This Deployment will not be context managed by the Flow. | `boolean` | `False` |
 | `grpc_metadata` | The metadata to be passed to the gRPC request. | `object` | `None` |
 | `tls` | If set, connect to deployment using tls encryption | `boolean` | `False` |
+| `field_map` |  | `object` | `{}` |

--- a/jina/orchestrate/deployments/__init__.py
+++ b/jina/orchestrate/deployments/__init__.py
@@ -138,6 +138,7 @@ class Deployment(JAMLCompatible, PostMixin, BaseOrchestrator, metaclass=Deployme
         env_from_secret: Optional[dict] = None,
         exit_on_exceptions: Optional[List[str]] = [],
         external: Optional[bool] = False,
+        field_map: Optional[dict] = {},
         floating: Optional[bool] = False,
         force_update: Optional[bool] = False,
         gpus: Optional[str] = None,
@@ -201,6 +202,7 @@ class Deployment(JAMLCompatible, PostMixin, BaseOrchestrator, metaclass=Deployme
         :param env_from_secret: The map of environment variables that are read from kubernetes cluster secrets
         :param exit_on_exceptions: List of exceptions that will cause the Executor to shut down.
         :param external: The Deployment will be considered an external Deployment that has been started independently from the Flow.This Deployment will not be context managed by the Flow.
+        :param field_map:
         :param floating: If set, the current Pod/Deployment can not be further chained, and the next `.add()` will chain after the last Pod/Deployment not this current one.
         :param force_update: If set, always pull the latest Hub Executor bundle even it exists on local
         :param gpus: This argument allows dockerized Jina Executors to discover local gpu devices.

--- a/jina/orchestrate/flow/base.py
+++ b/jina/orchestrate/flow/base.py
@@ -846,6 +846,7 @@ class Flow(
         env_from_secret: Optional[dict] = None,
         exit_on_exceptions: Optional[List[str]] = [],
         external: Optional[bool] = False,
+        field_map: Optional[dict] = {},
         floating: Optional[bool] = False,
         force_update: Optional[bool] = False,
         gpus: Optional[str] = None,
@@ -909,6 +910,7 @@ class Flow(
         :param env_from_secret: The map of environment variables that are read from kubernetes cluster secrets
         :param exit_on_exceptions: List of exceptions that will cause the Executor to shut down.
         :param external: The Deployment will be considered an external Deployment that has been started independently from the Flow.This Deployment will not be context managed by the Flow.
+        :param field_map:
         :param floating: If set, the current Pod/Deployment can not be further chained, and the next `.add()` will chain after the last Pod/Deployment not this current one.
         :param force_update: If set, always pull the latest Hub Executor bundle even it exists on local
         :param gpus: This argument allows dockerized Jina Executors to discover local gpu devices.
@@ -1059,6 +1061,7 @@ class Flow(
         :param env_from_secret: The map of environment variables that are read from kubernetes cluster secrets
         :param exit_on_exceptions: List of exceptions that will cause the Executor to shut down.
         :param external: The Deployment will be considered an external Deployment that has been started independently from the Flow.This Deployment will not be context managed by the Flow.
+        :param field_map:
         :param floating: If set, the current Pod/Deployment can not be further chained, and the next `.add()` will chain after the last Pod/Deployment not this current one.
         :param force_update: If set, always pull the latest Hub Executor bundle even it exists on local
         :param gpus: This argument allows dockerized Jina Executors to discover local gpu devices.

--- a/jina/parsers/orchestrate/deployment.py
+++ b/jina/parsers/orchestrate/deployment.py
@@ -70,5 +70,10 @@ def mixin_base_deployment_parser(parser):
     )
 
     gp.add_argument(
-        '--field-map', action=KVAppendAction, metavar='KEY: VALUE', nargs='*', help=''
+        '--field-map',
+        action=KVAppendAction,
+        metavar='KEY: VALUE',
+        nargs='*',
+        help='',
+        default={},
     )

--- a/jina/parsers/orchestrate/deployment.py
+++ b/jina/parsers/orchestrate/deployment.py
@@ -68,3 +68,7 @@ def mixin_base_deployment_parser(parser):
         default=False,
         help='If set, connect to deployment using tls encryption',
     )
+
+    gp.add_argument(
+        '--field-map', action=KVAppendAction, metavar='KEY: VALUE', nargs='*', help=''
+    )

--- a/jina/serve/executors/__init__.py
+++ b/jina/serve/executors/__init__.py
@@ -617,6 +617,7 @@ class BaseExecutor(JAMLCompatible, metaclass=ExecutorType):
         env_from_secret: Optional[dict] = None,
         exit_on_exceptions: Optional[List[str]] = [],
         external: Optional[bool] = False,
+        field_map: Optional[dict] = {},
         floating: Optional[bool] = False,
         force_update: Optional[bool] = False,
         gpus: Optional[str] = None,
@@ -680,6 +681,7 @@ class BaseExecutor(JAMLCompatible, metaclass=ExecutorType):
         :param env_from_secret: The map of environment variables that are read from kubernetes cluster secrets
         :param exit_on_exceptions: List of exceptions that will cause the Executor to shut down.
         :param external: The Deployment will be considered an external Deployment that has been started independently from the Flow.This Deployment will not be context managed by the Flow.
+        :param field_map:
         :param floating: If set, the current Pod/Deployment can not be further chained, and the next `.add()` will chain after the last Pod/Deployment not this current one.
         :param force_update: If set, always pull the latest Hub Executor bundle even it exists on local
         :param gpus: This argument allows dockerized Jina Executors to discover local gpu devices.

--- a/jina/serve/runtimes/worker/request_handling.py
+++ b/jina/serve/runtimes/worker/request_handling.py
@@ -403,6 +403,8 @@ class WorkerRequestHandler:
         except AttributeError:
             pass
 
+        requests[0].field_map_document_array = self.args.field_map
+
         if exec_endpoint in self._batchqueue_config:
             assert len(requests) == 1, 'dynamic batching does not support no_reduce'
 

--- a/jina/serve/runtimes/worker/request_handling.py
+++ b/jina/serve/runtimes/worker/request_handling.py
@@ -362,7 +362,7 @@ class WorkerRequestHandler:
                     f'The return type must be DocumentArray / Dict / `None`, '
                     f'but getting {return_data!r}'
                 )
-
+        requests[0].document_array_cls = DocumentArray
         WorkerRequestHandler.replace_docs(
             requests[0], docs, self.args.output_array_type
         )

--- a/jina/types/request/data.py
+++ b/jina/types/request/data.py
@@ -44,9 +44,16 @@ class DataRequest(Request):
                         self._content.docs_bytes
                     )
                 else:
-                    self._loaded_doc_array = self.document_array_cls.from_protobuf(
-                        self._content.docs
-                    )
+                    if docarray_v2:
+                        self._loaded_doc_array = (
+                            self.document_array_cls.from_protobuf_smart(
+                                self._content.docs
+                            )
+                        )
+                    else:
+                        self._loaded_doc_array = self.document_array_cls.from_protobuf(
+                            self._content.docs
+                        )
 
             return self._loaded_doc_array
 

--- a/jina_cli/autocomplete.py
+++ b/jina_cli/autocomplete.py
@@ -384,6 +384,7 @@ ac_table = {
             '--grpc-metadata',
             '--deployment-role',
             '--tls',
+            '--field-map',
         ],
         'client': [
             '--help',

--- a/tests/integration/docarray_v2/test_v2.py
+++ b/tests/integration/docarray_v2/test_v2.py
@@ -42,7 +42,9 @@ def test_send_custom_doc():
             docs[0].text = 'hello world'
 
     with Flow().add(uses=MyExec) as f:
-        doc = f.post(on='/foo', inputs=MyDoc(text='hello'))
+        doc = f.post(
+            on='/foo', inputs=MyDoc(text='hello'), return_type=DocumentArray[MyDoc]
+        )
         assert doc[0].text == 'hello world'
 
 
@@ -111,7 +113,7 @@ def test_different_output_input():
             inputs=InputDoc(img=Image(tensor=np.zeros(3))),
             return_type=DocumentArray[OutputDoc],
         )
-        assert docs[0].embedding.shape == 5
+        assert docs[0].embedding.shape == (5,)
         assert docs.__class__.document_type == OutputDoc
 
 

--- a/tests/integration/docarray_v2/test_v2.py
+++ b/tests/integration/docarray_v2/test_v2.py
@@ -101,17 +101,17 @@ def test_different_output_input():
             self, docs: DocumentArray[InputDoc], **kwargs
         ) -> DocumentArray[OutputDoc]:
             docs_return = DocumentArray[OutputDoc](
-                [OutputDoc(embedding=np.zeros((100, 1))) for _ in range(len(docs))]
+                [OutputDoc(embedding=np.zeros(5)) for _ in range(len(docs))]
             )
             return docs_return
 
     with Flow().add(uses=MyExec) as f:
         docs = f.post(
             on='/bar',
-            inputs=InputDoc(img=Image(tensor=np.zeros((3, 224, 224)))),
+            inputs=InputDoc(img=Image(tensor=np.zeros(3))),
             return_type=DocumentArray[OutputDoc],
         )
-        assert docs[0].embedding.shape == (100, 1)
+        assert docs[0].embedding.shape == 5
         assert docs.__class__.document_type == OutputDoc
 
 
@@ -158,10 +158,10 @@ def test_interoperability():
 
             for doc in docs:
                 assert doc.link == 'hello.png'
-                assert (doc.url == np.zeros((3, 224, 224))).all()
+                assert (doc.array == np.zeros(3)).all()
 
             docs_return = DocumentArray[OutputDoc](
-                [OutputDoc(embedding=np.zeros((100, 1))) for _ in range(len(docs))]
+                [OutputDoc(embedding=np.zeros(5)) for _ in range(len(docs))]
             )
             return docs_return
 
@@ -169,11 +169,11 @@ def test_interoperability():
         url: AnyUrl
         tensor: NdArray
 
-    with Deployment(uses=MyExec) as dep:
+    with Deployment(uses=MyExec, field_map={'url': 'link', 'tensor': 'array'}) as dep:
         docs = dep.post(
             on='/bar',
-            inputs=A(url='hello.png', tensor=np.zeros((3, 224, 224))),
+            inputs=A(url='hello.png', tensor=np.zeros(3)),
             return_type=DocumentArray[OutputDoc],
         )
-        assert docs[0].embedding.shape == (100, 1)
+        assert docs[0].embedding.shape == (5,)
         assert docs.__class__.document_type == OutputDoc

--- a/tests/integration/docarray_v2/test_v2.py
+++ b/tests/integration/docarray_v2/test_v2.py
@@ -148,7 +148,7 @@ def test_interoperability():
         array: NdArray
 
     class OutputDoc(BaseDocument):
-        embedding: AnyTensor
+        embedding: NdArray
 
     class MyExec(Executor):
         @requests(on='/bar')


### PR DESCRIPTION
# Context

this PR add schema field mapping feature from docarray v2 to ensure interoperability.

Relying on this pr : https://github.com/docarray/docarray/pull/1133


```python
    class InputDoc(BaseDocument):
        link: AnyUrl
        array: NdArray

    class OutputDoc(BaseDocument):
        embedding: NdArray

    class MyExec(Executor):
        @requests(on='/bar')
        def bar(
            self, docs: DocumentArray[InputDoc], **kwargs
        ) -> DocumentArray[OutputDoc]:

            for doc in docs:
                assert doc.link == 'hello.png'
                assert (doc.array == np.zeros(3)).all()

            docs_return = DocumentArray[OutputDoc](
                [OutputDoc(embedding=np.zeros(5)) for _ in range(len(docs))]
            )
            return docs_return

    class A(BaseDocument):
        url: AnyUrl
        tensor: NdArray

    with Deployment(uses=MyExec, field_map={'url': 'link', 'tensor': 'array'}) as dep:
        docs = dep.post(
            on='/bar',
            inputs=A(url='hello.png', tensor=np.zeros(3)),
            return_type=DocumentArray[OutputDoc],
        )
        assert docs[0].embedding.shape == (5,)
        assert docs.__class__.document_type == OutputDoc
```