### PR TITLE
fix: return awaited text in content type

### DIFF
--- a/jina/clients/base/helper.py
+++ b/jina/clients/base/helper.py
@@ -174,7 +174,7 @@ class HTTPClientlet(AioHttpClientlet):
                 try:
                     r_str = await response.json()
                 except aiohttp.ContentTypeError:
-                    r_str = response.text()
+                    r_str = await response.text()
                 handle_response_status(response.status, r_str, self.url)
                 return response
             except (ValueError, ConnectionError, BadClient, aiohttp.ClientError) as err:

--- a/jina/clients/base/helper.py
+++ b/jina/clients/base/helper.py
@@ -174,7 +174,7 @@ class HTTPClientlet(AioHttpClientlet):
                 try:
                     r_str = await response.json()
                 except aiohttp.ContentTypeError:
-                    r_str = response.text
+                    r_str = response.text()
                 handle_response_status(response.status, r_str, self.url)
                 return response
             except (ValueError, ConnectionError, BadClient, aiohttp.ClientError) as err:


### PR DESCRIPTION
`response.text` is a function and needs to be awaited to get the value. Error message now looks something like

<img width="1084" alt="image" src="https://user-images.githubusercontent.com/6537525/236514466-67ba8134-76bb-4a79-a6df-2caf2081ca93.png">


<!---Decomposing the complex issue into subtasks can help you build it step-by-step. Thanks for your pull request! :rocket: --->
<!---We know that dev life is hectic, but **please provide a (brief) description** of what your PR does, and how it does it. **Otherwise, your PR cannot be reviewed!** --->
<!---This policy was agreed upon in a past company retro, and makes everyone's life a little easier. Thanks for your collaboration!--->

**Goals:**
<!---https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword--->

- resolves #ISSUE-NUMBER
- ...
- ...

- ...
- ...
- [ ] check and update documentation. See [guide](https://github.com/jina-ai/jina/blob/master/CONTRIBUTING.md#-contributing-documentation) and ask the team.
