### PR TITLE
Bump grpcio to v1.64 to fix build error

### DIFF
--- a/extra-requirements.txt
+++ b/extra-requirements.txt
@@ -27,9 +27,9 @@
 
 numpy:                      core
 protobuf>=3.19.0:           core
-grpcio>=1.46.0,<=1.57.0:    core
-grpcio-reflection>=1.46.0,<=1.57.0:  core
-grpcio-health-checking>=1.46.0,<=1.57.0:  core
+grpcio>=1.46.0,<=1.64.0:    core
+grpcio-reflection>=1.46.0,<=1.64.0:  core
+grpcio-health-checking>=1.46.0,<=1.64.0:  core
 pyyaml>=5.3.1:              core
 packaging>=20.0:            core
 docarray>=0.16.4:           core


### PR DESCRIPTION
<!---Decomposing the complex issue into subtasks can help you build it step-by-step. Thanks for your pull request! :rocket: --->
<!---We know that dev life is hectic, but **please provide a (brief) description** of what your PR does, and how it does it. **Otherwise, your PR cannot be reviewed!** --->
<!---This policy was agreed upon in a past company retro, and makes everyone's life a little easier. Thanks for your collaboration!--->

**Goals:**
<!---https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword--->

Hi, the latest version of jina installed via poetry fails due to its dependency, `grpcio v1.57.0`, failing to build on x86_64 Linux w/ Python v3.12.3. A Google search brought me to google/bumble#459, which hinted that the solution might be to upgrade to v1.64.0. Sure enough, changing the dependency version fixes the build.

- resolves #ISSUE-NUMBER
- ...
- ...

- ...
- ...
- [ ] check and update documentation. See [guide](https://github.com/jina-ai/jina/blob/master/CONTRIBUTING.md#-contributing-documentation) and ask the team.
