### PR TITLE
fix: enable root logging always

### DIFF
--- a/jina/logging/logger.py
+++ b/jina/logging/logger.py
@@ -118,7 +118,6 @@ class JinaLogger:
         name: Optional[str] = None,
         log_config: Optional[str] = None,
         quiet: bool = False,
-        suppress_root_logging: bool = True,
         **kwargs,
     ):
 

--- a/jina/logging/logger.py
+++ b/jina/logging/logger.py
@@ -105,8 +105,6 @@ class JinaLogger:
 
     :param context: The context identifier of the class, module or method.
     :param log_config: The configuration file for the logger.
-    :param suppress_root_logging: Deprecated flag that determines whether to suppress root logging. Root logging is enabled by default.
-    configuration to group logs by deployment.
     :return:: an executor object.
     """
 

--- a/jina/logging/logger.py
+++ b/jina/logging/logger.py
@@ -105,7 +105,7 @@ class JinaLogger:
 
     :param context: The context identifier of the class, module or method.
     :param log_config: The configuration file for the logger.
-    :param suppress_root_logging: The flag determines whether to suppress root logging.
+    :param suppress_root_logging: Deprecated flag that determines whether to suppress root logging. Root logging is enabled by default.
     configuration to group logs by deployment.
     :return:: an executor object.
     """
@@ -132,11 +132,6 @@ class JinaLogger:
 
         if not name:
             name = os.getenv('JINA_DEPLOYMENT_NAME', context)
-
-        # Remove all handlers associated with the root logger object when suppress_root_logging is true.
-        if suppress_root_logging:
-            for handler in logging.root.handlers[:]:
-                logging.root.removeHandler(handler)
 
         self.logger = logging.getLogger(context)
         self.logger.propagate = False

--- a/scripts/get-openapi-schemas.py
+++ b/scripts/get-openapi-schemas.py
@@ -3,7 +3,7 @@ import json
 from jina.logging.logger import JinaLogger
 from jina.parsers import set_gateway_parser
 from jina.serve.runtimes.gateway.http.app import get_fastapi_app
-from jina.serve.streamer import GatewayStreamer
+from jina.serve.runtimes.gateway.streamer import GatewayStreamer
 
 JINA_LOGO_URL = 'https://api.jina.ai/logo/logo-product/jina-core/horizontal-layout/colored/Product%20logo_Core_vertical_colorful%402x-margin.png'
 GATEWAY_SCHEMA_FILENAME = 'gateway.json'

--- a/tests/unit/logging/test_logging.py
+++ b/tests/unit/logging/test_logging.py
@@ -47,15 +47,12 @@ def test_logging_default():
     with JinaLogger('test_logger') as logger:
         log(logger)
         assert len(logger.handlers) == 1
-    
+
     # test whether suppress root handlers
     logging.root.handlers.append(logging.StreamHandler(sys.stdout))
     with JinaLogger('test_logger', suppress_root_logging=False) as logger:
         log(logger)
         assert len(logging.root.handlers) > 0
-    with JinaLogger('test_logger') as logger:
-        log(logger)
-        assert len(logging.root.handlers) == 0
 
 
 def test_logging_level_yaml(monkeypatch):


### PR DESCRIPTION
**Goals:**
<!---https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword--->

- enable root logging always to allow DEBUG logging of other dependencies.

The current JINA_LOG_LEVEL controls the log level of the `JinaLogger`. Debug logging of other dependencies like urllib3 can be enabled by adding `logging.get_logger('urllib3').setLevel(logging.DEBUG)` at start of the Flow when running locally. This of course has limitations when deploying Gateway & Executors to the cloud.