### PR TITLE
feat: catch ContentTypeError for retry in POST requests

### DIFF
--- a/jina/clients/base/helper.py
+++ b/jina/clients/base/helper.py
@@ -150,7 +150,7 @@ class HTTPClientlet(AioHttpClientlet):
                     r_str = response.text
                 handle_response_status(response.status, r_str, self.url)
                 return response
-            except (ValueError, ConnectionError, BadClient, aiohttp.ClientError, aiohttp.ContentTypeError) as err:
+            except (ValueError, ConnectionError, BadClient, aiohttp.ClientError) as err:
                 await retry.wait_or_raise_err(
                     attempt=attempt,
                     err=err,

--- a/jina/clients/base/helper.py
+++ b/jina/clients/base/helper.py
@@ -147,7 +147,7 @@ class HTTPClientlet(AioHttpClientlet):
                 r_str = await response.json()
                 handle_response_status(response.status, r_str, self.url)
                 return response
-            except (ValueError, ConnectionError, BadClient, aiohttp.ClientError) as err:
+            except (ValueError, ConnectionError, BadClient, aiohttp.ClientError, aiohttp.ContentTypeError) as err:
                 await retry.wait_or_raise_err(
                     attempt=attempt,
                     err=err,

--- a/jina/clients/base/helper.py
+++ b/jina/clients/base/helper.py
@@ -1,6 +1,6 @@
 import asyncio
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Optional, Union, Dict
 
 import aiohttp
 from aiohttp import WSMsgType
@@ -144,7 +144,10 @@ class HTTPClientlet(AioHttpClientlet):
                 response = await self.session.post(
                     url=self.url, json=req_dict
                 ).__aenter__()
-                r_str = await response.json()
+                try:
+                    r_str = await response.json()
+                except aiohttp.ContentTypeError:
+                    r_str = response.text
                 handle_response_status(response.status, r_str, self.url)
                 return response
             except (ValueError, ConnectionError, BadClient, aiohttp.ClientError, aiohttp.ContentTypeError) as err:
@@ -308,13 +311,13 @@ class WebsocketClientlet(AioHttpClientlet):
         return self.websocket.close_code if self.websocket else None
 
 
-def handle_response_status(http_status: int, response_string: str, url: str):
+def handle_response_status(http_status: int, response_content: Union[Dict, str], url: str):
     """
     Raise BadClient exception for HTTP 404 status.
     Raise ConnectionError for HTTP status codes 504, 504 if header information is available.
     Raise ValueError for everything other non 200 status code.
     :param http_status: http status code
-    :param response_string: response string
+    :param response_content: response content as json dict or string
     :param url: request url string
     """
     if http_status == status.HTTP_404_NOT_FOUND:
@@ -324,15 +327,16 @@ def handle_response_status(http_status: int, response_string: str, url: str):
         or http_status == status.HTTP_504_GATEWAY_TIMEOUT
     ):
         if (
-            'header' in response_string
-            and 'status' in response_string['header']
-            and 'description' in response_string['header']['status']
+            isinstance(response_content, dict)
+            and 'header' in response_content
+            and 'status' in response_content['header']
+            and 'description' in response_content['header']['status']
         ):
-            raise ConnectionError(response_string['header']['status']['description'])
+            raise ConnectionError(response_content['header']['status']['description'])
         else:
-            raise ValueError(response_string)
+            raise ValueError(response_content)
     elif (
         http_status < status.HTTP_200_OK
         or http_status > status.HTTP_300_MULTIPLE_CHOICES
     ):  # failure codes
-        raise ValueError(response_string)
+        raise ValueError(response_content)


### PR DESCRIPTION
When querying a POST route we always try to retrive a json format from the response. It happens that we sometimes receive a plain html format, in case the json cannot be decoded, ended up in a raise of the following error: `Attempt to decode JSON with unexpected mimetype: text/html; charset=utf-8`. Adding this type of Exception in the catch allow to perform a retry.
