### PR TITLE
fix: add and use post endpoint for streaming

### DIFF
--- a/docs/concepts/serving/executor/add-endpoints.md
+++ b/docs/concepts/serving/executor/add-endpoints.md
@@ -382,7 +382,7 @@ Streaming endpoints receive one Document as input and yields one Document at a t
 
 Streaming endpoints are only supported for HTTP and gRPC protocols and for Deployment and Flow with one single Executor.
 
-For HTTP deploymnent streaming executors generate both a GET and POST endpoint.
+For HTTP deployment streaming executors generate both a GET and POST endpoint.
 The GET endpoint support documents with string, integer, or float fields only,
 whereas, POST requests support all docarrays.
 The Jina client uses the POST endpoints.

--- a/docs/concepts/serving/executor/add-endpoints.md
+++ b/docs/concepts/serving/executor/add-endpoints.md
@@ -381,6 +381,11 @@ Streaming endpoints receive one Document as input and yields one Document at a t
 :class: note
 
 Streaming endpoints are only supported for HTTP and gRPC protocols and for Deployment and Flow with one single Executor.
+
+For HTTP deploymnent streaming executors generate both a GET and POST endpoint.
+The GET endpoint support documents with string, integer, or float fields only,
+whereas, POST requests support all docarrays.
+The Jina client uses the POST endpoints.
 ```
 
 A streaming endpoint has the following signature:

--- a/jina/clients/base/helper.py
+++ b/jina/clients/base/helper.py
@@ -200,7 +200,7 @@ class HTTPClientlet(AioHttpClientlet):
         request_kwargs = {
             'url': self.url,
             'headers': {'Accept': 'text/event-stream'},
-            'json': doc.dict(),
+            'json': doc.dict() if docarray_v2 else doc.to_dict(),
         }
 
         async with self.session.post(**request_kwargs) as response:

--- a/jina/clients/base/helper.py
+++ b/jina/clients/base/helper.py
@@ -197,19 +197,15 @@ class HTTPClientlet(AioHttpClientlet):
         :param on: Request endpoint
         :yields: responses
         """
-        if docarray_v2:
-            req_dict = doc.dict()
-        else:
-            req_dict = doc.to_dict()
+        req_dict = doc.json()
 
         request_kwargs = {
             'url': self.url,
             'headers': {'Accept': 'text/event-stream'},
         }
-        req_dict = {key: value for key, value in req_dict.items() if value is not None}
-        request_kwargs['params'] = req_dict
+        request_kwargs['data'] = req_dict
 
-        async with self.session.get(**request_kwargs) as response:
+        async with self.session.post(**request_kwargs) as response:
             async for chunk in response.content.iter_any():
                 events = chunk.split(b'event: ')[1:]
                 for event in events:

--- a/jina/clients/base/helper.py
+++ b/jina/clients/base/helper.py
@@ -197,13 +197,11 @@ class HTTPClientlet(AioHttpClientlet):
         :param on: Request endpoint
         :yields: responses
         """
-        req_dict = doc.json()
-
         request_kwargs = {
             'url': self.url,
             'headers': {'Accept': 'text/event-stream'},
+            'data': doc.json(),
         }
-        request_kwargs['data'] = req_dict
 
         async with self.session.post(**request_kwargs) as response:
             async for chunk in response.content.iter_any():

--- a/jina/clients/base/helper.py
+++ b/jina/clients/base/helper.py
@@ -200,7 +200,7 @@ class HTTPClientlet(AioHttpClientlet):
         request_kwargs = {
             'url': self.url,
             'headers': {'Accept': 'text/event-stream'},
-            'data': doc.json(),
+            'json': doc.dict(),
         }
 
         async with self.session.post(**request_kwargs) as response:

--- a/jina/serve/runtimes/gateway/http_fastapi_app_docarrayv2.py
+++ b/jina/serve/runtimes/gateway/http_fastapi_app_docarrayv2.py
@@ -280,7 +280,7 @@ def get_fastapi_app(
 
             async def event_generator():
                 async for doc, error in streamer.stream_doc(
-                    doc=input_doc_model(**body.data), exec_endpoint=endpoint_path
+                    doc=input_doc_model(**body), exec_endpoint=endpoint_path
                 ):
                     if error:
                         raise HTTPException(status_code=499, detail=str(error))

--- a/jina/serve/runtimes/gateway/http_fastapi_app_docarrayv2.py
+++ b/jina/serve/runtimes/gateway/http_fastapi_app_docarrayv2.py
@@ -276,11 +276,11 @@ def get_fastapi_app(
             methods=['POST'],
             summary=f'Streaming Endpoint {endpoint_path}',
         )
-        async def streaming_post(body: input_doc_model, request: Request):
+        async def streaming_post(body: dict):
 
             async def event_generator():
                 async for doc, error in streamer.stream_doc(
-                    doc=body, exec_endpoint=endpoint_path
+                    doc=input_doc_model.parse_obj(body), exec_endpoint=endpoint_path
                 ):
                     if error:
                         raise HTTPException(status_code=499, detail=str(error))

--- a/jina/serve/runtimes/gateway/http_fastapi_app_docarrayv2.py
+++ b/jina/serve/runtimes/gateway/http_fastapi_app_docarrayv2.py
@@ -241,7 +241,7 @@ def get_fastapi_app(
                 )
                 return result
 
-    def add_streaming_get_route(
+    def add_streaming_routes(
         endpoint_path,
         input_doc_model=None,
     ):
@@ -258,6 +258,29 @@ def get_fastapi_app(
             async def event_generator():
                 async for doc, error in streamer.stream_doc(
                     doc=input_doc_model(**query_params), exec_endpoint=endpoint_path
+                ):
+                    if error:
+                        raise HTTPException(status_code=499, detail=str(error))
+                    yield {
+                        'event': 'update',
+                        'data': doc.dict()
+                    }
+                yield {
+                    'event': 'end'
+                }
+
+            return EventSourceResponse(event_generator())
+
+        @app.api_route(
+            path=f'/{endpoint_path.strip("/")}',
+            methods=['POST'],
+            summary=f'Streaming Endpoint {endpoint_path}',
+        )
+        async def streaming_post(body: input_doc_model, request: Request):
+
+            async def event_generator():
+                async for doc, error in streamer.stream_doc(
+                    doc=input_doc_model(**body.data), exec_endpoint=endpoint_path
                 ):
                     if error:
                         raise HTTPException(status_code=499, detail=str(error))
@@ -293,7 +316,7 @@ def get_fastapi_app(
             )
 
             if is_generator:
-                add_streaming_get_route(
+                add_streaming_routes(
                     endpoint,
                     input_doc_model=input_doc_model,
                 )

--- a/jina/serve/runtimes/gateway/http_fastapi_app_docarrayv2.py
+++ b/jina/serve/runtimes/gateway/http_fastapi_app_docarrayv2.py
@@ -280,7 +280,7 @@ def get_fastapi_app(
 
             async def event_generator():
                 async for doc, error in streamer.stream_doc(
-                    doc=input_doc_model(**body), exec_endpoint=endpoint_path
+                    doc=body, exec_endpoint=endpoint_path
                 ):
                     if error:
                         raise HTTPException(status_code=499, detail=str(error))

--- a/jina/serve/runtimes/worker/http_fastapi_app.py
+++ b/jina/serve/runtimes/worker/http_fastapi_app.py
@@ -138,8 +138,6 @@ def get_fastapi_app(
             req = DataRequest()
             req.header.exec_endpoint = endpoint_path
             if not docarray_v2:
-                from docarray import Document
-
                 req.data.docs = DocumentArray([Document.from_dict(query_params)])
             else:
                 req.document_array_cls = DocList[input_doc_model]
@@ -158,8 +156,6 @@ def get_fastapi_app(
             req = DataRequest()
             req.header.exec_endpoint = endpoint_path
             if not docarray_v2:
-                from docarray import Document
-
                 req.data.docs = DocumentArray([body])
             else:
                 req.document_array_cls = DocList[input_doc_model]

--- a/jina/serve/runtimes/worker/http_fastapi_app.py
+++ b/jina/serve/runtimes/worker/http_fastapi_app.py
@@ -122,7 +122,7 @@ def get_fastapi_app(
                 ret = output_model(data=docs_response, parameters=resp.parameters)
                 return ret
 
-    def add_streaming_get_route(
+    def add_streaming_routes(
             endpoint_path,
             input_doc_model=None,
     ):
@@ -143,7 +143,27 @@ def get_fastapi_app(
                 req.data.docs = DocumentArray([Document.from_dict(query_params)])
             else:
                 req.document_array_cls = DocList[input_doc_model]
-                req.data.docs = DocList[input_doc_model]([input_doc_model(**query_params)])
+                req.data.docs = DocList[input_doc_model](
+                    [input_doc_model(**query_params)]
+                )
+            event_generator = _gen_dict_documents(await caller(req))
+            return EventSourceResponse(event_generator)
+
+        @app.api_route(
+            path=f'/{endpoint_path.strip("/")}',
+            methods=['POST'],
+            summary=f'Streaming Endpoint {endpoint_path}',
+        )
+        async def streaming_post(body: input_doc_model, request: Request):
+            req = DataRequest()
+            req.header.exec_endpoint = endpoint_path
+            if not docarray_v2:
+                from docarray import Document
+
+                req.data.docs = DocumentArray([body])
+            else:
+                req.document_array_cls = DocList[input_doc_model]
+                req.data.docs = DocList[input_doc_model]([body])
             event_generator = _gen_dict_documents(await caller(req))
             return EventSourceResponse(event_generator)
 
@@ -176,7 +196,7 @@ def get_fastapi_app(
             )
 
             if is_generator:
-                add_streaming_get_route(
+                add_streaming_routes(
                     endpoint,
                     input_doc_model=input_doc_model,
                 )

--- a/tests/integration/docarray_v2/test_issues.py
+++ b/tests/integration/docarray_v2/test_issues.py
@@ -1,8 +1,10 @@
-from typing import List, Optional
+from typing import List, Optional, Dict
 
+import pytest
 from docarray import BaseDoc, DocList
+from pydantic import Field
 
-from jina import Executor, Flow, requests
+from jina import Executor, Flow, requests, Deployment, Client
 
 
 class Nested2Doc(BaseDoc):
@@ -92,3 +94,46 @@ def test_issue_6084():
     f = Flow().add(uses=MyIssue6084Exec).add(uses=MyIssue6084Exec)
     with f:
         pass
+
+
+@pytest.mark.asyncio
+async def test_issue_6090():
+    class NestedFieldSchema(BaseDoc):
+        name: str = "test_name"
+        dict_field: Dict = Field(default_factory=dict)
+
+    class MyDocument(BaseDoc):
+        text: str = "test"
+        nested_field: NestedFieldSchema = Field(default_factory=NestedFieldSchema)
+        dict_field: Dict = Field(default_factory=dict)
+        bool_field: bool = False
+
+    class MyExecutor(Executor):
+        @requests(on="/stream")
+        async def stream(
+            self, doc: MyDocument, parameters: Optional[Dict] = None, **kwargs
+        ) -> MyDocument:
+            for i in range(4):
+                yield MyDocument(text=f"hello world {doc.text} {i}")
+
+    docs = []
+    protocol = "http"
+    with Deployment(uses=MyExecutor, protocol=protocol, port=11112) as dep:
+        client = Client(port=11112, protocol=protocol, asyncio=True)
+        example_doc = MyDocument(text="my input text")
+        async for doc in client.stream_doc(
+            on="/stream",
+            inputs=example_doc,
+            input_type=MyDocument,
+            return_type=MyDocument,
+        ):
+            docs.append(doc)
+
+    assert [d.text for d in docs] == [
+        "hello world my input text 0",
+        "hello world my input text 1",
+        "hello world my input text 2",
+        "hello world my input text 3",
+    ]
+    assert docs[0].nested_field.name == "test_name"
+

--- a/tests/integration/docarray_v2/test_issues.py
+++ b/tests/integration/docarray_v2/test_issues.py
@@ -122,8 +122,8 @@ async def test_issue_6090():
 
     docs = []
     protocol = "http"
-    with Deployment(uses=MyExecutor, protocol=protocol, port=11112) as dep:
-        client = Client(port=11112, protocol=protocol, asyncio=True)
+    with Deployment(uses=MyExecutor, protocol=protocol) as dep:
+        client = Client(port=dep.port, protocol=protocol, asyncio=True)
         example_doc = InputWithComplexFields(text="my input text")
         async for doc in client.stream_doc(
             on="/stream",

--- a/tests/integration/docarray_v2/test_streaming.py
+++ b/tests/integration/docarray_v2/test_streaming.py
@@ -143,17 +143,19 @@ async def test_streaming_delay(protocol, include_gateway):
     ):
         client = Client(port=port, protocol=protocol, asyncio=True)
         i = 0
-        start_time = time.time()
-        async for doc in client.stream_doc(
+        stream = client.stream_doc(
             on='/hello',
             inputs=MyDocument(text='hello world', number=i),
             return_type=MyDocument,
-        ):
+        )
+        start_time = None
+        async for doc in stream:
+            start_time = start_time or time.time()
             assert doc.text == f'hello world {i}'
             i += 1
-
+            delay = time.time() - start_time
             # 0.5 seconds between each request + 0.5 seconds tolerance interval
-            assert time.time() - start_time < (0.5 * i) + 0.5
+            assert delay < (0.5 * i), f'Expected delay to be less than {0.5 * i}, got {delay} on iteration {i}'
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
<!---Decomposing the complex issue into subtasks can help you build it step-by-step. Thanks for your pull request! :rocket: --->
<!---We know that dev life is hectic, but **please provide a (brief) description** of what your PR does, and how it does it. **Otherwise, your PR cannot be reviewed!** --->
<!---This policy was agreed upon in a past company retro, and makes everyone's life a little easier. Thanks for your collaboration!--->

Making a new PR that follows conventions to replace https://github.com/jina-ai/jina/pull/6091

Http streaming breaks when the input doc schema has fields which are not str, int, or float. This includes dicts, bools, and nested objects (See [Issue 6090](https://github.com/jina-ai/jina/issues/6090)). In addition it caps the input size to 2000 characters (Much less when you factor in URL encoding)

This PR changes the get endpoints to post endpoints. Not sure if we want to keep the get endpoints for backwards compatibility.



**Goals:**
<!---https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword--->

- resolves [Issue 6090](https://github.com/jina-ai/jina/issues/6090)
- [x] check and update documentation. See [guide](https://github.com/jina-ai/jina/blob/master/CONTRIBUTING.md#-contributing-documentation) and ask the team.
