### PR TITLE
chore: ignore dynamically generated protobuf docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -151,3 +151,6 @@ output/
 # kubernetes testing
 .pytest-kind
 .kube
+
+# dynamically generated protobuf docs
+docs/proto/docs.md


### PR DESCRIPTION
Every time we build the docs, we dynamically generate [the Protobuf documentation](https://docs.jina.ai/proto/docs/) in markdown (via `docs/Makefile`). It gets stored in the filesystem and it's easy to accidentally stage and push in git.

Since it's dynamically generated each time, we don't want/need it in the repo

**Goals:**

- Avoid accidentally committing unnecessary files.