### PR TITLE
fix: remove outdated protobuf that caused notebook crash

### DIFF
--- a/.github/getting-started/notebook.ipynb
+++ b/.github/getting-started/notebook.ipynb
@@ -38,7 +38,7 @@
       },
       "outputs": [],
       "source": [
-        "!pip install jina transformers==4.26.1 sentencepiece==0.1.97 torch==1.13.1 protobuf==3.19.6"
+        "!pip install jina transformers==4.26.1 sentencepiece==0.1.97 torch==1.13.1"
       ]
     },
     {


### PR DESCRIPTION
The notebook was crashing due to a pinned version of protobuf (that we initially used as a workaround for a different bug).

That caused it to crash with the current version of Jina. Removing the pinned version fixes that crash