### PR TITLE
fix typos inside docs/concepts directory

### DIFF
--- a/docs/concepts/client/third-party-clients.md
+++ b/docs/concepts/client/third-party-clients.md
@@ -96,7 +96,7 @@ The response you receive includes `data` (an array of [Documents](https://docarr
 
 ```{admonition} See also: Flow REST API
 :class: seealso
-For a more detailed descripton of the REST API of a generic Flow, including the complete request body schema and request samples, please check:
+For a more detailed description of the REST API of a generic Flow, including the complete request body schema and request samples, please check:
 
 1. [OpenAPI Schema](https://api.jina.ai/rest/latest.json)
 2. [Redoc UI](https://api.jina.ai/rest/)

--- a/docs/concepts/jcloud/index.md
+++ b/docs/concepts/jcloud/index.md
@@ -44,7 +44,7 @@ If you installed the JCloud CLI individually, all of its commands fall under the
 In case the command `jc` is already occupied by another tool, use `jcloud` instead. If your pip install doesn't register bash commands for you, you can run `python -m jcloud -h`.
 ````
 
-For the rest of this section, we use `jc` or `jcloud`. But again they are interchangable with `jina cloud`.
+For the rest of this section, we use `jc` or `jcloud`. But again they are interchangeable with `jina cloud`.
 
 ## Flows
 
@@ -83,7 +83,7 @@ jcloud:
   docarray: docarray-version
 ```
 
-The `jina` and `docarray` corresponds to your development enviornment's `jina` and `docarray` versions.
+The `jina` and `docarray` corresponds to your development environment's `jina` and `docarray` versions.
 ````
 
 ````{tip}

--- a/docs/concepts/serving/executor/hot-reload.md
+++ b/docs/concepts/serving/executor/hot-reload.md
@@ -48,7 +48,7 @@ with dep:
     dep.block()
 ```
 
-We can see that the Executor is successfuly serving:
+We can see that the Executor is successfully serving:
 
 ```python
 from jina import Client

--- a/docs/concepts/serving/gateway/customization.md
+++ b/docs/concepts/serving/gateway/customization.md
@@ -422,7 +422,7 @@ class MyGateway(Gateway):
         self.server = Server(Config(app, host=self.host, port=self.port))
 ```
 
-```{admonition} Nonte
+```{admonition} Note
 :class: note
 
 Jina provides the Gateway with a list of ports and protocols to expose. Therefore, a custom Gateway can handle requests 
@@ -478,7 +478,7 @@ You may want to dockerize your custom Gateway so you can isolate its dependencie
 or Kubernetes.
 
 This assumes that you've already implemented a custom Gateway class and have defined a `config.yml` for it.
-In this case, dockerizing the Gateway is straighforward:
+In this case, dockerizing the Gateway is straightforward:
 * If you need dependencies other than Jina, make sure to add a `requirements.txt` file (for instance, you use a server library).
 * Create a `Dockerfile` as follows:
 1. Use a [Jina based image](https://hub.docker.com/r/jinaai/jina) with the `standard` tag as the base image in your Dockerfile.

--- a/docs/concepts/serving/gateway/customize-http-endpoints.md
+++ b/docs/concepts/serving/gateway/customize-http-endpoints.md
@@ -144,7 +144,7 @@ To enable this endpoint, all you need to do is set `expose_graphql_endpoint=True
 ```python
 from jina import Flow
 
-f = Flow().config_gateway(protocol='http', expose_graphql_endpont=True)
+f = Flow().config_gateway(protocol='http', expose_graphql_endpoint=True)
 ```
 ````
 
@@ -160,7 +160,7 @@ with:
 ````{admonition} See Also
 :class: seealso
 
-For more details about the Jina GraphQL enpoint, see {ref}`here <flow-graphql>`.
+For more details about the Jina GraphQL endpoint, see {ref}`here <flow-graphql>`.
 ````
 
 


### PR DESCRIPTION
Multiple typos inside docs/concepts directory has been fixed.

- [x] check and update documentation. See [guide](https://github.com/jina-ai/jina/blob/master/CONTRIBUTING.md#-contributing-documentation) and ask the team.
