### PR TITLE
docs: fix typo inside docs/tutorials

### DIFF
--- a/docs/tutorials/gpu-executor.md
+++ b/docs/tutorials/gpu-executor.md
@@ -389,7 +389,7 @@ That's more than a **6x speedup!** And that's not even the best we can do - if w
 :class: hint
 
 You've probably noticed that there was a delay (about 3 seconds) when creating the Deployment.
-This is because the weights of our model had to be transfered from CPU to GPU when we
+This is because the weights of our model had to be transferred from CPU to GPU when we
 initialized the Executor. However, this action only occurs once in the lifetime of the Executor,
 so for most use cases we don't need to worry about it.
 ```


### PR DESCRIPTION
Typo inside docs/tutorials/gpu-executor.md has been fixed.

- [x] check and update documentation. See [guide](https://github.com/jina-ai/jina/blob/master/CONTRIBUTING.md#-contributing-documentation) and ask the team.
