### PR TITLE
fix: composite gateway tracing support

### DIFF
--- a/jina/serve/gateway.py
+++ b/jina/serve/gateway.py
@@ -9,6 +9,8 @@ from jina.serve.runtimes.gateway.request_handling import GatewayRequestHandler
 
 __all__ = ['BaseGateway']
 
+from jina.serve.runtimes.gateway.streamer import GatewayStreamer
+
 
 class GatewayType(type(JAMLCompatible), type):
     """The class of Gateway type, which is the metaclass of :class:`BaseGateway`."""
@@ -56,14 +58,16 @@ class BaseGateway(JAMLCompatible, metaclass=GatewayType):
     """
 
     def __init__(
-            self,
-            name: Optional[str] = 'gateway',
-            runtime_args: Optional[Dict] = None,
-            **kwargs,
+        self,
+        name: Optional[str] = 'gateway',
+        streamer: Optional[GatewayStreamer] = None,
+        runtime_args: Optional[Dict] = None,
+        **kwargs,
     ):
         """
         :param name: Gateway pod name
         :param runtime_args: a dict of arguments injected from :class:`Runtime` during runtime
+        :param streamer: GatewayStreamer object to be set if not None
         :param kwargs: additional extra keyword arguments to avoid failing when extra params ara passed that are not expected
         """
         self._add_runtime_args(runtime_args)
@@ -76,8 +80,7 @@ class BaseGateway(JAMLCompatible, metaclass=GatewayType):
         )
         self.logger = JinaLogger(self.name, **vars(self.runtime_args))
         self._request_handler = GatewayRequestHandler(
-            args=self.runtime_args,
-            logger=self.logger,
+            args=self.runtime_args, logger=self.logger, streamer=streamer
         )
         self.streamer = self._request_handler.streamer  # backward compatibility
         self.executor = self._request_handler.executor  # backward compatibility

--- a/jina/serve/gateway.py
+++ b/jina/serve/gateway.py
@@ -1,15 +1,16 @@
 import abc
 from types import SimpleNamespace
-from typing import Dict, Optional
+from typing import TYPE_CHECKING, Dict, Optional
 
 from jina.jaml import JAMLCompatible
 from jina.logging.logger import JinaLogger
 from jina.serve.helper import store_init_kwargs, wrap_func
 from jina.serve.runtimes.gateway.request_handling import GatewayRequestHandler
 
-__all__ = ['BaseGateway']
+if TYPE_CHECKING:
+    from jina.serve.runtimes.gateway.streamer import GatewayStreamer
 
-from jina.serve.runtimes.gateway.streamer import GatewayStreamer
+__all__ = ['BaseGateway']
 
 
 class GatewayType(type(JAMLCompatible), type):
@@ -60,7 +61,7 @@ class BaseGateway(JAMLCompatible, metaclass=GatewayType):
     def __init__(
         self,
         name: Optional[str] = 'gateway',
-        streamer: Optional[GatewayStreamer] = None,
+        streamer: Optional['GatewayStreamer'] = None,
         runtime_args: Optional[Dict] = None,
         **kwargs,
     ):

--- a/jina/serve/runtimes/gateway/composite/gateway.py
+++ b/jina/serve/runtimes/gateway/composite/gateway.py
@@ -22,9 +22,17 @@ class CompositeGateway(BaseGateway):
         self.gateways: List[BaseGateway] = []
         for port, protocol in zip(self.ports, self.protocols):
             gateway_cls = _get_gateway_class(protocol)
-            # ignore metrics_registry since it is not copyable
+            # ignore monitoring and tracing args since they are not copyable
+            print(self.runtime_args)
             runtime_args = self._deepcopy_with_ignore_attrs(
-                self.runtime_args, ['metrics_registry']
+                self.runtime_args,
+                [
+                    'metrics_registry',
+                    'tracer_provider',
+                    'grpc_tracing_server_interceptors',
+                    'aio_tracing_client_interceptors',
+                    'tracing_client_interceptor',
+                ],
             )
             runtime_args.port = [port]
             runtime_args.protocol = [protocol]

--- a/jina/serve/runtimes/gateway/composite/gateway.py
+++ b/jina/serve/runtimes/gateway/composite/gateway.py
@@ -23,7 +23,6 @@ class CompositeGateway(BaseGateway):
         for port, protocol in zip(self.ports, self.protocols):
             gateway_cls = _get_gateway_class(protocol)
             # ignore monitoring and tracing args since they are not copyable
-            print(self.runtime_args)
             runtime_args = self._deepcopy_with_ignore_attrs(
                 self.runtime_args,
                 [

--- a/jina/serve/runtimes/gateway/composite/gateway.py
+++ b/jina/serve/runtimes/gateway/composite/gateway.py
@@ -22,22 +22,23 @@ class CompositeGateway(BaseGateway):
         self.gateways: List[BaseGateway] = []
         for port, protocol in zip(self.ports, self.protocols):
             gateway_cls = _get_gateway_class(protocol)
+
             # ignore monitoring and tracing args since they are not copyable
+            ignored_attrs = [
+                'metrics_registry',
+                'tracer_provider',
+                'grpc_tracing_server_interceptors',
+                'aio_tracing_client_interceptors',
+                'tracing_client_interceptor',
+            ]
             runtime_args = self._deepcopy_with_ignore_attrs(
-                self.runtime_args,
-                [
-                    'metrics_registry',
-                    'tracer_provider',
-                    'grpc_tracing_server_interceptors',
-                    'aio_tracing_client_interceptors',
-                    'tracing_client_interceptor',
-                ],
+                self.runtime_args, ignored_attrs
             )
             runtime_args.port = [port]
             runtime_args.protocol = [protocol]
             gateway_kwargs = {k: v for k, v in kwargs.items() if k != 'runtime_args'}
             gateway_kwargs['runtime_args'] = dict(vars(runtime_args))
-            gateway = gateway_cls(**gateway_kwargs)
+            gateway = gateway_cls(streamer=self.streamer, **gateway_kwargs)
             gateway.streamer = self.streamer
             self.gateways.append(gateway)
 

--- a/jina/serve/runtimes/gateway/request_handling.py
+++ b/jina/serve/runtimes/gateway/request_handling.py
@@ -38,27 +38,24 @@ class GatewayRequestHandler:
         deployments_metadata = json.loads(self.runtime_args.deployments_metadata)
         deployments_no_reduce = json.loads(self.runtime_args.deployments_no_reduce)
 
-        print('init streamer')
-        if streamer:
-            self.streamer = streamer
-        else:
-            self.streamer = GatewayStreamer(
-                graph_representation=graph_description,
-                executor_addresses=deployments_addresses,
-                graph_conditions=graph_conditions,
-                deployments_metadata=deployments_metadata,
-                deployments_no_reduce=deployments_no_reduce,
-                timeout_send=self.runtime_args.timeout_send,
-                retries=self.runtime_args.retries,
-                compression=self.runtime_args.compression,
-                runtime_name=self.runtime_args.runtime_name,
-                prefetch=self.runtime_args.prefetch,
-                logger=self.logger,
-                metrics_registry=self.runtime_args.metrics_registry,
-                meter=self.runtime_args.meter,
-                aio_tracing_client_interceptors=self.runtime_args.aio_tracing_client_interceptors,
-                tracing_client_interceptor=self.runtime_args.tracing_client_interceptor,
-            )
+        self.streamer = streamer or GatewayStreamer(
+            graph_representation=graph_description,
+            executor_addresses=deployments_addresses,
+            graph_conditions=graph_conditions,
+            deployments_metadata=deployments_metadata,
+            deployments_no_reduce=deployments_no_reduce,
+            timeout_send=self.runtime_args.timeout_send,
+            retries=self.runtime_args.retries,
+            compression=self.runtime_args.compression,
+            runtime_name=self.runtime_args.runtime_name,
+            prefetch=self.runtime_args.prefetch,
+            logger=self.logger,
+            metrics_registry=self.runtime_args.metrics_registry,
+            meter=self.runtime_args.meter,
+            aio_tracing_client_interceptors=self.runtime_args.aio_tracing_client_interceptors,
+            tracing_client_interceptor=self.runtime_args.tracing_client_interceptor,
+        )
+
         GatewayStreamer._set_env_streamer_args(
             graph_representation=graph_description,
             executor_addresses=deployments_addresses,

--- a/jina/serve/runtimes/gateway/request_handling.py
+++ b/jina/serve/runtimes/gateway/request_handling.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, AsyncIterator
+from typing import TYPE_CHECKING, AsyncIterator, Optional
 
 from jina.helper import get_full_version
 from jina.proto import jina_pb2
@@ -7,21 +7,29 @@ from jina.types.request.status import StatusMessage
 
 if TYPE_CHECKING:  # pragma: no cover
     from types import SimpleNamespace
-    from jina.types.request import Request
+
     from jina.logging.logger import JinaLogger
+    from jina.serve.runtimes.gateway.streamer import GatewayStreamer
+    from jina.types.request import Request
 
 
 class GatewayRequestHandler:
     """Object to encapsulate the code related to handle the data requests in the Gateway"""
+
     def __init__(
-            self,
-            args: 'SimpleNamespace',
-            logger: 'JinaLogger',
-            **kwargs,
+        self,
+        args: 'SimpleNamespace',
+        logger: 'JinaLogger',
+        streamer: Optional['GatewayStreamer'] = None,
+        **kwargs,
     ):
         import json
 
-        from jina.serve.runtimes.gateway.streamer import GatewayStreamer, _ExecutorStreamer
+        from jina.serve.runtimes.gateway.streamer import (
+            GatewayStreamer,
+            _ExecutorStreamer,
+        )
+
         self.runtime_args = args
         self.logger = logger
         graph_description = json.loads(self.runtime_args.graph_description)
@@ -30,23 +38,27 @@ class GatewayRequestHandler:
         deployments_metadata = json.loads(self.runtime_args.deployments_metadata)
         deployments_no_reduce = json.loads(self.runtime_args.deployments_no_reduce)
 
-        self.streamer = GatewayStreamer(
-            graph_representation=graph_description,
-            executor_addresses=deployments_addresses,
-            graph_conditions=graph_conditions,
-            deployments_metadata=deployments_metadata,
-            deployments_no_reduce=deployments_no_reduce,
-            timeout_send=self.runtime_args.timeout_send,
-            retries=self.runtime_args.retries,
-            compression=self.runtime_args.compression,
-            runtime_name=self.runtime_args.runtime_name,
-            prefetch=self.runtime_args.prefetch,
-            logger=self.logger,
-            metrics_registry=self.runtime_args.metrics_registry,
-            meter=self.runtime_args.meter,
-            aio_tracing_client_interceptors=self.runtime_args.aio_tracing_client_interceptors,
-            tracing_client_interceptor=self.runtime_args.tracing_client_interceptor,
-        )
+        print('init streamer')
+        if streamer:
+            self.streamer = streamer
+        else:
+            self.streamer = GatewayStreamer(
+                graph_representation=graph_description,
+                executor_addresses=deployments_addresses,
+                graph_conditions=graph_conditions,
+                deployments_metadata=deployments_metadata,
+                deployments_no_reduce=deployments_no_reduce,
+                timeout_send=self.runtime_args.timeout_send,
+                retries=self.runtime_args.retries,
+                compression=self.runtime_args.compression,
+                runtime_name=self.runtime_args.runtime_name,
+                prefetch=self.runtime_args.prefetch,
+                logger=self.logger,
+                metrics_registry=self.runtime_args.metrics_registry,
+                meter=self.runtime_args.meter,
+                aio_tracing_client_interceptors=self.runtime_args.aio_tracing_client_interceptors,
+                tracing_client_interceptor=self.runtime_args.tracing_client_interceptor,
+            )
         GatewayStreamer._set_env_streamer_args(
             graph_representation=graph_description,
             executor_addresses=deployments_addresses,
@@ -81,7 +93,7 @@ class GatewayRequestHandler:
         da = DocumentArray([Document()])
         try:
             async for _ in self.streamer.stream_docs(
-                    docs=da, exec_endpoint=__dry_run_endpoint__, request_size=1
+                docs=da, exec_endpoint=__dry_run_endpoint__, request_size=1
             ):
                 pass
             status_message = StatusMessage()
@@ -109,7 +121,7 @@ class GatewayRequestHandler:
         return info_proto
 
     async def stream(
-            self, request_iterator, context=None, *args, **kwargs
+        self, request_iterator, context=None, *args, **kwargs
     ) -> AsyncIterator['Request']:
         """
         stream requests from client iterator and stream responses back.
@@ -121,12 +133,12 @@ class GatewayRequestHandler:
         :yield: responses to the request after streaming to Executors in Flow
         """
         async for resp in self.streamer.rpc_stream(
-                request_iterator=request_iterator, context=context, *args, **kwargs
+            request_iterator=request_iterator, context=context, *args, **kwargs
         ):
             yield resp
 
     async def process_single_data(
-            self, request: DataRequest, context=None
+        self, request: DataRequest, context=None
     ) -> DataRequest:
         """Implements request and response handling of a single DataRequest
         :param request: DataRequest from Client

--- a/jina_cli/api.py
+++ b/jina_cli/api.py
@@ -59,8 +59,8 @@ def executor_native(args: 'Namespace'):
 
     with runtime_cls(args) as rt:
         name = (
-            rt._worker_request_handler._executor.metas.name
-            if hasattr(rt, '_worker_request_handler')
+            rt._request_handler._executor.metas.name
+            if hasattr(rt, '_request_handler') and hasattr(rt._request_handler, '_executor')
             else rt.name
         )
         rt.logger.info(f'Executor {name} started')

--- a/tests/integration/instrumentation/test_flow_instrumentation.py
+++ b/tests/integration/instrumentation/test_flow_instrumentation.py
@@ -76,7 +76,6 @@ def test_multiprotocol_gateway_instrumentation(
     jaeger_port,
     otlp_collector,
     otlp_receiver_port,
-    client_type,
 ):
     grpc_port, http_port, websocket_port = random_port(), random_port(), random_port()
     f = Flow(

--- a/tests/integration/instrumentation/test_flow_instrumentation.py
+++ b/tests/integration/instrumentation/test_flow_instrumentation.py
@@ -2,7 +2,8 @@ import time
 
 import pytest
 
-from jina import Flow
+from jina import Client, Flow
+from jina.helper import random_port
 from tests.integration.instrumentation import (
     ExecutorFailureWithTracing,
     ExecutorTestWithTracing,
@@ -69,6 +70,60 @@ def test_gateway_instrumentation(
 
     trace_ids = get_trace_ids(client_traces)
     assert len(trace_ids) == 1
+
+
+def test_multiprotocol_gateway_instrumentation(
+    jaeger_port,
+    otlp_collector,
+    otlp_receiver_port,
+    client_type,
+):
+    grpc_port, http_port, websocket_port = random_port(), random_port(), random_port()
+    f = Flow(
+        protocol=['grpc', 'http', 'websocket'],
+        port=[grpc_port, http_port, websocket_port],
+        tracing=True,
+        traces_exporter_host='http://localhost',
+        traces_exporter_port=otlp_receiver_port,
+    ).add(
+        uses=ExecutorTestWithTracing,
+        tracing=True,
+        traces_exporter_host='http://localhost',
+        traces_exporter_port=otlp_receiver_port,
+    )
+
+    with f:
+        from docarray import DocumentArray
+
+        Client(protocol='grpc', port=grpc_port).post(
+            f'/search', DocumentArray.empty(), continue_on_error=True
+        )
+        Client(protocol='http', port=http_port).post(
+            f'/search', DocumentArray.empty(), continue_on_error=True
+        )
+        Client(protocol='websocket', port=websocket_port).post(
+            f'/search', DocumentArray.empty(), continue_on_error=True
+        )
+
+        # give some time for the tracing and metrics exporters to finish exporting.
+        # the client is slow to export the data
+        time.sleep(8)
+
+    services = get_services(jaeger_port)
+    expected_services = [
+        'executor0/rep-0',
+        'gateway/rep-0',
+        'GRPCClient',
+        'HTTPClient',
+        'WebSocketClient',
+    ]
+    assert len(services) == 5
+    assert set(services).issubset(expected_services)
+
+    client_traces = get_traces(jaeger_port, client_type)
+    (server_spans, client_spans, _) = partition_spans_by_kind(client_traces)
+    assert len(server_spans) == 15
+    assert len(client_spans) == 5
 
 
 def test_executor_instrumentation(jaeger_port, otlp_collector, otlp_receiver_port):

--- a/tests/integration/instrumentation/test_flow_instrumentation.py
+++ b/tests/integration/instrumentation/test_flow_instrumentation.py
@@ -120,10 +120,11 @@ def test_multiprotocol_gateway_instrumentation(
     assert len(services) == 5
     assert set(services).issubset(expected_services)
 
-    client_traces = get_traces(jaeger_port, client_type)
-    (server_spans, client_spans, _) = partition_spans_by_kind(client_traces)
-    assert len(server_spans) == 15
-    assert len(client_spans) == 5
+    for client_type in ['GRPCClient', 'HTTPClient', 'WebSocketClient']:
+        client_traces = get_traces(jaeger_port, client_type)
+        (server_spans, client_spans, _) = partition_spans_by_kind(client_traces)
+        assert len(server_spans) == 5
+        assert len(client_spans) == 5
 
 
 def test_executor_instrumentation(jaeger_port, otlp_collector, otlp_receiver_port):

--- a/tests/unit/orchestrate/flow/flow-construct/test_flow_multiprotocol.py
+++ b/tests/unit/orchestrate/flow/flow-construct/test_flow_multiprotocol.py
@@ -2,6 +2,7 @@ import itertools
 import os.path
 
 import pytest
+import requests as req
 from docarray import Document, DocumentArray
 
 from jina import Client, Executor, Flow, requests
@@ -121,14 +122,24 @@ def test_flow_multiprotocol_ports_protocols_mismatch():
 
 
 def test_flow_multiprotocol_with_monitoring():
+    port_monitoring = random_port()
     ports = [random_port(), random_port(), random_port()]
     protocols = PROTOCOLS
-    flow = Flow().config_gateway(port=ports, protocol=protocols, monitoring=True)
+    flow = Flow().config_gateway(
+        port=ports, protocol=protocols, monitoring=True, port_monitoring=port_monitoring
+    )
 
     with flow:
         for port, protocol in zip(ports, protocols):
             client = Client(port=port, protocol=protocol)
             client.post('/', inputs=[Document()])
+
+        resp = req.get(f'http://localhost:{port_monitoring}/')
+        assert resp.status_code == 200
+        assert (
+            'jina_successful_requests_total{runtime_name="gateway/rep-0"} 3.0'
+            in str(resp.content)
+        )
 
 
 def test_flow_multiprotocol_with_tracing():

--- a/tests/unit/orchestrate/flow/flow-construct/test_flow_multiprotocol.py
+++ b/tests/unit/orchestrate/flow/flow-construct/test_flow_multiprotocol.py
@@ -124,7 +124,18 @@ def test_flow_multiprotocol_with_monitoring():
     ports = [random_port(), random_port(), random_port()]
     protocols = PROTOCOLS
     flow = Flow().config_gateway(port=ports, protocol=protocols, monitoring=True)
-    
+
+    with flow:
+        for port, protocol in zip(ports, protocols):
+            client = Client(port=port, protocol=protocol)
+            client.post('/', inputs=[Document()])
+
+
+def test_flow_multiprotocol_with_tracing():
+    ports = [random_port(), random_port(), random_port()]
+    protocols = PROTOCOLS
+    flow = Flow().config_gateway(port=ports, protocol=protocols, tracing=True)
+
     with flow:
         for port, protocol in zip(ports, protocols):
             client = Client(port=port, protocol=protocol)


### PR DESCRIPTION
fix: composite gateway tracing support

before the PR, doing `jina gateway --protocol HTTP GRPC --port 8081 8085 --tracing` should result in an error
```grpc._cython.cygrpc.Channel.__reduce_cython__
TypeError: no default __reduce__ due to non-trivial __cinit__```