### PR TITLE
fix: typos inside docs/cloud-nativeness

### DIFF
--- a/docs/cloud-nativeness/docker-compose.md
+++ b/docs/cloud-nativeness/docker-compose.md
@@ -98,7 +98,7 @@ flow.to_docker_compose_yaml('docker-compose.yml')
 
 ````{admonition} Hint
 :class: hint
-You can use a custom jina Docker image for the Gateway service by setting the envrironment variable `JINA_GATEWAY_IMAGE` to the desired image before generating the configuration.
+You can use a custom jina Docker image for the Gateway service by setting the environment variable `JINA_GATEWAY_IMAGE` to the desired image before generating the configuration.
 ````
 
 let's take a look at the generated compose file:

--- a/docs/cloud-nativeness/k8s.md
+++ b/docs/cloud-nativeness/k8s.md
@@ -43,7 +43,7 @@ You, the user, know your use case and requirements the best.
 This means that, while Jina generates configurations for you that run out of the box, as a professional user you should always see them as just a starting point to get you off the ground.
 
 ```{hint}
-The export funciton {meth}`~jina.Deployment.to_kubernetes_yaml` and {meth}`~jina.Flow.to_kubernetes_yaml` are helper functions to get your stared off the ground. **There are meant to be updated and adapted to every use case**
+The export function {meth}`~jina.Deployment.to_kubernetes_yaml` and {meth}`~jina.Flow.to_kubernetes_yaml` are helper functions to get your stared off the ground. **There are meant to be updated and adapted to every use case**
 ```
 ````{admonition} Matching Jina versions
 :class: caution
@@ -155,7 +155,7 @@ To expose your Gateway replicas outside Kubernetes, you can add a load balancer 
 
 ````{admonition} Hint
 :class: hint
-You can use a custom Docker image for the Gateway deployment by setting the envrironment variable `JINA_GATEWAY_IMAGE` to the desired image before generating the configuration.
+You can use a custom Docker image for the Gateway deployment by setting the environment variable `JINA_GATEWAY_IMAGE` to the desired image before generating the configuration.
 ````
 
 ## See also

--- a/docs/cloud-nativeness/kubernetes.md
+++ b/docs/cloud-nativeness/kubernetes.md
@@ -277,7 +277,7 @@ And as always, feel free to modify these files as you see fit for your use case.
 ````{admonition} Caution: Executor YAML configurations
 :class: caution
 
-As a general rule, the configuration files produced by `to_kubernets_yaml()` should run out of the box, and if you strictly
+As a general rule, the configuration files produced by `to_kubernetes_yaml()` should run out of the box, and if you strictly
 follow this how-to they will.
 
 However, there is an exception to this: If you use a local dockerized Executor, and this Executors configuration is stored


### PR DESCRIPTION
This PR fixes multiple typos inside of docs/cloud-nativeness directory.

- [x] check and update documentation. See [guide](https://github.com/jina-ai/jina/blob/master/CONTRIBUTING.md#-contributing-documentation) and ask the team.
