### PR TITLE
Revert "fix: add and use post endpoint for streaming"

### DIFF
--- a/docs/concepts/serving/executor/add-endpoints.md
+++ b/docs/concepts/serving/executor/add-endpoints.md
@@ -381,11 +381,6 @@ Streaming endpoints receive one Document as input and yields one Document at a t
 :class: note
 
 Streaming endpoints are only supported for HTTP and gRPC protocols and for Deployment and Flow with one single Executor.
-
-For HTTP deployment streaming executors generate both a GET and POST endpoint.
-The GET endpoint support documents with string, integer, or float fields only,
-whereas, POST requests support all docarrays.
-The Jina client uses the POST endpoints.
 ```
 
 A streaming endpoint has the following signature:

--- a/jina/clients/base/helper.py
+++ b/jina/clients/base/helper.py
@@ -197,13 +197,19 @@ class HTTPClientlet(AioHttpClientlet):
         :param on: Request endpoint
         :yields: responses
         """
+        if docarray_v2:
+            req_dict = doc.dict()
+        else:
+            req_dict = doc.to_dict()
+
         request_kwargs = {
             'url': self.url,
             'headers': {'Accept': 'text/event-stream'},
-            'json': doc.dict() if docarray_v2 else doc.to_dict(),
         }
+        req_dict = {key: value for key, value in req_dict.items() if value is not None}
+        request_kwargs['params'] = req_dict
 
-        async with self.session.post(**request_kwargs) as response:
+        async with self.session.get(**request_kwargs) as response:
             async for chunk in response.content.iter_any():
                 events = chunk.split(b'event: ')[1:]
                 for event in events:

--- a/jina/serve/runtimes/gateway/http_fastapi_app_docarrayv2.py
+++ b/jina/serve/runtimes/gateway/http_fastapi_app_docarrayv2.py
@@ -241,7 +241,7 @@ def get_fastapi_app(
                 )
                 return result
 
-    def add_streaming_routes(
+    def add_streaming_get_route(
         endpoint_path,
         input_doc_model=None,
     ):
@@ -258,29 +258,6 @@ def get_fastapi_app(
             async def event_generator():
                 async for doc, error in streamer.stream_doc(
                     doc=input_doc_model(**query_params), exec_endpoint=endpoint_path
-                ):
-                    if error:
-                        raise HTTPException(status_code=499, detail=str(error))
-                    yield {
-                        'event': 'update',
-                        'data': doc.dict()
-                    }
-                yield {
-                    'event': 'end'
-                }
-
-            return EventSourceResponse(event_generator())
-
-        @app.api_route(
-            path=f'/{endpoint_path.strip("/")}',
-            methods=['POST'],
-            summary=f'Streaming Endpoint {endpoint_path}',
-        )
-        async def streaming_post(body: dict):
-
-            async def event_generator():
-                async for doc, error in streamer.stream_doc(
-                    doc=input_doc_model.parse_obj(body), exec_endpoint=endpoint_path
                 ):
                     if error:
                         raise HTTPException(status_code=499, detail=str(error))
@@ -316,7 +293,7 @@ def get_fastapi_app(
             )
 
             if is_generator:
-                add_streaming_routes(
+                add_streaming_get_route(
                     endpoint,
                     input_doc_model=input_doc_model,
                 )

--- a/tests/integration/docarray_v2/test_issues.py
+++ b/tests/integration/docarray_v2/test_issues.py
@@ -1,10 +1,8 @@
-from typing import List, Optional, Dict
+from typing import List, Optional
 
-import pytest
 from docarray import BaseDoc, DocList
-from pydantic import Field
 
-from jina import Executor, Flow, requests, Deployment, Client
+from jina import Executor, Flow, requests
 
 
 class Nested2Doc(BaseDoc):
@@ -94,50 +92,3 @@ def test_issue_6084():
     f = Flow().add(uses=MyIssue6084Exec).add(uses=MyIssue6084Exec)
     with f:
         pass
-
-
-@pytest.mark.asyncio
-async def test_issue_6090():
-    """Tests if streaming works with pydantic models with complex fields which are not
-    str, int, or float.
-    """
-
-    class NestedFieldSchema(BaseDoc):
-        name: str = "test_name"
-        dict_field: Dict = Field(default_factory=dict)
-
-    class InputWithComplexFields(BaseDoc):
-        text: str = "test"
-        nested_field: NestedFieldSchema = Field(default_factory=NestedFieldSchema)
-        dict_field: Dict = Field(default_factory=dict)
-        bool_field: bool = False
-
-    class MyExecutor(Executor):
-        @requests(on="/stream")
-        async def stream(
-            self, doc: InputWithComplexFields, parameters: Optional[Dict] = None, **kwargs
-        ) -> InputWithComplexFields:
-            for i in range(4):
-                yield InputWithComplexFields(text=f"hello world {doc.text} {i}")
-
-    docs = []
-    protocol = "http"
-    with Deployment(uses=MyExecutor, protocol=protocol) as dep:
-        client = Client(port=dep.port, protocol=protocol, asyncio=True)
-        example_doc = InputWithComplexFields(text="my input text")
-        async for doc in client.stream_doc(
-            on="/stream",
-            inputs=example_doc,
-            input_type=InputWithComplexFields,
-            return_type=InputWithComplexFields,
-        ):
-            docs.append(doc)
-
-    assert [d.text for d in docs] == [
-        "hello world my input text 0",
-        "hello world my input text 1",
-        "hello world my input text 2",
-        "hello world my input text 3",
-    ]
-    assert docs[0].nested_field.name == "test_name"
-

--- a/tests/integration/docarray_v2/test_streaming.py
+++ b/tests/integration/docarray_v2/test_streaming.py
@@ -143,19 +143,17 @@ async def test_streaming_delay(protocol, include_gateway):
     ):
         client = Client(port=port, protocol=protocol, asyncio=True)
         i = 0
-        stream = client.stream_doc(
+        start_time = time.time()
+        async for doc in client.stream_doc(
             on='/hello',
             inputs=MyDocument(text='hello world', number=i),
             return_type=MyDocument,
-        )
-        start_time = None
-        async for doc in stream:
-            start_time = start_time or time.time()
+        ):
             assert doc.text == f'hello world {i}'
             i += 1
-            delay = time.time() - start_time
+
             # 0.5 seconds between each request + 0.5 seconds tolerance interval
-            assert delay < (0.5 * i), f'Expected delay to be less than {0.5 * i}, got {delay} on iteration {i}'
+            assert time.time() - start_time < (0.5 * i) + 0.5
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Reverts jina-ai/jina#6093

@JoanFM, This PR had an issue, the change I made to the streaming delay test was a patch. It looks like streaming does not work when I use post with a gateway, however, I have been able to update the endpoint so `get` works with either query params or a json body. Let's revert this and I will push my new branch.