### PR TITLE
fix: use container STOP so that containers running CUDA can be killed

### DIFF
--- a/jina/orchestrate/pods/container.py
+++ b/jina/orchestrate/pods/container.py
@@ -430,7 +430,7 @@ class ContainerPod(BasePod):
         """
         # terminate the docker
         try:
-            self._container.kill(signal='SIGTERM')
+            self._container.stop()
         finally:
             self.is_shutdown.wait(self.args.timeout_ctrl)
             self.logger.debug(f'terminating the runtime process')

--- a/jina/orchestrate/pods/container.py
+++ b/jina/orchestrate/pods/container.py
@@ -219,6 +219,9 @@ def run(
     cancel = threading.Event()
     fail_to_start = threading.Event()
 
+    def _cancel(*args, **kwargs):
+        logger.debug(f' Process observing container receives signal')
+        cancel.set()
     if not __windows__:
         try:
             for signame in {signal.SIGINT, signal.SIGTERM}:
@@ -456,5 +459,5 @@ class ContainerPod(BasePod):
         except docker.errors.NotFound:
             pass
         self.logger.debug(f'joining the process')
-        self.worker.join(*args, **kwargs)
+        self.worker.join(timeout=10, *args, **kwargs)
         self.logger.debug(f'successfully joined the process')

--- a/tests/unit/orchestrate/pods/container/test_container_pod.py
+++ b/tests/unit/orchestrate/pods/container/test_container_pod.py
@@ -180,9 +180,9 @@ def test_pass_arbitrary_kwargs(monkeypatch, mocker):
             def reload(self):
                 pass
 
-            def kill(self, signal, *args):
-                assert signal == 'SIGTERM'
-
+            def stop(self, *args, **kwargs):
+                pass
+        
         def __init__(self):
             pass
 


### PR DESCRIPTION
<!---Decomposing the complex issue into subtasks can help you build it step-by-step. Thanks for your pull request! :rocket: --->
<!---We know that dev life is hectic, but **please provide a (brief) description** of what your PR does, and how it does it. **Otherwise, your PR cannot be reviewed!** --->
<!---This policy was agreed upon in a past company retro, and makes everyone's life a little easier. Thanks for your collaboration!--->

**Goals:**
<!---https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword--->

- resolves #ISSUE-NUMBER
- ...
- ...

- ...
- ...
- [ ] check and update documentation. See [guide](https://github.com/jina-ai/jina/blob/master/CONTRIBUTING.md#-contributing-documentation) and ask the team.
