### PR TITLE
fix: fix the way endpoints are printed

### DIFF
--- a/jina/orchestrate/deployments/__init__.py
+++ b/jina/orchestrate/deployments/__init__.py
@@ -560,7 +560,9 @@ class Deployment(JAMLCompatible, PostMixin, BaseOrchestrator, metaclass=Deployme
             args.graph_description = (
                 '{"start-gateway": ["executor"], "executor": ["end-gateway"]}'
             )
-            _update_gateway_args(args, gateway_load_balancer=self._gateway_load_balancer)
+            _update_gateway_args(
+                args, gateway_load_balancer=self._gateway_load_balancer
+            )
             self.pod_args['gateway'] = args
         else:
             self.pod_args['gateway'] = None

--- a/jina/orchestrate/deployments/__init__.py
+++ b/jina/orchestrate/deployments/__init__.py
@@ -1129,6 +1129,7 @@ class Deployment(JAMLCompatible, PostMixin, BaseOrchestrator, metaclass=Deployme
             self.enter_context(self.head_pod)
         if self._include_gateway:
             _args = self.pod_args['gateway']
+            _update_gateway_args(_args, gateway_load_balancer=getattr(_args, 'gateway_load_balancer', False))
             _args.noblock_on_start = True
             self.gateway_pod = PodFactory.build_pod(
                 _args, gateway_load_balancer=self._gateway_load_balancer
@@ -1747,7 +1748,6 @@ class Deployment(JAMLCompatible, PostMixin, BaseOrchestrator, metaclass=Deployme
         if ProtocolType.HTTP.to_string().lower() in [p.lower() for p in _protocols]:
 
             http_ext_table = self._init_table()
-            print(f' {swagger_ui_link}')
             http_ext_table.add_row(':speech_balloon:', 'Swagger UI', swagger_ui_link)
 
             http_ext_table.add_row(':books:', 'Redoc', redoc_link)

--- a/jina/orchestrate/deployments/__init__.py
+++ b/jina/orchestrate/deployments/__init__.py
@@ -560,6 +560,7 @@ class Deployment(JAMLCompatible, PostMixin, BaseOrchestrator, metaclass=Deployme
             args.graph_description = (
                 '{"start-gateway": ["executor"], "executor": ["end-gateway"]}'
             )
+            _update_gateway_args(args, gateway_load_balancer=self._gateway_load_balancer)
             self.pod_args['gateway'] = args
         else:
             self.pod_args['gateway'] = None
@@ -1129,7 +1130,6 @@ class Deployment(JAMLCompatible, PostMixin, BaseOrchestrator, metaclass=Deployme
             self.enter_context(self.head_pod)
         if self._include_gateway:
             _args = self.pod_args['gateway']
-            _update_gateway_args(_args, gateway_load_balancer=getattr(_args, 'gateway_load_balancer', False))
             _args.noblock_on_start = True
             self.gateway_pod = PodFactory.build_pod(
                 _args, gateway_load_balancer=self._gateway_load_balancer


### PR DESCRIPTION
Fix the issue with this behavior when no ports are provided with Deployments with multiple protocols:

```python
import os
from jina import Deployment, Executor, requests, Client
d = Deployment(protocol=['grpc', 'http'])
with d:
    pass
```

Before:
![image](https://github.com/jina-ai/jina/assets/19825685/afbbdb69-2cf3-4670-afff-2912dc20cf78)


After:

![image](https://github.com/jina-ai/jina/assets/19825685/07bdfbdc-cbf0-4b1c-a84b-ae4a0ecbdfdd)


