### PR TITLE
fix(readme): pipeline notebook url

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ an astronaut is walking in a park
 ### Build a pipeline
 
 <!-- start build-pipelines -->
-[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/jina-ai/jina/blob/docs-readme-changes/.github/getting-started/notebook.ipynb)
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/jina-ai/jina/blob/master/.github/getting-started/notebook.ipynb#scrollTo=YfNm1nScH30U)
 
 Sometimes you want to chain microservices together into a pipeline. That's where a [Flow](https://docs.jina.ai/concepts/flow/) comes in.
 


### PR DESCRIPTION
Notebook link for building pipeline was previously broken. This PR:

- Sends user to the correct URL
- Sends user to the Flow-specific part of the notebook

- [X] check and update documentation. See [guide](https://github.com/jina-ai/jina/blob/master/CONTRIBUTING.md#-contributing-documentation) and ask the team.
