### PR TITLE
chore: add warning when architectures do not match

### DIFF
--- a/jina/orchestrate/pods/container.py
+++ b/jina/orchestrate/pods/container.py
@@ -146,17 +146,11 @@ def _docker_run(
         ports = {f'{args.port}/tcp': args.port} if not net_mode else None
 
     if platform.system() == 'Darwin':
-        try:
-            host_processor_architecture = subprocess.check_output(['uname', '-p'])
-        except subprocess.CalledProcessError:
-            # assume it's an amd processor
-            host_processor_architecture = 'amd'
         image_architecture = client.images.get(uses_img).attrs.get('Architecture', '')
-        if not image_architecture.startswith(
-            'arm'
-        ) and host_processor_architecture.startswith('arm'):
+        if not image_architecture.startswith('arm'):
             logger.warning(
-                'Host machine uses an AMD processor but the container does not support this architecture'
+                'The pulled image container does not support ARM architecture while the host machine relies on MacOS (Darwin).'
+                'The image may run with poor performance or fail if run via emulation.'
             )
     docker_kwargs = args.docker_kwargs or {}
     container = client.containers.run(

--- a/jina/orchestrate/pods/container.py
+++ b/jina/orchestrate/pods/container.py
@@ -2,6 +2,8 @@ import argparse
 import asyncio
 import copy
 import multiprocessing
+import platform
+import subprocess
 import os
 import re
 import signal
@@ -143,6 +145,14 @@ def _docker_run(
     else:
         ports = {f'{args.port}/tcp': args.port} if not net_mode else None
 
+    if platform.system() == 'Darwin':
+        try:
+            host_processor_architecture = subprocess.check_output(['uname', '-p'])
+            image_architecture = client.images.get(uses_img).attrs["Architecture"]
+            if image_architecture.startswith('amd'):
+                pass
+        except:
+            pass
     docker_kwargs = args.docker_kwargs or {}
     container = client.containers.run(
         uses_img,


### PR DESCRIPTION
When an Executor container image is executed and the image does not support AMD architecture while the host machine uses MacOS (Darwin), the following warning will appear to the user:
<img width="1384" alt="image" src="https://user-images.githubusercontent.com/15269265/220885471-283d8dee-dc7b-41d6-8f67-fd4c32a7821d.png">
